### PR TITLE
feat(axon_rust-a4w): fast sitemap-first map command rewrite

### DIFF
--- a/crates/cli/commands/map.rs
+++ b/crates/cli/commands/map.rs
@@ -94,3 +94,5 @@ pub async fn run_map(cfg: &Config, start_url: &str) -> Result<(), Box<dyn Error>
 
 #[cfg(test)]
 mod map_migration_tests;
+#[cfg(test)]
+mod map_sitemap_tests;

--- a/crates/cli/commands/map.rs
+++ b/crates/cli/commands/map.rs
@@ -53,10 +53,12 @@ pub async fn run_map(cfg: &Config, start_url: &str) -> Result<(), Box<dyn Error>
     let mapped_urls = result.payload["mapped_urls"].as_u64().unwrap_or(0);
     let thin_pages = result.payload["thin_pages"].as_u64().unwrap_or(0);
     let elapsed_ms = result.payload["elapsed_ms"].as_u64().unwrap_or(0);
+    let map_source = result.payload["map_source"].as_str().unwrap_or("unknown");
+    let warning = result.payload["warning"].as_str();
 
     if let Some(s) = map_spinner {
         s.finish(&format!(
-            "map complete (pages={pages_seen} sitemap_urls={sitemap_urls})"
+            "map complete (source={map_source} urls={mapped_urls} sitemap_urls={sitemap_urls})"
         ));
     }
 
@@ -64,7 +66,15 @@ pub async fn run_map(cfg: &Config, start_url: &str) -> Result<(), Box<dyn Error>
         println!("{}", result.payload);
     } else {
         println!("{}", primary(&format!("Map Results for {start_url}")));
-        println!("{} {}", muted("Showing"), mapped_urls);
+        println!(
+            "{} {} (source: {})",
+            muted("Showing"),
+            mapped_urls,
+            map_source
+        );
+        if let Some(w) = warning {
+            println!("{} {}", muted("Warning:"), w);
+        }
         println!();
         if let Some(urls) = result.payload["urls"].as_array() {
             for url in urls {
@@ -76,7 +86,7 @@ pub async fn run_map(cfg: &Config, start_url: &str) -> Result<(), Box<dyn Error>
     }
 
     log_done(&format!(
-        "command=map mapped_urls={mapped_urls} sitemap_urls={sitemap_urls} pages_seen={pages_seen} thin_pages={thin_pages} elapsed_ms={elapsed_ms}"
+        "command=map mapped_urls={mapped_urls} map_source={map_source} sitemap_urls={sitemap_urls} pages_seen={pages_seen} thin_pages={thin_pages} elapsed_ms={elapsed_ms}"
     ));
 
     Ok(())

--- a/crates/cli/commands/map/map_sitemap_tests.rs
+++ b/crates/cli/commands/map/map_sitemap_tests.rs
@@ -1,0 +1,650 @@
+//! Targeted tests for sitemap-first map behavior.
+//!
+//! Tests cover the 3-stage fallback chain:
+//!   sitemap discovery → bounded-structure fallback → crawl (opt-in only)
+//!
+//! All tests use httpmock for network isolation.
+
+use super::map_payload;
+use crate::crates::core::config::{Config, MapFallback, RenderMode};
+use crate::crates::core::http::set_allow_loopback;
+use httpmock::prelude::*;
+use serial_test::serial;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+struct LoopbackGuard;
+
+impl LoopbackGuard {
+    fn new() -> Self {
+        set_allow_loopback(true);
+        Self
+    }
+}
+
+impl Drop for LoopbackGuard {
+    fn drop(&mut self) {
+        set_allow_loopback(false);
+    }
+}
+
+fn base_config() -> Config {
+    Config {
+        json_output: true,
+        discover_sitemaps: true,
+        fetch_retries: 0,
+        retry_backoff_ms: 0,
+        request_timeout_ms: Some(5_000),
+        render_mode: RenderMode::Http,
+        ..Config::default()
+    }
+}
+
+fn sitemap_xml(urls: &[&str]) -> String {
+    let mut xml = String::from(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+"#,
+    );
+    for url in urls {
+        xml.push_str(&format!("  <url><loc>{url}</loc></url>\n"));
+    }
+    xml.push_str("</urlset>\n");
+    xml
+}
+
+fn sitemap_index_xml(child_urls: &[&str]) -> String {
+    let mut xml = String::from(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+"#,
+    );
+    for url in child_urls {
+        xml.push_str(&format!("  <sitemap><loc>{url}</loc></sitemap>\n"));
+    }
+    xml.push_str("</sitemapindex>\n");
+    xml
+}
+
+/// Register all default sitemap seed paths as 404, except the one being tested.
+fn mock_all_sitemaps_404(server: &MockServer) {
+    for path in &[
+        "/sitemap.xml",
+        "/sitemap_index.xml",
+        "/sitemap-index.xml",
+        "/wp-sitemap.xml",
+        "/sitemap/sitemap-index.xml",
+    ] {
+        server.mock(|when, then| {
+            when.method(GET).path(*path);
+            then.status(404);
+        });
+    }
+    server.mock(|when, then| {
+        when.method(GET).path("/robots.txt");
+        then.status(404);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Sitemap-first behavior — robots.txt → sitemap.xml → 10 URLs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_sitemap_first_uses_sitemap_urls() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    let page_urls: Vec<String> = (1..=10).map(|i| format!("{base}/page-{i}")).collect();
+    let page_url_refs: Vec<&str> = page_urls.iter().map(String::as_str).collect();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/robots.txt");
+        then.status(200)
+            .header("content-type", "text/plain")
+            .body(format!(
+                "User-agent: *\nDisallow:\nSitemap: {base}/sitemap.xml\n"
+            ));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/sitemap.xml");
+        then.status(200)
+            .header("content-type", "application/xml")
+            .body(sitemap_xml(&page_url_refs));
+    });
+    for path in &[
+        "/sitemap_index.xml",
+        "/sitemap-index.xml",
+        "/wp-sitemap.xml",
+        "/sitemap/sitemap-index.xml",
+    ] {
+        server.mock(|when, then| {
+            when.method(GET).path(*path);
+            then.status(404);
+        });
+    }
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    let urls = result["urls"].as_array().expect("urls must be array");
+    assert_eq!(
+        urls.len(),
+        10,
+        "expected 10 sitemap URLs, got {}: {:?}",
+        urls.len(),
+        urls
+    );
+    assert_eq!(
+        result["map_source"].as_str(),
+        Some("sitemap"),
+        "expected map_source=sitemap"
+    );
+    // pages_seen must be 0 in sitemap mode
+    assert_eq!(
+        result["pages_seen"].as_u64(),
+        Some(0),
+        "pages_seen must be 0 in sitemap mode"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Fallback trigger correctness — sitemap parsed but all out-of-scope
+//         → map_source stays "sitemap", no anchor fallback
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_out_of_scope_sitemap_no_anchor_fallback() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    // Sitemap exists and is parsed, but URLs are all on a different host.
+    server.mock(|when, then| {
+        when.method(GET).path("/robots.txt");
+        then.status(404);
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/sitemap.xml");
+        then.status(200)
+            .header("content-type", "application/xml")
+            .body(sitemap_xml(&[
+                "https://other.example.com/page1",
+                "https://other.example.com/page2",
+            ]));
+    });
+    for path in &[
+        "/sitemap_index.xml",
+        "/sitemap-index.xml",
+        "/wp-sitemap.xml",
+        "/sitemap/sitemap-index.xml",
+    ] {
+        server.mock(|when, then| {
+            when.method(GET).path(*path);
+            then.status(404);
+        });
+    }
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    // map_source must be "sitemap" — sitemap was parsed even though all URLs were out-of-scope.
+    // The fallback trigger is parsed_sitemap_documents == 0, not urls.len() == 0.
+    assert_eq!(
+        result["map_source"].as_str(),
+        Some("sitemap"),
+        "map_source must be 'sitemap' when sitemap was parsed but all URLs out-of-scope"
+    );
+    // URLs must be empty (all filtered out)
+    let urls = result["urls"].as_array().expect("urls must be array");
+    assert_eq!(
+        urls.len(),
+        0,
+        "expected 0 URLs after scope filtering, got {urls:?}"
+    );
+    // warning must be null — no anchor fallback was triggered
+    assert!(
+        result["warning"].is_null(),
+        "warning must be null when sitemap was parsed (no anchor fallback)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Bounded structure fallback — no sitemap → root page anchors
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_bounded_structure_fallback_uses_anchor_hrefs() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    mock_all_sitemaps_404(&server);
+
+    // Root page with internal anchor links
+    let link_html = (1..=10)
+        .map(|i| format!(r#"<a href="{base}/section-{i}">Section {i}</a>"#))
+        .collect::<Vec<_>>()
+        .join("\n");
+    server.mock(|when, then| {
+        when.method(GET).path("/");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body(format!("<html><body>{link_html}</body></html>"));
+    });
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    assert_eq!(
+        result["map_source"].as_str(),
+        Some("bounded-structure"),
+        "expected map_source=bounded-structure when no sitemaps found"
+    );
+    let urls = result["urls"].as_array().expect("urls must be array");
+    assert!(
+        !urls.is_empty(),
+        "expected anchor URLs in bounded-structure mode, got empty"
+    );
+    // Verify the URLs are from the mock server host
+    for url in urls {
+        let u = url.as_str().expect("url must be a string");
+        assert!(
+            u.contains("127.0.0.1") || u.contains("localhost"),
+            "expected internal URL, got: {u}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: No-crawl lock-in — bounded-structure mode does NOT invoke Spider
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_structure_mode_does_not_crawl() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    mock_all_sitemaps_404(&server);
+
+    // Root page with some links
+    let root_mock = server.mock(|when, then| {
+        when.method(GET).path("/");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body(format!(
+                r#"<html><body>
+                    <a href="{base}/doc1">Doc 1</a>
+                    <a href="{base}/doc2">Doc 2</a>
+                    <a href="{base}/doc3">Doc 3</a>
+                    <a href="{base}/doc4">Doc 4</a>
+                    <a href="{base}/doc5">Doc 5</a>
+                </body></html>"#
+            ));
+    });
+
+    // These pages must NOT be fetched in bounded-structure mode.
+    // If Spider crawls, it would fetch these — track hits to detect crawling.
+    let deep_mock = server.mock(|when, then| {
+        when.method(GET).path_matches(r"^/doc\d+$");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body("<html><body>deep page content</body></html>");
+    });
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    assert_eq!(
+        result["map_source"].as_str(),
+        Some("bounded-structure"),
+        "expected bounded-structure"
+    );
+    // Root was fetched once for anchor extraction
+    assert!(root_mock.calls() >= 1, "root page should be fetched");
+    // Deep pages must NOT be fetched — Spider crawl was NOT triggered
+    assert_eq!(
+        deep_mock.calls(),
+        0,
+        "deep pages must NOT be fetched in bounded-structure mode (no Spider crawl)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Sitemap index recursion — child sitemaps resolved and included
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_sitemap_index_recursion() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/robots.txt");
+        then.status(404);
+    });
+
+    // Root sitemap is a sitemap index pointing to two child sitemaps
+    server.mock(|when, then| {
+        when.method(GET).path("/sitemap.xml");
+        then.status(200)
+            .header("content-type", "application/xml")
+            .body(sitemap_index_xml(&[
+                &format!("{base}/sitemap-1.xml"),
+                &format!("{base}/sitemap-2.xml"),
+            ]));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/sitemap-1.xml");
+        then.status(200)
+            .header("content-type", "application/xml")
+            .body(sitemap_xml(&[&format!("{base}/a"), &format!("{base}/b")]));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/sitemap-2.xml");
+        then.status(200)
+            .header("content-type", "application/xml")
+            .body(sitemap_xml(&[&format!("{base}/c"), &format!("{base}/d")]));
+    });
+    for path in &[
+        "/sitemap_index.xml",
+        "/sitemap-index.xml",
+        "/wp-sitemap.xml",
+        "/sitemap/sitemap-index.xml",
+    ] {
+        server.mock(|when, then| {
+            when.method(GET).path(*path);
+            then.status(404);
+        });
+    }
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    assert_eq!(
+        result["map_source"].as_str(),
+        Some("sitemap"),
+        "expected sitemap source"
+    );
+    let urls = result["urls"].as_array().expect("urls must be array");
+    assert!(
+        urls.len() >= 4,
+        "expected at least 4 URLs from child sitemaps, got {}: {:?}",
+        urls.len(),
+        urls
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Scoping — out-of-host URLs filtered from sitemap
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_sitemap_out_of_host_urls_filtered() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/robots.txt");
+        then.status(404);
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/sitemap.xml");
+        then.status(200)
+            .header("content-type", "application/xml")
+            .body(sitemap_xml(&[
+                &format!("{base}/in-scope"),
+                "https://different-host.example.com/out-of-scope",
+                "https://evil.example.com/also-out",
+            ]));
+    });
+    for path in &[
+        "/sitemap_index.xml",
+        "/sitemap-index.xml",
+        "/wp-sitemap.xml",
+        "/sitemap/sitemap-index.xml",
+    ] {
+        server.mock(|when, then| {
+            when.method(GET).path(*path);
+            then.status(404);
+        });
+    }
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    let urls: Vec<&str> = result["urls"]
+        .as_array()
+        .expect("urls must be array")
+        .iter()
+        .map(|v| v.as_str().expect("url must be string"))
+        .collect();
+
+    // Out-of-host URLs must not appear
+    assert!(
+        !urls
+            .iter()
+            .any(|u| u.contains("different-host.example.com")),
+        "out-of-host URL must be filtered: {urls:?}"
+    );
+    assert!(
+        !urls.iter().any(|u| u.contains("evil.example.com")),
+        "out-of-host URL must be filtered: {urls:?}"
+    );
+    // In-scope URL must appear
+    let in_scope = format!("{base}/in-scope");
+    assert!(
+        urls.contains(&in_scope.as_str()),
+        "in-scope URL must be present: {urls:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: --map-fallback crawl opt-in triggers crawl when no sitemap
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_map_fallback_crawl_opt_in() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    mock_all_sitemaps_404(&server);
+
+    // Root page with links
+    server.mock(|when, then| {
+        when.method(GET).path("/");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body(format!(
+                r#"<html><body>
+                    <a href="{base}/doc-a">Doc A</a>
+                    <a href="{base}/doc-b">Doc B</a>
+                </body></html>"#
+            ));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/doc-a");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body("<html><body>Doc A content that is long enough to pass thin check</body></html>");
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/doc-b");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body("<html><body>Doc B content that is long enough to pass thin check</body></html>");
+    });
+
+    let cfg = Config {
+        map_fallback: MapFallback::Crawl,
+        ..base_config()
+    };
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    assert_eq!(
+        result["map_source"].as_str(),
+        Some("crawl"),
+        "expected map_source=crawl when --map-fallback crawl is set"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Security — cross-origin anchor URLs NOT in bounded-structure output
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_bounded_structure_cross_origin_filtered() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    mock_all_sitemaps_404(&server);
+
+    server.mock(|when, then| {
+        when.method(GET).path("/");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body(format!(
+                r#"<html><body>
+                    <a href="{base}/safe-page">Safe</a>
+                    <a href="https://other.example.com/external">External</a>
+                    <a href="https://evil.example.com/phish">Evil</a>
+                </body></html>"#
+            ));
+    });
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    let urls: Vec<&str> = result["urls"]
+        .as_array()
+        .expect("urls must be array")
+        .iter()
+        .map(|v| v.as_str().expect("url must be string"))
+        .collect();
+
+    // Cross-origin URLs must not appear
+    assert!(
+        !urls.iter().any(|u| u.contains("other.example.com")),
+        "cross-origin URL must not appear in bounded-structure output: {urls:?}"
+    );
+    assert!(
+        !urls.iter().any(|u| u.contains("evil.example.com")),
+        "cross-origin URL must not appear in bounded-structure output: {urls:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: pages_seen = 0 in sitemap mode
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_pages_seen_zero_in_sitemap_mode() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/robots.txt");
+        then.status(404);
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/sitemap.xml");
+        then.status(200)
+            .header("content-type", "application/xml")
+            .body(sitemap_xml(&[
+                &format!("{base}/a"),
+                &format!("{base}/b"),
+                &format!("{base}/c"),
+            ]));
+    });
+    for path in &[
+        "/sitemap_index.xml",
+        "/sitemap-index.xml",
+        "/wp-sitemap.xml",
+        "/sitemap/sitemap-index.xml",
+    ] {
+        server.mock(|when, then| {
+            when.method(GET).path(*path);
+            then.status(404);
+        });
+    }
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    assert_eq!(
+        result["map_source"].as_str(),
+        Some("sitemap"),
+        "expected sitemap source"
+    );
+    assert_eq!(
+        result["pages_seen"].as_u64(),
+        Some(0),
+        "pages_seen must be 0 in sitemap mode (no pages crawled)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: warning field set when bounded-structure returns fewer than 5 URLs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn test_warning_when_bounded_structure_too_few_urls() {
+    let _guard = LoopbackGuard::new();
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    mock_all_sitemaps_404(&server);
+
+    // Root page with only 3 internal links — fewer than 5
+    server.mock(|when, then| {
+        when.method(GET).path("/");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body(format!(
+                r#"<html><body>
+                    <a href="{base}/p1">P1</a>
+                    <a href="{base}/p2">P2</a>
+                    <a href="{base}/p3">P3</a>
+                </body></html>"#
+            ));
+    });
+
+    let cfg = base_config();
+    let result = map_payload(&cfg, &base).await.expect("map_payload failed");
+
+    assert_eq!(
+        result["map_source"].as_str(),
+        Some("bounded-structure"),
+        "expected bounded-structure"
+    );
+    // warning must be non-null when fewer than 5 URLs found
+    assert!(
+        result["warning"].is_string(),
+        "warning must be a non-null string when bounded-structure returns < 5 URLs, got: {}",
+        result["warning"]
+    );
+    let warning_text = result["warning"].as_str().unwrap();
+    assert!(
+        warning_text.contains("crawl") || warning_text.contains("SPA"),
+        "warning should suggest using --map-fallback crawl: {warning_text}"
+    );
+}

--- a/crates/core/config.rs
+++ b/crates/core/config.rs
@@ -7,6 +7,6 @@ mod types;
 pub use parse::{build_cli_command, parse_args};
 pub use secret::Secret;
 pub use types::{
-    CommandKind, Config, ConfigOverrides, EvaluateResponsesMode, McpTransport, PerformanceProfile,
-    RedditSort, RedditTime, RenderMode, ScrapeFormat,
+    CommandKind, Config, ConfigOverrides, EvaluateResponsesMode, MapFallback, McpTransport,
+    PerformanceProfile, RedditSort, RedditTime, RenderMode, ScrapeFormat,
 };

--- a/crates/core/config/cli.rs
+++ b/crates/core/config/cli.rs
@@ -1,6 +1,6 @@
 mod global_args;
 
-use super::types::{EvaluateResponsesMode, McpTransport, RedditSort, RedditTime};
+use super::types::{EvaluateResponsesMode, MapFallback, McpTransport, RedditSort, RedditTime};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 pub(super) use global_args::GlobalArgs;
@@ -30,7 +30,7 @@ pub(super) enum CliCommand {
     /// Manage recurring watch definitions and runs
     Watch(WatchArgs),
     /// Discover all URLs on a site without scraping
-    Map(UrlArg),
+    Map(MapArgs),
     /// LLM-powered structured data extraction from URLs
     Extract(ExtractArgs),
     /// Web search via Tavily, auto-queues crawl jobs for results
@@ -234,6 +234,17 @@ pub(super) enum GraphSubcommand {
 pub(super) struct UrlArg {
     #[arg(value_name = "URL")]
     pub(super) value: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub(super) struct MapArgs {
+    #[arg(value_name = "URL")]
+    pub(super) value: Option<String>,
+    /// Fallback strategy when no sitemap documents are found.
+    /// `structure`: fetch root page and extract anchor hrefs (default, fast).
+    /// `crawl`: run a full Spider.rs crawl (slow, legacy — explicit opt-in).
+    #[arg(long, value_enum)]
+    pub(super) map_fallback: Option<MapFallback>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/core/config/cli/global_args.rs
+++ b/crates/core/config/cli/global_args.rs
@@ -101,6 +101,10 @@ pub(in crate::crates::core::config) struct GlobalArgs {
     #[arg(global = true, long, default_value_t = 0)]
     pub(in crate::crates::core::config) sitemap_since_days: u32,
 
+    /// Maximum number of sitemap URLs to process per map/backfill operation (default: 512)
+    #[arg(global = true, long, default_value_t = 512)]
+    pub(in crate::crates::core::config) max_sitemaps: usize,
+
     /// Enable crawl cache reuse. Disable with `--cache false`.
     #[arg(global = true, long, action = ArgAction::Set, default_value_t = true)]
     pub(in crate::crates::core::config) cache: bool,

--- a/crates/core/config/parse/build_config.rs
+++ b/crates/core/config/parse/build_config.rs
@@ -2,7 +2,7 @@ use super::super::cli::{
     Cli, CliCommand, ExportSubcommand, RefreshScheduleSubcommand, RefreshSubcommand,
 };
 use super::super::types::{
-    CommandKind, Config, EvaluateResponsesMode, McpTransport, RedditSort, RedditTime,
+    CommandKind, Config, EvaluateResponsesMode, MapFallback, McpTransport, RedditSort, RedditTime,
 };
 use super::docker::normalize_local_service_url;
 use super::excludes;
@@ -96,6 +96,7 @@ pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
     let mut mcp_transport = None;
     let mut export_include_history = false;
     let mut export_verify_input = None;
+    let mut map_fallback = MapFallback::Structure;
     let (command, positional) = match cli.command {
         CliCommand::Scrape(args) => (CommandKind::Scrape, args.positional_urls),
         CliCommand::Crawl(args) => (
@@ -150,10 +151,15 @@ pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
                 args.positional_urls
             },
         ),
-        CliCommand::Map(args) => (
-            CommandKind::Map,
-            args.value.into_iter().collect::<Vec<String>>(),
-        ),
+        CliCommand::Map(args) => {
+            if let Some(fb) = args.map_fallback {
+                map_fallback = fb;
+            }
+            (
+                CommandKind::Map,
+                args.value.into_iter().collect::<Vec<String>>(),
+            )
+        }
         CliCommand::Extract(args) => (
             CommandKind::Extract,
             if let Some(job) = args.job {
@@ -343,6 +349,8 @@ pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
         drop_thin_markdown: global.drop_thin_markdown,
         discover_sitemaps: global.discover_sitemaps,
         sitemap_since_days: global.sitemap_since_days,
+        map_fallback,
+        max_sitemaps: global.max_sitemaps,
         cache: global.cache,
         cache_skip_browser: global.cache_skip_browser,
         format: global.format,

--- a/crates/core/config/types.rs
+++ b/crates/core/config/types.rs
@@ -6,8 +6,8 @@ pub mod subconfigs;
 
 pub use config::Config;
 pub use enums::{
-    CommandKind, EvaluateResponsesMode, McpTransport, PerformanceProfile, RedditSort, RedditTime,
-    RenderMode, ScrapeFormat,
+    CommandKind, EvaluateResponsesMode, MapFallback, McpTransport, PerformanceProfile, RedditSort,
+    RedditTime, RenderMode, ScrapeFormat,
 };
 pub use overrides::ConfigOverrides;
 

--- a/crates/core/config/types/config.rs
+++ b/crates/core/config/types/config.rs
@@ -1,6 +1,6 @@
 use super::enums::{
-    CommandKind, EvaluateResponsesMode, McpTransport, PerformanceProfile, RedditSort, RedditTime,
-    RenderMode, ScrapeFormat,
+    CommandKind, EvaluateResponsesMode, MapFallback, McpTransport, PerformanceProfile, RedditSort,
+    RedditTime, RenderMode, ScrapeFormat,
 };
 use std::path::PathBuf;
 
@@ -99,6 +99,12 @@ pub struct Config {
 
     /// Only backfill sitemap URLs with `<lastmod>` within the last N days (0 = no filter). Flag: `--sitemap-since-days`.
     pub sitemap_since_days: u32,
+
+    /// Fallback strategy for `map` when no sitemap documents are found. Flag: `--map-fallback`.
+    pub map_fallback: MapFallback,
+
+    /// Maximum number of sitemap URLs to process per map/backfill operation. Flag: `--max-sitemaps`.
+    pub max_sitemaps: usize,
 
     /// Enable Spider's built-in crawl-result caching. Flag: `--cache`.
     pub cache: bool,

--- a/crates/core/config/types/config_impls.rs
+++ b/crates/core/config/types/config_impls.rs
@@ -1,7 +1,7 @@
 use super::config::Config;
 use super::enums::{
-    CommandKind, EvaluateResponsesMode, McpTransport, PerformanceProfile, RedditSort, RedditTime,
-    RenderMode, ScrapeFormat,
+    CommandKind, EvaluateResponsesMode, MapFallback, McpTransport, PerformanceProfile, RedditSort,
+    RedditTime, RenderMode, ScrapeFormat,
 };
 use std::env;
 use std::fmt;
@@ -41,6 +41,8 @@ impl Default for Config {
             drop_thin_markdown: true,
             discover_sitemaps: true,
             sitemap_since_days: 0,
+            map_fallback: MapFallback::Structure,
+            max_sitemaps: 512,
             cache: true,
             cache_skip_browser: false,
             format: ScrapeFormat::Markdown,

--- a/crates/core/config/types/enums.rs
+++ b/crates/core/config/types/enums.rs
@@ -152,6 +152,29 @@ impl fmt::Display for RedditTime {
     }
 }
 
+/// Fallback strategy when `axon map` finds no sitemap documents.
+///
+/// `Structure` (default): fetch the root page and extract anchor hrefs (bounded, fast).
+/// `Crawl`: run a full Spider.rs crawl (slow, legacy behaviour — explicit opt-in only).
+#[derive(
+    Debug, Clone, Copy, Default, ValueEnum, serde::Serialize, serde::Deserialize, PartialEq, Eq,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum MapFallback {
+    #[default]
+    Structure,
+    Crawl,
+}
+
+impl fmt::Display for MapFallback {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Structure => "structure",
+            Self::Crawl => "crawl",
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy, ValueEnum, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum PerformanceProfile {

--- a/crates/crawl/engine.rs
+++ b/crates/crawl/engine.rs
@@ -1,6 +1,7 @@
 mod cdp_render;
 mod collector;
 mod dir_ops;
+pub(crate) mod map;
 mod runtime;
 pub(crate) mod sitemap;
 #[cfg(test)]
@@ -10,17 +11,13 @@ mod url_utils;
 mod waf;
 
 use crate::crates::core::config::{Config, RenderMode};
-use crate::crates::core::content::{
-    build_selector_config, build_transform_config, extract_anchor_hrefs,
-};
-use crate::crates::core::http::{fetch_html, http_client, normalize_url, validate_url};
+use crate::crates::core::content::{build_selector_config, build_transform_config};
 use crate::crates::core::logging::{log_done, log_info};
 use crate::crates::crawl::manifest::ManifestEntry;
 use collector::{CollectorConfig, collect_crawl_pages};
 use dir_ops::prepare_crawl_output_dir;
 pub use dir_ops::update_latest_reflink;
 use runtime::configure_website;
-use spider::url::Url;
 #[cfg(test)]
 use spider::website::Website;
 use std::collections::{HashMap, HashSet};
@@ -30,13 +27,18 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::Sender;
 
+pub use map::MapResult;
+pub(crate) use map::{append_html_anchor_backfill, map_with_sitemap};
+#[cfg(test)]
+pub(crate) use map::{derive_map_scope, merge_map_candidate_urls};
 pub(crate) use runtime::resolve_cdp_ws_url;
 pub(crate) use sitemap::append_candidate_backfill;
 pub use sitemap::{BackfillStats, append_sitemap_backfill};
 pub(crate) use sitemap::{SitemapDiscovery, discover_sitemap_urls};
 pub(crate) use thin_refetch::chrome_refetch_thin_pages;
-use url_utils::normalize_map_candidate_url;
-pub(crate) use url_utils::{MapScope, canonicalize_url_for_dedupe, is_excluded_url_path};
+pub(crate) use url_utils::{
+    MapScope, canonicalize_url_for_dedupe, is_excluded_url_path, normalize_map_candidate_url,
+};
 #[cfg(test)]
 pub(crate) use url_utils::{is_junk_discovered_url, regex_escape};
 pub use waf::{WafDiagnostics, build_waf_diagnostics};
@@ -85,274 +87,6 @@ pub fn should_fallback_to_chrome(summary: &CrawlSummary, max_pages: u32, cfg: &C
         return false;
     }
     summary.markdown_files < (max_pages / 10).max(cfg.auto_switch_min_pages as u32)
-}
-
-fn should_retry_map_with_chrome(summary: &CrawlSummary) -> bool {
-    summary.pages_seen <= 2
-}
-
-fn should_retry_map_with_html_fallback(url_count: usize) -> bool {
-    url_count <= 2
-}
-
-/// Fallback page limit when `max_pages` is uncapped (0).
-fn effective_fallback_limit(cfg: &Config) -> usize {
-    if cfg.max_pages == 0 {
-        500
-    } else {
-        cfg.max_pages as usize
-    }
-}
-
-fn merge_map_candidate_urls(
-    existing: Vec<String>,
-    candidates: Vec<String>,
-    scope: &MapScope,
-    drop_query: bool,
-) -> Vec<String> {
-    let mut merged = Vec::new();
-    let mut seen = HashSet::new();
-
-    for url in existing {
-        let Some(canonical) = canonicalize_url_for_dedupe(&url) else {
-            continue;
-        };
-        if seen.insert(canonical.clone()) {
-            merged.push(canonical);
-        }
-    }
-
-    for url in candidates {
-        let Some(canonical) = normalize_map_candidate_url(&url, scope, drop_query) else {
-            continue;
-        };
-        if seen.insert(canonical.clone()) {
-            merged.push(canonical);
-        }
-    }
-
-    merged
-}
-
-pub(crate) async fn append_html_anchor_backfill(
-    cfg: &Config,
-    start_url: &str,
-    output_dir: &Path,
-    seen_urls: &HashSet<String>,
-    summary: &mut CrawlSummary,
-) -> Result<Vec<String>, Box<dyn Error>> {
-    let crawl_start_url = resolve_map_seed_url(start_url)
-        .await
-        .unwrap_or_else(|_| normalize_url(start_url).into_owned());
-    let scope =
-        derive_map_scope(start_url, &crawl_start_url).ok_or("failed to derive map scope")?;
-    let fallback_limit = effective_fallback_limit(cfg);
-
-    let client = http_client()
-        .map_err(|e| format!("http client init failed for backfill of {start_url}: {e}"))?;
-    let html = fetch_html(client, &crawl_start_url)
-        .await
-        .map_err(|e| format!("fetch failed for backfill of {crawl_start_url}: {e}"))?;
-    let fallback_urls = extract_anchor_hrefs(&crawl_start_url, &html, fallback_limit);
-
-    // Skip the intermediate Vec<String> clone of seen_urls. Instead, pass an
-    // empty existing list and rely on the filter below to deduplicate against
-    // seen_urls. merge_map_candidate_urls handles internal dedup of fallback_urls.
-    let merged_urls = merge_map_candidate_urls(Vec::new(), fallback_urls, &scope, true);
-    let candidates: Vec<String> = merged_urls
-        .into_iter()
-        .filter(|url| {
-            !seen_urls.contains(url) && !is_excluded_url_path(url, &cfg.exclude_path_prefix)
-        })
-        .collect();
-
-    let (_, added_urls) =
-        append_candidate_backfill(cfg, output_dir, seen_urls, candidates, summary).await?;
-    Ok(added_urls)
-}
-
-fn derive_map_scope_url(requested_url: &str, resolved_url: &str) -> Option<String> {
-    let requested_canonical = canonicalize_url_for_dedupe(requested_url)?;
-    let requested = Url::parse(&requested_canonical).ok()?;
-    let resolved_canonical = canonicalize_url_for_dedupe(resolved_url)
-        .or_else(|| canonicalize_url_for_dedupe(requested_url))?;
-    let mut resolved = Url::parse(&resolved_canonical).ok()?;
-
-    let requested_path = requested.path().trim_end_matches('/').to_string();
-    let resolved_path = resolved.path().trim_end_matches('/').to_string();
-    let scope_path = if !requested_path.is_empty()
-        && requested.host_str()? != resolved.host_str()?
-        && resolved_path.is_empty()
-    {
-        requested_path
-    } else {
-        resolved_path
-    };
-
-    resolved.set_path(if scope_path.is_empty() {
-        "/"
-    } else {
-        &scope_path
-    });
-    canonicalize_url_for_dedupe(resolved.as_ref())
-}
-
-fn derive_map_scope(requested_url: &str, resolved_url: &str) -> Option<MapScope> {
-    let scope_url = derive_map_scope_url(requested_url, resolved_url)?;
-    let parsed = Url::parse(&scope_url).ok()?;
-    let path = parsed.path().trim_end_matches('/');
-
-    Some(MapScope {
-        host: parsed.host_str()?.to_string(),
-        path_prefix: if path.is_empty() {
-            None
-        } else {
-            Some(path.to_string())
-        },
-    })
-}
-
-async fn resolve_map_seed_url(start_url: &str) -> Result<String, Box<dyn Error>> {
-    let normalized = normalize_url(start_url);
-    validate_url(&normalized).map_err(|e| format!("invalid map seed URL {normalized}: {e}"))?;
-    let client =
-        http_client().map_err(|e| format!("http client init for map seed {normalized}: {e}"))?;
-
-    if let Ok(response) = client.head(normalized.as_ref()).send().await
-        && response.status().is_success()
-    {
-        let final_url = response.url().to_string();
-        // Re-validate the final URL after redirects to prevent a public URL
-        // from redirecting to an internal/private address.
-        validate_url(&final_url)
-            .map_err(|e| format!("map seed redirect target blocked: {final_url}: {e}"))?;
-        return Ok(final_url);
-    }
-
-    let response = client
-        .get(normalized.as_ref())
-        .send()
-        .await
-        .map_err(|e| format!("GET failed resolving map seed {normalized}: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("non-success status resolving map seed {normalized}: {e}"))?;
-    let final_url = response.url().to_string();
-    validate_url(&final_url)
-        .map_err(|e| format!("map seed redirect target blocked: {final_url}: {e}"))?;
-    Ok(final_url)
-}
-
-pub(crate) async fn crawl_and_collect_map(
-    cfg: &Config,
-    start_url: &str,
-    mode: RenderMode,
-    scope: &MapScope,
-) -> Result<(CrawlSummary, Vec<String>), Box<dyn Error>> {
-    let mut website = configure_website(cfg, start_url, mode)
-        .await
-        .map_err(|e| format!("failed to configure website for map of {start_url}: {e}"))?;
-    let start = Instant::now();
-
-    match mode {
-        RenderMode::Http => website.crawl_raw().await,
-        RenderMode::Chrome | RenderMode::AutoSwitch => website.crawl().await,
-    }
-
-    let mut summary = CrawlSummary::default();
-    let mut urls = Vec::new();
-    let mut seen = HashSet::new();
-    let exclude_path_prefix = cfg.exclude_path_prefix.clone();
-
-    for link in website.get_links() {
-        let page_url = link.as_ref().to_string();
-        if is_excluded_url_path(&page_url, &exclude_path_prefix) {
-            continue;
-        }
-        let Some(canonical_url) = normalize_map_candidate_url(&page_url, scope, true) else {
-            continue;
-        };
-        if !seen.insert(canonical_url.clone()) {
-            continue;
-        }
-        summary.pages_seen += 1;
-        urls.push(canonical_url);
-    }
-
-    summary.elapsed_ms = start.elapsed().as_millis();
-    Ok((summary, urls))
-}
-
-/// The unified result of a `map` operation: crawler-discovered URLs merged with
-/// sitemap-discovered URLs, deduplicated and sorted.
-#[derive(Debug, Default)]
-pub struct MapResult {
-    pub summary: CrawlSummary,
-    /// All discovered URLs (crawler + sitemap), sorted and deduplicated.
-    pub urls: Vec<String>,
-    /// Raw number of URLs returned by `discover_sitemap_urls` before any
-    /// deduplication against crawler-discovered URLs.  This is the count of
-    /// `<loc>` entries in the sitemap(s), not the count of net-new URLs that
-    /// were absent from the crawler results.
-    pub sitemap_urls: usize,
-}
-
-/// Discover all URLs reachable from `start_url` and merge with sitemap
-/// discovery, returning a single deduplicated sorted list.
-///
-/// Handles the AutoSwitch fallback to Chrome when HTTP finds zero pages.
-/// Sitemap merge/sort/dedup happens here — callers receive a final unified set.
-pub async fn map_with_sitemap(cfg: &Config, start_url: &str) -> Result<MapResult, Box<dyn Error>> {
-    let initial_mode = match cfg.render_mode {
-        RenderMode::AutoSwitch => RenderMode::Http,
-        m => m,
-    };
-    let crawl_start_url = resolve_map_seed_url(start_url)
-        .await
-        .unwrap_or_else(|_| normalize_url(start_url).into_owned());
-    let scope =
-        derive_map_scope(start_url, &crawl_start_url).ok_or("failed to derive map scope")?;
-    let scope_start_url = derive_map_scope_url(start_url, &crawl_start_url)
-        .unwrap_or_else(|| crawl_start_url.clone());
-
-    let (mut summary, mut urls) =
-        crawl_and_collect_map(cfg, &crawl_start_url, initial_mode, &scope).await?;
-
-    if matches!(cfg.render_mode, RenderMode::AutoSwitch)
-        && should_retry_map_with_chrome(&summary)
-        && let Ok((chrome_summary, chrome_urls)) =
-            crawl_and_collect_map(cfg, &crawl_start_url, RenderMode::Chrome, &scope).await
-        && chrome_summary.pages_seen > summary.pages_seen
-    {
-        summary = chrome_summary;
-        urls = chrome_urls;
-    }
-
-    if should_retry_map_with_html_fallback(urls.len()) {
-        let fallback_limit = effective_fallback_limit(cfg);
-        if let Ok(client) = http_client()
-            && let Ok(html) = fetch_html(client, &crawl_start_url).await
-        {
-            let fallback_urls = extract_anchor_hrefs(&crawl_start_url, &html, fallback_limit);
-            urls = merge_map_candidate_urls(urls, fallback_urls, &scope, true);
-            summary.pages_seen = urls.len() as u32;
-        }
-    }
-
-    let raw_sitemap_count = if cfg.discover_sitemaps {
-        let sitemap_url_list = discover_sitemap_urls(cfg, &scope_start_url).await?.urls;
-        let count = sitemap_url_list.len();
-        urls = merge_map_candidate_urls(urls, sitemap_url_list, &scope, true);
-        summary.pages_seen = urls.len() as u32;
-        count
-    } else {
-        0
-    };
-
-    Ok(MapResult {
-        summary,
-        urls,
-        sitemap_urls: raw_sitemap_count,
-    })
 }
 
 #[expect(

--- a/crates/crawl/engine/map.rs
+++ b/crates/crawl/engine/map.rs
@@ -1,0 +1,368 @@
+use super::sitemap::{SitemapDiscovery, discover_sitemap_urls};
+use super::url_utils::{MapScope, canonicalize_url_for_dedupe, normalize_map_candidate_url};
+use super::{CrawlSummary, append_candidate_backfill, is_excluded_url_path};
+use crate::crates::core::config::{Config, MapFallback, RenderMode};
+use crate::crates::core::content::extract_anchor_hrefs;
+use crate::crates::core::http::{fetch_html, http_client, normalize_url, validate_url};
+use crate::crates::core::logging::log_info;
+use spider::url::Url;
+use std::collections::HashSet;
+use std::error::Error;
+use std::path::Path;
+use std::time::Instant;
+
+/// The unified result of a `map` operation: URLs discovered via sitemaps, bounded
+/// structure extraction, or full crawl (when `--map-fallback crawl` is set).
+#[derive(Debug, Default)]
+pub struct MapResult {
+    pub summary: CrawlSummary,
+    /// All discovered URLs, sorted and deduplicated.
+    pub urls: Vec<String>,
+    /// Raw number of `<loc>` entries found in sitemaps before dedup.
+    pub sitemap_urls: usize,
+    /// How URLs were discovered: "sitemap", "bounded-structure", or "crawl".
+    pub map_source: String,
+    /// Optional warning, e.g. when bounded-structure fallback returns very few URLs.
+    pub warning: Option<String>,
+}
+
+fn effective_fallback_limit(cfg: &Config) -> usize {
+    if cfg.max_pages == 0 {
+        500
+    } else {
+        cfg.max_pages as usize
+    }
+}
+
+pub(crate) fn merge_map_candidate_urls(
+    existing: Vec<String>,
+    candidates: Vec<String>,
+    scope: &MapScope,
+    drop_query: bool,
+) -> Vec<String> {
+    let mut merged = Vec::new();
+    let mut seen = HashSet::new();
+
+    for url in existing {
+        let Some(canonical) = canonicalize_url_for_dedupe(&url) else {
+            continue;
+        };
+        if seen.insert(canonical.clone()) {
+            merged.push(canonical);
+        }
+    }
+
+    for url in candidates {
+        let Some(canonical) = normalize_map_candidate_url(&url, scope, drop_query) else {
+            continue;
+        };
+        if seen.insert(canonical.clone()) {
+            merged.push(canonical);
+        }
+    }
+
+    merged
+}
+
+/// Resolve the final URL after redirects, used as the crawl/scope seed.
+pub(crate) async fn resolve_map_seed_url(start_url: &str) -> Result<String, Box<dyn Error>> {
+    let normalized = normalize_url(start_url);
+    validate_url(&normalized).map_err(|e| format!("invalid map seed URL {normalized}: {e}"))?;
+    let client =
+        http_client().map_err(|e| format!("http client init for map seed {normalized}: {e}"))?;
+
+    if let Ok(response) = client.head(normalized.as_ref()).send().await
+        && response.status().is_success()
+    {
+        let final_url = response.url().to_string();
+        validate_url(&final_url)
+            .map_err(|e| format!("map seed redirect target blocked: {final_url}: {e}"))?;
+        return Ok(final_url);
+    }
+
+    let response = client
+        .get(normalized.as_ref())
+        .send()
+        .await
+        .map_err(|e| format!("GET failed resolving map seed {normalized}: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("non-success status resolving map seed {normalized}: {e}"))?;
+    let final_url = response.url().to_string();
+    validate_url(&final_url)
+        .map_err(|e| format!("map seed redirect target blocked: {final_url}: {e}"))?;
+    Ok(final_url)
+}
+
+fn derive_map_scope_url(requested_url: &str, resolved_url: &str) -> Option<String> {
+    let requested_canonical = canonicalize_url_for_dedupe(requested_url)?;
+    let requested = Url::parse(&requested_canonical).ok()?;
+    let resolved_canonical = canonicalize_url_for_dedupe(resolved_url)
+        .or_else(|| canonicalize_url_for_dedupe(requested_url))?;
+    let mut resolved = Url::parse(&resolved_canonical).ok()?;
+
+    let requested_path = requested.path().trim_end_matches('/').to_string();
+    let resolved_path = resolved.path().trim_end_matches('/').to_string();
+    let scope_path = if !requested_path.is_empty()
+        && requested.host_str()? != resolved.host_str()?
+        && resolved_path.is_empty()
+    {
+        requested_path
+    } else {
+        resolved_path
+    };
+
+    resolved.set_path(if scope_path.is_empty() {
+        "/"
+    } else {
+        &scope_path
+    });
+    canonicalize_url_for_dedupe(resolved.as_ref())
+}
+
+pub(crate) fn derive_map_scope(requested_url: &str, resolved_url: &str) -> Option<MapScope> {
+    let scope_url = derive_map_scope_url(requested_url, resolved_url)?;
+    let parsed = Url::parse(&scope_url).ok()?;
+    let path = parsed.path().trim_end_matches('/');
+
+    Some(MapScope {
+        host: parsed.host_str()?.to_string(),
+        path_prefix: if path.is_empty() {
+            None
+        } else {
+            Some(path.to_string())
+        },
+    })
+}
+
+/// Run a full Spider.rs crawl and collect map-format results.
+/// Only called when `--map-fallback crawl` is set.
+pub(super) async fn crawl_and_collect_map(
+    cfg: &Config,
+    start_url: &str,
+    mode: RenderMode,
+    scope: &MapScope,
+) -> Result<(CrawlSummary, Vec<String>), Box<dyn Error>> {
+    use super::runtime::configure_website;
+    let mut website = configure_website(cfg, start_url, mode)
+        .await
+        .map_err(|e| format!("failed to configure website for map of {start_url}: {e}"))?;
+    let start = Instant::now();
+
+    match mode {
+        RenderMode::Http => website.crawl_raw().await,
+        RenderMode::Chrome | RenderMode::AutoSwitch => website.crawl().await,
+    }
+
+    let mut summary = CrawlSummary::default();
+    let mut urls = Vec::new();
+    let mut seen = HashSet::new();
+    let exclude_path_prefix = cfg.exclude_path_prefix.clone();
+
+    for link in website.get_links() {
+        let page_url = link.as_ref().to_string();
+        if is_excluded_url_path(&page_url, &exclude_path_prefix) {
+            continue;
+        }
+        let Some(canonical_url) = normalize_map_candidate_url(&page_url, scope, true) else {
+            continue;
+        };
+        if !seen.insert(canonical_url.clone()) {
+            continue;
+        }
+        summary.pages_seen += 1;
+        urls.push(canonical_url);
+    }
+
+    summary.elapsed_ms = start.elapsed().as_millis();
+    Ok((summary, urls))
+}
+
+/// Fetch root HTML and extract anchor hrefs as a bounded fallback.
+/// Returns (urls, warning) — warning is non-None when fewer than 5 URLs found.
+async fn bounded_structure_fallback(
+    cfg: &Config,
+    scope_start_url: &str,
+    scope: &MapScope,
+) -> (Vec<String>, Option<String>) {
+    let fallback_limit = effective_fallback_limit(cfg);
+    let client = match http_client() {
+        Ok(c) => c,
+        Err(e) => {
+            log_info(&format!("bounded-structure: http_client failed: {e}"));
+            return (
+                vec![],
+                Some("bounded-structure fallback: http client unavailable".to_string()),
+            );
+        }
+    };
+    let html = match fetch_html(client, scope_start_url).await {
+        Ok(h) => h,
+        Err(e) => {
+            log_info(&format!(
+                "bounded-structure: fetch failed for {scope_start_url}: {e}"
+            ));
+            return (
+                vec![],
+                Some(format!(
+                    "bounded-structure fallback failed to fetch {scope_start_url}; \
+                     consider --map-fallback crawl for SPA sites"
+                )),
+            );
+        }
+    };
+
+    let anchor_urls = extract_anchor_hrefs(scope_start_url, &html, fallback_limit);
+    let urls = merge_map_candidate_urls(Vec::new(), anchor_urls, scope, true);
+    let urls: Vec<String> = urls
+        .into_iter()
+        .filter(|url| !is_excluded_url_path(url, &cfg.exclude_path_prefix))
+        .collect();
+
+    let warning = if urls.len() < 5 {
+        Some(format!(
+            "bounded-structure fallback returned {} URL(s); \
+             consider --map-fallback crawl for SPA sites",
+            urls.len()
+        ))
+    } else {
+        None
+    };
+
+    (urls, warning)
+}
+
+/// Discover all URLs reachable from `start_url` using a sitemap-first strategy.
+///
+/// Flow:
+/// 1. Resolve seed URL + discover sitemaps in parallel.
+/// 2. If sitemaps were parsed (`parsed_sitemap_documents > 0`): use sitemap URLs, done.
+/// 3. If no sitemaps parsed AND `cfg.map_fallback == Crawl`: run full crawl.
+/// 4. If no sitemaps parsed AND `cfg.map_fallback == Structure` (default):
+///    fetch root HTML and extract anchor hrefs (bounded, fast).
+///
+/// NOTE: sitemap discovery runs against the original `start_url` host (before redirect),
+/// in parallel with seed URL resolution. Out-of-scope URLs from redirected hosts are
+/// filtered by `normalize_map_candidate_url` once the scope is derived.
+pub async fn map_with_sitemap(cfg: &Config, start_url: &str) -> Result<MapResult, Box<dyn Error>> {
+    let start = Instant::now();
+
+    // Step 1: resolve seed URL and discover sitemaps in parallel.
+    // Errors are converted to String before the join point so both futures are Send.
+    let (seed_result, sitemap_result) = tokio::join!(
+        async {
+            resolve_map_seed_url(start_url)
+                .await
+                .map_err(|e| e.to_string())
+        },
+        async {
+            discover_sitemap_urls(cfg, start_url)
+                .await
+                .map_err(|e| e.to_string())
+        }
+    );
+
+    let crawl_start_url = seed_result.unwrap_or_else(|_| normalize_url(start_url).into_owned());
+    let scope =
+        derive_map_scope(start_url, &crawl_start_url).ok_or("failed to derive map scope")?;
+    let scope_start_url = derive_map_scope_url(start_url, &crawl_start_url)
+        .unwrap_or_else(|| crawl_start_url.clone());
+
+    let sitemap_discovery: SitemapDiscovery = sitemap_result.unwrap_or_default();
+    let raw_sitemap_count = sitemap_discovery.discovered_urls;
+
+    log_info(&format!(
+        "map sitemap_docs={} sitemap_urls={} url={}",
+        sitemap_discovery.parsed_sitemap_documents, raw_sitemap_count, start_url
+    ));
+
+    // Step 2: if sitemaps were found and parsed, use them directly — no fallback.
+    if sitemap_discovery.parsed_sitemap_documents > 0 {
+        let urls = merge_map_candidate_urls(Vec::new(), sitemap_discovery.urls, &scope, true);
+        let urls: Vec<String> = urls
+            .into_iter()
+            .filter(|url| !is_excluded_url_path(url, &cfg.exclude_path_prefix))
+            .collect();
+        let summary = CrawlSummary {
+            elapsed_ms: start.elapsed().as_millis(),
+            ..Default::default()
+        };
+        return Ok(MapResult {
+            summary,
+            sitemap_urls: raw_sitemap_count,
+            urls,
+            map_source: "sitemap".to_string(),
+            warning: None,
+        });
+    }
+
+    // Step 3: no sitemap documents parsed — check fallback mode.
+    match cfg.map_fallback {
+        MapFallback::Crawl => {
+            // Explicit opt-in: run full Spider.rs crawl (legacy behaviour).
+            let initial_mode = match cfg.render_mode {
+                RenderMode::AutoSwitch => RenderMode::Http,
+                m => m,
+            };
+            let (summary, urls) =
+                crawl_and_collect_map(cfg, &crawl_start_url, initial_mode, &scope).await?;
+            Ok(MapResult {
+                summary,
+                sitemap_urls: raw_sitemap_count,
+                urls,
+                map_source: "crawl".to_string(),
+                warning: None,
+            })
+        }
+        MapFallback::Structure => {
+            // Default: bounded anchor extraction from homepage (fast, no full crawl).
+            let (urls, warning) = bounded_structure_fallback(cfg, &scope_start_url, &scope).await;
+            let summary = CrawlSummary {
+                elapsed_ms: start.elapsed().as_millis(),
+                ..Default::default()
+            };
+            Ok(MapResult {
+                summary,
+                sitemap_urls: raw_sitemap_count,
+                urls,
+                map_source: "bounded-structure".to_string(),
+                warning,
+            })
+        }
+    }
+}
+
+/// HTML anchor backfill: used by sync-crawl as a post-crawl supplement.
+/// NOT part of the map command's primary flow.
+pub(crate) async fn append_html_anchor_backfill(
+    cfg: &Config,
+    start_url: &str,
+    output_dir: &Path,
+    seen_urls: &HashSet<String>,
+    summary: &mut CrawlSummary,
+) -> Result<Vec<String>, Box<dyn Error>> {
+    let crawl_start_url = resolve_map_seed_url(start_url)
+        .await
+        .unwrap_or_else(|_| normalize_url(start_url).into_owned());
+    let scope =
+        derive_map_scope(start_url, &crawl_start_url).ok_or("failed to derive map scope")?;
+    let fallback_limit = effective_fallback_limit(cfg);
+
+    let client = http_client()
+        .map_err(|e| format!("http client init failed for backfill of {start_url}: {e}"))?;
+    let html = fetch_html(client, &crawl_start_url)
+        .await
+        .map_err(|e| format!("fetch failed for backfill of {crawl_start_url}: {e}"))?;
+    let fallback_urls = extract_anchor_hrefs(&crawl_start_url, &html, fallback_limit);
+
+    let merged_urls = merge_map_candidate_urls(Vec::new(), fallback_urls, &scope, true);
+    let candidates: Vec<String> = merged_urls
+        .into_iter()
+        .filter(|url| {
+            !seen_urls.contains(url) && !is_excluded_url_path(url, &cfg.exclude_path_prefix)
+        })
+        .collect();
+
+    let (_, added_urls) =
+        append_candidate_backfill(cfg, output_dir, seen_urls, candidates, summary).await?;
+    Ok(added_urls)
+}

--- a/crates/crawl/engine/sitemap.rs
+++ b/crates/crawl/engine/sitemap.rs
@@ -74,6 +74,8 @@ fn sitemap_seed_queue(scheme: &str, host: &str) -> VecDeque<String> {
         format!("{scheme}://{host}/sitemap.xml"),
         format!("{scheme}://{host}/sitemap_index.xml"),
         format!("{scheme}://{host}/sitemap-index.xml"),
+        format!("{scheme}://{host}/wp-sitemap.xml"),
+        format!("{scheme}://{host}/sitemap/sitemap-index.xml"),
     ])
 }
 
@@ -272,8 +274,7 @@ pub async fn discover_sitemap_urls(
         .backfill_concurrency_limit
         .unwrap_or(cfg.batch_concurrency)
         .clamp(1, 1024);
-    // TODO: use cfg.max_sitemaps once the field is added to Config
-    let max_sitemaps = 512usize;
+    let max_sitemaps = cfg.max_sitemaps;
     let mut parsed_sitemaps = 0usize;
     let mut failed_fetches = 0usize;
 

--- a/crates/crawl/engine/tests.rs
+++ b/crates/crawl/engine/tests.rs
@@ -333,22 +333,6 @@ fn test_fallback_custom_min_pages() {
 }
 
 #[test]
-fn test_map_retry_gate_low_coverage() {
-    assert!(should_retry_map_with_chrome(&summary(0, 0, 0)));
-    assert!(should_retry_map_with_chrome(&summary(1, 0, 1)));
-    assert!(should_retry_map_with_chrome(&summary(2, 0, 2)));
-    assert!(!should_retry_map_with_chrome(&summary(3, 0, 3)));
-}
-
-#[test]
-fn test_should_retry_map_with_html_fallback_for_two_or_fewer_urls() {
-    assert!(should_retry_map_with_html_fallback(0));
-    assert!(should_retry_map_with_html_fallback(1));
-    assert!(should_retry_map_with_html_fallback(2));
-    assert!(!should_retry_map_with_html_fallback(3));
-}
-
-#[test]
 fn test_merge_map_candidate_urls_adds_only_new_scoped_urls() {
     let scope = MapScope {
         host: "example.github.io".to_string(),

--- a/crates/services/map.rs
+++ b/crates/services/map.rs
@@ -54,13 +54,20 @@ pub async fn discover(
     )
     .await;
 
+    // pages_seen is 0 in sitemap/bounded-structure modes (no pages were crawled).
+    // In crawl mode, summary.pages_seen carries the actual crawl count.
+    let pages_seen = result.summary.pages_seen;
+    let thin_pages = result.summary.thin_pages;
+
     let payload = serde_json::json!({
         "url": url,
         "mapped_urls": mapped_count,
         "sitemap_urls": result.sitemap_urls,
-        "pages_seen": result.summary.pages_seen,
-        "thin_pages": result.summary.thin_pages,
+        "pages_seen": pages_seen,
+        "thin_pages": thin_pages,
         "elapsed_ms": result.summary.elapsed_ms,
+        "map_source": result.map_source,
+        "warning": result.warning,
         "urls": urls,
     });
 

--- a/docs/commands/map.md
+++ b/docs/commands/map.md
@@ -1,10 +1,7 @@
 # axon map
-Last Modified: 2026-03-03
+Last Modified: 2026-04-27
 
-Version: 1.0.0
-Last Updated: 20:29:46 | 03/03/2026 EST
-
-Discover URLs from a site without writing markdown artifacts. Runs inline and returns discovered URLs plus crawl/map summary metrics.
+Discover all URLs on a site without scraping page content. Fast by default (seconds via sitemap discovery), with an explicit fallback chain for sites that have no sitemap.
 
 ## Synopsis
 
@@ -25,45 +22,63 @@ All global flags apply. Key flags:
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--max-depth <n>` | `5` | Maximum depth for URL discovery. |
-| `--render-mode <mode>` | `auto-switch` | `auto-switch` starts in HTTP and retries in Chrome when accepted HTTP coverage is still very low. |
-| `--discover-sitemaps <bool>` | `true` | Append sitemap/robots-discovered URLs and dedupe final list. |
+| `--map-fallback <structure\|crawl>` | `structure` | Fallback when no sitemap is found. `structure`: extract anchors from root page (fast). `crawl`: full Spider.rs crawl (slow, legacy — explicit opt-in). |
+| `--max-sitemaps <n>` | `512` | Maximum sitemap documents to process per map operation. |
+| `--discover-sitemaps <bool>` | `true` | Enable sitemap discovery (primary URL source). |
+| `--sitemap-since-days <n>` | `0` | Only include sitemap URLs with `<lastmod>` within the last N days (0 = no filter). |
 | `--include-subdomains <bool>` | `false` | Include subdomains under same parent domain. |
 | `--json` | `false` | Print structured payload including all discovered URLs. |
+
+## How it works
+
+`axon map` uses a **sitemap-first** strategy:
+
+1. **Sitemap discovery** (primary): fetches `robots.txt` and default sitemap paths in parallel with seed URL resolution. Checks: `sitemap.xml`, `sitemap_index.xml`, `sitemap-index.xml`, `wp-sitemap.xml`, `sitemap/sitemap-index.xml`.
+2. **Bounded structure fallback** (default, when no sitemap parsed): fetches the root page once and extracts anchor hrefs (up to 500 URLs). Fast, no full crawl. Triggered when `parsed_sitemap_documents == 0`.
+3. **Full crawl** (opt-in only): set `--map-fallback crawl` to use Spider.rs. This is the legacy behaviour — slower but handles SPAs and complex navigation.
+
+> **Important:** the fallback from sitemap to structure is triggered by `parsed_sitemap_documents == 0`, not by an empty URL list. If a sitemap was found but all URLs were out of scope, `map_source` will be `"sitemap"` and the URL list will be empty — no anchor fallback is applied in this case.
 
 ## Examples
 
 ```bash
-# Positional start URL
+# Default: sitemap-first, bounded-structure fallback
 axon map https://example.com/docs
-
-# Using --start-url
-axon map --start-url https://example.com/docs
 
 # JSON output for automation
 axon map https://example.com --json
 
-# Disable sitemap discovery
+# Opt-in to full crawl fallback (legacy, slow)
+axon map https://example.com --map-fallback crawl
+
+# Limit sitemap documents processed
+axon map https://example.com --max-sitemaps 128
+
+# Disable sitemap discovery entirely (forces bounded-structure or crawl fallback)
 axon map https://example.com --discover-sitemaps false
 ```
 
 ## Output
 
 JSON mode returns:
-- `url`
-- `mapped_urls`
-- `sitemap_urls`
-- `pages_seen`
-- `thin_pages`
-- `elapsed_ms`
-- `urls` (full discovered list)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | string | The start URL |
+| `mapped_urls` | number | Count of discovered URLs in the output |
+| `sitemap_urls` | number | Raw `<loc>` count from sitemaps (before dedup/scope filter) |
+| `pages_seen` | number | Pages fetched during crawl (`0` in sitemap/structure modes) |
+| `thin_pages` | number | Pages below `--min-markdown-chars` (`0` in non-crawl modes) |
+| `elapsed_ms` | number | Time taken in milliseconds |
+| `map_source` | string | How URLs were discovered: `"sitemap"`, `"bounded-structure"`, or `"crawl"` |
+| `warning` | string or null | Non-null when bounded-structure returns fewer than 5 URLs (suggests using `--map-fallback crawl`) |
+| `urls` | array | All discovered URLs, sorted and deduplicated |
 
 ## Behavior Notes
 
-- `map` validates the URL before crawl starts.
-- `map` resolves redirects before deriving its final host/path scope.
-- Path-rooted seeds such as `https://example.github.io/project/` stay scoped to that project subtree in the final result set.
-- When `--render-mode auto-switch`, Chrome fallback is attempted when accepted HTTP coverage is still two URLs or fewer.
-- If coverage remains two URLs or fewer after the crawler pass, `map` may fetch the seed HTML once and extract deterministic anchor links before sitemap URLs are appended.
-- Final map results reject malformed discovered URLs and canonicalize accepted URLs before dedupe.
-- `map` is synchronous and does not enqueue jobs.
+- `map` validates the URL before any network calls.
+- `map` resolves redirects before deriving its scope. Sitemap discovery runs against the original host in parallel with redirect resolution.
+- Path-rooted seeds such as `https://example.github.io/project/` stay scoped to that subtree.
+- `map` is synchronous (inline) and does not enqueue jobs.
+- No Chrome is used in sitemap or bounded-structure modes. Chrome is only used when `--map-fallback crawl` with `--render-mode chrome` or `auto-switch`.
+- All discovered URLs are validated and canonicalized before output.


### PR DESCRIPTION
## Summary

- Replaces crawl-first `axon map` with sitemap-first URL discovery
- `axon map` now completes in seconds for sites with sitemaps (vs minutes before)
- New fallback chain: sitemap discovery → bounded anchor extraction → optional full crawl
- New flag: `--map-fallback structure|crawl` (default: structure)
- Engine split: `crates/crawl/engine/map.rs` extracted from `engine.rs` (monolith compliance)

## Changes

- `crates/core/config/types/enums.rs` — `MapFallback` enum (Structure/Crawl variants)
- `crates/core/config/types/config.rs` — `map_fallback` and `max_sitemaps` fields
- `crates/core/config/cli.rs` — `MapArgs` with `--map-fallback` flag
- `crates/core/config/cli/global_args.rs` — `--max-sitemaps` global flag
- `crates/crawl/engine/map.rs` — NEW: sitemap-first map engine (split from engine.rs)
- `crates/crawl/engine.rs` — reduced from 542 to 274 lines (monolith compliant)
- `crates/crawl/engine/sitemap.rs` — 2 extra seed paths, wires `cfg.max_sitemaps`
- `crates/services/map.rs` — `map_source`, `warning` output fields; `pages_seen=0` in non-crawl modes
- `crates/cli/commands/map.rs` — shows `map_source` in human output
- `docs/commands/map.md` — updated docs for sitemap-first behavior
- `crates/cli/commands/map/map_sitemap_tests.rs` — NEW: 10 targeted tests

## Fallback Chain

1. Sitemap discovery (robots.txt + 5 default paths + index recursion) — primary
2. Bounded anchor extraction from homepage (if `parsed_sitemap_documents == 0`)
3. Full crawl (only if `--map-fallback crawl`)

## Beads
- axon_rust-a4w.1: MapFallback config flag + max_sitemaps
- axon_rust-a4w.2: Engine rewrite (sitemap-first)
- axon_rust-a4w.3: Service layer output schema
- axon_rust-a4w.4: Tests (10 targeted)
- axon_rust-a4w.5: Docs update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite axon map to a sitemap-first engine with a fast, no-crawl default fallback. Mapping now completes in seconds on sites with sitemaps and only runs a full crawl when explicitly requested.

- New Features
  - Sitemap-first discovery with fallback: sitemap → bounded anchor extraction → optional full crawl via `--map-fallback crawl`.
  - New flags: `--map-fallback structure|crawl` (default: structure) and global `--max-sitemaps <n>` (default: 512).
  - Output now includes `map_source` and optional `warning`; `pages_seen=0` in non-crawl modes; CLI prints `map_source`.
  - Sitemap discovery adds `wp-sitemap.xml` and `sitemap/sitemap-index.xml`; respects `max_sitemaps`.
  - Docs updated and 10 targeted tests cover sitemap-first and fallback behavior.

- Refactors
  - Extracted sitemap-first map engine to `crates/crawl/engine/map.rs`; trimmed `engine.rs`.
  - Service and CLI wiring updated to use the new engine and flags.

<sup>Written for commit 7aa5d50fbc6350ac46055715bc923521fbc0fc5e. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/63?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--map-fallback` flag to control fallback behavior when sitemaps aren't discovered
  * Added `--max-sitemaps` global flag to limit sitemap processing (defaults to 512)
  * Map output now displays the discovery method used and includes optional warning messages when applicable

* **Documentation**
  * Updated map command documentation with new configuration options and behavior details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->