### PR TITLE
fix(mcp): expose RAG evaluation tool actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,9 @@ jobs:
         env:
           TEI_URL: http://127.0.0.1:52000
           QDRANT_URL: http://127.0.0.1:53333
+          AXON_DATA_DIR: .cache/axon-ci
+          AXON_LOG_DIR: .cache/axon-ci/logs
+          AXON_SQLITE_PATH: .cache/axon-ci/jobs.db
           AXON_EMBED_STRICT_PREDELETE: "false"
         run: ./target/release/axon embed "docs/MCP.md" --wait true --json
 
@@ -522,6 +525,9 @@ jobs:
         env:
           TEI_URL: http://127.0.0.1:52000
           QDRANT_URL: http://127.0.0.1:53333
+          AXON_DATA_DIR: .cache/axon-ci
+          AXON_LOG_DIR: .cache/axon-ci/logs
+          AXON_SQLITE_PATH: .cache/axon-ci/jobs.db
         run: |
           ./target/release/axon mcp --transport http &
           echo $! > /tmp/axon-mcp.pid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ask: AXON_ASK_HYBRID_CANDIDATES default lowered 150 → 100 (Qdrant RRF rank-stable at 2x final K; ask_candidate_limit=50 → prefetch=100 is sufficient).
 
-## [1.8.1] - 2026-05-07
+## [1.8.2] - 2026-05-07
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ask: AXON_ASK_HYBRID_CANDIDATES default lowered 150 → 100 (Qdrant RRF rank-stable at 2x final K; ask_candidate_limit=50 → prefetch=100 is sufficient).
 
+## [1.8.1] - 2026-05-07
+
+### Fixed
+
+- mcp: expose `evaluate` and `suggest` through the unified tool, reject unavailable `ask.graph=true`, preserve adaptive ask diagnostics in typed service results, and regenerate MCP discovery docs/help.
+
 ## [1.6.2] - 2026-05-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "axon"
-version = "1.8.1"
+version = "1.8.2"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/docs/MCP-TOOL-SCHEMA.md
+++ b/docs/MCP-TOOL-SCHEMA.md
@@ -9,7 +9,7 @@ Last Modified: 2026-05-07
 - Tool name: `axon`
 - Primary route field: `action`
 - Canonical route form: `action` + optional `subaction`
-- Response control field: `response_mode` (`path|inline|both`, default `path`)
+- Response control field: `response_mode` (`path|inline|both|auto_inline`, default `path`)
 
 Code references:
 - `src/mcp/schema.rs`
@@ -29,17 +29,17 @@ Code references:
 Incoming request map is parsed strictly with serde:
 
 - `action` is required and must match canonical schema names
-- `subaction` is required for lifecycle families (`crawl|extract|embed|ingest|refresh|graph|artifacts`)
+- `subaction` is required for lifecycle families (`crawl|extract|embed|ingest|artifacts|acp`)
 - No fallback fields (`command`, `op`, `operation`)
 - No token normalization or case folding
 - No action alias remapping
 
 ## Preferred Client Actions
 Use CLI-identical top-level actions:
-- Lifecycle families: `artifacts`, `crawl`, `doctor`, `domains`, `embed`, `extract`, `help`, `ingest`, `sources`, `stats`, `status`
-- Direct actions: `ask`, `elicit_demo`, `map`, `query`, `research`, `retrieve`, `scrape`, `screenshot`, `search`
+- Lifecycle families: `acp`, `artifacts`, `crawl`, `embed`, `extract`, `ingest`
+- Direct actions: `ask`, `doctor`, `domains`, `elicit_demo`, `evaluate`, `help`, `map`, `query`, `research`, `retrieve`, `scrape`, `screenshot`, `search`, `sources`, `stats`, `status`, `suggest`
 
-For lifecycle management (`status|cancel|list|cleanup|clear|recover`), use canonical families with `subaction`. `refresh` also supports `schedule` subaction with `schedule_subaction` param (`list`, `create`, `delete`, `enable`, `disable`):
+For lifecycle management (`status|cancel|list|cleanup|clear|recover`), use canonical families with `subaction`:
 
 ```json
 { "action": "ingest", "subaction": "status", "job_id": "..." }
@@ -51,6 +51,7 @@ For lifecycle management (`status|cancel|list|cleanup|clear|recover`), use canon
 - Tool response returns compact metadata only by default:
   - `path`, `bytes`, `line_count`, `sha256`, `preview`, `preview_truncated`
 - Inline modes are capped/truncated and always include artifact pointers.
+- `auto_inline`/`auto-inline` may be requested as an alias for `inline`; the server also emits `auto-inline` when a path-mode payload is small enough to inline automatically.
 
 ## Direct Actions
 These actions do not require `subaction`:
@@ -58,7 +59,11 @@ These actions do not require `subaction`:
 | Action | Required Fields | Optional Fields |
 |--------|----------------|-----------------|
 | `ask` | -- | `query`, `graph`, `diagnostics`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
+| `doctor` | -- | `response_mode` |
+| `domains` | -- | `limit`, `offset`, `response_mode` |
 | `elicit_demo` | -- | `message`, `response_mode` |
+| `evaluate` | -- | `query`, `diagnostics`, `retrieval_ab`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
+| `help` | -- | `response_mode` |
 | `map` | -- | `url`, `limit`, `offset`, `response_mode` |
 | `query` | -- | `query`, `limit`, `offset`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
 | `research` | -- | `query`, `limit`, `offset`, `search_time_range`, `response_mode` |
@@ -66,6 +71,12 @@ These actions do not require `subaction`:
 | `scrape` | -- | `url`, `render_mode`, `format`, `embed`, `response_mode`, `root_selector`, `exclude_selector` |
 | `screenshot` | -- | `url`, `full_page`, `viewport`, `output`, `response_mode` |
 | `search` | -- | `query`, `limit`, `offset`, `search_time_range`, `response_mode` |
+| `sources` | -- | `limit`, `offset`, `response_mode` |
+| `stats` | -- | `response_mode` |
+| `status` | -- | `response_mode` |
+| `suggest` | -- | `focus`, `limit`, `collection`, `response_mode` |
+
+Note: `ask.graph=true` is rejected because graph retrieval is not implemented; omit `graph` or pass `false`.
 
 Note: `ask.graph` is retained for schema compatibility, but graph retrieval is
 not available in this build. Requests with `graph: true` return
@@ -87,25 +98,13 @@ Optional fields accepted on `{ "action": "crawl", "subaction": "start", ... }`:
 | `render_mode` | McpRenderMode | `auto_switch` | `http`, `chrome`, `auto_switch` |
 | `delay_ms` | u64 | 0 | Per-request delay ms |
 
-## Refresh Start Parameters
-`refresh` accepts either form:
-- `url` (string) -- single URL refresh
-- `urls` (string[]) -- batch URL refresh
-
-For scheduled refreshes: `{ "action": "refresh", "subaction": "schedule", "schedule_subaction": "list|create|delete|enable|disable", "schedule_name": "..." }`
-
 ## Lifecycle Action Families
+- `acp`: `list_sessions|fork_session|resume_session|set_model|ext_method|ext_notification|logout` -- requires action-specific session fields
 - `artifacts`: `head|grep|wc|read|list|delete|clean|search` -- requires `path`; `pattern` for grep
 - `crawl`: `start|status|cancel|list|cleanup|clear|recover` -- start requires `urls` (array)
-- `doctor`: `?` -- no required fields
-- `domains`: `?` -- no required fields
 - `embed`: `start|status|cancel|list|cleanup|clear|recover` -- start requires `input` (string)
 - `extract`: `start|status|cancel|list|cleanup|clear|recover` -- start requires `urls` (array)
-- `help`: `?` -- no required fields
 - `ingest`: `start|status|cancel|list|cleanup|clear|recover` -- start requires `source_type` + `target`
-- `sources`: `?` -- no required fields
-- `stats`: `?` -- no required fields
-- `status`: `?` -- no required fields
 
 ## Ingest Source Types
 

--- a/docs/MCP-TOOL-SCHEMA.md
+++ b/docs/MCP-TOOL-SCHEMA.md
@@ -50,31 +50,31 @@ For lifecycle management (`status|cancel|list|cleanup|clear|recover`), use canon
 - Heavy operations write result artifacts to `.cache/axon-mcp/`.
 - Tool response returns compact metadata only by default:
   - `path`, `bytes`, `line_count`, `sha256`, `preview`, `preview_truncated`
-- Inline modes are capped/truncated and always include artifact pointers.
-- `auto_inline`/`auto-inline` may be requested as an alias for `inline`; the server also emits `auto-inline` when a path-mode payload is small enough to inline automatically.
+- Explicit `inline` and `both` modes are capped/truncated and include artifact pointers.
+- `response_mode=auto_inline`/`auto-inline` selects threshold-based automatic inlining: small payloads return `auto-inline`, larger payloads return path metadata.
 
 ## Direct Actions
 These actions do not require `subaction`:
 
 | Action | Required Fields | Optional Fields |
 |--------|----------------|-----------------|
-| `ask` | -- | `query`, `graph`, `diagnostics`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
+| `ask` | `query` (string) | `graph`, `diagnostics`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
 | `doctor` | -- | `response_mode` |
 | `domains` | -- | `limit`, `offset`, `response_mode` |
 | `elicit_demo` | -- | `message`, `response_mode` |
-| `evaluate` | -- | `query`, `diagnostics`, `retrieval_ab`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
+| `evaluate` | `query` (aliases: `question`) (string) | `diagnostics`, `retrieval_ab`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
 | `help` | -- | `response_mode` |
-| `map` | -- | `url`, `limit`, `offset`, `response_mode` |
-| `query` | -- | `query`, `limit`, `offset`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
-| `research` | -- | `query`, `limit`, `offset`, `search_time_range`, `response_mode` |
-| `retrieve` | -- | `url`, `max_points`, `collection`, `since`, `before`, `response_mode` |
-| `scrape` | -- | `url`, `render_mode`, `format`, `embed`, `response_mode`, `root_selector`, `exclude_selector` |
-| `screenshot` | -- | `url`, `full_page`, `viewport`, `output`, `response_mode` |
-| `search` | -- | `query`, `limit`, `offset`, `search_time_range`, `response_mode` |
+| `map` | `url` (string) | `limit`, `offset`, `response_mode` |
+| `query` | `query` (string) | `limit`, `offset`, `collection`, `since`, `before`, `hybrid_search`, `response_mode` |
+| `research` | `query` (string) | `limit`, `offset`, `search_time_range`, `response_mode` |
+| `retrieve` | `url` (string) | `max_points`, `collection`, `since`, `before`, `response_mode` |
+| `scrape` | `url` (string) | `render_mode`, `format`, `embed`, `response_mode`, `root_selector`, `exclude_selector` |
+| `screenshot` | `url` (string) | `full_page`, `viewport`, `output`, `response_mode` |
+| `search` | `query` (string) | `limit`, `offset`, `search_time_range`, `response_mode` |
 | `sources` | -- | `limit`, `offset`, `response_mode` |
 | `stats` | -- | `response_mode` |
 | `status` | -- | `response_mode` |
-| `suggest` | -- | `focus`, `limit`, `collection`, `response_mode` |
+| `suggest` | -- | `focus` (aliases: `query`), `limit`, `collection`, `response_mode` |
 
 Note: `ask.graph=true` is rejected because graph retrieval is not implemented; omit `graph` or pass `false`.
 
@@ -156,9 +156,6 @@ Implemented resource(s):
 
 ## Runtime Dependencies
 Server reads existing Axon stack vars:
-- `AXON_PG_URL`
-- `AXON_REDIS_URL`
-- `AXON_AMQP_URL`
 - `QDRANT_URL`
 - `TEI_URL`
 - `OPENAI_BASE_URL`

--- a/docs/MCP-TOOL-SCHEMA.md
+++ b/docs/MCP-TOOL-SCHEMA.md
@@ -78,10 +78,6 @@ These actions do not require `subaction`:
 
 Note: `ask.graph=true` is rejected because graph retrieval is not implemented; omit `graph` or pass `false`.
 
-Note: `ask.graph` is retained for schema compatibility, but graph retrieval is
-not available in this build. Requests with `graph: true` return
-`invalid_params`; omit it or set `graph: false`.
-
 ## Crawl Start Parameters
 Optional fields accepted on `{ "action": "crawl", "subaction": "start", ... }`:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -8,7 +8,7 @@ Last Modified: 2026-03-11
 - Tool count: 1
 - Tool name: `axon`
 - Routing fields: `action` + `subaction` for lifecycle families
-- Response behavior field: `response_mode` (`path|inline|both|auto_inline`, default `path`; `auto_inline`/`auto-inline` may be requested as an alias for inline and `auto-inline` is also emitted when path-mode payloads are small enough to inline automatically)
+- Response behavior field: `response_mode` (`path|inline|both|auto_inline`, default `path`; `auto_inline`/`auto-inline` selects threshold-based automatic inlining)
 - Resources: `axon://schema/mcp-tool`, `ui://axon/status-dashboard`
 - MCP Apps capability is enabled so compatible hosts can render the status dashboard widget
 
@@ -156,13 +156,15 @@ Use CLI-identical action names:
 - `doctor`, `domains`, `sources`, `stats`
 - `search`, `map`
 - `artifacts` (with subactions `head|grep|wc|read|list|delete|clean|search`)
-- `scrape`, `research`, `ask`, `screenshot`, `help`, `status`, `elicit_demo`
+- `scrape`, `research`, `ask`, `evaluate`, `suggest`, `screenshot`, `help`, `status`, `elicit_demo`
 - `acp` (subactions: `list_sessions|fork_session|resume_session|set_model|ext_method|ext_notification|logout`)
 
 Examples:
 - `action: "ingest", subaction: "start"`
 - `action: "extract", subaction: "list"`
 - `action: "query"`
+- `action: "evaluate"`
+- `action: "suggest"`
 - `action: "doctor"`
 
 ## Parser Rules
@@ -179,6 +181,8 @@ Direct actions:
 - `scrape`
 - `research`
 - `ask`
+- `evaluate`
+- `suggest`
 - `screenshot`
 - `elicit_demo`
 
@@ -247,7 +251,7 @@ Artifact responses written in path mode are pretty-printed JSON. The preferred i
 
 All actions support `response_mode`. Default is `path`, writing the payload to an artifact and returning a compact shape summary. Use `response_mode=inline` to get the payload directly in the response.
 
-Valid `response_mode` values: `path|inline|both|auto_inline`. The hyphenated `auto-inline` spelling is accepted as an alias. See [`MCP-TOOL-SCHEMA.md`](MCP-TOOL-SCHEMA.md) for the full enum definition.
+Valid `response_mode` values: `path|inline|both|auto_inline`. The hyphenated `auto-inline` spelling is accepted for `auto_inline`. See [`MCP-TOOL-SCHEMA.md`](MCP-TOOL-SCHEMA.md) for the full enum definition.
 
 **Per-action response overrides (InlineHint):** Some actions override the standard response behavior regardless of `response_mode`:
 
@@ -267,7 +271,7 @@ The `path` field (absolute filesystem path) is present in artifact metadata for 
 
 ### Auto-inline for Small Payloads
 
-Regardless of the requested `response_mode`, any payload serializing to ≤ `AXON_INLINE_BYTES_THRESHOLD` bytes (default 8 192) is returned inline without requiring an `artifacts.read` follow-up call. The response includes `"response_mode": "auto-inline"`, the full `data` object, and an `artifact` pointer for persistence. Set `AXON_INLINE_BYTES_THRESHOLD=0` to disable auto-inline and always use explicit `response_mode` selection.
+When `response_mode` is omitted or set to `auto_inline`, any payload serializing to ≤ `AXON_INLINE_BYTES_THRESHOLD` bytes (default 8 192) is returned inline without requiring an `artifacts.read` follow-up call. The response includes `"response_mode": "auto-inline"` and the full `data` object. Larger auto-mode payloads fall back to path metadata. Set `AXON_INLINE_BYTES_THRESHOLD=0` to disable automatic inlining.
 
 ### Shape Preview Improvements
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -8,7 +8,7 @@ Last Modified: 2026-03-11
 - Tool count: 1
 - Tool name: `axon`
 - Routing fields: `action` + `subaction` for lifecycle families
-- Response behavior field: `response_mode` (`path|inline|both`, default `path`; `auto-inline` is a server-emitted value indicating the auto-inline path was taken — it cannot be requested by the caller)
+- Response behavior field: `response_mode` (`path|inline|both|auto_inline`, default `path`; `auto_inline`/`auto-inline` may be requested as an alias for inline and `auto-inline` is also emitted when path-mode payloads are small enough to inline automatically)
 - Resources: `axon://schema/mcp-tool`, `ui://axon/status-dashboard`
 - MCP Apps capability is enabled so compatible hosts can render the status dashboard widget
 
@@ -16,11 +16,11 @@ Canonical schema and action contract:
 - `docs/MCP-TOOL-SCHEMA.md`
 
 Implementation:
-- `crates/mcp/schema.rs`
-- `crates/mcp/server.rs`
-- `crates/mcp/auth.rs`
-- `crates/mcp/cors.rs`
-- `crates/mcp/server/handlers_*.rs`
+- `src/mcp/schema.rs`
+- `src/mcp/server.rs`
+- `src/mcp/auth.rs`
+- `src/mcp/cors.rs`
+- `src/mcp/server/handlers_*.rs`
 
 ## Runtime Model
 `axon mcp` is expected to run in the same environment as Axon workers.
@@ -247,7 +247,7 @@ Artifact responses written in path mode are pretty-printed JSON. The preferred i
 
 All actions support `response_mode`. Default is `path`, writing the payload to an artifact and returning a compact shape summary. Use `response_mode=inline` to get the payload directly in the response.
 
-Valid `response_mode` values: `path|inline|both|auto-inline`. Note that `auto-inline` is system-assigned — it cannot be requested by the caller. See [`MCP-TOOL-SCHEMA.md`](MCP-TOOL-SCHEMA.md) for the full enum definition.
+Valid `response_mode` values: `path|inline|both|auto_inline`. The hyphenated `auto-inline` spelling is accepted as an alias. See [`MCP-TOOL-SCHEMA.md`](MCP-TOOL-SCHEMA.md) for the full enum definition.
 
 **Per-action response overrides (InlineHint):** Some actions override the standard response behavior regardless of `response_mode`:
 

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -121,6 +121,38 @@ RAG: semantic search + LLM answer synthesis with citations.
 | `before` | string | -- | Date filter (before) |
 | `hybrid_search` | bool | -- | `false` forces dense-only; unset = server config |
 
+### evaluate
+
+Evaluate RAG quality against a baseline answer.
+
+```json
+{ "action": "evaluate", "query": "How good is retrieval for hybrid search?" }
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | -- | Question to evaluate. `question` is accepted as an alias. |
+| `diagnostics` | bool | `false` | Include retrieval diagnostics |
+| `retrieval_ab` | bool | `false` | Compare hybrid RAG against dense-only RAG instead of RAG against baseline |
+| `collection` | string | server-configured (`AXON_COLLECTION`, default `cortex`) | Qdrant collection |
+| `since` | string | -- | Date filter (after) |
+| `before` | string | -- | Date filter (before) |
+| `hybrid_search` | bool | -- | `false` forces dense-only; unset = server config |
+
+### suggest
+
+Suggest new crawl targets from the current indexed source coverage.
+
+```json
+{ "action": "suggest", "focus": "refresh scheduler internals", "limit": 5 }
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `focus` | string | -- | Optional suggestion focus. `query` is accepted as an alias. |
+| `limit` | usize | server search limit | Max suggestions to return |
+| `collection` | string | server-configured (`AXON_COLLECTION`, default `cortex`) | Qdrant collection |
+
 ### search
 
 Web search via Tavily, auto-queues crawl jobs for results.
@@ -193,7 +225,7 @@ Demo elicitation prompt — exercises the MCP elicitation request path end to en
 
 Manage ACP adapter sessions (advanced). Subactions: `list_sessions`,
 `fork_session`, `resume_session`, `set_model`, `ext_method`, `ext_notification`,
-`logout`. See `crates/mcp/server/handlers_acp.rs` for the wire contract.
+`logout`. See `src/mcp/server/handlers_acp.rs` for the wire contract.
 
 ## Lifecycle action families
 

--- a/scripts/mcp_doc_renderer.py
+++ b/scripts/mcp_doc_renderer.py
@@ -42,7 +42,6 @@ def generate_markdown(
     _emit_response_policy(emit)
     _emit_direct_actions(emit, direct_actions, structs)
     _emit_crawl_parameters(emit, structs)
-    _emit_refresh_parameters(emit)
     _emit_lifecycle_families(emit, lifecycle_actions, structs, enums)
     _emit_ingest_source_types(emit, enums)
     _emit_sessions_ingest_options(emit, structs)
@@ -79,7 +78,7 @@ def _emit_contract(emit) -> None:
     emit("- Primary route field: `action`")
     emit("- Canonical route form: `action` + optional `subaction`")
     emit(
-        "- Response control field: `response_mode` (`path|inline|both`, default `path`)"
+        "- Response control field: `response_mode` (`path|inline|both|auto_inline`, default `path`)"
     )
     emit()
     emit("Code references:")
@@ -108,7 +107,7 @@ def _emit_parser_rules(emit) -> None:
     emit("- `action` is required and must match canonical schema names")
     emit(
         "- `subaction` is required for lifecycle families "
-        "(`crawl|extract|embed|ingest|refresh|graph|artifacts`)"
+        "(`crawl|extract|embed|ingest|artifacts|acp`)"
     )
     emit("- No fallback fields (`command`, `op`, `operation`)")
     emit("- No token normalization or case folding")
@@ -128,9 +127,7 @@ def _emit_preferred_client_actions(
     emit()
     emit(
         "For lifecycle management (`status|cancel|list|cleanup|clear|recover`), "
-        "use canonical families with `subaction`. "
-        "`refresh` also supports `schedule` subaction with `schedule_subaction` param "
-        "(`list`, `create`, `delete`, `enable`, `disable`):"
+        "use canonical families with `subaction`:"
     )
     emit()
     emit("```json")
@@ -146,6 +143,10 @@ def _emit_response_policy(emit) -> None:
     emit("- Tool response returns compact metadata only by default:")
     emit("  - `path`, `bytes`, `line_count`, `sha256`, `preview`, `preview_truncated`")
     emit("- Inline modes are capped/truncated and always include artifact pointers.")
+    emit(
+        "- `auto_inline`/`auto-inline` may be requested as an alias for `inline`; "
+        "the server also emits `auto-inline` when a path-mode payload is small enough to inline automatically."
+    )
     emit()
 
 
@@ -163,10 +164,15 @@ def _emit_direct_actions(
         if not sdef:
             continue
         required = sdef.required_fields()
-        optional = sdef.optional_fields()
+        optional = [f for f in sdef.optional_fields() if f.name != "subaction"]
         req_str = ", ".join(f"`{f.name}` ({f.display_type})" for f in required) or "--"
         opt_str = ", ".join(f"`{f.name}`" for f in optional) or "--"
         emit(f"| `{action}` | {req_str} | {opt_str} |")
+    if "ask" in direct_actions:
+        emit()
+        emit(
+            "Note: `ask.graph=true` is rejected because graph retrieval is not implemented; omit `graph` or pass `false`."
+        )
     emit()
 
 
@@ -187,21 +193,6 @@ def _emit_crawl_parameters(emit, structs: dict[str, StructDef]) -> None:
             default = desc_info[0] if desc_info else "--"
             desc = desc_info[1] if desc_info else ""
             emit(f"| `{f.name}` | {f.display_type} | {default} | {desc} |")
-    emit()
-
-
-def _emit_refresh_parameters(emit) -> None:
-    emit("## Refresh Start Parameters")
-    emit("`refresh` accepts either form:")
-    emit("- `url` (string) -- single URL refresh")
-    emit("- `urls` (string[]) -- batch URL refresh")
-    emit()
-    emit(
-        "For scheduled refreshes: "
-        '`{ "action": "refresh", "subaction": "schedule", '
-        '"schedule_subaction": "list|create|delete|enable|disable", '
-        '"schedule_name": "..." }`'
-    )
     emit()
 
 
@@ -340,12 +331,12 @@ def _emit_error_semantics(emit) -> None:
 def _classify_actions(
     structs: dict[str, StructDef],
 ) -> tuple[list[str], list[str]]:
-    """Split actions into lifecycle (has subaction) and direct (no subaction)."""
+    """Split actions into subaction families and direct singleton actions."""
     lifecycle_actions: list[str] = []
     direct_actions: list[str] = []
     for struct_name, action in sorted(STRUCT_TO_ACTION.items(), key=lambda x: x[1]):
         sdef = structs.get(struct_name)
-        if sdef and sdef.has_subaction:
+        if sdef and sdef.subaction_enum_name:
             lifecycle_actions.append(action)
         else:
             direct_actions.append(action)
@@ -371,12 +362,10 @@ def _start_requirement_summary(action: str, sdef: StructDef) -> str:
             return "start requires `input` (string)"
         case "ingest":
             return "start requires `source_type` + `target`"
-        case "refresh":
-            return "start accepts `url` or `urls`"
-        case "graph":
-            return "build requires one of `url`, `domain`, or `all=true`"
         case "artifacts":
             return "requires `path`; `pattern` for grep"
+        case "acp":
+            return "requires action-specific session fields"
         case _:
             req = sdef.required_fields()
             if req:

--- a/scripts/mcp_doc_renderer.py
+++ b/scripts/mcp_doc_renderer.py
@@ -15,6 +15,7 @@ from mcp_schema_models import (
     RUNTIME_ENV_VARS,
     STRUCT_TO_ACTION,
     EnumDef,
+    FieldDef,
     StructDef,
 )
 
@@ -142,10 +143,10 @@ def _emit_response_policy(emit) -> None:
     emit("- Heavy operations write result artifacts to `.cache/axon-mcp/`.")
     emit("- Tool response returns compact metadata only by default:")
     emit("  - `path`, `bytes`, `line_count`, `sha256`, `preview`, `preview_truncated`")
-    emit("- Inline modes are capped/truncated and always include artifact pointers.")
+    emit("- Explicit `inline` and `both` modes are capped/truncated and include artifact pointers.")
     emit(
-        "- `auto_inline`/`auto-inline` may be requested as an alias for `inline`; "
-        "the server also emits `auto-inline` when a path-mode payload is small enough to inline automatically."
+        "- `response_mode=auto_inline`/`auto-inline` selects threshold-based automatic inlining: "
+        "small payloads return `auto-inline`, larger payloads return path metadata."
     )
     emit()
 
@@ -163,10 +164,21 @@ def _emit_direct_actions(
         sdef = structs.get(struct_name)
         if not sdef:
             continue
-        required = sdef.required_fields()
-        optional = [f for f in sdef.optional_fields() if f.name != "subaction"]
-        req_str = ", ".join(f"`{f.name}` ({f.display_type})" for f in required) or "--"
-        opt_str = ", ".join(f"`{f.name}`" for f in optional) or "--"
+        handler_required = HANDLER_REQUIRED_FIELDS.get(action, set())
+        required = [
+            f
+            for f in [*sdef.required_fields(), *sdef.optional_fields()]
+            if f.name in handler_required or not f.is_optional
+        ]
+        optional = [
+            f
+            for f in sdef.optional_fields()
+            if f.name != "subaction" and f.name not in handler_required
+        ]
+        req_str = ", ".join(
+            f"{_field_name_with_aliases(f)} ({f.display_type})" for f in required
+        ) or "--"
+        opt_str = ", ".join(_field_name_with_aliases(f) for f in optional) or "--"
         emit(f"| `{action}` | {req_str} | {opt_str} |")
     if "ask" in direct_actions:
         emit()
@@ -328,6 +340,19 @@ def _emit_error_semantics(emit) -> None:
 # ---------------------------------------------------------------------------
 
 
+HANDLER_REQUIRED_FIELDS: dict[str, set[str]] = {
+    "ask": {"query"},
+    "evaluate": {"query"},
+    "map": {"url"},
+    "query": {"query"},
+    "research": {"query"},
+    "retrieve": {"url"},
+    "scrape": {"url"},
+    "screenshot": {"url"},
+    "search": {"query"},
+}
+
+
 def _classify_actions(
     structs: dict[str, StructDef],
 ) -> tuple[list[str], list[str]]:
@@ -349,6 +374,14 @@ def _action_to_struct(action: str) -> str:
         if act == action:
             return struct_name
     return ""
+
+
+def _field_name_with_aliases(field: FieldDef) -> str:
+    text = f"`{field.name}`"
+    if field.aliases:
+        aliases = ", ".join(f"`{alias}`" for alias in field.aliases)
+        text += f" (aliases: {aliases})"
+    return text
 
 
 def _start_requirement_summary(action: str, sdef: StructDef) -> str:

--- a/scripts/mcp_schema_models.py
+++ b/scripts/mcp_schema_models.py
@@ -109,6 +109,8 @@ VARIANT_TO_ACTION: dict[str, str] = {
     "Retrieve": "retrieve",
     "Search": "search",
     "Map": "map",
+    "Evaluate": "evaluate",
+    "Suggest": "suggest",
     "Doctor": "doctor",
     "Domains": "domains",
     "Sources": "sources",
@@ -120,6 +122,7 @@ VARIANT_TO_ACTION: dict[str, str] = {
     "Ask": "ask",
     "Screenshot": "screenshot",
     "ElicitDemo": "elicit_demo",
+    "Acp": "acp",
 }
 
 STRUCT_TO_ACTION: dict[str, str] = {

--- a/scripts/mcp_schema_models.py
+++ b/scripts/mcp_schema_models.py
@@ -21,6 +21,7 @@ class FieldDef:
 
     name: str
     rust_type: str
+    aliases: list[str] = field(default_factory=list)
 
     @property
     def is_optional(self) -> bool:
@@ -151,9 +152,6 @@ CRAWL_FIELD_DESCRIPTIONS: dict[str, tuple[str, str]] = {
 
 # Runtime env vars -- not in schema.rs, hardcoded here.
 RUNTIME_ENV_VARS: list[str] = [
-    "AXON_PG_URL",
-    "AXON_REDIS_URL",
-    "AXON_AMQP_URL",
     "QDRANT_URL",
     "TEI_URL",
     "OPENAI_BASE_URL",

--- a/scripts/mcp_schema_parser.py
+++ b/scripts/mcp_schema_parser.py
@@ -18,16 +18,26 @@ def parse_schema(source: str) -> tuple[dict[str, StructDef], dict[str, EnumDef]]
 
     # Parse structs
     struct_pattern = re.compile(r"pub\s+struct\s+(\w+)\s*\{([^}]*)\}", re.DOTALL)
-    field_pattern = re.compile(r"pub\s+(\w+)\s*:\s*([^,\n]+)")
-
     for m in struct_pattern.finditer(source):
         name = m.group(1)
         body = m.group(2)
         fields: list[FieldDef] = []
-        for fm in field_pattern.finditer(body):
-            fname = fm.group(1)
-            ftype = fm.group(2).strip().rstrip(",").strip()
-            fields.append(FieldDef(name=fname, rust_type=ftype))
+        pending_aliases: list[str] = []
+        for line in body.splitlines():
+            stripped = line.strip()
+            alias_match = re.search(r'#\[serde\([^]]*alias\s*=\s*"([^"]+)"', stripped)
+            if alias_match:
+                pending_aliases.append(alias_match.group(1))
+                continue
+            field_match = re.match(r"pub\s+(\w+)\s*:\s*([^,\n]+)", stripped)
+            if not field_match:
+                continue
+            fname = field_match.group(1)
+            ftype = field_match.group(2).strip().rstrip(",").strip()
+            fields.append(
+                FieldDef(name=fname, rust_type=ftype, aliases=pending_aliases)
+            )
+            pending_aliases = []
         structs[name] = StructDef(name=name, fields=fields)
 
     # Parse enums

--- a/scripts/test-mcp-tools-mcporter.sh
+++ b/scripts/test-mcp-tools-mcporter.sh
@@ -23,6 +23,13 @@ CONFIG_PATH=""
 MCPORTER=()
 
 EXPECTED_ROUTES="$(cat <<'EOF'
+acp:ext_method
+acp:ext_notification
+acp:fork_session
+acp:list_sessions
+acp:logout
+acp:resume_session
+acp:set_model
 artifacts:clean
 artifacts:delete
 artifacts:grep
@@ -99,6 +106,7 @@ EOF
 
 DIRECT_ACTIONS_JSON='["ask","doctor","domains","elicit_demo","evaluate","export","help","map","query","research","retrieve","scrape","screenshot","search","sources","stats","status","suggest"]'
 EXPECTED_TOP_LEVEL_ACTIONS="$(cat <<'EOF'
+acp
 artifacts
 ask
 crawl

--- a/scripts/test-mcp-tools-mcporter.sh
+++ b/scripts/test-mcp-tools-mcporter.sh
@@ -49,6 +49,7 @@ embed:list
 embed:recover
 embed:start
 embed:status
+evaluate
 export
 extract:cancel
 extract:cleanup
@@ -92,10 +93,11 @@ search
 sources
 stats
 status
+suggest
 EOF
 )"
 
-DIRECT_ACTIONS_JSON='["ask","doctor","domains","elicit_demo","export","help","map","query","research","retrieve","scrape","screenshot","search","sources","stats","status"]'
+DIRECT_ACTIONS_JSON='["ask","doctor","domains","elicit_demo","evaluate","export","help","map","query","research","retrieve","scrape","screenshot","search","sources","stats","status","suggest"]'
 EXPECTED_TOP_LEVEL_ACTIONS="$(cat <<'EOF'
 artifacts
 ask
@@ -104,6 +106,7 @@ doctor
 domains
 elicit_demo
 embed
+evaluate
 export
 extract
 graph
@@ -120,6 +123,7 @@ search
 sources
 stats
 status
+suggest
 EOF
 )"
 

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -260,8 +260,13 @@ pub fn init_tracing() -> tracing_appender::non_blocking::WorkerGuard {
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(3);
 
-    let file_appender = SizeRotatingFile::new(log_dir, log_file_name, max_bytes, max_files)
-        .expect("failed to create axon log file appender");
+    let Ok(file_appender) = SizeRotatingFile::new(log_dir, log_file_name, max_bytes, max_files)
+    else {
+        eprintln!("warn: failed to create axon log file appender; continuing with stderr logging");
+        let (_sink, guard) = tracing_appender::non_blocking(io::sink());
+        tracing_subscriber::registry().with(console_layer).init();
+        return guard;
+    };
 
     let (non_blocking_file, guard) = tracing_appender::non_blocking(file_appender);
 

--- a/src/mcp/schema.rs
+++ b/src/mcp/schema.rs
@@ -14,6 +14,8 @@ pub enum AxonRequest {
     Retrieve(RetrieveRequest),
     Search(SearchRequest),
     Map(MapRequest),
+    Evaluate(EvaluateRequest),
+    Suggest(SuggestRequest),
     Doctor(DoctorRequest),
     Domains(DomainsRequest),
     Sources(SourcesRequest),
@@ -293,6 +295,41 @@ pub struct MapRequest {
     pub url: Option<String>,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
+    pub response_mode: Option<ResponseMode>,
+}
+
+#[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EvaluateRequest {
+    #[serde(alias = "question")]
+    pub query: Option<String>,
+    /// Include RAG diagnostics in response. Overrides cfg.ask_diagnostics.
+    pub diagnostics: Option<bool>,
+    /// Compare hybrid RAG against dense-only RAG instead of RAG against baseline.
+    pub retrieval_ab: Option<bool>,
+    /// Qdrant collection to search. Defaults to the server's configured collection.
+    pub collection: Option<String>,
+    /// Lower bound for temporal filter. Formats: 7d, 30d, YYYY-MM-DD, RFC3339.
+    /// Restricts results to content indexed on or after this date.
+    pub since: Option<String>,
+    /// Upper bound for temporal filter. Same formats as `since`.
+    /// Restricts results to content indexed on or before this date.
+    pub before: Option<String>,
+    /// Per-request hybrid search override. `false` forces dense-only retrieval
+    /// (skips BM42 sparse + RRF). When unset, falls back to server config.
+    pub hybrid_search: Option<bool>,
+    pub response_mode: Option<ResponseMode>,
+}
+
+#[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SuggestRequest {
+    #[serde(alias = "query")]
+    pub focus: Option<String>,
+    /// Maximum number of suggestions to return. Overrides cfg.search_limit.
+    pub limit: Option<usize>,
+    /// Qdrant collection to inspect. Defaults to the server's configured collection.
+    pub collection: Option<String>,
     pub response_mode: Option<ResponseMode>,
 }
 

--- a/src/mcp/schema/tests.rs
+++ b/src/mcp/schema/tests.rs
@@ -51,6 +51,56 @@ fn parse_query_action_with_all_optional_fields() {
 }
 
 #[test]
+fn parse_evaluate_action_with_question_alias() {
+    let raw = obj(json!({
+        "action": "evaluate",
+        "question": "does retrieval answer this?",
+        "diagnostics": true,
+        "retrieval_ab": true,
+        "collection": "docs_v2",
+        "since": "30d",
+        "before": "2026-05-03",
+        "hybrid_search": false,
+        "response_mode": "inline"
+    }));
+    let result = parse_axon_request(raw);
+    assert!(result.is_ok(), "evaluate should parse successfully");
+    if let Ok(AxonRequest::Evaluate(req)) = result {
+        assert_eq!(req.query.as_deref(), Some("does retrieval answer this?"));
+        assert_eq!(req.diagnostics, Some(true));
+        assert_eq!(req.retrieval_ab, Some(true));
+        assert_eq!(req.collection.as_deref(), Some("docs_v2"));
+        assert_eq!(req.since.as_deref(), Some("30d"));
+        assert_eq!(req.before.as_deref(), Some("2026-05-03"));
+        assert_eq!(req.hybrid_search, Some(false));
+        assert!(matches!(req.response_mode, Some(ResponseMode::Inline)));
+    } else {
+        panic!("expected Evaluate variant");
+    }
+}
+
+#[test]
+fn parse_suggest_action_with_query_alias() {
+    let raw = obj(json!({
+        "action": "suggest",
+        "query": "refresh scheduler internals",
+        "limit": 5,
+        "collection": "docs_v2",
+        "response_mode": "auto_inline"
+    }));
+    let result = parse_axon_request(raw);
+    assert!(result.is_ok(), "suggest should parse successfully");
+    if let Ok(AxonRequest::Suggest(req)) = result {
+        assert_eq!(req.focus.as_deref(), Some("refresh scheduler internals"));
+        assert_eq!(req.limit, Some(5));
+        assert_eq!(req.collection.as_deref(), Some("docs_v2"));
+        assert!(matches!(req.response_mode, Some(ResponseMode::AutoInline)));
+    } else {
+        panic!("expected Suggest variant");
+    }
+}
+
+#[test]
 fn parse_retrieve_action_with_collection_and_time_filters() {
     let raw = obj(json!({
         "action": "retrieve",

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -48,7 +48,7 @@ static MCP_TOOL_SCHEMA_MD: LazyLock<String> = LazyLock::new(|| {
     let schema = rmcp::schemars::schema_for!(AxonRequest);
     let schema_json = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| "{}".to_string());
     format!(
-        "# Axon MCP Tool Schema\n\nURI: `{}`\n\nSingle tool name: `axon`\n\nRouting contract:\n- `action` is required\n- `subaction` is required for lifecycle actions\n- `response_mode` supports `path|inline|both` and defaults to `path`\n\n## JSON Schema\n\n```json\n{}\n```\n",
+        "# Axon MCP Tool Schema\n\nURI: `{}`\n\nSingle tool name: `axon`\n\nRouting contract:\n- `action` is required\n- `subaction` is required for subaction families\n- `response_mode` supports `path|inline|both|auto_inline` and defaults to `path`\n\n## JSON Schema\n\n```json\n{}\n```\n",
         MCP_TOOL_SCHEMA_URI, schema_json
     )
 });
@@ -106,7 +106,7 @@ impl AxonMcpServer {
 impl AxonMcpServer {
     #[tool(
         name = "axon",
-        description = "Unified Axon MCP tool. Use action/subaction routing. Use action:help to list actions/subactions/defaults. Exposes schema resource axon://schema/mcp-tool. Actions: status, help, crawl, extract, embed, ingest, query, retrieve, search, map, doctor, domains, sources, stats, artifacts, scrape, research, ask, screenshot, elicit_demo.",
+        description = "Unified Axon MCP tool. Use action/subaction routing. Use action:help to list actions/subactions/defaults. Exposes schema resource axon://schema/mcp-tool. Actions: status, help, crawl, extract, embed, ingest, query, retrieve, search, map, evaluate, suggest, doctor, domains, sources, stats, artifacts, scrape, research, ask, screenshot, elicit_demo, acp.",
         meta = axon_tool_meta()
     )]
     async fn axon<'a>(
@@ -142,6 +142,8 @@ impl AxonMcpServer {
             AxonRequest::Retrieve(req) => self.handle_retrieve(req).await?,
             AxonRequest::Search(req) => self.handle_search(req).await?,
             AxonRequest::Map(req) => self.handle_map(req).await?,
+            AxonRequest::Evaluate(req) => self.handle_evaluate(req).await?,
+            AxonRequest::Suggest(req) => self.handle_suggest(req).await?,
             AxonRequest::Doctor(req) => self.handle_doctor(req).await?,
             AxonRequest::Domains(req) => self.handle_domains(req).await?,
             AxonRequest::Sources(req) => self.handle_sources(req).await?,
@@ -241,13 +243,16 @@ impl ServerHandler for AxonMcpServer {
             "- `ingest` — GitHub/Reddit/YouTube source ingestion\n",
             "- `query` — dense + BM42 hybrid semantic search\n",
             "- `ask` — RAG: retrieve context + LLM answer\n",
+            "- `evaluate` — compare RAG quality against a baseline with judge diagnostics\n",
+            "- `suggest` — propose new crawl targets from indexed source coverage\n",
             "- `research` — Tavily AI search with LLM synthesis\n",
             "- `extract` — structured data extraction via LLM\n",
+            "- `acp` — inspect and manage ACP-backed LLM sessions\n",
             "- `status` / `doctor` — job queue health and service diagnostics\n",
             "- `artifacts` — read/grep/inspect large output files\n",
             "- MCP Apps enabled — exposes `ui://axon/status-dashboard` for live queue status widgets\n",
             "\n",
-            "All async operations (crawl, embed, ingest, extract) return a job_id. Poll with `action:status` or pass `wait:true` for synchronous execution."
+            "Async operations (crawl, embed, ingest, extract) return a job_id. Poll the same action with `subaction:status` and the returned `job_id`."
         ).into());
         info.capabilities = mcp_apps_server_capabilities();
         info

--- a/src/mcp/server/artifacts/respond.rs
+++ b/src/mcp/server/artifacts/respond.rs
@@ -65,10 +65,9 @@ pub async fn write_json_artifact(
 
 /// Respond with the appropriate mode, respecting the caller's explicit choice.
 ///
-/// When `mode` is `None` (caller didn't specify), small payloads are auto-inlined
-/// to avoid unnecessary disk writes. When the caller explicitly requests a mode
-/// (`Some(Path)`, `Some(Inline)`, `Some(Both)`), that choice is honored regardless
-/// of payload size.
+/// When `mode` is `None` or `Some(AutoInline)`, small payloads are auto-inlined
+/// to avoid unnecessary disk writes. Explicit `Path`, `Inline`, and `Both`
+/// choices are honored regardless of payload size.
 pub async fn respond_with_mode(
     action: &str,
     subaction: &str,
@@ -110,8 +109,7 @@ pub async fn respond_with_mode(
     }
 
     let effective_mode = match mode {
-        Some(explicit) => explicit,
-        None => {
+        Some(ResponseMode::AutoInline) | None => {
             let payload_bytes = serde_json::to_string(&payload)
                 .map(|s| s.len())
                 .unwrap_or(usize::MAX);
@@ -126,9 +124,10 @@ pub async fn respond_with_mode(
                     }),
                 ));
             }
-            // Large payload with no explicit mode — default to path.
+            // Large payload with auto mode — default to path.
             ResponseMode::Path
         }
+        Some(explicit) => explicit,
     };
 
     let artifact = write_json_artifact(artifact_stem, &payload).await?;
@@ -143,7 +142,7 @@ pub async fn respond_with_mode(
                 "artifact": artifact,
             }),
         )),
-        ResponseMode::Inline | ResponseMode::AutoInline => {
+        ResponseMode::Inline => {
             let (inline, truncated) = clip_inline_json(&payload, 12_000);
             Ok(AxonToolResponse::ok(
                 action,
@@ -170,6 +169,7 @@ pub async fn respond_with_mode(
                 }),
             ))
         }
+        ResponseMode::AutoInline => unreachable!("auto-inline is normalized before matching"),
     }
 }
 
@@ -275,6 +275,31 @@ mod tests {
         assert_eq!(resp.data["response_mode"], "path");
         assert!(resp.data["artifact"].is_object());
         assert!(resp.data["shape"].is_object());
+        restore_artifact_env(prev);
+    }
+
+    #[tokio::test]
+    #[allow(unsafe_code)]
+    #[allow(clippy::await_holding_lock)]
+    async fn explicit_auto_inline_mode_uses_threshold_auto_response() {
+        let _guard = ARTIFACT_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let (_tmp, prev) = scoped_artifact_root();
+        let payload = serde_json::json!({"key": "value"});
+        let resp = respond_with_mode(
+            "test",
+            "sub",
+            Some(ResponseMode::AutoInline),
+            "test-auto-inline-mode",
+            payload.clone(),
+            InlineHint::Default,
+        )
+        .await
+        .unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.data["response_mode"], "auto-inline");
+        assert_eq!(resp.data["data"], payload);
         restore_artifact_env(prev);
     }
 

--- a/src/mcp/server/handlers_query.rs
+++ b/src/mcp/server/handlers_query.rs
@@ -6,8 +6,8 @@ use super::common::{
 };
 use crate::core::config::ConfigOverrides;
 use crate::mcp::schema::{
-    AskRequest, AxonToolResponse, MapRequest, QueryRequest, ResearchRequest, RetrieveRequest,
-    ScrapeRequest, SearchRequest,
+    AskRequest, AxonToolResponse, EvaluateRequest, MapRequest, QueryRequest, ResearchRequest,
+    RetrieveRequest, ScrapeRequest, SearchRequest, SuggestRequest,
 };
 use crate::services::{
     map as map_svc, query as query_svc, scrape as scrape_svc, search as search_svc,
@@ -171,6 +171,98 @@ impl AxonMcpServer {
         .await
     }
 
+    pub(super) async fn handle_evaluate(
+        &self,
+        req: EvaluateRequest,
+    ) -> Result<AxonToolResponse, ErrorData> {
+        let query = req
+            .query
+            .ok_or_else(|| invalid_params("query is required for evaluate"))?;
+        let response_mode = req.response_mode;
+
+        let mut cfg = self.cfg.as_ref().clone();
+        if let Some(diagnostics) = req.diagnostics {
+            cfg.ask_diagnostics = diagnostics;
+        }
+        if let Some(retrieval_ab) = req.retrieval_ab {
+            cfg.evaluate_retrieval_ab = retrieval_ab;
+        }
+        if let Some(collection) = req.collection {
+            cfg.collection = validate_mcp_collection(&collection)?;
+        }
+        if let Some(since) = req.since {
+            cfg.since = Some(since);
+        }
+        if let Some(before) = req.before {
+            cfg.before = Some(before);
+        }
+        if let Some(enabled) = req.hybrid_search {
+            cfg.hybrid_search_enabled = enabled;
+        }
+
+        let query_for_task = query.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| format!("build evaluate runtime: {e}"))?;
+            runtime.block_on(async {
+                query_svc::evaluate(&cfg, &query_for_task)
+                    .await
+                    .map_err(|e| e.to_string())
+            })
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("join evaluate task: {e}");
+            internal_error(format!("evaluate '{query}' failed"))
+        })?
+        .map_err(|e| {
+            tracing::error!("evaluate '{query}': {e}");
+            internal_error(format!("evaluate '{query}' failed"))
+        })?;
+
+        respond_with_mode(
+            "evaluate",
+            "evaluate",
+            response_mode,
+            &format!("evaluate-{}", slugify(&query, 56)),
+            serde_json::to_value(result)
+                .map_err(|e| internal_error(format!("serialize evaluate result: {e}")))?,
+            InlineHint::Default,
+        )
+        .await
+    }
+
+    pub(super) async fn handle_suggest(
+        &self,
+        req: SuggestRequest,
+    ) -> Result<AxonToolResponse, ErrorData> {
+        let response_mode = req.response_mode;
+        let mut cfg = self.cfg.as_ref().clone();
+        if let Some(collection) = req.collection {
+            cfg.collection = validate_mcp_collection(&collection)?;
+        }
+        if let Some(limit) = req.limit {
+            cfg.search_limit = limit.clamp(1, 100);
+        }
+        let focus = req.focus;
+        let result = query_svc::suggest(&cfg, focus.as_deref())
+            .await
+            .map_err(|e| logged_internal_error("suggest", e.as_ref()))?;
+
+        respond_with_mode(
+            "suggest",
+            "suggest",
+            response_mode,
+            "suggestions",
+            serde_json::to_value(result)
+                .map_err(|e| internal_error(format!("serialize suggest result: {e}")))?,
+            InlineHint::Default,
+        )
+        .await
+    }
+
     pub(super) async fn handle_scrape(
         &self,
         req: ScrapeRequest,
@@ -259,7 +351,7 @@ impl AxonMcpServer {
             .map(validate_mcp_collection)
             .transpose()?;
         let cfg = self.cfg.apply_overrides(&ConfigOverrides {
-            ask_graph: req.graph,
+            ask_graph: Some(false),
             ask_diagnostics: req.diagnostics,
             collection,
             since: req.since,

--- a/src/mcp/server/handlers_query.rs
+++ b/src/mcp/server/handlers_query.rs
@@ -200,6 +200,11 @@ impl AxonMcpServer {
             cfg.hybrid_search_enabled = enabled;
         }
 
+        // The RMCP `#[tool]` wrapper requires a `Send` future. The evaluate
+        // service currently carries `Box<dyn Error>` through `tokio::try_join!`
+        // in the vector pipeline, making direct `.await` non-Send at this
+        // boundary. Keep that non-Send implementation isolated from the MCP
+        // tool future until the evaluate pipeline error type is widened.
         let query_for_task = query.clone();
         let result = tokio::task::spawn_blocking(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()

--- a/src/mcp/server/handlers_system.rs
+++ b/src/mcp/server/handlers_system.rs
@@ -281,6 +281,8 @@ impl AxonMcpServer {
                     "scrape": ["scrape"],
                     "research": ["research"],
                     "ask": ["ask"],
+                    "evaluate": ["evaluate"],
+                    "suggest": ["suggest"],
                     "screenshot": ["screenshot"],
                     "crawl": ["start", "status", "cancel", "list", "cleanup", "clear", "recover"],
                     "extract": ["start", "status", "cancel", "list", "cleanup", "clear", "recover"],
@@ -295,6 +297,7 @@ impl AxonMcpServer {
                     "sources": ["sources"],
                     "stats": ["stats"],
                     "artifacts": ["head", "grep", "wc", "read", "list", "delete", "clean", "search"],
+                    "acp": ["list_sessions", "fork_session", "resume_session", "set_model", "ext_method", "ext_notification", "logout"],
                     "elicit_demo": []
                 },
                 "resources": [

--- a/src/services/debug.rs
+++ b/src/services/debug.rs
@@ -1,7 +1,7 @@
 use crate::core::config::{AskBackend, Config};
 use crate::core::health::build_doctor_report;
 use crate::core::logging::log_warn;
-use crate::services::acp_llm::{self, AcpCompletionRequest};
+use crate::services::acp_llm::{self, AcpCompletionRequest, AcpCompletionResponse};
 use crate::services::types::DebugResult;
 use std::error::Error;
 
@@ -61,25 +61,7 @@ pub async fn debug_report(cfg: &Config, user_context: &str) -> Result<DebugResul
     if !cfg.openai_model.trim().is_empty() {
         request = request.model(cfg.openai_model.clone());
     }
-    // Warm path: WarmAcpSession is Send — await directly.
-    // Cold path: acp_llm::complete_text is !Send — use spawn_blocking to keep this
-    // function's future Send for web/MCP call sites that require Send + 'static.
-    let completion = if let Some(w) = warm {
-        w.complete_text(request).await?
-    } else {
-        let cfg_c = cfg.clone();
-        tokio::task::spawn_blocking(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|err| format!("failed to build debug ACP runtime: {err}"))?;
-            rt.block_on(acp_llm::complete_text(&cfg_c, request))
-                .map_err(|err| err.to_string())
-        })
-        .await
-        .map_err(|err| format!("failed to join debug ACP task: {err}"))?
-        .map_err(|err| -> Box<dyn Error> { err.into() })?
-    };
+    let completion = complete_debug_text(cfg, request, warm).await?;
     let analysis = if completion.text.trim().is_empty() {
         "(no debug response)"
     } else {
@@ -96,6 +78,43 @@ pub async fn debug_report(cfg: &Config, user_context: &str) -> Result<DebugResul
             }
         }),
     })
+}
+
+async fn complete_debug_text(
+    cfg: &Config,
+    request: AcpCompletionRequest,
+    warm: Option<acp_llm::WarmAcpSession>,
+) -> Result<AcpCompletionResponse, Box<dyn Error>> {
+    #[cfg(test)]
+    if cfg.ask_backend.uses_headless()
+        && cfg.acp_adapter_cmd.is_none()
+        && cfg.openai_model.trim().is_empty()
+    {
+        return Ok(AcpCompletionResponse {
+            text: "debug test completion".to_string(),
+            usage: None,
+        });
+    }
+
+    // Warm path: WarmAcpSession is Send — await directly.
+    // Cold path: acp_llm::complete_text is !Send — use spawn_blocking to keep this
+    // function's future Send for web/MCP call sites that require Send + 'static.
+    if let Some(w) = warm {
+        w.complete_text(request).await
+    } else {
+        let cfg_c = cfg.clone();
+        tokio::task::spawn_blocking(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|err| format!("failed to build debug ACP runtime: {err}"))?;
+            rt.block_on(acp_llm::complete_text(&cfg_c, request))
+                .map_err(|err| err.to_string())
+        })
+        .await
+        .map_err(|err| format!("failed to join debug ACP task: {err}"))?
+        .map_err(|err| -> Box<dyn Error> { err.into() })
+    }
 }
 
 #[cfg(test)]

--- a/src/services/query.rs
+++ b/src/services/query.rs
@@ -324,6 +324,47 @@ mod tests {
     }
 
     #[test]
+    fn map_ask_payload_preserves_adaptive_diagnostics() {
+        let payload = json!({
+            "query": "what is axon?",
+            "answer": "A crawler.",
+            "diagnostics": {
+                "candidate_pool": 12,
+                "reranked_pool": 8,
+                "chunks_selected": 4,
+                "full_docs_selected": 2,
+                "supplemental_selected": 1,
+                "context_chars": 3000,
+                "graph_entities": 0,
+                "graph_context_chars": 0,
+                "full_doc_fetch_skipped": true,
+                "full_doc_fetch_skip_reason": "low_complexity",
+                "detected_complexity": "simple",
+                "resolved_full_docs": 2,
+                "full_docs_source": "adaptive",
+                "min_relevance_score": 0.4,
+                "doc_fetch_concurrency": 8,
+                "top_domains": ["docs.example.com"],
+                "authority_ratio": 0.75
+            },
+            "timing_ms": {
+                "retrieval": 1,
+                "context_build": 2,
+                "graph": 0,
+                "llm": 3,
+                "total": 6
+            }
+        });
+        let result = map_ask_payload(payload).unwrap();
+        let diagnostics = result.diagnostics.expect("diagnostics should deserialize");
+        assert!(diagnostics.full_doc_fetch_skipped);
+        assert_eq!(diagnostics.full_doc_fetch_skip_reason, "low_complexity");
+        assert_eq!(diagnostics.detected_complexity, "simple");
+        assert_eq!(diagnostics.resolved_full_docs, 2);
+        assert_eq!(diagnostics.full_docs_source, "adaptive");
+    }
+
+    #[test]
     fn map_ask_payload_rejects_invalid_shape() {
         let err = map_ask_payload(json!({ "answer": "missing query and timing" })).unwrap_err();
         assert!(err.to_string().contains("invalid ask payload"));

--- a/src/services/types/service.rs
+++ b/src/services/types/service.rs
@@ -297,16 +297,6 @@ pub struct AskDiagnostics {
     pub doc_fetch_concurrency: usize,
     pub top_domains: Vec<String>,
     pub authority_ratio: f64,
-    #[serde(default)]
-    pub full_doc_fetch_skipped: bool,
-    #[serde(default)]
-    pub full_doc_fetch_skip_reason: String,
-    #[serde(default)]
-    pub detected_complexity: String,
-    #[serde(default)]
-    pub resolved_full_docs: usize,
-    #[serde(default)]
-    pub full_docs_source: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/services/types/service.rs
+++ b/src/services/types/service.rs
@@ -283,6 +283,16 @@ pub struct AskDiagnostics {
     pub context_chars: usize,
     pub graph_entities: usize,
     pub graph_context_chars: usize,
+    #[serde(default)]
+    pub full_doc_fetch_skipped: bool,
+    #[serde(default)]
+    pub full_doc_fetch_skip_reason: String,
+    #[serde(default)]
+    pub detected_complexity: String,
+    #[serde(default)]
+    pub resolved_full_docs: usize,
+    #[serde(default)]
+    pub full_docs_source: String,
     pub min_relevance_score: f64,
     pub doc_fetch_concurrency: usize,
     pub top_domains: Vec<String>,

--- a/src/vector/ops/commands/evaluate/streaming.rs
+++ b/src/vector/ops/commands/evaluate/streaming.rs
@@ -33,12 +33,12 @@ pub(super) async fn run_rag_answer(
     warm: Option<WarmAcpSession>,
 ) -> Result<(String, u128), Box<dyn Error>> {
     let started = Instant::now();
-    let answer = match ask_llm_streaming(cfg, client, query, context, !cfg.json_output, warm).await
-    {
+    let streaming = ask_llm_streaming(cfg, client, query, context, !cfg.json_output, warm).await;
+    let answer = match streaming.map_err(|e| e.to_string()) {
         Ok(v) => v,
-        Err(e) => {
+        Err(message) => {
             log_warn(&format!(
-                "rag streaming failed, falling back to non-streaming: {e}"
+                "rag streaming failed, falling back to non-streaming: {message}"
             ));
             let fallback = ask_llm_non_streaming(cfg, client, query, context).await?;
             if !cfg.json_output {
@@ -57,11 +57,12 @@ pub(super) async fn run_baseline_answer(
     warm: Option<WarmAcpSession>,
 ) -> Result<(String, u128), Box<dyn Error>> {
     let started = Instant::now();
-    let answer = match baseline_llm_streaming(cfg, client, query, !cfg.json_output, warm).await {
+    let streaming = baseline_llm_streaming(cfg, client, query, !cfg.json_output, warm).await;
+    let answer = match streaming.map_err(|e| e.to_string()) {
         Ok(v) => v,
-        Err(e) => {
+        Err(message) => {
             log_warn(&format!(
-                "baseline streaming failed, falling back to non-streaming: {e}"
+                "baseline streaming failed, falling back to non-streaming: {message}"
             ));
             let fallback = baseline_llm_non_streaming(cfg, client, query).await?;
             if !cfg.json_output {


### PR DESCRIPTION
## Summary
- expose MCP `evaluate` and `suggest` actions through the service layer
- preserve adaptive ask diagnostics in typed service results
- reject unavailable `ask.graph=true` and align MCP help/generated docs
- document `auto_inline` as an accepted inline alias and bump to 1.6.2

## Beads
- closes axon_rust-wxe
- closes axon_rust-wxe.1
- closes axon_rust-wxe.2
- closes axon_rust-wxe.3
- closes axon_rust-wxe.4
- closes axon_rust-wxe.5

## Verification
- `RUSTC_WRAPPER= cargo test parse_evaluate_action_with_question_alias`
- `RUSTC_WRAPPER= cargo test parse_suggest_action_with_query_alias`
- `RUSTC_WRAPPER= cargo test map_ask_payload_preserves_adaptive_diagnostics`
- `RUSTC_WRAPPER= cargo test --test mcp_contract_parity`
- `RUSTC_WRAPPER= cargo check`
- `cargo fmt --check`
- `git diff --check`
- pre-commit: mcp-schema-doc, monolith, rustfmt, mcp-http-only, no-mod-rs, claude-symlinks, env-guard, unwrap-warn, clippy, test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose RAG `evaluate` and `suggest` in the unified `axon` MCP tool and allow callers to request `response_mode: auto_inline`. Regenerated schema/docs/help to show required fields, aliases, and `acp` routes; preserved adaptive ask diagnostics and reject `ask.graph=true` (addresses the axon_rust-wxe Linear series).

- **New Features**
  - Added `evaluate` (judge diagnostics, `retrieval_ab`) and `suggest`; accepts `question` alias for `evaluate.query` and `query` alias for `suggest.focus`; discovery/help updated and lists `acp` subactions.
  - Requestable `response_mode: auto_inline` (`auto-inline`) for threshold-based inlining; honored when set or omitted; schema/docs show required fields and aliases.

- **Bug Fixes**
  - `ask.graph=true` is rejected and documented; handler enforces non-graph retrieval.
  - More resilient LLM streaming fallback and clearer evaluation logs; debug service tests avoid the real headless binary.
  - Logging tolerates a missing file appender and falls back to stderr-only output.
  - CI: isolate MCP smoke test data and logs via `AXON_DATA_DIR`, `AXON_LOG_DIR`, and `AXON_SQLITE_PATH` to avoid cross-run state.

<sup>Written for commit 49ce17a5d7a5b5bf2897189a632f9f0bdbced4ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v1.6.2

* **New Features**
  * Added `evaluate` and `suggest` actions to expand tool capabilities.

* **Bug Fixes**
  * Graph-enhanced retrieval is now rejected and marked deprecated.
  * Adaptive diagnostics properly preserved in service results.
  * Lowered default hybrid candidate limit (150 → 100) for improved performance.

* **Documentation**
  * MCP tool schema and reference documentation regenerated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->