### PR TITLE
fix/empty env and docker cache

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -42,3 +43,7 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
+      - name: Warn on Claude review infrastructure failure
+        if: steps.claude-review.outcome != 'success'
+        run: |
+          echo "::warning title=Claude review unavailable::anthropics/claude-code-action did not complete successfully. Treating review as best-effort so transient quota or service issues do not block the PR."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.3] - 2026-05-10
+
+### Fixed
+
+- http: route internal Qdrant and TEI calls through the internal service client so `AXON_SERVER_URL` does not accidentally bounce container-local maintenance traffic back through the public server endpoint.
+- serve: initialize the unified server service context eagerly and clear `AXON_SERVER_URL` inside the Docker service so container-local commands stay on direct service URLs.
+- dev: wire the local sccache wrapper defaults into `just` recipes for faster, consistent local builds.
+
 ## [1.9.2] - 2026-05-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.2] - 2026-05-10
+
+### Fixed
+
+- status: make `axon status --server-url ...` reuse the same detailed human renderer as local mode instead of collapsing server responses to totals-only output.
+- http: keep the shared client builder warning-free in test builds so clippy/hooks no longer fail on dead code and unused SSRF-guard plumbing.
+
 ## [1.9.1] - 2026-05-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.5] - 2026-05-11
+
+### Fixed
+
+- ci: make the Claude review workflow best-effort so Anthropic quota or service outages warn instead of failing the PR.
+
 ## [1.9.4] - 2026-05-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.4] - 2026-05-11
+
+### Fixed
+
+- dev: remove user-specific `sccache` wrapper paths and socket defaults from `Justfile` so local recipes stay portable across developers and machines.
+- config: preserve an explicit `--output-dir` even when it matches the clap default, instead of letting `AXON_OUTPUT_DIR` or post-init default derivation override it.
+
 ## [1.9.3] - 2026-05-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-05-10
+
+### Fixed
+
+- config: ignore blank optional path env vars such as `AXON_OUTPUT_DIR`, `AXON_SQLITE_PATH`, and `AXON_LOG_DIR`, falling back to canonical `~/.axon` defaults instead of treating empty strings as real paths.
+- docker: align the builder image with the pinned Rust `1.94.0` toolchain so cached Docker rebuilds avoid repeated Rust toolchain installation.
+
 ## [1.9.0] - 2026-05-09
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "1.9.4"
+version = "1.9.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "1.9.2"
+version = "1.9.3"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "1.9.4"
+version = "1.9.5"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "1.9.3"
+version = "1.9.4"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
-rust_dev_env := "if command -v sccache >/dev/null 2>&1; then export RUSTC_WRAPPER=sccache; fi; if command -v mold >/dev/null 2>&1; then export RUSTFLAGS=\"${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold\"; fi"
+rust_dev_env := "export SCCACHE_SERVER_UDS=${SCCACHE_SERVER_UDS:-/tmp/sccache-jmagar.sock}; export SCCACHE_LOG=${SCCACHE_LOG:-error}; if [ -x /home/jmagar/.local/bin/sccache-wrapper ]; then export RUSTC_WRAPPER=/home/jmagar/.local/bin/sccache-wrapper; elif command -v sccache >/dev/null 2>&1; then export RUSTC_WRAPPER=sccache; fi; if command -v mold >/dev/null 2>&1; then export RUSTFLAGS=\"${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold\"; fi"
 
 default:
     @just --list
@@ -185,7 +185,9 @@ dev:
     just stop
     sleep 1
     export RUST_LOG="${RUST_LOG:-info,axon.mcp.oauth=info,axon::crates::mcp=info}"
-    if command -v sccache >/dev/null 2>&1; then export RUSTC_WRAPPER=sccache; fi
+    export SCCACHE_SERVER_UDS="${SCCACHE_SERVER_UDS:-/tmp/sccache-jmagar.sock}"
+    export SCCACHE_LOG="${SCCACHE_LOG:-error}"
+    if [ -x /home/jmagar/.local/bin/sccache-wrapper ]; then export RUSTC_WRAPPER=/home/jmagar/.local/bin/sccache-wrapper; elif command -v sccache >/dev/null 2>&1; then export RUSTC_WRAPPER=sccache; fi
     if command -v mold >/dev/null 2>&1; then export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold"; fi
     cargo build --locked --bin axon
     AXON_BIN="${CARGO_TARGET_DIR:-$(pwd)/target}/debug/axon"

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
-rust_dev_env := "export SCCACHE_SERVER_UDS=${SCCACHE_SERVER_UDS:-/tmp/sccache-jmagar.sock}; export SCCACHE_LOG=${SCCACHE_LOG:-error}; if [ -x /home/jmagar/.local/bin/sccache-wrapper ]; then export RUSTC_WRAPPER=/home/jmagar/.local/bin/sccache-wrapper; elif command -v sccache >/dev/null 2>&1; then export RUSTC_WRAPPER=sccache; fi; if command -v mold >/dev/null 2>&1; then export RUSTFLAGS=\"${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold\"; fi"
+rust_dev_env := "export SCCACHE_SERVER_UDS=${SCCACHE_SERVER_UDS:-/tmp/sccache-${USER:-$(id -u)}.sock}; export SCCACHE_LOG=${SCCACHE_LOG:-error}; if [ -n \"${HOME:-}\" ] && [ -x \"${HOME}/.local/bin/sccache-wrapper\" ]; then export RUSTC_WRAPPER=\"${HOME}/.local/bin/sccache-wrapper\"; elif command -v sccache >/dev/null 2>&1; then export RUSTC_WRAPPER=sccache; fi; if command -v mold >/dev/null 2>&1; then export RUSTFLAGS=\"${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold\"; fi"
 
 default:
     @just --list
@@ -185,10 +185,7 @@ dev:
     just stop
     sleep 1
     export RUST_LOG="${RUST_LOG:-info,axon.mcp.oauth=info,axon::crates::mcp=info}"
-    export SCCACHE_SERVER_UDS="${SCCACHE_SERVER_UDS:-/tmp/sccache-jmagar.sock}"
-    export SCCACHE_LOG="${SCCACHE_LOG:-error}"
-    if [ -x /home/jmagar/.local/bin/sccache-wrapper ]; then export RUSTC_WRAPPER=/home/jmagar/.local/bin/sccache-wrapper; elif command -v sccache >/dev/null 2>&1; then export RUSTC_WRAPPER=sccache; fi
-    if command -v mold >/dev/null 2>&1; then export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold"; fi
+    {{rust_dev_env}};
     cargo build --locked --bin axon
     AXON_BIN="${CARGO_TARGET_DIR:-$(pwd)/target}/debug/axon"
     docker compose --env-file "${AXON_ENV_FILE:-$HOME/.axon/.env}" -f docker-compose.yaml up -d --wait axon-qdrant axon-tei axon-chrome

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Rust-based crawl, scrape, ingest, embed, query, and RAG engine with a unified CLI, MCP server, async workers, and web panel. Self-hosted research and knowledge-base backbone.
 
-Version: 1.9.1 | License: MIT
+Version: 1.9.2 | License: MIT
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Rust-based crawl, scrape, ingest, embed, query, and RAG engine with a unified CLI, MCP server, async workers, and web panel. Self-hosted research and knowledge-base backbone.
 
-Version: 1.9.3 | License: MIT
+Version: 1.9.4 | License: MIT
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Rust-based crawl, scrape, ingest, embed, query, and RAG engine with a unified CLI, MCP server, async workers, and web panel. Self-hosted research and knowledge-base backbone.
 
-Version: 1.9.2 | License: MIT
+Version: 1.9.3 | License: MIT
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Rust-based crawl, scrape, ingest, embed, query, and RAG engine with a unified CLI, MCP server, async workers, and web panel. Self-hosted research and knowledge-base backbone.
 
-Version: 1.9.0 | License: MIT
+Version: 1.9.1 | License: MIT
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Rust-based crawl, scrape, ingest, embed, query, and RAG engine with a unified CLI, MCP server, async workers, and web panel. Self-hosted research and knowledge-base backbone.
 
-Version: 1.9.4 | License: MIT
+Version: 1.9.5 | License: MIT
 
 ---
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # ── Builder ───────────────────────────────────────────────────────────────────
-FROM rust:1.83-bookworm AS builder
+FROM rust:1.94.0-bookworm AS builder
 
 # Build deps for sqlx-sqlite (libsqlite3), reqwest+rustls (pkg-config), and
 # anything that links against system libraries during cargo build.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,10 @@ services:
       # how external traffic reaches it. Non-loopback bind requires a token.
       AXON_MCP_HTTP_HOST: 0.0.0.0
       AXON_MCP_HTTP_PORT: "8001"
+      # AXON_SERVER_URL is a client-side switch. The shared ~/.axon/.env may
+      # set it for host CLI commands, but the server container must not inherit
+      # it or container-local maintenance commands will route back through HTTP.
+      AXON_SERVER_URL: ""
       # ~/.axon canonical layout inside the container.
       HOME: /home/axon
       AXON_HOME: /home/axon/.axon

--- a/docs/sessions/2026-05-10-empty-env-docker-cache-fix.md
+++ b/docs/sessions/2026-05-10-empty-env-docker-cache-fix.md
@@ -1,0 +1,120 @@
+---
+date: 2026-05-10 01:30:25 EST
+repo: git@github.com:jmagar/axon.git
+branch: fix/empty-env-and-docker-cache
+head: 870aeb34
+agent: Codex
+session id: unknown
+transcript: unavailable
+working directory: /home/jmagar/workspace/axon_rust
+worktree: /home/jmagar/workspace/axon_rust  870aeb34 [fix/empty-env-and-docker-cache]
+---
+
+# Session: Empty Env and Docker Cache Fix
+
+## User Request
+
+Investigate why `axon crawl https://help.getzep.com/overview` failed with `--output-dir` requiring a value, then quick-push the resulting fixes.
+
+## Session Overview
+
+- Fixed blank optional path env handling for `AXON_OUTPUT_DIR`, `AXON_SQLITE_PATH`, and `AXON_LOG_DIR`.
+- Repointed the local `axon` command away from a stale plugin-cache binary and rebuilt the runtime image.
+- Updated Docker builder base image to match the pinned Rust `1.94.0` toolchain.
+- Bumped the project version from `1.9.0` to `1.9.1` and pushed branch `fix/empty-env-and-docker-cache`.
+
+## Sequence of Events
+
+1. Reproduced the original CLI parse failure and found `AXON_OUTPUT_DIR=` in `~/.axon/.env`.
+2. Confirmed the installed `/home/jmagar/.local/bin/axon` pointed at a stale plugin-cache binary reporting `axon 1.8.4`.
+3. Moved `AXON_OUTPUT_DIR` parsing out of clap env parsing and into config resolution so blank values fall through.
+4. Fixed the same blank-env pattern for `AXON_LOG_DIR` and `AXON_SQLITE_PATH`.
+5. Rebuilt and restarted the Axon container, corrected tailnet publish/origin env, and verified server-mode crawl submission.
+6. Investigated slow Docker rebuilds and `sccache` warnings, then aligned the Docker builder image to `rust:1.94.0-bookworm`.
+7. Versioned, committed, and pushed the fix branch.
+
+## Key Findings
+
+- `AXON_OUTPUT_DIR=` caused clap to treat `--output-dir` as present with no value.
+- `AXON_LOG_DIR=` caused the logger to try creating an appender in an empty path.
+- `AXON_SQLITE_PATH=` caused the container to open the wrong SQLite path, leading to missing job-table startup errors.
+- Docker was using `rust:1.83-bookworm` while `rust-toolchain.toml` pins `1.94.0`, forcing rustup work inside the build.
+- `sccache.service` was OOM-killed on May 9 after peaking at 11.2G memory; current stats showed it running with a 68.75% Rust hit rate.
+
+## Technical Decisions
+
+- Removed clap-level `env = "AXON_OUTPUT_DIR"` for `output_dir` and resolved the env var through the existing trimmed `read_env()` helper.
+- Kept CLI flag priority over env by only consulting `AXON_OUTPUT_DIR` when the flag/default value is still unchanged.
+- Derived default output from `axon_data_base_dir().join("output")` to honor the canonical `~/.axon` layout.
+- Left the server plaintext guard intact and used explicit machine-local env opt-ins for the trusted tailnet endpoint.
+- Chose the low-risk Docker cache fix first: exact Rust builder image alignment instead of introducing cargo-chef in this patch.
+
+## Files Modified
+
+- `src/core/config/cli.rs` / `src/core/config/cli/global_args.rs`: expose and use a shared default output-dir constant.
+- `src/core/config/parse/build_config.rs`: ignore blank `AXON_OUTPUT_DIR` and `AXON_SQLITE_PATH`.
+- `src/core/config/parse/build_config/post_init.rs`: derive output dir from canonical Axon data root.
+- `src/core/config/parse/build_config/tests.rs`: add coverage for blank output/sqlite env vars and env/flag priority.
+- `src/core/logging.rs`: ignore blank `AXON_LOG_DIR` and `AXON_LOG_FILE`.
+- `config/Dockerfile`: use `rust:1.94.0-bookworm`.
+- `Cargo.toml`, `Cargo.lock`, `apps/web/package.json`, `README.md`, `CHANGELOG.md`: version `1.9.1`.
+
+## Commands Executed
+
+- `axon --version`: found stale `axon 1.8.4` before repointing the symlink.
+- `cargo test -q output_dir -- --test-threads=1`: passed.
+- `cargo test -q sqlite_path -- --test-threads=1`: passed.
+- `cargo test -q version_bearing_files_stay_in_sync`: passed.
+- `cargo check -q`: passed.
+- `docker build --target builder -f config/Dockerfile . --progress=plain`: verified builder cache behavior.
+- `axon crawl https://help.getzep.com/overview --max-pages 1 --wait false --json`: succeeded through server mode and created job `547924c2-9589-4741-be47-2f04a37b3a57`.
+
+## Errors Encountered
+
+- Initial CLI parse failure: blank `AXON_OUTPUT_DIR` was interpreted as a missing `--output-dir` value.
+- Container crash loop: blank `AXON_SQLITE_PATH` led to missing SQLite job tables.
+- Tailnet server-mode failure: container was published only to loopback; corrected machine-local publish/origin env.
+- Host conflict on port 8001: a stale plugin-cache `axon serve mcp` process held the port; killed it so the container could own the canonical port.
+- Slow Docker builds: base image/toolchain mismatch forced rustup downloads; fixed by using the exact pinned Rust image.
+
+## Behavior Changes
+
+| Before | After |
+|---|---|
+| Blank `AXON_OUTPUT_DIR=` could abort CLI parsing. | Blank `AXON_OUTPUT_DIR` falls through to canonical output defaults. |
+| Blank `AXON_SQLITE_PATH=` could point SQLite at an empty path. | Blank `AXON_SQLITE_PATH` falls through to `~/.axon/jobs.db`. |
+| Blank `AXON_LOG_DIR=` caused appender creation warnings. | Blank log path env values fall through to `~/.axon/logs/axon.log`. |
+| Docker builder started from Rust 1.83 then rustup-installed 1.94.0. | Docker builder starts from Rust 1.94.0. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo check -q` | Rust check passes | Passed | pass |
+| `cargo test -q output_dir -- --test-threads=1` | output-dir env tests pass | 4 passed | pass |
+| `cargo test -q sqlite_path -- --test-threads=1` | sqlite-path env test passes | 1 passed | pass |
+| `cargo test -q version_bearing_files_stay_in_sync` | version files in sync | Passed | pass |
+| `docker build --target builder -f config/Dockerfile . --progress=plain` | second build uses cached builder steps | completed in 1.517s on immediate repeat | pass |
+| `axon crawl https://help.getzep.com/overview --max-pages 1 --wait false --json` | submits crawl via server mode | returned job `547924c2-9589-4741-be47-2f04a37b3a57` | pass |
+| pre-commit hook | monolith, rustfmt, env guard, clippy, tests pass | all passed | pass |
+
+## Risks and Rollback
+
+- Risk: Docker builder image tag `rust:1.94.0-bookworm` must remain available upstream. Roll back `config/Dockerfile` to the prior builder image if unavailable.
+- Risk: machine-local `~/.axon/.env` was adjusted during validation but is not tracked in this commit.
+- Rollback path: revert commit `870aeb34` and restore the previous `~/.axon/.env` values if server publication needs to return to loopback only.
+
+## Decisions Not Taken
+
+- Did not add `cargo-chef`; exact toolchain alignment gave a low-risk cache improvement and verified immediate repeat builds at 1.517s.
+- Did not weaken the plaintext bearer-token guard; used explicit `AXON_SERVER_INSECURE=1` only for the trusted tailnet endpoint.
+
+## Open Questions
+
+- Whether `sccache.service` should get a memory limit, lower job concurrency, or a monitoring alert after the observed OOM kill.
+- Whether Docker build cache should be further improved with dependency-layer planning such as cargo-chef.
+
+## Next Steps
+
+- Open a PR for `fix/empty-env-and-docker-cache`.
+- Consider a separate follow-up to harden the user `sccache` service against OOM restarts.

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -9,6 +9,7 @@ use crate::services::system::{build_status_payload, load_status_jobs};
 use crate::services::types::ServiceJob;
 use std::collections::HashMap;
 use std::error::Error;
+use std::fmt::Write as _;
 
 pub async fn run_status(
     cfg: &Config,
@@ -59,29 +60,62 @@ async fn run_status_impl(
     service_context: &ServiceContext,
 ) -> Result<(), Box<dyn Error>> {
     let (jobs, _totals) = load_status_jobs(service_context).await?;
-    let crawl_url_map: HashMap<uuid::Uuid, &str> = jobs
-        .crawl
+    print!("{}", render_status_jobs(&jobs));
+    Ok(())
+}
+
+pub(crate) fn render_status_payload(payload: &serde_json::Value) -> Result<String, Box<dyn Error>> {
+    #[derive(serde::Deserialize)]
+    struct StatusPayload {
+        local_crawl_jobs: Vec<ServiceJob>,
+        local_extract_jobs: Vec<ServiceJob>,
+        local_embed_jobs: Vec<ServiceJob>,
+        local_ingest_jobs: Vec<ServiceJob>,
+    }
+
+    let payload: StatusPayload = serde_json::from_value(payload.clone())?;
+    Ok(render_status_jobs_from_slices(
+        &payload.local_crawl_jobs,
+        &payload.local_extract_jobs,
+        &payload.local_embed_jobs,
+        &payload.local_ingest_jobs,
+    ))
+}
+
+fn render_status_jobs(jobs: &crate::services::system::StatusJobs) -> String {
+    render_status_jobs_from_slices(&jobs.crawl, &jobs.extract, &jobs.embed, &jobs.ingest)
+}
+
+fn render_status_jobs_from_slices(
+    crawl_jobs: &[ServiceJob],
+    extract_jobs: &[ServiceJob],
+    embed_jobs: &[ServiceJob],
+    ingest_jobs: &[ServiceJob],
+) -> String {
+    let crawl_url_map: HashMap<uuid::Uuid, &str> = crawl_jobs
         .iter()
         .filter_map(|job| {
             let url = job.url.as_deref()?;
             Some((job.id, url))
         })
         .collect();
-    let embed_jobs_by_id: HashMap<String, &ServiceJob> = jobs
-        .embed
+    let embed_jobs_by_id: HashMap<String, &ServiceJob> = embed_jobs
         .iter()
         .map(|job| (job.id.to_string(), job))
         .collect();
-    let embed_doc_totals = embed_doc_totals_from_crawls(&jobs.crawl);
-    print_status_section(
+    let embed_doc_totals = embed_doc_totals_from_crawls(crawl_jobs);
+    let mut out = String::new();
+    write_status_section(
+        &mut out,
         "Crawl",
-        &jobs.crawl,
+        crawl_jobs,
         |job| job.url.clone().unwrap_or_else(|| job.id.to_string()),
         |job| crawl_progress_summary(job, &embed_jobs_by_id, &embed_doc_totals),
     );
-    print_status_section(
+    write_status_section(
+        &mut out,
         "Extract",
-        &jobs.extract,
+        extract_jobs,
         |job| {
             job.urls_json
                 .as_ref()
@@ -90,9 +124,10 @@ async fn run_status_impl(
         },
         extract_progress_summary,
     );
-    print_status_section(
+    write_status_section(
+        &mut out,
         "Embed",
-        &jobs.embed,
+        embed_jobs,
         |job| {
             job.target
                 .as_deref()
@@ -101,9 +136,10 @@ async fn run_status_impl(
         },
         |job| embed_progress_summary(job, embed_doc_totals.get(&job.id.to_string()).copied()),
     );
-    print_status_section(
+    write_status_section(
+        &mut out,
         "Ingest",
-        &jobs.ingest,
+        ingest_jobs,
         |job| match (&job.source_type, &job.target) {
             (Some(source_type), Some(target)) => format!("{source_type}: {target}"),
             (_, Some(target)) => target.clone(),
@@ -111,7 +147,7 @@ async fn run_status_impl(
         },
         ingest_progress_summary,
     );
-    Ok(())
+    out
 }
 
 fn crawl_progress_summary(
@@ -253,23 +289,25 @@ fn ingest_progress_summary(job: &ServiceJob) -> Option<String> {
     Some(format!("{chunks} chunks"))
 }
 
-fn print_status_section(
+fn write_status_section(
+    out: &mut String,
     title: &str,
     jobs: &[ServiceJob],
     label_for: impl Fn(&ServiceJob) -> String,
     progress_for: impl Fn(&ServiceJob) -> Option<String>,
 ) {
-    println!("{}", primary(title));
+    let _ = writeln!(out, "{}", primary(title));
     if jobs.is_empty() {
-        println!("  {}", muted("None."));
-        println!();
+        let _ = writeln!(out, "  {}", muted("None."));
+        let _ = writeln!(out);
         return;
     }
 
     for job in jobs.iter().take(10) {
         let label = label_for(job);
         if let Some(p) = progress_for(job) {
-            println!(
+            let _ = writeln!(
+                out,
                 "  {} {} {} {}  {}",
                 symbol_for_status(&job.status),
                 human_status_text(&job.status),
@@ -278,7 +316,8 @@ fn print_status_section(
                 muted(&p),
             );
         } else {
-            println!(
+            let _ = writeln!(
+                out,
                 "  {} {} {} {}",
                 symbol_for_status(&job.status),
                 human_status_text(&job.status),
@@ -291,10 +330,10 @@ fn print_status_section(
             .as_deref()
             .and_then(|err| job_error_hint(&job.status, err))
         {
-            println!("    {}", muted(&err));
+            let _ = writeln!(out, "    {}", muted(&err));
         }
     }
-    println!();
+    let _ = writeln!(out);
 }
 
 fn job_error_hint(status: &str, error_text: &str) -> Option<String> {
@@ -309,4 +348,63 @@ fn job_error_hint(status: &str, error_text: &str) -> Option<String> {
         };
     }
     Some(error_text.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::system::StatusJobs;
+    use chrono::Utc;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    fn job(status: &str) -> ServiceJob {
+        ServiceJob {
+            id: Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap(),
+            status: status.to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            error_text: None,
+            url: Some("https://example.com/docs".to_string()),
+            source_type: None,
+            target: Some("https://example.com/docs".to_string()),
+            urls_json: None,
+            result_json: Some(json!({
+                "pages_crawled": 3,
+                "md_created": 2,
+                "elapsed_ms": 1200,
+                "docs_embedded": 2,
+                "docs_total": 2,
+                "chunks_embedded": 8
+            })),
+            config_json: None,
+        }
+    }
+
+    #[test]
+    fn render_status_payload_matches_local_renderer() {
+        let jobs = StatusJobs {
+            crawl: vec![job("completed")],
+            extract: Vec::new(),
+            embed: vec![job("completed")],
+            ingest: Vec::new(),
+        };
+        let payload = build_status_payload(
+            &jobs.crawl,
+            &jobs.extract,
+            &jobs.embed,
+            &jobs.ingest,
+            &crate::services::types::StatusTotals::default(),
+        );
+
+        let from_jobs = render_status_jobs(&jobs);
+        let from_payload = render_status_payload(&payload).expect("payload should render");
+
+        assert_eq!(from_payload, from_jobs);
+        assert!(from_payload.contains("Crawl"));
+        assert!(from_payload.contains("Embed"));
+        assert!(from_payload.contains("2 docs"));
+    }
 }

--- a/src/cli/server_mode.rs
+++ b/src/cli/server_mode.rs
@@ -141,7 +141,7 @@ fn render_server_result(
     }
 
     match cfg.command {
-        CommandKind::Status => render_server_status(result),
+        CommandKind::Status => render_server_status(result)?,
         CommandKind::Crawl => render_server_job_command("Crawl", result),
         CommandKind::Extract => render_server_job_command("Extract", result),
         CommandKind::Embed => render_server_job_command("Embed", result),
@@ -156,22 +156,13 @@ fn render_server_result(
     Ok(())
 }
 
-fn render_server_status(result: &serde_json::Value) {
-    println!("{}", primary("Axon Status (server mode)"));
-    if let Some(totals) = result.get("totals").and_then(|value| value.as_object()) {
-        for name in ["crawl", "extract", "embed", "ingest"] {
-            let count = totals
-                .get(name)
-                .and_then(|value| value.as_i64())
-                .unwrap_or(0);
-            println!("  {} {} total", muted(&format!("{name:<7}")), count);
-        }
-    } else {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(result).unwrap_or_else(|_| result.to_string())
-        );
-    }
+fn render_server_status(result: &serde_json::Value) -> Result<(), Box<dyn Error>> {
+    print!("{}", server_status_text(result)?);
+    Ok(())
+}
+
+fn server_status_text(result: &serde_json::Value) -> Result<String, Box<dyn Error>> {
+    cli::commands::status::render_status_payload(result)
 }
 
 fn render_server_job_command(title: &str, result: &serde_json::Value) {
@@ -306,6 +297,10 @@ fn server_mode_rejects_host_local_embed_input(input: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::types::ServiceJob;
+    use chrono::Utc;
+    use serde_json::json;
+    use uuid::Uuid;
 
     fn cfg(command: CommandKind, positional: &[&str]) -> Config {
         let mut cfg = Config::test_default();
@@ -416,5 +411,49 @@ mod tests {
                 .contains("server mode does not accept host-local embed paths yet"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn server_status_text_matches_local_status_renderer() {
+        let job = ServiceJob {
+            id: Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap(),
+            status: "completed".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            error_text: None,
+            url: Some("https://example.com/docs".to_string()),
+            source_type: None,
+            target: Some("https://example.com/docs".to_string()),
+            urls_json: None,
+            result_json: Some(json!({
+                "md_created": 2,
+                "elapsed_ms": 1200,
+                "docs_embedded": 2,
+                "docs_total": 2,
+                "chunks_embedded": 8
+            })),
+            config_json: None,
+        };
+        let payload = json!({
+            "local_crawl_jobs": [job.clone()],
+            "local_extract_jobs": [],
+            "local_embed_jobs": [job],
+            "local_ingest_jobs": [],
+            "totals": {
+                "crawl": 1,
+                "extract": 0,
+                "embed": 1,
+                "ingest": 0
+            }
+        });
+
+        let rendered = server_status_text(&payload).expect("status payload should render");
+
+        assert!(rendered.contains("Crawl"));
+        assert!(rendered.contains("Embed"));
+        assert!(!rendered.contains("server mode"));
+        assert!(rendered.contains("2 docs"));
     }
 }

--- a/src/core/config/cli.rs
+++ b/src/core/config/cli.rs
@@ -3,7 +3,7 @@ mod global_args;
 use super::types::{EvaluateResponsesMode, MapFallback, McpTransport, RedditSort, RedditTime};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
-pub(super) use global_args::GlobalArgs;
+pub(super) use global_args::{DEFAULT_OUTPUT_DIR, GlobalArgs};
 
 #[derive(Debug, Parser)]
 #[command(

--- a/src/core/config/cli/global_args.rs
+++ b/src/core/config/cli/global_args.rs
@@ -2,6 +2,8 @@ use crate::core::config::types::{PerformanceProfile, RenderMode, ScrapeFormat};
 use clap::{ArgAction, Args};
 use std::path::PathBuf;
 
+pub(in crate::core::config) const DEFAULT_OUTPUT_DIR: &str = ".cache/axon-rust/output";
+
 #[derive(Debug, Args)]
 pub(in crate::core::config) struct GlobalArgs {
     #[arg(global = true, long, default_value = "")]
@@ -24,12 +26,7 @@ pub(in crate::core::config) struct GlobalArgs {
     pub(in crate::core::config) exclude_path_prefix: Vec<String>,
 
     /// Directory for saved markdown/HTML output files
-    #[arg(
-        global = true,
-        long,
-        default_value = ".cache/axon-rust/output",
-        env = "AXON_OUTPUT_DIR"
-    )]
+    #[arg(global = true, long, default_value = DEFAULT_OUTPUT_DIR)]
     pub(in crate::core::config) output_dir: PathBuf,
 
     /// Explicit output file path (overrides --output-dir)

--- a/src/core/config/parse.rs
+++ b/src/core/config/parse.rs
@@ -10,7 +10,7 @@ use super::cli::Cli;
 use super::help::maybe_print_top_level_help_and_exit;
 use super::types::Config;
 use crate::core::ui::report_error;
-use clap::{Command, CommandFactory, Parser};
+use clap::{Command, CommandFactory, FromArgMatches, parser::ValueSource};
 
 pub(crate) use docker::is_docker_service_host;
 
@@ -20,8 +20,11 @@ pub fn build_cli_command() -> Command {
 
 pub fn parse_args() -> Config {
     maybe_print_top_level_help_and_exit();
-    let cli = Cli::parse();
-    match build_config::into_config(cli) {
+    let matches = Cli::command().get_matches();
+    let output_dir_was_explicit =
+        matches.value_source("output_dir") == Some(ValueSource::CommandLine);
+    let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
+    match build_config::into_config_with_sources(cli, output_dir_was_explicit) {
         Ok(cfg) => cfg,
         Err(msg) => {
             report_error(&msg);

--- a/src/core/config/parse/build_config.rs
+++ b/src/core/config/parse/build_config.rs
@@ -13,7 +13,7 @@ mod post_init;
 #[cfg(test)]
 mod tests;
 
-use super::super::cli::Cli;
+use super::super::cli::{Cli, DEFAULT_OUTPUT_DIR};
 use super::super::types::{CommandKind, Config};
 use super::excludes;
 use super::helpers::{
@@ -23,7 +23,6 @@ use super::helpers::{
 // inside `config_literal::build` (via `resolve_mcp_transport`) so the
 // `cargo xtask check-mcp-http` grep keeps finding the canonical knob name.
 use super::toml_config::load_toml_config;
-use std::env;
 
 pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
     let mut global = cli.global;
@@ -74,12 +73,14 @@ pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
     let sqlite_path = global
         .sqlite_path
         .take()
-        .or_else(|| {
-            env::var("AXON_SQLITE_PATH")
-                .ok()
-                .map(std::path::PathBuf::from)
-        })
+        .or_else(|| read_env("AXON_SQLITE_PATH").map(std::path::PathBuf::from))
         .unwrap_or_else(default_sqlite_path);
+
+    if global.output_dir == std::path::Path::new(DEFAULT_OUTPUT_DIR)
+        && let Some(output_dir) = read_env("AXON_OUTPUT_DIR")
+    {
+        global.output_dir = std::path::PathBuf::from(output_dir);
+    }
 
     let mut crawl_concurrency_limit = global.crawl_concurrency_limit;
     let mut backfill_concurrency_limit = global.backfill_concurrency_limit;

--- a/src/core/config/parse/build_config.rs
+++ b/src/core/config/parse/build_config.rs
@@ -24,7 +24,15 @@ use super::helpers::{
 // `cargo xtask check-mcp-http` grep keeps finding the canonical knob name.
 use super::toml_config::load_toml_config;
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
+    into_config_with_sources(cli, false)
+}
+
+pub(super) fn into_config_with_sources(
+    cli: Cli,
+    output_dir_was_explicit: bool,
+) -> Result<Config, String> {
     let mut global = cli.global;
     let fetch_retries_was_set = global.fetch_retries.is_some();
     let retry_backoff_was_set = global.retry_backoff_ms.is_some();
@@ -76,7 +84,8 @@ pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
         .or_else(|| read_env("AXON_SQLITE_PATH").map(std::path::PathBuf::from))
         .unwrap_or_else(default_sqlite_path);
 
-    if global.output_dir == std::path::Path::new(DEFAULT_OUTPUT_DIR)
+    if !output_dir_was_explicit
+        && global.output_dir == std::path::Path::new(DEFAULT_OUTPUT_DIR)
         && let Some(output_dir) = read_env("AXON_OUTPUT_DIR")
     {
         global.output_dir = std::path::PathBuf::from(output_dir);
@@ -114,6 +123,7 @@ pub(super) fn into_config(cli: Cli) -> Result<Config, String> {
             disable_default_excludes: normalized_excludes.disable_defaults,
             fetch_retries_was_set,
             retry_backoff_was_set,
+            output_dir_was_explicit,
         },
     )?;
 

--- a/src/core/config/parse/build_config/post_init.rs
+++ b/src/core/config/parse/build_config/post_init.rs
@@ -4,8 +4,9 @@
 //!   * Validates the parent of `output_path` exists when explicitly set.
 //!   * Restores default exclude-path prefixes when the user did not opt out.
 //!   * Applies `performance::profile_settings()` to fields the user did not set.
-//!   * Derives `output_dir` from `AXON_DATA_DIR` when still at the clap default.
+//!   * Derives `output_dir` from the canonical Axon data directory when still at the clap default.
 
+use super::super::super::cli::DEFAULT_OUTPUT_DIR;
 use super::super::super::types::Config;
 use super::super::excludes;
 use super::super::performance;
@@ -54,11 +55,9 @@ pub(super) fn apply(cfg: &mut Config, ctx: PostInit) -> Result<(), String> {
     cfg.crawl_broadcast_buffer_min = ps.broadcast_buffer_min;
     cfg.crawl_broadcast_buffer_max = ps.broadcast_buffer_max;
 
-    // Derive output_dir from AXON_DATA_DIR when still at the clap default.
-    if cfg.output_dir == std::path::Path::new(".cache/axon-rust/output")
-        && let Some(data_dir) = crate::core::paths::axon_data_dir()
-    {
-        cfg.output_dir = data_dir.join("output");
+    // Derive output_dir from the canonical data directory when still at the clap default.
+    if cfg.output_dir == std::path::Path::new(DEFAULT_OUTPUT_DIR) {
+        cfg.output_dir = crate::core::paths::axon_data_base_dir().join("output");
     }
     Ok(())
 }

--- a/src/core/config/parse/build_config/post_init.rs
+++ b/src/core/config/parse/build_config/post_init.rs
@@ -16,6 +16,7 @@ pub(super) struct PostInit {
     pub disable_default_excludes: bool,
     pub fetch_retries_was_set: bool,
     pub retry_backoff_was_set: bool,
+    pub output_dir_was_explicit: bool,
 }
 
 pub(super) fn apply(cfg: &mut Config, ctx: PostInit) -> Result<(), String> {
@@ -56,7 +57,7 @@ pub(super) fn apply(cfg: &mut Config, ctx: PostInit) -> Result<(), String> {
     cfg.crawl_broadcast_buffer_max = ps.broadcast_buffer_max;
 
     // Derive output_dir from the canonical data directory when still at the clap default.
-    if cfg.output_dir == std::path::Path::new(DEFAULT_OUTPUT_DIR) {
+    if !ctx.output_dir_was_explicit && cfg.output_dir == std::path::Path::new(DEFAULT_OUTPUT_DIR) {
         cfg.output_dir = crate::core::paths::axon_data_base_dir().join("output");
     }
     Ok(())

--- a/src/core/config/parse/build_config/tests.rs
+++ b/src/core/config/parse/build_config/tests.rs
@@ -11,10 +11,10 @@
 mod lite_mode;
 mod priority_chain;
 
-pub(super) use super::into_config;
+pub(super) use super::{into_config, into_config_with_sources};
 pub(super) use crate::core::config::cli::Cli;
 pub(super) use crate::core::config::parse::docker::normalize_local_service_url;
-pub(super) use clap::Parser;
+pub(super) use clap::{CommandFactory, FromArgMatches, Parser, parser::ValueSource};
 pub(super) use std::env;
 pub(super) use std::io::Write as _;
 pub(super) use std::path::Path;
@@ -34,6 +34,22 @@ pub(super) fn cli_with_services(extra: &[&str]) -> Cli {
     ];
     args.extend_from_slice(extra);
     Cli::parse_from(args)
+}
+
+pub(super) fn cli_with_services_and_sources(extra: &[&str]) -> (Cli, bool) {
+    let mut args = vec![
+        "axon",
+        "--qdrant-url",
+        "http://127.0.0.1:53333",
+        "--tei-url",
+        "http://127.0.0.1:52000",
+    ];
+    args.extend_from_slice(extra);
+    let matches = Cli::command().get_matches_from(args);
+    let output_dir_was_explicit =
+        matches.value_source("output_dir") == Some(ValueSource::CommandLine);
+    let cli = Cli::from_arg_matches(&matches).expect("cli should parse");
+    (cli, output_dir_was_explicit)
 }
 
 /// Save/restore an env var around a test body so panics don't leak state.
@@ -120,5 +136,28 @@ fn output_dir_flag_wins_over_env() {
         .expect("--output-dir flag should parse");
 
         assert_eq!(cfg.output_dir, Path::new("/tmp/axon-output-from-flag"));
+    });
+}
+
+#[allow(unsafe_code)]
+#[test]
+fn explicit_default_output_dir_flag_wins_over_env() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    with_env_saved(&["AXON_OUTPUT_DIR"], || unsafe {
+        env::set_var("AXON_OUTPUT_DIR", "/tmp/axon-output-from-env");
+
+        let (cli, output_dir_was_explicit) = cli_with_services_and_sources(&[
+            "--output-dir",
+            crate::core::config::cli::DEFAULT_OUTPUT_DIR,
+            "crawl",
+            "https://example.com",
+        ]);
+        let cfg = into_config_with_sources(cli, output_dir_was_explicit)
+            .expect("explicit default --output-dir should parse");
+
+        assert_eq!(
+            cfg.output_dir,
+            Path::new(crate::core::config::cli::DEFAULT_OUTPUT_DIR)
+        );
     });
 }

--- a/src/core/config/parse/build_config/tests.rs
+++ b/src/core/config/parse/build_config/tests.rs
@@ -17,6 +17,7 @@ pub(super) use crate::core::config::parse::docker::normalize_local_service_url;
 pub(super) use clap::Parser;
 pub(super) use std::env;
 pub(super) use std::io::Write as _;
+pub(super) use std::path::Path;
 pub(super) use std::sync::Mutex;
 pub(super) use tempfile::Builder as TempfileBuilder;
 
@@ -51,4 +52,73 @@ pub(super) fn with_env_saved<F: FnOnce()>(keys: &[&str], body: F) {
             }
         }
     }
+}
+
+#[allow(unsafe_code)]
+#[test]
+fn empty_output_dir_env_falls_through_to_default_data_dir_output() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    with_env_saved(&["AXON_OUTPUT_DIR", "AXON_DATA_DIR"], || unsafe {
+        env::set_var("AXON_OUTPUT_DIR", "");
+        env::remove_var("AXON_DATA_DIR");
+
+        let cfg = into_config(cli_with_services(&["crawl", "https://example.com"]))
+            .expect("empty AXON_OUTPUT_DIR should not fail clap/config parsing");
+
+        assert_eq!(
+            cfg.output_dir,
+            crate::core::paths::axon_data_base_dir().join("output")
+        );
+    });
+}
+
+#[allow(unsafe_code)]
+#[test]
+fn empty_sqlite_path_env_falls_through_to_default_jobs_db() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    with_env_saved(&["AXON_SQLITE_PATH", "AXON_DATA_DIR"], || unsafe {
+        env::set_var("AXON_SQLITE_PATH", "");
+        env::remove_var("AXON_DATA_DIR");
+
+        let cfg = into_config(cli_with_services(&["crawl", "https://example.com"]))
+            .expect("empty AXON_SQLITE_PATH should not produce an empty database path");
+
+        assert_eq!(
+            cfg.sqlite_path,
+            crate::core::paths::axon_data_base_dir().join("jobs.db")
+        );
+    });
+}
+
+#[allow(unsafe_code)]
+#[test]
+fn nonempty_output_dir_env_overrides_default() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    with_env_saved(&["AXON_OUTPUT_DIR"], || unsafe {
+        env::set_var("AXON_OUTPUT_DIR", "/tmp/axon-output-from-env");
+
+        let cfg = into_config(cli_with_services(&["crawl", "https://example.com"]))
+            .expect("non-empty AXON_OUTPUT_DIR should parse");
+
+        assert_eq!(cfg.output_dir, Path::new("/tmp/axon-output-from-env"));
+    });
+}
+
+#[allow(unsafe_code)]
+#[test]
+fn output_dir_flag_wins_over_env() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    with_env_saved(&["AXON_OUTPUT_DIR"], || unsafe {
+        env::set_var("AXON_OUTPUT_DIR", "/tmp/axon-output-from-env");
+
+        let cfg = into_config(cli_with_services(&[
+            "--output-dir",
+            "/tmp/axon-output-from-flag",
+            "crawl",
+            "https://example.com",
+        ]))
+        .expect("--output-dir flag should parse");
+
+        assert_eq!(cfg.output_dir, Path::new("/tmp/axon-output-from-flag"));
+    });
 }

--- a/src/core/http.rs
+++ b/src/core/http.rs
@@ -17,6 +17,7 @@ mod ssrf;
 mod tests;
 
 // Re-export the full public API so downstream `use crate::core::http::*` continues to work.
+pub(crate) use client::internal_service_http_client;
 pub use client::{build_client, fetch_html, http_client};
 pub use error::HttpError;
 pub use headers::parse_custom_headers;

--- a/src/core/http/client.rs
+++ b/src/core/http/client.rs
@@ -15,10 +15,24 @@ pub(crate) static HTTP_CLIENT: LazyLock<Result<reqwest::Client, String>> = LazyL
 });
 
 #[cfg(not(test))]
+pub(crate) static INTERNAL_SERVICE_HTTP_CLIENT: LazyLock<Result<reqwest::Client, String>> =
+    LazyLock::new(|| {
+        let ua = std::env::var("AXON_CHROME_USER_AGENT").ok();
+        build_client_without_ssrf_resolver(30, ua.as_deref()).map_err(|e| e.to_string())
+    });
+
+#[cfg(not(test))]
 pub fn http_client() -> anyhow::Result<&'static reqwest::Client> {
     HTTP_CLIENT
         .as_ref()
         .map_err(|err| anyhow::Error::msg(format!("failed to initialize HTTP client: {err}")))
+}
+
+#[cfg(not(test))]
+pub(crate) fn internal_service_http_client() -> anyhow::Result<&'static reqwest::Client> {
+    INTERNAL_SERVICE_HTTP_CLIENT.as_ref().map_err(|err| {
+        anyhow::Error::msg(format!("failed to initialize internal HTTP client: {err}"))
+    })
 }
 
 #[cfg(test)]
@@ -35,10 +49,34 @@ pub fn http_client() -> anyhow::Result<&'static reqwest::Client> {
     Ok(Box::leak(Box::new(client)))
 }
 
+#[cfg(test)]
+pub(crate) fn internal_service_http_client() -> anyhow::Result<&'static reqwest::Client> {
+    http_client()
+}
+
 pub fn build_client(
     timeout_secs: u64,
     user_agent: Option<&str>,
 ) -> Result<reqwest::Client, HttpError> {
+    build_client_with_options(timeout_secs, user_agent, true)
+}
+
+#[cfg(not(test))]
+fn build_client_without_ssrf_resolver(
+    timeout_secs: u64,
+    user_agent: Option<&str>,
+) -> Result<reqwest::Client, HttpError> {
+    build_client_with_options(timeout_secs, user_agent, false)
+}
+
+fn build_client_with_options(
+    timeout_secs: u64,
+    user_agent: Option<&str>,
+    ssrf_dns_guard: bool,
+) -> Result<reqwest::Client, HttpError> {
+    #[cfg(test)]
+    let _ = ssrf_dns_guard;
+
     // Explicit connection pool sizing. reqwest defaults `pool_max_idle_per_host`
     // to `usize::MAX`, which under sustained dual-Qdrant + TEI load on a single
     // host can drift toward ephemeral-port pressure (Linux default range ~28K).
@@ -64,7 +102,9 @@ pub fn build_client(
     // validate_url() still guards parse-time SSRF checks in tests.
     #[cfg(not(test))]
     {
-        builder = builder.dns_resolver(super::ssrf::SsrfBlockingResolver);
+        if ssrf_dns_guard {
+            builder = builder.dns_resolver(super::ssrf::SsrfBlockingResolver);
+        }
     }
     if let Some(ua) = user_agent {
         builder = builder.user_agent(ua);

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -13,6 +13,13 @@ use tracing_subscriber::fmt::{
 };
 use tracing_subscriber::registry::LookupSpan;
 
+fn read_trimmed_env(var: &str) -> Option<String> {
+    std::env::var(var)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
 // ── Console event formatter ──────────────────────────────────────────────────
 //
 // Renders log lines on stderr as:
@@ -232,14 +239,10 @@ pub fn init_tracing() -> tracing_appender::non_blocking::WorkerGuard {
     //
     // tracing_appender::non_blocking serialises writes through one worker
     // thread, so the guard MUST be held for the process lifetime.
-    let log_dir: PathBuf = std::env::var("AXON_LOG_DIR")
+    let log_dir: PathBuf = read_trimmed_env("AXON_LOG_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            super::paths::axon_data_dir()
-                .map(|d| d.join("logs"))
-                .unwrap_or_else(|| PathBuf::from("logs"))
-        });
-    let log_file_name = std::env::var("AXON_LOG_FILE").unwrap_or_else(|_| "axon.log".to_string());
+        .unwrap_or_else(|| super::paths::axon_data_base_dir().join("logs"));
+    let log_file_name = read_trimmed_env("AXON_LOG_FILE").unwrap_or_else(|| "axon.log".to_string());
 
     let max_bytes = std::env::var("AXON_LOG_MAX_BYTES")
         .ok()

--- a/src/mcp/server/http.rs
+++ b/src/mcp/server/http.rs
@@ -51,6 +51,14 @@ pub async fn run_unified_server(
     let setup_required = panel.setup_required();
     let cfg_arc = Arc::new(cfg.clone());
     let service_context = Arc::new(OnceCell::<Arc<ServiceContext>>::new());
+    let eager_context = Arc::new(
+        ServiceContext::new_with_workers(Arc::clone(&cfg_arc))
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error> { e })?,
+    );
+    service_context
+        .set(eager_context)
+        .map_err(|_| "serve: failed to initialize service context")?;
     let web_router = crate::web::router(
         Arc::clone(&cfg_arc),
         panel,

--- a/src/vector/ops/qdrant/client.rs
+++ b/src/vector/ops/qdrant/client.rs
@@ -8,7 +8,7 @@
 //! - All delete operations use [`qdrant_delete_with_retry`] with exponential backoff.
 
 use crate::core::config::Config;
-use crate::core::http::http_client;
+use crate::core::http::internal_service_http_client;
 use crate::core::logging::log_warn;
 use anyhow::{Result, anyhow};
 use reqwest::StatusCode;
@@ -173,7 +173,7 @@ pub(crate) async fn qdrant_scroll_pages_selective(
     with_payload: serde_json::Value,
     process_page: impl FnMut(&[serde_json::Value]) -> bool,
 ) -> Result<()> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let endpoint = qdrant_collection_endpoint(cfg, "points/scroll")?;
     let body = serde_json::json!({
         "limit": 256,
@@ -191,7 +191,7 @@ async fn scroll_url_set(
     filter: serde_json::Value,
     limit: Option<usize>,
 ) -> Result<HashSet<String>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let endpoint = qdrant_collection_endpoint(cfg, "points/scroll")?;
     let mut seen = HashSet::new();
     let body = serde_json::json!({
@@ -242,7 +242,7 @@ pub async fn qdrant_urls_for_domain(cfg: &Config, domain: &str) -> Result<HashSe
 /// Delete all Qdrant points matching `url` via payload filter.
 #[cfg(test)]
 pub(crate) async fn qdrant_delete_by_url_filter(cfg: &Config, url: &str) -> Result<()> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let endpoint = qdrant_collection_endpoint(cfg, "points/delete?wait=true")?;
     qdrant_delete_with_retry(
         client,
@@ -273,7 +273,7 @@ pub(crate) async fn qdrant_delete_stale_tail(
     url: &str,
     new_chunk_count: usize,
 ) -> Result<()> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let endpoint = qdrant_collection_endpoint(cfg, "points/delete?wait=false")?;
     qdrant_delete_with_retry(
         client,
@@ -313,7 +313,7 @@ pub async fn qdrant_delete_stale_domain_urls(
         .iter()
         .map(|url| serde_json::json!({"key": "url", "match": {"value": url}}))
         .collect();
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     // Use wait=false for maintenance deletes — matches qdrant_delete_stale_tail pattern.
     // The preceding scroll already verified which URLs are stale; no immediate
     // consistency is needed, and wait=true blocks on HNSW index rebuild per batch.
@@ -337,7 +337,7 @@ pub(crate) async fn qdrant_delete_points(cfg: &Config, ids: &[String]) -> Result
     if ids.is_empty() {
         return Ok(0);
     }
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = qdrant_collection_endpoint(cfg, "points/delete?wait=true")?;
     for batch in ids.chunks(1000) {
         qdrant_delete_with_retry(
@@ -376,7 +376,7 @@ pub(crate) async fn qdrant_facet_filtered(
     limit: usize,
     filter: serde_json::Value,
 ) -> Result<Vec<(String, usize)>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = qdrant_collection_endpoint(cfg, "facet")?;
     let mut body = serde_json::json!({
         "key": key,
@@ -461,7 +461,7 @@ pub(crate) async fn qdrant_retrieve_by_url_details(
     url_match: &str,
     max_points: Option<usize>,
 ) -> Result<QdrantRetrieveByUrlResult> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let endpoint = qdrant_collection_endpoint(cfg, "points/scroll")?;
     let url_filter = super::filter::url_filter(url_match);
     let filter =

--- a/src/vector/ops/qdrant/dual_search.rs
+++ b/src/vector/ops/qdrant/dual_search.rs
@@ -34,7 +34,7 @@
 //!   process for legacy collections, then the VectorMode cache kicks in).
 
 use crate::core::config::Config;
-use crate::core::http::http_client;
+use crate::core::http::internal_service_http_client;
 use crate::core::logging::log_debug;
 use crate::vector::ops::sparse::SparseVector;
 use crate::vector::ops::tei::qdrant_store::{VectorMode, get_or_fetch_vector_mode};
@@ -171,7 +171,7 @@ pub(crate) async fn qdrant_dual_search(
         "searches": [primary_body, secondary_body],
     });
 
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = qdrant_collection_endpoint(cfg, "points/query/batch")?;
 
     let started = Instant::now();

--- a/src/vector/ops/qdrant/hybrid.rs
+++ b/src/vector/ops/qdrant/hybrid.rs
@@ -4,7 +4,7 @@
 //! Only called for collections in `VectorMode::Named` (named dense + sparse vectors).
 
 use crate::core::config::Config;
-use crate::core::http::http_client;
+use crate::core::http::internal_service_http_client;
 use crate::core::logging::log_debug;
 use crate::vector::ops::sparse::SparseVector;
 use anyhow::Result;
@@ -98,7 +98,7 @@ pub(crate) async fn qdrant_hybrid_search(
     candidates_override: Option<usize>,
     filter: Option<&serde_json::Value>,
 ) -> Result<Vec<QdrantSearchHit>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = qdrant_collection_endpoint(cfg, "points/query")?;
 
     let candidates = candidates_override
@@ -172,7 +172,7 @@ pub(crate) async fn qdrant_named_dense_search(
     limit: usize,
     filter: Option<&serde_json::Value>,
 ) -> Result<Vec<QdrantSearchHit>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = qdrant_collection_endpoint(cfg, "points/query")?;
 
     let hnsw_ef = cfg.hnsw_ef_search;

--- a/src/vector/ops/qdrant/search.rs
+++ b/src/vector/ops/qdrant/search.rs
@@ -5,7 +5,7 @@
 //! [`hybrid`](super::hybrid).
 
 use crate::core::config::Config;
-use crate::core::http::http_client;
+use crate::core::http::internal_service_http_client;
 use crate::core::logging::log_debug;
 use anyhow::Result;
 use std::time::Instant;
@@ -28,7 +28,7 @@ pub(crate) async fn qdrant_search(
     limit: usize,
     filter: Option<&serde_json::Value>,
 ) -> Result<Vec<QdrantSearchHit>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = qdrant_collection_endpoint(cfg, "points/search")?;
     let hnsw_ef = cfg.hnsw_ef_search_legacy;
     let search_start = Instant::now();

--- a/src/vector/ops/stats.rs
+++ b/src/vector/ops/stats.rs
@@ -3,11 +3,11 @@ mod pg;
 mod qdrant_fetch;
 
 use crate::core::config::Config;
-use crate::core::http::http_client;
+use crate::core::http::internal_service_http_client;
 use std::error::Error;
 
 pub async fn stats_payload(cfg: &Config) -> Result<serde_json::Value, Box<dyn Error>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let (info, count, docs_count) = qdrant_fetch::fetch_qdrant_snapshots(cfg, client).await?;
 
     let points_count = count["result"]["count"].as_u64().unwrap_or(0);

--- a/src/vector/ops/tei/qdrant_store.rs
+++ b/src/vector/ops/tei/qdrant_store.rs
@@ -1,5 +1,5 @@
 use crate::core::config::Config;
-use crate::core::http::http_client;
+use crate::core::http::internal_service_http_client;
 use crate::core::logging::{log_debug, log_info, log_warn};
 use crate::vector::ops::qdrant::{env_usize_clamped, qdrant_base};
 use reqwest::StatusCode;
@@ -141,7 +141,7 @@ pub(crate) async fn get_or_fetch_vector_mode(cfg: &Config) -> Result<VectorMode,
             cfg.collection, mode
         ));
     }
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = format!("{}/collections/{}", qdrant_base(cfg), cfg.collection);
     const MODE_PROBE_MAX_ATTEMPTS: usize = 3;
     let mut resp = None;
@@ -279,7 +279,7 @@ pub(super) async fn ensure_collection(
     cfg: &Config,
     dim: usize,
 ) -> Result<VectorMode, Box<dyn Error>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = format!("{}/collections/{}", qdrant_base(cfg), cfg.collection);
 
     let get_resp = client.get(&url).send().await?;
@@ -359,7 +359,7 @@ pub(super) async fn ensure_collection(
 
 /// PATCH an existing Named collection to add the `bm42` sparse vector config.
 async fn patch_add_sparse(cfg: &Config) -> Result<(), Box<dyn Error>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let url = format!("{}/collections/{}", qdrant_base(cfg), cfg.collection);
     client
         .patch(&url)
@@ -393,7 +393,7 @@ pub(super) async fn qdrant_upsert(
     if points.is_empty() {
         return Ok(());
     }
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let upsert_batch_size = env_usize_clamped("AXON_QDRANT_UPSERT_BATCH_SIZE", 256, 1, 4096);
     let url = format!(
         "{}/collections/{}/points?wait=true",

--- a/src/vector/ops/tei/qdrant_store/payload_indexes.rs
+++ b/src/vector/ops/tei/qdrant_store/payload_indexes.rs
@@ -1,5 +1,5 @@
 use crate::core::config::Config;
-use crate::core::http::http_client;
+use crate::core::http::internal_service_http_client;
 use crate::vector::ops::qdrant::qdrant_base;
 use std::error::Error;
 use std::future::Future;
@@ -12,7 +12,7 @@ type IndexFut<'a> =
 /// These indexes are required by the Qdrant `/facet` endpoint used by the
 /// `domains` and `sources` MCP actions. The operation is idempotent.
 pub(super) async fn ensure_payload_indexes(cfg: &Config) -> Result<(), Box<dyn Error>> {
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let index_url = format!(
         "{}/collections/{}/index?wait=false",
         qdrant_base(cfg),

--- a/src/vector/ops/tei/tei_client.rs
+++ b/src/vector/ops/tei/tei_client.rs
@@ -1,5 +1,5 @@
 use crate::core::config::Config;
-use crate::core::http::http_client;
+use crate::core::http::internal_service_http_client;
 use crate::core::logging::{log_debug, log_warn};
 use crate::vector::ops::qdrant::env_usize_clamped;
 use rand::RngExt as _;
@@ -251,7 +251,7 @@ async fn tei_embed_raw(cfg: &Config, inputs: &[String]) -> Result<Vec<Vec<f32>>,
     if inputs.is_empty() {
         return Ok(Vec::new());
     }
-    let client = http_client()?;
+    let client = internal_service_http_client()?;
     let mut vectors = Vec::new();
 
     let batch_size = cfg.tei_max_client_batch_size.clamp(1, 128);


### PR DESCRIPTION
- **fix(config): ignore blank optional path envs**
- **docs: save empty env fix session**
- **fix: unify server-mode status output**
- **fix: isolate internal service http routing**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank env path handling and preserves an explicit --output-dir, unifies `axon status` output, routes Qdrant/TEI calls through an internal client, aligns Docker/dev setup, and makes the Claude review workflow best-effort.

- **Bug Fixes**
  - Ignore blank path envs (`AXON_OUTPUT_DIR`, `AXON_SQLITE_PATH`, `AXON_LOG_DIR`/`AXON_LOG_FILE`) and preserve an explicit `--output-dir` even if it matches the default.
  - Server mode `axon status` now uses the same detailed renderer as local mode.
  - Route Qdrant/TEI calls through an internal service HTTP client; eagerly init the server service context; set `AXON_SERVER_URL=""` in the Docker service to keep maintenance calls local.
  - CI: mark `anthropics/claude-code-action` as best-effort (`continue-on-error: true`) and emit a warning instead of failing the PR when unavailable.

- **Dependencies**
  - Update Docker builder to `rust:1.94.0-bookworm`; bump versions to 1.9.5 in Cargo and `@axon/admin-panel`.
  - Simplify portable `sccache` setup in `Justfile` (no user-specific paths; default UDS/log vars).

<sup>Written for commit 604687dd73cfa13142afd022a7bb54b5c8846f7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

