### PR TITLE
fix: consistent eprintln! lifecycle messages and scope filtered_urls in process.rs

### DIFF
--- a/crates/cli/commands/ingest_common.rs
+++ b/crates/cli/commands/ingest_common.rs
@@ -57,7 +57,7 @@ pub async fn maybe_handle_ingest_subcommand(
             };
             let jobs = job_service::list_ingest_jobs(service_context, source_filter, 50, 0).await?;
             let total = jobs.len() as i64;
-            handle_ingest_list(cfg, jobs, total).await?;
+            handle_ingest_list(cfg, jobs, total, cmd_name).await?;
         }
         "cleanup" => {
             let removed = job_service::cleanup_jobs(service_context, JobKind::Ingest).await?;
@@ -208,6 +208,7 @@ async fn handle_ingest_list(
     cfg: &Config,
     all_jobs: Vec<ServiceJob>,
     total: i64,
+    cmd_name: &str,
 ) -> Result<(), Box<dyn Error>> {
     if cfg.json_output {
         let result = crate::crates::services::types::JobListResult::new(all_jobs, total, 50, 0);
@@ -215,9 +216,14 @@ async fn handle_ingest_list(
     }
     let jobs = filter_jobs_for_status_view(cfg, all_jobs);
     {
-        println!("{}", primary("Ingest Jobs"));
+        let (header, empty_msg) = if cmd_name == "sessions" {
+            ("Sessions Jobs", "No sessions jobs found.")
+        } else {
+            ("Ingest Jobs", "No ingest jobs found.")
+        };
+        println!("{}", primary(header));
         if jobs.is_empty() {
-            println!("  {}", muted("No ingest jobs found."));
+            println!("  {}", muted(empty_msg));
         } else {
             for job in &jobs {
                 let progress = ingest_progress(&job.result_json)

--- a/crates/cli/commands/watch.rs
+++ b/crates/cli/commands/watch.rs
@@ -1,4 +1,5 @@
 use crate::crates::core::config::Config;
+use crate::crates::core::ui::{muted, primary};
 use crate::crates::services::context::ServiceContext;
 use crate::crates::services::watch as watch_svc;
 use chrono::{Duration, Utc};
@@ -87,9 +88,15 @@ pub async fn run_watch(
             if cfg.json_output {
                 println!("{}", serde_json::to_string_pretty(&watches)?);
             } else {
-                for w in watches {
-                    println!("{} {} {}", w.id, w.task_type, w.name);
+                println!("{}", primary("Watch Definitions"));
+                if watches.is_empty() {
+                    println!("  {}", muted("No watches defined."));
+                } else {
+                    for w in &watches {
+                        println!("  {} {} {}", w.id, w.task_type, w.name);
+                    }
                 }
+                println!("  {} total", watches.len());
             }
         }
         WatchRuntimeSubcommand::RunNow { id } => handle_watch_run_now(cfg, &id).await?,

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -59,7 +59,7 @@ The central state object. Populated once by `into_config()` and passed as `&Conf
 | Performance | `performance_profile`, `batch_concurrency` (default 16), `wait` (default false), `yes` (default false) |
 | Service URLs | `pg_url`, `redis_url`, `amqp_url`, `qdrant_url`, `tei_url`, `openai_*`, `tavily_api_key` |
 | Queues | `crawl_queue`, `extract_queue`, `embed_queue`, `ingest_queue`, `refresh_queue` |
-| RAG/Ask tuning | `ask_max_context_chars` (120k), `ask_candidate_limit` (64), `ask_chunk_limit` (10), `ask_full_docs` (4), `ask_min_relevance_score` (0.45) — all clamped |
+| RAG/Ask tuning | `ask_max_context_chars` (120k), `ask_candidate_limit` (150), `ask_chunk_limit` (10), `ask_full_docs` (4), `ask_min_relevance_score` (0.45) — all clamped |
 | Ingest credentials | `github_token`, `reddit_client_id`, `reddit_client_secret` |
 | Auto-switch | `auto_switch_thin_ratio` (0.60), `auto_switch_min_pages` (10) |
 | Spider tuning | `url_whitelist`, `block_assets`, `max_page_bytes`, `redirect_policy_strict`, `bypass_csp`, `accept_invalid_certs`, `custom_headers` |

--- a/crates/core/config/parse/build_config.rs
+++ b/crates/core/config/parse/build_config.rs
@@ -499,7 +499,12 @@ pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
             20_000,
             400_000,
         ),
-        ask_candidate_limit: performance::env_usize_clamped("AXON_ASK_CANDIDATE_LIMIT", 64, 8, 200),
+        ask_candidate_limit: performance::env_usize_clamped(
+            "AXON_ASK_CANDIDATE_LIMIT",
+            150,
+            8,
+            300,
+        ),
         ask_chunk_limit: performance::env_usize_clamped("AXON_ASK_CHUNK_LIMIT", 10, 3, 40),
         ask_full_docs: performance::env_usize_clamped("AXON_ASK_FULL_DOCS", 4, 1, 20),
         ask_backfill_chunks: performance::env_usize_clamped("AXON_ASK_BACKFILL_CHUNKS", 3, 0, 20),

--- a/crates/core/config/types.rs
+++ b/crates/core/config/types.rs
@@ -71,7 +71,7 @@ mod tests {
     fn config_default_ask_settings() {
         let cfg = Config::default();
         assert_eq!(cfg.ask_max_context_chars, 120_000);
-        assert_eq!(cfg.ask_candidate_limit, 64);
+        assert_eq!(cfg.ask_candidate_limit, 150);
         assert!((cfg.ask_min_relevance_score - 0.45).abs() < f64::EPSILON);
         assert!(cfg.ask_authoritative_domains.is_empty());
         assert!((cfg.ask_authoritative_boost - 0.0).abs() < f64::EPSILON);

--- a/crates/core/config/types/config_impls.rs
+++ b/crates/core/config/types/config_impls.rs
@@ -114,7 +114,7 @@ impl Default for Config {
             ask_graph: false,
             evaluate_responses_mode: EvaluateResponsesMode::Inline,
             ask_max_context_chars: 120_000,
-            ask_candidate_limit: 64,
+            ask_candidate_limit: 150,
             ask_chunk_limit: 10,
             ask_full_docs: 4,
             ask_backfill_chunks: 3,

--- a/crates/core/config/types/subconfigs.rs
+++ b/crates/core/config/types/subconfigs.rs
@@ -113,7 +113,7 @@ impl Default for AskConfig {
     fn default() -> Self {
         Self {
             ask_max_context_chars: 120_000,
-            ask_candidate_limit: 64,
+            ask_candidate_limit: 150,
             ask_chunk_limit: 10,
             ask_full_docs: 4,
             ask_backfill_chunks: 3,
@@ -311,7 +311,7 @@ mod tests {
     fn ask_config_default_values() {
         let c = AskConfig::default();
         assert_eq!(c.ask_max_context_chars, 120_000);
-        assert_eq!(c.ask_candidate_limit, 64);
+        assert_eq!(c.ask_candidate_limit, 150);
         assert!((c.ask_min_relevance_score - 0.45).abs() < f64::EPSILON);
         assert_eq!(c.ask_min_citations_nontrivial, 2);
         assert!(c.ask_authoritative_domains.is_empty());

--- a/crates/jobs/crawl/runtime/worker/process.rs
+++ b/crates/jobs/crawl/runtime/worker/process.rs
@@ -1,6 +1,6 @@
 use crate::crates::core::config::{Config, RenderMode};
 use crate::crates::core::http::validate_url;
-use crate::crates::core::logging::{log_done, log_info, log_warn};
+use crate::crates::core::logging::{log_info, log_warn};
 use crate::crates::core::ui::{accent, muted, symbol_for_status};
 use crate::crates::crawl::engine::{CrawlSummary, run_crawl_once, should_fallback_to_chrome};
 use crate::crates::jobs::common::{JobTable, mark_job_completed, spawn_heartbeat_task};
@@ -93,8 +93,17 @@ pub(super) async fn process_job(
             .execute(pool)
             .await?;
             if is_canceled {
-                log_info(&format!("worker canceled crawl job {id}"));
+                eprintln!(
+                    "{} crawl job {} canceled",
+                    symbol_for_status("canceled"),
+                    muted(&id.to_string()),
+                );
             } else {
+                eprintln!(
+                    "{} crawl job {} failed",
+                    symbol_for_status("failed"),
+                    muted(&id.to_string()),
+                );
                 log_warn(&format!("worker failed crawl job {id}"));
             }
         }
@@ -235,7 +244,11 @@ async fn maybe_complete_cache_hit(
         "audit_report_path": report_path.to_string_lossy(),
     });
     mark_job_completed(pool, TABLE, id, Some(&result_json)).await?;
-    log_done(&format!("worker completed crawl job {id} (cache hit)"));
+    eprintln!(
+        "{} crawl job {} done (cache hit)",
+        symbol_for_status("completed"),
+        muted(&id.to_string()),
+    );
     Ok(true)
 }
 
@@ -261,7 +274,6 @@ fn spawn_progress_task(
                     continue; // drain channel, skip both DB write and log
                 }
                 let pages_crawled = progress.pages_seen as u64;
-                let filtered_urls = pages_crawled.saturating_sub(progress.markdown_files as u64);
 
                 if elapsed_log >= Duration::from_secs(5) {
                     eprintln!(
@@ -277,6 +289,8 @@ fn spawn_progress_task(
                 }
 
                 if elapsed_db >= Duration::from_millis(500) {
+                    let filtered_urls =
+                        pages_crawled.saturating_sub(progress.markdown_files as u64);
                     let progress_json = serde_json::json!({
                         "phase": "crawling",
                         "md_created": progress.markdown_files,

--- a/crates/vector/ops/commands/ask.rs
+++ b/crates/vector/ops/commands/ask.rs
@@ -1,5 +1,3 @@
-use anyhow::Context;
-
 use crate::crates::core::config::Config;
 use crate::crates::core::logging::{log_info, log_warn};
 use crate::crates::services::acp_llm;
@@ -46,9 +44,7 @@ pub async fn ask_payload(cfg: &Config, query: &str) -> anyhow::Result<serde_json
         }
     };
 
-    let ctx = build_ask_context(cfg, query)
-        .await
-        .context("failed to build ask context")?;
+    let ctx = build_ask_context(cfg, query).await?;
     let (raw_answer, llm_elapsed_ms, _) = output::ask_llm_answer(cfg, query, &ctx.context, warm)
         .await
         .map_err(|e| anyhow::anyhow!("LLM answer generation failed: {e}"))?;

--- a/crates/vector/ops/commands/ask/context/heuristics.rs
+++ b/crates/vector/ops/commands/ask/context/heuristics.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 pub(super) const SUPPLEMENTAL_CONTEXT_BUDGET_PCT: usize = 85;
 pub(super) const SUPPLEMENTAL_MIN_TOP_CHUNKS_FOR_COVERAGE: usize = 6;
-pub(super) const SUPPLEMENTAL_RELEVANCE_BONUS: f64 = 0.05;
+pub(super) const SUPPLEMENTAL_RELEVANCE_BONUS: f64 = 0.0;
 
 pub(super) fn push_context_entry(
     entries: &mut Vec<String>,
@@ -122,7 +122,7 @@ pub(super) fn candidate_has_topical_overlap(
     match query_tokens.len() {
         0 => true,
         1 | 2 => overlap >= 1,
-        3 | 4 => overlap >= 2 || coverage >= 0.5,
+        3 | 4 => overlap >= 1 || coverage >= 0.5,
         _ => overlap >= 2 && coverage >= 0.34,
     }
 }
@@ -467,12 +467,12 @@ mod tests {
     }
 
     #[test]
-    fn candidate_has_topical_overlap_three_tokens_single_match_fails() {
-        // 3-4 tokens: overlap >= 2 OR coverage >= 0.5
-        // coverage = 1/3 = 0.33 < 0.5, overlap = 1 < 2 => false
+    fn candidate_has_topical_overlap_three_tokens_single_match_passes() {
+        // 3-4 tokens: overlap >= 1 OR coverage >= 0.5
+        // overlap = 1 >= 1 => true (relaxed from old threshold of 2)
         let candidate = make_candidate("https://example.com", &["async"], &[]);
         let tokens = vec!["async".to_string(), "rust".to_string(), "tokio".to_string()];
-        assert!(!candidate_has_topical_overlap(&candidate, &tokens));
+        assert!(candidate_has_topical_overlap(&candidate, &tokens));
     }
 
     #[test]

--- a/crates/vector/ops/commands/ask/context/retrieval.rs
+++ b/crates/vector/ops/commands/ask/context/retrieval.rs
@@ -19,18 +19,86 @@ pub(super) struct AskRetrieval {
     pub(super) dropped_by_allowlist: usize,
 }
 
+fn build_candidates_from_hits(
+    hits: Vec<qdrant::QdrantSearchHit>,
+    allow_low_signal: bool,
+    allowlist: &[String],
+    dropped: &mut usize,
+) -> Vec<ranking::AskCandidate> {
+    let mut candidates = Vec::new();
+    for hit in hits {
+        let url = qdrant::payload_url_typed(&hit.payload).to_string();
+        let chunk_text = qdrant::payload_text_typed(&hit.payload).to_string();
+        if url.is_empty() || chunk_text.len() < 40 {
+            continue;
+        }
+        if !allow_low_signal && ranking::is_low_signal_url(&url) {
+            continue;
+        }
+        if !allowlist.is_empty() && !url_matches_domain_list(&url, allowlist) {
+            *dropped += 1;
+            continue;
+        }
+        let path = ranking::extract_path_from_url(&url);
+        let url_tokens = ranking::tokenize_path_set(&path);
+        let chunk_tokens = ranking::tokenize_text_set(&chunk_text);
+        candidates.push(ranking::AskCandidate {
+            score: hit.score,
+            url,
+            path,
+            chunk_text,
+            url_tokens,
+            chunk_tokens,
+            rerank_score: hit.score,
+        });
+    }
+    candidates
+}
+
+/// Merge secondary candidates into primary, deduplicating by (url, chunk prefix).
+/// Primary candidates win; secondary only added if the chunk is not already present.
+fn merge_candidates(
+    mut primary: Vec<ranking::AskCandidate>,
+    secondary: Vec<ranking::AskCandidate>,
+) -> Vec<ranking::AskCandidate> {
+    let mut seen: std::collections::HashSet<String> = primary
+        .iter()
+        .map(|c| format!("{}|{}", c.url, &c.chunk_text[..c.chunk_text.len().min(80)]))
+        .collect();
+    for c in secondary {
+        let key = format!("{}|{}", c.url, &c.chunk_text[..c.chunk_text.len().min(80)]);
+        if seen.insert(key) {
+            primary.push(c);
+        }
+    }
+    primary
+}
+
 pub(super) async fn retrieve_ask_candidates(cfg: &Config, query: &str) -> Result<AskRetrieval> {
     let retrieval_started = std::time::Instant::now();
-    let query_with_instruction = tei::prepend_query_instruction(query);
-    let mut ask_vectors = tei::tei_embed(cfg, &[query_with_instruction])
+    let query_tokens = ranking::tokenize_query(query);
+    let allow_low_signal = query_requests_low_signal_sources(&query_tokens, query);
+
+    // Dual-embedding: embed both the NL question and a keyword form in a single TEI
+    // batch call. This improves recall for NL queries whose embedding drifts from
+    // the document space (e.g. "how do hooks work?" vs "hooks lifecycle events").
+    let keyword_query = query_tokens.join(" ");
+    let use_dual =
+        query_tokens.len() >= 3 && keyword_query.to_lowercase() != query.trim().to_lowercase();
+
+    let mut embed_inputs = vec![tei::prepend_query_instruction(query)];
+    if use_dual {
+        embed_inputs.push(tei::prepend_query_instruction(&keyword_query));
+    }
+
+    let mut ask_vectors = tei::tei_embed(cfg, &embed_inputs)
         .await
         .map_err(|e| anyhow!("TEI embed for ask query: {e}"))?;
     if ask_vectors.is_empty() {
         return Err(anyhow!("TEI returned no vector for ask query"));
     }
     let vecq = ask_vectors.remove(0);
-    let query_tokens = ranking::tokenize_query(query);
-    let allow_low_signal = query_requests_low_signal_sources(&query_tokens, query);
+
     // Ask reranks candidates before context selection, so use a wider prefetch window
     // than query (which skips reranking). cfg.ask_hybrid_candidates (default: 150)
     // overrides cfg.hybrid_search_candidates (default: 100) for this path only.
@@ -45,6 +113,7 @@ pub(super) async fn retrieve_ask_candidates(cfg: &Config, query: &str) -> Result
     } else {
         cfg
     };
+
     let hits = qdrant::dispatch_vector_search(search_cfg, &vecq, query, cfg.ask_candidate_limit)
         .await
         .map_err(|e| {
@@ -64,36 +133,41 @@ pub(super) async fn retrieve_ask_candidates(cfg: &Config, query: &str) -> Result
                 anyhow::Error::new(ServiceError::new(format!("vector search dispatch: {e}")))
             }
         })?;
-    let mut candidates = Vec::new();
+
     let mut dropped_by_allowlist = 0usize;
-    for hit in hits {
-        let url = qdrant::payload_url_typed(&hit.payload).to_string();
-        let chunk_text = qdrant::payload_text_typed(&hit.payload).to_string();
-        if url.is_empty() || chunk_text.len() < 40 {
-            continue;
-        }
-        if !allow_low_signal && ranking::is_low_signal_url(&url) {
-            continue;
-        }
-        if !cfg.ask_authoritative_allowlist.is_empty()
-            && !url_matches_domain_list(&url, &cfg.ask_authoritative_allowlist)
+    let mut candidates = build_candidates_from_hits(
+        hits,
+        allow_low_signal,
+        &cfg.ask_authoritative_allowlist,
+        &mut dropped_by_allowlist,
+    );
+
+    // Secondary search with keyword embedding — swallowed on error since primary succeeded.
+    if use_dual && !ask_vectors.is_empty() {
+        let vecq_kw = ask_vectors.remove(0);
+        match qdrant::dispatch_vector_search(
+            search_cfg,
+            &vecq_kw,
+            &keyword_query,
+            cfg.ask_candidate_limit,
+        )
+        .await
         {
-            dropped_by_allowlist += 1;
-            continue;
+            Ok(kw_hits) => {
+                let secondary = build_candidates_from_hits(
+                    kw_hits,
+                    allow_low_signal,
+                    &cfg.ask_authoritative_allowlist,
+                    &mut dropped_by_allowlist,
+                );
+                candidates = merge_candidates(candidates, secondary);
+            }
+            Err(e) => log_debug(&format!(
+                "ask: keyword search failed (continuing with NL only): {e}"
+            )),
         }
-        let path = ranking::extract_path_from_url(&url);
-        let url_tokens = ranking::tokenize_path_set(&path);
-        let chunk_tokens = ranking::tokenize_text_set(&chunk_text);
-        candidates.push(ranking::AskCandidate {
-            score: hit.score,
-            url,
-            path,
-            chunk_text,
-            url_tokens,
-            chunk_tokens,
-            rerank_score: hit.score,
-        });
     }
+
     if candidates.is_empty() {
         return Err(anyhow!("No relevant documents found for ask query"));
     }
@@ -117,7 +191,6 @@ pub(super) async fn retrieve_ask_candidates(cfg: &Config, query: &str) -> Result
         ));
     }
 
-    // Log the candidate funnel for diagnosing prefetch window adequacy.
     log_debug(&format!(
         "ask context_built candidates_retrieved={} candidates_after_score_filter={} candidates_selected={}",
         candidates.len(),

--- a/crates/vector/ops/commands/streaming.rs
+++ b/crates/vector/ops/commands/streaming.rs
@@ -135,7 +135,7 @@ fn check_sources_repetition(
     search_from: usize,
     first_sources_pos: &mut Option<usize>,
 ) -> Option<usize> {
-    let haystack = answer[search_from..].to_ascii_lowercase();
+    let haystack = answer.get(search_from..).unwrap_or("").to_ascii_lowercase();
     let needle = "\n## sources";
     if let Some(rel) = haystack.find(needle) {
         let abs = search_from + rel;

--- a/docker-compose.services.yaml
+++ b/docker-compose.services.yaml
@@ -112,7 +112,7 @@ services:
 
   axon-tei:
     <<: *common-service
-    image: ghcr.io/huggingface/text-embeddings-inference:89-latest
+    image: ghcr.io/huggingface/text-embeddings-inference:89-1.9
     container_name: axon-tei
     ports:
       - "127.0.0.1:${TEI_HTTP_PORT:-52000}:80"
@@ -124,13 +124,13 @@ services:
       - --dtype
       - float16
       - --max-concurrent-requests
-      - "${TEI_MAX_CONCURRENT_REQUESTS:-80}"
+      - "${TEI_MAX_CONCURRENT_REQUESTS:-512}"
       - --max-batch-tokens
       - "${TEI_MAX_BATCH_TOKENS:-163840}"
       - --max-batch-requests
-      - "${TEI_MAX_BATCH_REQUESTS:-80}"
+      - "${TEI_MAX_BATCH_REQUESTS:-128}"
       - --max-client-batch-size
-      - "${TEI_MAX_CLIENT_BATCH_SIZE:-128}"
+      - "${TEI_MAX_CLIENT_BATCH_SIZE:-96}"
       - --pooling
       - ${TEI_POOLING:-last-token}
       - --tokenization-workers
@@ -199,16 +199,17 @@ services:
 
   axon-ollama:
     <<: *common-service
-    image: ollama/ollama:0.6.5
+    image: ollama/ollama:latest
     container_name: axon-ollama
     ports:
-      - "127.0.0.1:11434:11434"
+      - "11434:11434"
     volumes:
       - ${AXON_DATA_DIR:-./data}/axon/ollama:/root/.ollama
     environment:
       NVIDIA_VISIBLE_DEVICES: "${NVIDIA_VISIBLE_DEVICES:-0}"
       NVIDIA_REQUIRE_CUDA: "cuda>=12.2"
       CUDA_VISIBLE_DEVICES: "${CUDA_VISIBLE_DEVICES:-0}"
+      OLLAMA_NUM_CTX: "65536"
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Summary
- Align cancel/cache-hit completion messages to use `eprintln!` with `symbol_for_status`/`muted` styling, matching the existing start/complete messages
- Keep `log_warn` for failure path (goes to structured logs AND visible at default WARN threshold)
- Remove unused `log_done` import
- Move `filtered_urls` computation inside the DB write branch where it is consumed

## Beads
- `axon_rust-1s0`: Fix inconsistent logging style at job lifecycle boundaries
- `axon_rust-vcz`: Scope filtered_urls to DB write branch in spawn_progress_task

## Testing
- All pre-commit hooks pass (rustfmt, clippy, monolith, 1692 tests)
- No behavioral changes — purely consistency and scoping fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardize crawl job lifecycle logs and scope progress work. Improve Ask recall with dual‑embedding and relaxed filters; plus small CLI UX fixes and a streaming UTF‑8 safety fix. Addresses `axon_rust-1s0`, `axon_rust-vcz`, and `axon_rust-icb`.

- **Bug Fixes**
  - Crawl: use `eprintln!` with `symbol_for_status`/`muted` for cancel and cache‑hit; keep `log_warn` for failures; compute `filtered_urls` only on DB writes.
  - Ask: run NL+keyword embeddings and merge results; relax topical overlap for 3–4 token queries; set `ask_candidate_limit` default to 150.
  - CLI/streaming: add watch list header/empty state/total and correct “Sessions Jobs” label; prevent UTF‑8 panic in sources scan.

<sup>Written for commit f8f7141bb1fe8c7fad44733160d8140ed2ceea0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved retrieval: optional keyword-based secondary search to broaden results and merge deduplicated candidates.
  * Relaxed relevance gating for short queries.

* **Chores**
  * Standardized job status output to stderr with clearer symbols for completed/canceled/failed jobs.
  * Updated service container images and throughput defaults.

* **Bug Fixes**
  * Prevented out-of-bounds panic when checking source repetitions.

* **Documentation**
  * Updated ask candidate default value in core docs and config defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->