### PR TITLE
Crawl status + watchdog recovery

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "1.9.5",
+  "version": "1.10.1",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -407,4 +407,30 @@ mod tests {
         assert!(from_payload.contains("Embed"));
         assert!(from_payload.contains("2 docs"));
     }
+
+    #[test]
+    fn render_status_payload_surfaces_reclaimed_pending_crawl_rows() {
+        let mut reclaimed = job("pending");
+        reclaimed.error_text = Some("reclaimed after unexpected shutdown".to_string());
+        reclaimed.result_json = None;
+
+        let payload = build_status_payload(
+            &[reclaimed],
+            &[],
+            &[],
+            &[],
+            &crate::services::types::StatusTotals::default(),
+        );
+
+        let rendered = render_status_payload(&payload).expect("payload should render");
+
+        assert!(
+            rendered.contains("recovered after worker shutdown"),
+            "expected reclaim hint; got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("reclaimed after unexpected shutdown"),
+            "raw reclaim marker leaked into output:\n{rendered}"
+        );
+    }
 }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -69,7 +69,7 @@ async fn run_status_impl(
     Ok(())
 }
 
-pub(crate) fn render_status_payload(payload: &serde_json::Value) -> Result<String, Box<dyn Error>> {
+pub(crate) fn render_status_payload(value: &serde_json::Value) -> Result<String, Box<dyn Error>> {
     #[derive(serde::Deserialize)]
     struct StatusPayload {
         local_crawl_jobs: Vec<ServiceJob>,
@@ -78,30 +78,46 @@ pub(crate) fn render_status_payload(payload: &serde_json::Value) -> Result<Strin
         local_ingest_jobs: Vec<ServiceJob>,
     }
 
-    let crawl_total = payload
+    // Defensive: clamp negative totals to 0 so a malformed payload can't
+    // either suppress the truncation note or panic the formatter.
+    let crawl_total = value
         .get("totals")
         .and_then(|t| t.get("crawl"))
         .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(0);
 
-    let p: StatusPayload = serde_json::from_value(payload.clone())?;
+    let parsed: StatusPayload = serde_json::from_value(value.clone())?;
+    let crawl_note = crawl_truncation_note(parsed.local_crawl_jobs.len(), crawl_total);
     Ok(render_status_jobs_from_slices(
-        &p.local_crawl_jobs,
-        &p.local_extract_jobs,
-        &p.local_embed_jobs,
-        &p.local_ingest_jobs,
-        crawl_total,
+        &parsed.local_crawl_jobs,
+        &parsed.local_extract_jobs,
+        &parsed.local_embed_jobs,
+        &parsed.local_ingest_jobs,
+        crawl_note.as_deref(),
     ))
 }
 
 fn render_status_jobs(jobs: &crate::services::system::StatusJobs, crawl_total: i64) -> String {
+    let crawl_note = crawl_truncation_note(jobs.crawl.len(), crawl_total.max(0));
     render_status_jobs_from_slices(
         &jobs.crawl,
         &jobs.extract,
         &jobs.embed,
         &jobs.ingest,
-        crawl_total,
+        crawl_note.as_deref(),
     )
+}
+
+/// Returns "showing N of M …" when the renderer will hide rows. N reflects
+/// what `write_status_section` will actually display (capped at
+/// `SECTION_DISPLAY_LIMIT`), so the note never advertises a count the
+/// renderer won't show.
+fn crawl_truncation_note(slice_len: usize, total: i64) -> Option<String> {
+    let displayed = slice_len.min(SECTION_DISPLAY_LIMIT);
+    let displayed_i64 = i64::try_from(displayed).unwrap_or(i64::MAX);
+    (total > displayed_i64)
+        .then(|| format!("showing {displayed} of {total} total · running jobs listed first"))
 }
 
 fn render_status_jobs_from_slices(
@@ -109,7 +125,7 @@ fn render_status_jobs_from_slices(
     extract_jobs: &[ServiceJob],
     embed_jobs: &[ServiceJob],
     ingest_jobs: &[ServiceJob],
-    crawl_total: i64,
+    crawl_note: Option<&str>,
 ) -> String {
     let crawl_url_map: HashMap<uuid::Uuid, &str> = crawl_jobs
         .iter()
@@ -123,18 +139,11 @@ fn render_status_jobs_from_slices(
         .map(|job| (job.id.to_string(), job))
         .collect();
     let embed_doc_totals = embed_doc_totals_from_crawls(crawl_jobs);
-    // write_status_section caps display at SECTION_DISPLAY_LIMIT rows; mirror
-    // that here so the truncation note never advertises a count the renderer
-    // won't actually show.
-    let crawl_displayed = crawl_jobs.len().min(SECTION_DISPLAY_LIMIT);
-    let crawl_note = (crawl_total > crawl_displayed as i64).then(|| {
-        format!("showing {crawl_displayed} of {crawl_total} total · running jobs listed first")
-    });
     let mut out = String::new();
     write_status_section(
         &mut out,
         "Crawl",
-        crawl_note.as_deref(),
+        crawl_note,
         crawl_jobs,
         |job| job.url.clone().unwrap_or_else(|| job.id.to_string()),
         |job| crawl_progress_summary(job, &embed_jobs_by_id, &embed_doc_totals),

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -60,8 +60,8 @@ async fn run_status_impl(
     _cfg: &Config,
     service_context: &ServiceContext,
 ) -> Result<(), Box<dyn Error>> {
-    let (jobs, _totals) = load_status_jobs(service_context).await?;
-    print!("{}", render_status_jobs(&jobs));
+    let (jobs, totals) = load_status_jobs(service_context).await?;
+    print!("{}", render_status_jobs(&jobs, totals.crawl));
     Ok(())
 }
 
@@ -74,17 +74,30 @@ pub(crate) fn render_status_payload(payload: &serde_json::Value) -> Result<Strin
         local_ingest_jobs: Vec<ServiceJob>,
     }
 
-    let payload: StatusPayload = serde_json::from_value(payload.clone())?;
+    let crawl_total = payload
+        .get("totals")
+        .and_then(|t| t.get("crawl"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    let p: StatusPayload = serde_json::from_value(payload.clone())?;
     Ok(render_status_jobs_from_slices(
-        &payload.local_crawl_jobs,
-        &payload.local_extract_jobs,
-        &payload.local_embed_jobs,
-        &payload.local_ingest_jobs,
+        &p.local_crawl_jobs,
+        &p.local_extract_jobs,
+        &p.local_embed_jobs,
+        &p.local_ingest_jobs,
+        crawl_total,
     ))
 }
 
-fn render_status_jobs(jobs: &crate::services::system::StatusJobs) -> String {
-    render_status_jobs_from_slices(&jobs.crawl, &jobs.extract, &jobs.embed, &jobs.ingest)
+fn render_status_jobs(jobs: &crate::services::system::StatusJobs, crawl_total: i64) -> String {
+    render_status_jobs_from_slices(
+        &jobs.crawl,
+        &jobs.extract,
+        &jobs.embed,
+        &jobs.ingest,
+        crawl_total,
+    )
 }
 
 fn render_status_jobs_from_slices(
@@ -92,6 +105,7 @@ fn render_status_jobs_from_slices(
     extract_jobs: &[ServiceJob],
     embed_jobs: &[ServiceJob],
     ingest_jobs: &[ServiceJob],
+    crawl_total: i64,
 ) -> String {
     let crawl_url_map: HashMap<uuid::Uuid, &str> = crawl_jobs
         .iter()
@@ -105,10 +119,18 @@ fn render_status_jobs_from_slices(
         .map(|job| (job.id.to_string(), job))
         .collect();
     let embed_doc_totals = embed_doc_totals_from_crawls(crawl_jobs);
+    let crawl_note = (crawl_total > crawl_jobs.len() as i64).then(|| {
+        format!(
+            "showing {} of {} total · running jobs listed first",
+            crawl_jobs.len(),
+            crawl_total,
+        )
+    });
     let mut out = String::new();
     write_status_section(
         &mut out,
         "Crawl",
+        crawl_note.as_deref(),
         crawl_jobs,
         |job| job.url.clone().unwrap_or_else(|| job.id.to_string()),
         |job| crawl_progress_summary(job, &embed_jobs_by_id, &embed_doc_totals),
@@ -116,6 +138,7 @@ fn render_status_jobs_from_slices(
     write_status_section(
         &mut out,
         "Extract",
+        None,
         extract_jobs,
         |job| {
             job.urls_json
@@ -128,6 +151,7 @@ fn render_status_jobs_from_slices(
     write_status_section(
         &mut out,
         "Embed",
+        None,
         embed_jobs,
         |job| {
             job.target
@@ -140,6 +164,7 @@ fn render_status_jobs_from_slices(
     write_status_section(
         &mut out,
         "Ingest",
+        None,
         ingest_jobs,
         |job| match (&job.source_type, &job.target) {
             (Some(source_type), Some(target)) => format!("{source_type}: {target}"),
@@ -293,11 +318,15 @@ fn ingest_progress_summary(job: &ServiceJob) -> Option<String> {
 fn write_status_section(
     out: &mut String,
     title: &str,
+    section_note: Option<&str>,
     jobs: &[ServiceJob],
     label_for: impl Fn(&ServiceJob) -> String,
     progress_for: impl Fn(&ServiceJob) -> Option<String>,
 ) {
     let _ = writeln!(out, "{}", primary(title));
+    if let Some(note) = section_note {
+        let _ = writeln!(out, "  {}", muted(note));
+    }
     if jobs.is_empty() {
         let _ = writeln!(out, "  {}", muted("None."));
         let _ = writeln!(out);
@@ -400,13 +429,39 @@ mod tests {
             &crate::services::types::StatusTotals::default(),
         );
 
-        let from_jobs = render_status_jobs(&jobs);
+        let totals = crate::services::types::StatusTotals::default();
+        let from_jobs = render_status_jobs(&jobs, totals.crawl);
         let from_payload = render_status_payload(&payload).expect("payload should render");
 
         assert_eq!(from_payload, from_jobs);
         assert!(from_payload.contains("Crawl"));
         assert!(from_payload.contains("Embed"));
         assert!(from_payload.contains("2 docs"));
+    }
+
+    #[test]
+    fn render_status_payload_mentions_when_crawl_rows_are_truncated() {
+        let payload = build_status_payload(
+            &[job("running"), job("pending")],
+            &[],
+            &[],
+            &[],
+            &crate::services::types::StatusTotals {
+                crawl: 24,
+                ..Default::default()
+            },
+        );
+
+        let rendered = render_status_payload(&payload).expect("payload should render");
+
+        assert!(
+            rendered.contains("showing 2 of 24"),
+            "expected truncation note; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("running jobs listed first"),
+            "expected ordering note; got:\n{rendered}"
+        );
     }
 
     #[test]

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -4,6 +4,7 @@ pub(crate) mod metrics;
 use crate::core::config::Config;
 use crate::core::logging::log_info;
 use crate::core::ui::{muted, primary, status_text as human_status_text, symbol_for_status};
+use crate::jobs::lite::store::RECLAIMED_ERROR_TEXT;
 use crate::services::context::ServiceContext;
 use crate::services::system::{build_status_payload, load_status_jobs};
 use crate::services::types::ServiceJob;
@@ -337,7 +338,7 @@ fn write_status_section(
 }
 
 fn job_error_hint(status: &str, error_text: &str) -> Option<String> {
-    if error_text.trim_start() == "reclaimed after unexpected shutdown" {
+    if error_text.trim_start() == RECLAIMED_ERROR_TEXT {
         return match status {
             "pending" => Some(
                 "recovered after worker shutdown; waiting for a worker to claim it".to_string(),
@@ -411,7 +412,7 @@ mod tests {
     #[test]
     fn render_status_payload_surfaces_reclaimed_pending_crawl_rows() {
         let mut reclaimed = job("pending");
-        reclaimed.error_text = Some("reclaimed after unexpected shutdown".to_string());
+        reclaimed.error_text = Some(RECLAIMED_ERROR_TEXT.to_string());
         reclaimed.result_json = None;
 
         let payload = build_status_payload(
@@ -429,7 +430,7 @@ mod tests {
             "expected reclaim hint; got:\n{rendered}"
         );
         assert!(
-            !rendered.contains("reclaimed after unexpected shutdown"),
+            !rendered.contains(RECLAIMED_ERROR_TEXT),
             "raw reclaim marker leaked into output:\n{rendered}"
         );
     }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -12,6 +12,10 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Write as _;
 
+/// Maximum number of rows rendered per section in the human status output.
+/// The truncation note ("showing N of M") is sized against this cap.
+const SECTION_DISPLAY_LIMIT: usize = 10;
+
 pub async fn run_status(
     cfg: &Config,
     service_context: &ServiceContext,
@@ -119,12 +123,12 @@ fn render_status_jobs_from_slices(
         .map(|job| (job.id.to_string(), job))
         .collect();
     let embed_doc_totals = embed_doc_totals_from_crawls(crawl_jobs);
-    let crawl_note = (crawl_total > crawl_jobs.len() as i64).then(|| {
-        format!(
-            "showing {} of {} total · running jobs listed first",
-            crawl_jobs.len(),
-            crawl_total,
-        )
+    // write_status_section caps display at SECTION_DISPLAY_LIMIT rows; mirror
+    // that here so the truncation note never advertises a count the renderer
+    // won't actually show.
+    let crawl_displayed = crawl_jobs.len().min(SECTION_DISPLAY_LIMIT);
+    let crawl_note = (crawl_total > crawl_displayed as i64).then(|| {
+        format!("showing {crawl_displayed} of {crawl_total} total · running jobs listed first")
     });
     let mut out = String::new();
     write_status_section(
@@ -333,7 +337,7 @@ fn write_status_section(
         return;
     }
 
-    for job in jobs.iter().take(10) {
+    for job in jobs.iter().take(SECTION_DISPLAY_LIMIT) {
         let label = label_for(job);
         if let Some(p) = progress_for(job) {
             let _ = writeln!(

--- a/src/core/config/cli/global_args.rs
+++ b/src/core/config/cli/global_args.rs
@@ -258,6 +258,16 @@ pub(in crate::core::config) struct GlobalArgs {
     )]
     pub(in crate::core::config) watchdog_confirm_secs: i64,
 
+    /// Seconds between periodic watchdog sweeps. Smaller = stale jobs are
+    /// reclaimed sooner, larger = fewer SQL writes when nothing is stale.
+    #[arg(
+        global = true,
+        long,
+        env = "AXON_WATCHDOG_SWEEP_SECS",
+        default_value_t = 15
+    )]
+    pub(in crate::core::config) watchdog_sweep_secs: i64,
+
     /// Cron interval: re-run the command every N seconds
     #[arg(global = true, long)]
     pub(in crate::core::config) cron_every_seconds: Option<u64>,

--- a/src/core/config/parse.rs
+++ b/src/core/config/parse.rs
@@ -35,15 +35,11 @@ pub fn parse_args() -> Config {
 
 #[cfg(test)]
 mod tests {
+    use super::build_config::tests::ENV_LOCK;
     use super::docker::is_docker_service_host;
     use crate::core::config::types::{CommandKind, McpTransport};
     use clap::Parser;
     use std::env;
-    use std::sync::Mutex;
-
-    /// Serializes tests that mutate process-wide environment variables.
-    /// Prevents parallel test data races on `std::env::set_var` / `remove_var`.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[allow(unsafe_code)]
     #[test]

--- a/src/core/config/parse/build_config.rs
+++ b/src/core/config/parse/build_config.rs
@@ -11,7 +11,7 @@ mod config_literal;
 mod post_init;
 
 #[cfg(test)]
-mod tests;
+pub(in crate::core::config::parse) mod tests;
 
 use super::super::cli::{Cli, DEFAULT_OUTPUT_DIR};
 use super::super::types::{CommandKind, Config};

--- a/src/core/config/parse/build_config/config_literal.rs
+++ b/src/core/config/parse/build_config/config_literal.rs
@@ -245,6 +245,7 @@ fn populate_misc(
     cfg.cron_max_runs = g.cron_max_runs.filter(|v| *v > 0);
     cfg.watchdog_stale_timeout_secs = g.watchdog_stale_timeout_secs.max(30);
     cfg.watchdog_confirm_secs = g.watchdog_confirm_secs.max(10);
+    cfg.watchdog_sweep_secs = g.watchdog_sweep_secs.clamp(1, 600);
     cfg.json_output = g.json;
     cfg.reclaimed_status_only = g.reclaimed;
     cfg.active_status_only = g.active;

--- a/src/core/config/parse/build_config/tests.rs
+++ b/src/core/config/parse/build_config/tests.rs
@@ -21,7 +21,7 @@ pub(super) use std::path::Path;
 pub(super) use std::sync::Mutex;
 pub(super) use tempfile::Builder as TempfileBuilder;
 
-pub(super) static ENV_LOCK: Mutex<()> = Mutex::new(());
+pub(in crate::core::config::parse) static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 // Convenience: build a CLI with stable service URLs via flags (avoids QDRANT_URL/TEI_URL env noise).
 pub(super) fn cli_with_services(extra: &[&str]) -> Cli {

--- a/src/core/config/types/config.rs
+++ b/src/core/config/types/config.rs
@@ -428,6 +428,11 @@ pub struct Config {
     /// Env: `AXON_JOB_STALE_CONFIRM_SECS`. Flag: `--watchdog-confirm-secs`.
     pub watchdog_confirm_secs: i64,
 
+    /// Seconds between periodic watchdog sweeps in the long-running worker process.
+    /// Smaller values reclaim stale jobs sooner at the cost of extra SQL writes.
+    /// Env: `AXON_WATCHDOG_SWEEP_SECS`. Default: 15.
+    pub watchdog_sweep_secs: i64,
+
     /// Emit machine-readable JSON output on stdout instead of human-readable text. Flag: `--json`.
     pub json_output: bool,
 

--- a/src/core/config/types/config_impls.rs
+++ b/src/core/config/types/config_impls.rs
@@ -129,6 +129,7 @@ impl Default for Config {
             cron_max_runs: None,
             watchdog_stale_timeout_secs: 300,
             watchdog_confirm_secs: 60,
+            watchdog_sweep_secs: 15,
             json_output: false,
             reclaimed_status_only: false,
             active_status_only: false,

--- a/src/jobs/backend.rs
+++ b/src/jobs/backend.rs
@@ -34,6 +34,16 @@ impl JobKind {
         }
     }
 
+    /// Human-readable name used in queue-cap error messages.
+    pub fn queue_name(self) -> &'static str {
+        match self {
+            Self::Crawl => "crawl",
+            Self::Embed => "embed",
+            Self::Extract => "extract",
+            Self::Ingest => "ingest",
+        }
+    }
+
     pub fn all() -> &'static [JobKind] {
         &[Self::Crawl, Self::Embed, Self::Extract, Self::Ingest]
     }

--- a/src/jobs/lite/migrations/0004_status_created_at_index.sql
+++ b/src/jobs/lite/migrations/0004_status_created_at_index.sql
@@ -1,0 +1,19 @@
+-- Composite (status, created_at DESC) index for the CASE-based ORDER BY in
+-- list_service_jobs (crawl path). The single-column idx_crawl_status index
+-- can satisfy the status filter but forces a temp-sort for the
+-- created_at DESC secondary key once axon_crawl_jobs grows past a few
+-- thousand rows. Same shape applied to the other three job tables so the
+-- same query template stays index-friendly if their list paths later add
+-- a CASE-status ORDER BY.
+
+CREATE INDEX IF NOT EXISTS idx_crawl_status_created
+    ON axon_crawl_jobs(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_embed_status_created
+    ON axon_embed_jobs(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_extract_status_created
+    ON axon_extract_jobs(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_status_created
+    ON axon_ingest_jobs(status, created_at DESC);

--- a/src/jobs/lite/ops/enqueue.rs
+++ b/src/jobs/lite/ops/enqueue.rs
@@ -69,7 +69,12 @@ async fn commit(conn: &mut SqliteConnection) -> Result<(), sqlx::Error> {
 }
 
 async fn rollback_best_effort(conn: &mut SqliteConnection) {
-    let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+    if let Err(e) = sqlx::query("ROLLBACK").execute(&mut *conn).await {
+        // Log so a failing ROLLBACK (disk-full, broken connection) is at
+        // least observable — the connection still goes back to the pool but
+        // we want operators to see it.
+        tracing::warn!(error = %e, "enqueue: ROLLBACK after failed transaction errored");
+    }
 }
 
 /// Insert a new job row with status='pending'. Returns the new job's UUID.
@@ -123,10 +128,17 @@ pub async fn enqueue_job(
     };
 
     match result {
-        Ok(()) => {
-            commit(&mut conn).await?;
-            Ok(id)
-        }
+        Ok(()) => match commit(&mut conn).await {
+            Ok(()) => Ok(id),
+            Err(commit_err) => {
+                // COMMIT failed — explicitly ROLLBACK before the connection
+                // returns to the pool so a stale `BEGIN IMMEDIATE` doesn't
+                // poison the next checkout. sqlx does not auto-rollback on
+                // PoolConnection::drop.
+                rollback_best_effort(&mut conn).await;
+                Err(commit_err.into())
+            }
+        },
         Err(e) => {
             rollback_best_effort(&mut conn).await;
             Err(e)

--- a/src/jobs/lite/ops/enqueue.rs
+++ b/src/jobs/lite/ops/enqueue.rs
@@ -70,9 +70,6 @@ async fn commit(conn: &mut SqliteConnection) -> Result<(), sqlx::Error> {
 
 async fn rollback_best_effort(conn: &mut SqliteConnection) {
     if let Err(e) = sqlx::query("ROLLBACK").execute(&mut *conn).await {
-        // Log so a failing ROLLBACK (disk-full, broken connection) is at
-        // least observable — the connection still goes back to the pool but
-        // we want operators to see it.
         tracing::warn!(error = %e, "enqueue: ROLLBACK after failed transaction errored");
     }
 }
@@ -131,10 +128,9 @@ pub async fn enqueue_job(
         Ok(()) => match commit(&mut conn).await {
             Ok(()) => Ok(id),
             Err(commit_err) => {
-                // COMMIT failed — explicitly ROLLBACK before the connection
-                // returns to the pool so a stale `BEGIN IMMEDIATE` doesn't
-                // poison the next checkout. sqlx does not auto-rollback on
-                // PoolConnection::drop.
+                // sqlx doesn't auto-rollback on PoolConnection::drop, so a
+                // failed COMMIT would leave the next pool checkout inside a
+                // stale BEGIN IMMEDIATE.
                 rollback_best_effort(&mut conn).await;
                 Err(commit_err.into())
             }

--- a/src/jobs/lite/ops/enqueue.rs
+++ b/src/jobs/lite/ops/enqueue.rs
@@ -1,10 +1,34 @@
-use sqlx::SqlitePool;
+use sqlx::{Sqlite, SqlitePool, Transaction};
 use uuid::Uuid;
 
 use crate::core::config::Config;
 use crate::jobs::backend::JobPayload;
 use crate::jobs::error::JobError;
 use crate::jobs::lite::store::now_ms;
+
+/// Same as `check_pending_cap_for` but runs against an open transaction so the
+/// COUNT and the subsequent INSERT serialize against concurrent enqueues.
+async fn check_pending_cap_for_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    table: &'static str,
+    queue_name: &'static str,
+    cap: u64,
+) -> Result<(), JobError> {
+    if cap == 0 {
+        return Ok(());
+    }
+    let query = format!("SELECT COUNT(*) FROM {table} WHERE status = 'pending'");
+    let count_i64: i64 = sqlx::query_scalar(&query).fetch_one(&mut **tx).await?;
+    let count: u64 = u64::try_from(count_i64).unwrap_or(0);
+    if count >= cap {
+        return Err(JobError::QueueCapacityExceeded {
+            kind: queue_name,
+            cap,
+            current: count,
+        });
+    }
+    Ok(())
+}
 
 /// Check whether the pending job count for a given queue is at or above the configured cap.
 ///
@@ -22,6 +46,7 @@ use crate::jobs::lite::store::now_ms;
 /// file (`"axon_crawl_jobs"`, `"axon_embed_jobs"`, `"axon_extract_jobs"`,
 /// `"axon_ingest_jobs"`). Do **not** call this function with attacker- or
 /// caller-controlled `table` values.
+#[cfg(test)]
 pub(super) async fn check_pending_cap_for(
     pool: &SqlitePool,
     table: &'static str,
@@ -61,10 +86,16 @@ pub async fn enqueue_job(
     let now = now_ms();
     let id_str = id.to_string();
 
+    // Use BEGIN IMMEDIATE so the cap COUNT and the INSERT serialize against
+    // concurrent enqueues. Without it, two callers can both observe count=0,
+    // pass the cap check, and double-insert past the configured cap.
+    let mut tx = pool.begin().await?;
+    sqlx::query("BEGIN IMMEDIATE").execute(&mut *tx).await.ok();
+
     match payload {
         JobPayload::Crawl { url, config_json } => {
-            check_pending_cap_for(
-                pool,
+            check_pending_cap_for_tx(
+                &mut tx,
                 "axon_crawl_jobs",
                 "crawl",
                 cfg.max_pending_crawl_jobs as u64,
@@ -79,12 +110,12 @@ pub async fn enqueue_job(
             .bind(config_json)
             .bind(now)
             .bind(now)
-            .execute(pool)
+            .execute(&mut *tx)
             .await?;
         }
         JobPayload::Embed { input, config_json } => {
-            check_pending_cap_for(
-                pool,
+            check_pending_cap_for_tx(
+                &mut tx,
                 "axon_embed_jobs",
                 "embed",
                 cfg.max_pending_embed_jobs as u64,
@@ -99,12 +130,12 @@ pub async fn enqueue_job(
             .bind(config_json)
             .bind(now)
             .bind(now)
-            .execute(pool)
+            .execute(&mut *tx)
             .await?;
         }
         JobPayload::Extract { urls, config_json } => {
-            check_pending_cap_for(
-                pool,
+            check_pending_cap_for_tx(
+                &mut tx,
                 "axon_extract_jobs",
                 "extract",
                 cfg.max_pending_extract_jobs as u64,
@@ -121,7 +152,7 @@ pub async fn enqueue_job(
             .bind(config_json)
             .bind(now)
             .bind(now)
-            .execute(pool)
+            .execute(&mut *tx)
             .await?;
         }
         JobPayload::Ingest {
@@ -129,8 +160,8 @@ pub async fn enqueue_job(
             source_type,
             config_json,
         } => {
-            check_pending_cap_for(
-                pool,
+            check_pending_cap_for_tx(
+                &mut tx,
                 "axon_ingest_jobs",
                 "ingest",
                 cfg.max_pending_ingest_jobs as u64,
@@ -146,10 +177,11 @@ pub async fn enqueue_job(
             .bind(config_json)
             .bind(now)
             .bind(now)
-            .execute(pool)
+            .execute(&mut *tx)
             .await?;
         }
     }
 
+    tx.commit().await?;
     Ok(id)
 }

--- a/src/jobs/lite/ops/enqueue.rs
+++ b/src/jobs/lite/ops/enqueue.rs
@@ -2,32 +2,28 @@ use sqlx::{SqliteConnection, SqlitePool, pool::PoolConnection};
 use uuid::Uuid;
 
 use crate::core::config::Config;
-use crate::jobs::backend::JobPayload;
+use crate::jobs::backend::{JobKind, JobPayload};
 use crate::jobs::error::JobError;
 use crate::jobs::lite::store::now_ms;
 
-/// Check whether the pending job count for a given queue is at or above the configured cap.
+/// Reject the enqueue when the queue is at or above its pending cap.
 ///
-/// `table` is the SQL table name (e.g. `axon_crawl_jobs`).
-/// `queue_name` is the human-readable queue name used in the error variant.
-/// `cap` is the cap (`0` = unlimited; `>= 1` rejects when `pending >= cap`).
+/// `cap == 0` is treated as unlimited. Generic over the executor so callers
+/// can pass `&SqlitePool` (test helpers) or `&mut SqliteConnection` (the
+/// immediate-transaction path used by `enqueue_job`).
 ///
-/// Generic over the executor so callers can pass `&SqlitePool` (test helpers)
-/// or `&mut SqliteConnection` (the immediate-transaction path used by
-/// `enqueue_job`). Both call sites share the same COUNT + threshold logic.
+/// Implementation note: we ask SQLite to return at most `cap + 1` row
+/// stubs (`SELECT 1 ... LIMIT cap+1`) instead of `SELECT COUNT(*)`. Cost is
+/// O(cap) on the `(status, created_at DESC)` index added in migration 0004,
+/// not O(pending) — caps below ~100 stay constant-time even when the
+/// pending queue grows large.
 ///
-/// # SQL injection safety
-///
-/// `table` is interpolated directly into the SQL string because sqlx does not
-/// support binding a table name. The invariant is that `table` is a compile-time
-/// `&'static str` literal, supplied only by the `enqueue_job` callsites in this
-/// file (`"axon_crawl_jobs"`, `"axon_embed_jobs"`, `"axon_extract_jobs"`,
-/// `"axon_ingest_jobs"`). Do **not** call this function with attacker- or
-/// caller-controlled `table` values.
+/// SAFETY: `kind.table_name()` returns a compile-time `&'static str` from a
+/// closed enum dispatch; no caller-controlled value reaches `format!`. Do
+/// not change to accept a runtime-derived table name.
 pub(super) async fn check_pending_cap_for<'e, E>(
     executor: E,
-    table: &'static str,
-    queue_name: &'static str,
+    kind: JobKind,
     cap: u64,
 ) -> Result<(), JobError>
 where
@@ -36,16 +32,19 @@ where
     if cap == 0 {
         return Ok(());
     }
-    let query = format!("SELECT COUNT(*) FROM {table} WHERE status = 'pending'");
-    let count_i64: i64 = sqlx::query_scalar(&query).fetch_one(executor).await?;
-    // SQLite COUNT(*) is non-negative in practice, but defend against a wrapping
-    // cast: clamp negatives to 0 and refuse to consult the cap if conversion fails.
-    let count: u64 = u64::try_from(count_i64).unwrap_or(0);
-    if count >= cap {
+    let table = kind.table_name();
+    let limit = i64::try_from(cap.saturating_add(1)).unwrap_or(i64::MAX);
+    let query = format!("SELECT 1 FROM {table} WHERE status = 'pending' LIMIT ?");
+    let rows: Vec<i64> = sqlx::query_scalar(&query)
+        .bind(limit)
+        .fetch_all(executor)
+        .await?;
+    let observed = rows.len() as u64;
+    if observed >= cap {
         return Err(JobError::QueueCapacityExceeded {
-            kind: queue_name,
+            kind: kind.queue_name(),
             cap,
-            current: count,
+            current: observed,
         });
     }
     Ok(())
@@ -81,7 +80,7 @@ async fn rollback_best_effort(conn: &mut SqliteConnection) {
 /// tests to use the built-in defaults (100/50/50/50) — those are well above any
 /// reasonable test fixture so production caps don't accidentally fail tests.
 ///
-/// The cap COUNT and the INSERT run inside a `BEGIN IMMEDIATE` transaction so
+/// The cap check and the INSERT run inside a `BEGIN IMMEDIATE` transaction so
 /// concurrent enqueues serialize on the SQLite RESERVED write lock — without
 /// it, two callers can both observe `count=0`, pass the cap check, and
 /// double-insert past the configured cap.
@@ -93,36 +92,16 @@ pub async fn enqueue_job(
     let id = Uuid::new_v4();
     let now = now_ms();
     let id_str = id.to_string();
+    let kind = payload.kind();
+    let cap = cap_for(kind, cfg);
 
     let mut conn = begin_immediate(pool).await?;
 
-    let result = match payload {
-        JobPayload::Crawl { url, config_json } => {
-            insert_crawl(&mut conn, &id_str, url, config_json, now, cfg).await
-        }
-        JobPayload::Embed { input, config_json } => {
-            insert_embed(&mut conn, &id_str, input, config_json, now, cfg).await
-        }
-        JobPayload::Extract { urls, config_json } => {
-            insert_extract(&mut conn, &id_str, urls, config_json, now, cfg).await
-        }
-        JobPayload::Ingest {
-            target,
-            source_type,
-            config_json,
-        } => {
-            insert_ingest(
-                &mut conn,
-                &id_str,
-                target,
-                source_type,
-                config_json,
-                now,
-                cfg,
-            )
-            .await
-        }
-    };
+    let result: Result<(), JobError> = async {
+        check_pending_cap_for(&mut *conn, kind, cap).await?;
+        insert_payload(&mut conn, &id_str, now, payload).await
+    }
+    .await;
 
     match result {
         Ok(()) => match commit(&mut conn).await {
@@ -142,121 +121,81 @@ pub async fn enqueue_job(
     }
 }
 
-async fn insert_crawl(
-    conn: &mut SqliteConnection,
-    id_str: &str,
-    url: &str,
-    config_json: &str,
-    now: i64,
-    cfg: &Config,
-) -> Result<(), JobError> {
-    check_pending_cap_for(
-        &mut *conn,
-        "axon_crawl_jobs",
-        "crawl",
-        cfg.max_pending_crawl_jobs as u64,
-    )
-    .await?;
-    sqlx::query(
-        "INSERT INTO axon_crawl_jobs (id, status, url, config_json, created_at, updated_at) \
-         VALUES (?, 'pending', ?, ?, ?, ?)",
-    )
-    .bind(id_str)
-    .bind(url)
-    .bind(config_json)
-    .bind(now)
-    .bind(now)
-    .execute(&mut *conn)
-    .await?;
-    Ok(())
+fn cap_for(kind: JobKind, cfg: &Config) -> u64 {
+    match kind {
+        JobKind::Crawl => cfg.max_pending_crawl_jobs as u64,
+        JobKind::Embed => cfg.max_pending_embed_jobs as u64,
+        JobKind::Extract => cfg.max_pending_extract_jobs as u64,
+        JobKind::Ingest => cfg.max_pending_ingest_jobs as u64,
+    }
 }
 
-async fn insert_embed(
+async fn insert_payload(
     conn: &mut SqliteConnection,
     id_str: &str,
-    input: &str,
-    config_json: &str,
     now: i64,
-    cfg: &Config,
+    payload: &JobPayload,
 ) -> Result<(), JobError> {
-    check_pending_cap_for(
-        &mut *conn,
-        "axon_embed_jobs",
-        "embed",
-        cfg.max_pending_embed_jobs as u64,
-    )
-    .await?;
-    sqlx::query(
-        "INSERT INTO axon_embed_jobs (id, status, input_text, config_json, created_at, updated_at) \
-         VALUES (?, 'pending', ?, ?, ?, ?)",
-    )
-    .bind(id_str)
-    .bind(input)
-    .bind(config_json)
-    .bind(now)
-    .bind(now)
-    .execute(&mut *conn)
-    .await?;
-    Ok(())
-}
-
-async fn insert_extract(
-    conn: &mut SqliteConnection,
-    id_str: &str,
-    urls: &[String],
-    config_json: &str,
-    now: i64,
-    cfg: &Config,
-) -> Result<(), JobError> {
-    check_pending_cap_for(
-        &mut *conn,
-        "axon_extract_jobs",
-        "extract",
-        cfg.max_pending_extract_jobs as u64,
-    )
-    .await?;
-    let urls_json = serde_json::to_string(urls).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
-    sqlx::query(
-        "INSERT INTO axon_extract_jobs (id, status, urls_json, config_json, created_at, updated_at) \
-         VALUES (?, 'pending', ?, ?, ?, ?)",
-    )
-    .bind(id_str)
-    .bind(&urls_json)
-    .bind(config_json)
-    .bind(now)
-    .bind(now)
-    .execute(&mut *conn)
-    .await?;
-    Ok(())
-}
-
-async fn insert_ingest(
-    conn: &mut SqliteConnection,
-    id_str: &str,
-    target: &str,
-    source_type: &str,
-    config_json: &str,
-    now: i64,
-    cfg: &Config,
-) -> Result<(), JobError> {
-    check_pending_cap_for(
-        &mut *conn,
-        "axon_ingest_jobs",
-        "ingest",
-        cfg.max_pending_ingest_jobs as u64,
-    )
-    .await?;
-    sqlx::query(
-        "INSERT INTO axon_ingest_jobs (id, status, target, source_type, config_json, created_at, updated_at) \
-         VALUES (?, 'pending', ?, ?, ?, ?, ?)",
-    )
-    .bind(id_str)
-    .bind(target)
-    .bind(source_type)
-    .bind(config_json)
-    .bind(now)
-    .bind(now)
-    .execute(&mut *conn)
-    .await?;
+    match payload {
+        JobPayload::Crawl { url, config_json } => {
+            sqlx::query(
+                "INSERT INTO axon_crawl_jobs (id, status, url, config_json, created_at, updated_at) \
+                 VALUES (?, 'pending', ?, ?, ?, ?)",
+            )
+            .bind(id_str)
+            .bind(url)
+            .bind(config_json)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *conn)
+            .await?;
+        }
+        JobPayload::Embed { input, config_json } => {
+            sqlx::query(
+                "INSERT INTO axon_embed_jobs (id, status, input_text, config_json, created_at, updated_at) \
+                 VALUES (?, 'pending', ?, ?, ?, ?)",
+            )
+            .bind(id_str)
+            .bind(input)
+            .bind(config_json)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *conn)
+            .await?;
+        }
+        JobPayload::Extract { urls, config_json } => {
+            let urls_json =
+                serde_json::to_string(urls).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
+            sqlx::query(
+                "INSERT INTO axon_extract_jobs (id, status, urls_json, config_json, created_at, updated_at) \
+                 VALUES (?, 'pending', ?, ?, ?, ?)",
+            )
+            .bind(id_str)
+            .bind(&urls_json)
+            .bind(config_json)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *conn)
+            .await?;
+        }
+        JobPayload::Ingest {
+            target,
+            source_type,
+            config_json,
+        } => {
+            sqlx::query(
+                "INSERT INTO axon_ingest_jobs (id, status, target, source_type, config_json, created_at, updated_at) \
+                 VALUES (?, 'pending', ?, ?, ?, ?, ?)",
+            )
+            .bind(id_str)
+            .bind(target)
+            .bind(source_type)
+            .bind(config_json)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *conn)
+            .await?;
+        }
+    }
     Ok(())
 }

--- a/src/jobs/lite/ops/enqueue.rs
+++ b/src/jobs/lite/ops/enqueue.rs
@@ -1,4 +1,4 @@
-use sqlx::{Sqlite, SqlitePool, Transaction};
+use sqlx::{SqliteConnection, SqlitePool, pool::PoolConnection};
 use uuid::Uuid;
 
 use crate::core::config::Config;
@@ -6,37 +6,15 @@ use crate::jobs::backend::JobPayload;
 use crate::jobs::error::JobError;
 use crate::jobs::lite::store::now_ms;
 
-/// Same as `check_pending_cap_for` but runs against an open transaction so the
-/// COUNT and the subsequent INSERT serialize against concurrent enqueues.
-async fn check_pending_cap_for_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    table: &'static str,
-    queue_name: &'static str,
-    cap: u64,
-) -> Result<(), JobError> {
-    if cap == 0 {
-        return Ok(());
-    }
-    let query = format!("SELECT COUNT(*) FROM {table} WHERE status = 'pending'");
-    let count_i64: i64 = sqlx::query_scalar(&query).fetch_one(&mut **tx).await?;
-    let count: u64 = u64::try_from(count_i64).unwrap_or(0);
-    if count >= cap {
-        return Err(JobError::QueueCapacityExceeded {
-            kind: queue_name,
-            cap,
-            current: count,
-        });
-    }
-    Ok(())
-}
-
 /// Check whether the pending job count for a given queue is at or above the configured cap.
 ///
 /// `table` is the SQL table name (e.g. `axon_crawl_jobs`).
 /// `queue_name` is the human-readable queue name used in the error variant.
 /// `cap` is the cap (`0` = unlimited; `>= 1` rejects when `pending >= cap`).
 ///
-/// Returns `Err(JobError::QueueCapacityExceeded { .. })` when the queue is full.
+/// Generic over the executor so callers can pass `&SqlitePool` (test helpers)
+/// or `&mut SqliteConnection` (the immediate-transaction path used by
+/// `enqueue_job`). Both call sites share the same COUNT + threshold logic.
 ///
 /// # SQL injection safety
 ///
@@ -46,18 +24,20 @@ async fn check_pending_cap_for_tx(
 /// file (`"axon_crawl_jobs"`, `"axon_embed_jobs"`, `"axon_extract_jobs"`,
 /// `"axon_ingest_jobs"`). Do **not** call this function with attacker- or
 /// caller-controlled `table` values.
-#[cfg(test)]
-pub(super) async fn check_pending_cap_for(
-    pool: &SqlitePool,
+pub(super) async fn check_pending_cap_for<'e, E>(
+    executor: E,
     table: &'static str,
     queue_name: &'static str,
     cap: u64,
-) -> Result<(), JobError> {
+) -> Result<(), JobError>
+where
+    E: sqlx::SqliteExecutor<'e>,
+{
     if cap == 0 {
         return Ok(());
     }
     let query = format!("SELECT COUNT(*) FROM {table} WHERE status = 'pending'");
-    let count_i64: i64 = sqlx::query_scalar(&query).fetch_one(pool).await?;
+    let count_i64: i64 = sqlx::query_scalar(&query).fetch_one(executor).await?;
     // SQLite COUNT(*) is non-negative in practice, but defend against a wrapping
     // cast: clamp negatives to 0 and refuse to consult the cap if conversion fails.
     let count: u64 = u64::try_from(count_i64).unwrap_or(0);
@@ -71,12 +51,38 @@ pub(super) async fn check_pending_cap_for(
     Ok(())
 }
 
+/// Acquire a dedicated connection and open a `BEGIN IMMEDIATE` transaction on
+/// it. sqlx's `pool.begin()` always emits plain `BEGIN` (deferred), and a
+/// follow-up `BEGIN IMMEDIATE` on the same connection errors as a nested
+/// transaction — so we go through a raw connection instead. The caller is
+/// responsible for issuing `COMMIT` (or `ROLLBACK`) before dropping the
+/// connection.
+async fn begin_immediate(pool: &SqlitePool) -> Result<PoolConnection<sqlx::Sqlite>, sqlx::Error> {
+    let mut conn = pool.acquire().await?;
+    sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+    Ok(conn)
+}
+
+async fn commit(conn: &mut SqliteConnection) -> Result<(), sqlx::Error> {
+    sqlx::query("COMMIT").execute(&mut *conn).await?;
+    Ok(())
+}
+
+async fn rollback_best_effort(conn: &mut SqliteConnection) {
+    let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+}
+
 /// Insert a new job row with status='pending'. Returns the new job's UUID.
 ///
 /// Pending-queue caps are sourced from `cfg.max_pending_{crawl,embed,extract,ingest}_jobs`
 /// (priority CLI flag > env > TOML > default). Pass `&Config::default_lite()` from
 /// tests to use the built-in defaults (100/50/50/50) — those are well above any
 /// reasonable test fixture so production caps don't accidentally fail tests.
+///
+/// The cap COUNT and the INSERT run inside a `BEGIN IMMEDIATE` transaction so
+/// concurrent enqueues serialize on the SQLite RESERVED write lock — without
+/// it, two callers can both observe `count=0`, pass the cap check, and
+/// double-insert past the configured cap.
 pub async fn enqueue_job(
     pool: &SqlitePool,
     payload: &JobPayload,
@@ -86,102 +92,163 @@ pub async fn enqueue_job(
     let now = now_ms();
     let id_str = id.to_string();
 
-    // Use BEGIN IMMEDIATE so the cap COUNT and the INSERT serialize against
-    // concurrent enqueues. Without it, two callers can both observe count=0,
-    // pass the cap check, and double-insert past the configured cap.
-    let mut tx = pool.begin().await?;
-    sqlx::query("BEGIN IMMEDIATE").execute(&mut *tx).await.ok();
+    let mut conn = begin_immediate(pool).await?;
 
-    match payload {
+    let result = match payload {
         JobPayload::Crawl { url, config_json } => {
-            check_pending_cap_for_tx(
-                &mut tx,
-                "axon_crawl_jobs",
-                "crawl",
-                cfg.max_pending_crawl_jobs as u64,
-            )
-            .await?;
-            sqlx::query(
-                "INSERT INTO axon_crawl_jobs (id, status, url, config_json, created_at, updated_at) \
-                 VALUES (?, 'pending', ?, ?, ?, ?)",
-            )
-            .bind(&id_str)
-            .bind(url)
-            .bind(config_json)
-            .bind(now)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
+            insert_crawl(&mut conn, &id_str, url, config_json, now, cfg).await
         }
         JobPayload::Embed { input, config_json } => {
-            check_pending_cap_for_tx(
-                &mut tx,
-                "axon_embed_jobs",
-                "embed",
-                cfg.max_pending_embed_jobs as u64,
-            )
-            .await?;
-            sqlx::query(
-                "INSERT INTO axon_embed_jobs (id, status, input_text, config_json, created_at, updated_at) \
-                 VALUES (?, 'pending', ?, ?, ?, ?)",
-            )
-            .bind(&id_str)
-            .bind(input)
-            .bind(config_json)
-            .bind(now)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
+            insert_embed(&mut conn, &id_str, input, config_json, now, cfg).await
         }
         JobPayload::Extract { urls, config_json } => {
-            check_pending_cap_for_tx(
-                &mut tx,
-                "axon_extract_jobs",
-                "extract",
-                cfg.max_pending_extract_jobs as u64,
-            )
-            .await?;
-            let urls_json =
-                serde_json::to_string(urls).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
-            sqlx::query(
-                "INSERT INTO axon_extract_jobs (id, status, urls_json, config_json, created_at, updated_at) \
-                 VALUES (?, 'pending', ?, ?, ?, ?)",
-            )
-            .bind(&id_str)
-            .bind(&urls_json)
-            .bind(config_json)
-            .bind(now)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
+            insert_extract(&mut conn, &id_str, urls, config_json, now, cfg).await
         }
         JobPayload::Ingest {
             target,
             source_type,
             config_json,
         } => {
-            check_pending_cap_for_tx(
-                &mut tx,
-                "axon_ingest_jobs",
-                "ingest",
-                cfg.max_pending_ingest_jobs as u64,
+            insert_ingest(
+                &mut conn,
+                &id_str,
+                target,
+                source_type,
+                config_json,
+                now,
+                cfg,
             )
-            .await?;
-            sqlx::query(
-                "INSERT INTO axon_ingest_jobs (id, status, target, source_type, config_json, created_at, updated_at) \
-                 VALUES (?, 'pending', ?, ?, ?, ?, ?)",
-            )
-            .bind(&id_str)
-            .bind(target)
-            .bind(source_type)
-            .bind(config_json)
-            .bind(now)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
+            .await
+        }
+    };
+
+    match result {
+        Ok(()) => {
+            commit(&mut conn).await?;
+            Ok(id)
+        }
+        Err(e) => {
+            rollback_best_effort(&mut conn).await;
+            Err(e)
         }
     }
+}
 
-    tx.commit().await?;
-    Ok(id)
+async fn insert_crawl(
+    conn: &mut SqliteConnection,
+    id_str: &str,
+    url: &str,
+    config_json: &str,
+    now: i64,
+    cfg: &Config,
+) -> Result<(), JobError> {
+    check_pending_cap_for(
+        &mut *conn,
+        "axon_crawl_jobs",
+        "crawl",
+        cfg.max_pending_crawl_jobs as u64,
+    )
+    .await?;
+    sqlx::query(
+        "INSERT INTO axon_crawl_jobs (id, status, url, config_json, created_at, updated_at) \
+         VALUES (?, 'pending', ?, ?, ?, ?)",
+    )
+    .bind(id_str)
+    .bind(url)
+    .bind(config_json)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+async fn insert_embed(
+    conn: &mut SqliteConnection,
+    id_str: &str,
+    input: &str,
+    config_json: &str,
+    now: i64,
+    cfg: &Config,
+) -> Result<(), JobError> {
+    check_pending_cap_for(
+        &mut *conn,
+        "axon_embed_jobs",
+        "embed",
+        cfg.max_pending_embed_jobs as u64,
+    )
+    .await?;
+    sqlx::query(
+        "INSERT INTO axon_embed_jobs (id, status, input_text, config_json, created_at, updated_at) \
+         VALUES (?, 'pending', ?, ?, ?, ?)",
+    )
+    .bind(id_str)
+    .bind(input)
+    .bind(config_json)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+async fn insert_extract(
+    conn: &mut SqliteConnection,
+    id_str: &str,
+    urls: &[String],
+    config_json: &str,
+    now: i64,
+    cfg: &Config,
+) -> Result<(), JobError> {
+    check_pending_cap_for(
+        &mut *conn,
+        "axon_extract_jobs",
+        "extract",
+        cfg.max_pending_extract_jobs as u64,
+    )
+    .await?;
+    let urls_json = serde_json::to_string(urls).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
+    sqlx::query(
+        "INSERT INTO axon_extract_jobs (id, status, urls_json, config_json, created_at, updated_at) \
+         VALUES (?, 'pending', ?, ?, ?, ?)",
+    )
+    .bind(id_str)
+    .bind(&urls_json)
+    .bind(config_json)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+async fn insert_ingest(
+    conn: &mut SqliteConnection,
+    id_str: &str,
+    target: &str,
+    source_type: &str,
+    config_json: &str,
+    now: i64,
+    cfg: &Config,
+) -> Result<(), JobError> {
+    check_pending_cap_for(
+        &mut *conn,
+        "axon_ingest_jobs",
+        "ingest",
+        cfg.max_pending_ingest_jobs as u64,
+    )
+    .await?;
+    sqlx::query(
+        "INSERT INTO axon_ingest_jobs (id, status, target, source_type, config_json, created_at, updated_at) \
+         VALUES (?, 'pending', ?, ?, ?, ?, ?)",
+    )
+    .bind(id_str)
+    .bind(target)
+    .bind(source_type)
+    .bind(config_json)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
 }

--- a/src/jobs/lite/ops/tests.rs
+++ b/src/jobs/lite/ops/tests.rs
@@ -1,10 +1,11 @@
 use super::enqueue::check_pending_cap_for;
 use crate::core::config::Config;
 use crate::jobs::backend::{JobKind, JobPayload};
+use crate::jobs::error::JobError;
 use crate::jobs::lite::ops::{
     cancel_row, claim_next_pending, enqueue_job, mark_completed, mark_failed, update_result_json,
 };
-use crate::jobs::lite::store::open_sqlite_pool;
+use crate::jobs::lite::store::{RECLAIMED_ERROR_TEXT, open_sqlite_pool};
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use std::time::Duration;
@@ -50,9 +51,10 @@ async fn claim_clears_reclaimed_error_text() {
     sqlx::query(
         "INSERT INTO axon_embed_jobs \
          (id, status, input_text, config_json, created_at, updated_at, error_text) \
-         VALUES (?, 'pending', 'docs', '{}', 1, 1, 'reclaimed after unexpected shutdown')",
+         VALUES (?, 'pending', 'docs', '{}', 1, 1, ?)",
     )
     .bind(&id)
+    .bind(RECLAIMED_ERROR_TEXT)
     .execute(&pool)
     .await
     .expect("insert reclaimed pending embed job");
@@ -480,6 +482,122 @@ async fn concurrent_claims_only_return_one_job() {
         .await
         .expect("fetch");
     assert_eq!(status.0, "running");
+
+    drop(pool_a);
+    drop(pool_b);
+    tokio::fs::remove_file(&path).await.ok();
+}
+
+#[tokio::test]
+async fn enqueue_retries_when_sqlite_write_lock_is_temporarily_held() {
+    let path = std::env::temp_dir()
+        .join(format!("axon-lite-enqueue-lock-{}.db", Uuid::new_v4()))
+        .to_string_lossy()
+        .into_owned();
+    let pool_a = open_sqlite_pool(&path).await.expect("pool a");
+    let pool_b = open_sqlite_pool(&path).await.expect("pool b");
+    let mut lock_conn = pool_a.acquire().await.expect("lock conn");
+
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *lock_conn)
+        .await
+        .expect("hold write lock");
+
+    let release = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(5_200)).await;
+        sqlx::query("ROLLBACK")
+            .execute(&mut *lock_conn)
+            .await
+            .expect("release write lock");
+    });
+
+    let id = enqueue_job(
+        &pool_b,
+        &JobPayload::Crawl {
+            url: "https://locked.example".into(),
+            config_json: "{}".into(),
+        },
+        &Config::default_lite(),
+    )
+    .await
+    .expect("enqueue should wait/retry until the write lock clears");
+
+    release.await.expect("release task");
+    let row: (String,) = sqlx::query_as("SELECT url FROM axon_crawl_jobs WHERE id = ?")
+        .bind(id.to_string())
+        .fetch_one(&pool_b)
+        .await
+        .expect("fetch inserted row");
+    assert_eq!(row.0, "https://locked.example");
+
+    drop(pool_a);
+    drop(pool_b);
+    tokio::fs::remove_file(&path).await.ok();
+}
+
+#[tokio::test]
+async fn concurrent_enqueue_respects_pending_cap_atomically() {
+    let path = std::env::temp_dir()
+        .join(format!("axon-lite-enqueue-cap-{}.db", Uuid::new_v4()))
+        .to_string_lossy()
+        .into_owned();
+    let pool_a = Arc::new(open_sqlite_pool(&path).await.expect("pool a"));
+    let pool_b = Arc::new(open_sqlite_pool(&path).await.expect("pool b"));
+    let mut cfg = Config::default_lite();
+    cfg.max_pending_crawl_jobs = 1;
+
+    let cfg_a = cfg.clone();
+    let cfg_b = cfg;
+    let first = {
+        let pool = Arc::clone(&pool_a);
+        tokio::spawn(async move {
+            enqueue_job(
+                pool.as_ref(),
+                &JobPayload::Crawl {
+                    url: "https://cap-a.example".into(),
+                    config_json: "{}".into(),
+                },
+                &cfg_a,
+            )
+            .await
+        })
+    };
+    let second = {
+        let pool = Arc::clone(&pool_b);
+        tokio::spawn(async move {
+            enqueue_job(
+                pool.as_ref(),
+                &JobPayload::Crawl {
+                    url: "https://cap-b.example".into(),
+                    config_json: "{}".into(),
+                },
+                &cfg_b,
+            )
+            .await
+        })
+    };
+
+    let results = [
+        first.await.expect("first join"),
+        second.await.expect("second join"),
+    ];
+    let successes = results.iter().filter(|result| result.is_ok()).count();
+    let cap_rejections = results
+        .iter()
+        .filter(|result| matches!(result, Err(JobError::QueueCapacityExceeded { .. })))
+        .count();
+    assert_eq!(successes, 1, "exactly one enqueue should fit cap=1");
+    assert_eq!(
+        cap_rejections, 1,
+        "the other enqueue should see the serialized pending count"
+    );
+
+    let pending: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM axon_crawl_jobs WHERE status='pending'")
+            .fetch_one(pool_a.as_ref())
+            .await
+            .expect("pending count");
+    assert_eq!(pending.0, 1);
 
     drop(pool_a);
     drop(pool_b);

--- a/src/jobs/lite/ops/tests.rs
+++ b/src/jobs/lite/ops/tests.rs
@@ -503,8 +503,11 @@ async fn enqueue_retries_when_sqlite_write_lock_is_temporarily_held() {
         .await
         .expect("hold write lock");
 
+    // 1.5s hold exercises the retry/wait path while staying well inside the
+    // 10s busy_timeout configured in open_sqlite_pool. The original 5.2s was
+    // chosen to outwait the prior 5s timeout — no longer needed.
     let release = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(5_200)).await;
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
         sqlx::query("ROLLBACK")
             .execute(&mut *lock_conn)
             .await

--- a/src/jobs/lite/ops/tests.rs
+++ b/src/jobs/lite/ops/tests.rs
@@ -312,7 +312,7 @@ async fn embed_queue_cap_rejects_when_full() {
     .await
     .expect("seed rows");
 
-    let err = check_pending_cap_for(&pool, "axon_embed_jobs", "embed", 2)
+    let err = check_pending_cap_for(&pool, JobKind::Embed, 2)
         .await
         .expect_err("should be at capacity");
     let msg = err.to_string();
@@ -322,7 +322,7 @@ async fn embed_queue_cap_rejects_when_full() {
     );
 
     // limit=3 allows one more
-    check_pending_cap_for(&pool, "axon_embed_jobs", "embed", 3)
+    check_pending_cap_for(&pool, JobKind::Embed, 3)
         .await
         .expect("limit=3 should allow 2 pending jobs");
 }
@@ -339,7 +339,7 @@ async fn extract_queue_cap_rejects_when_full() {
     .await
     .expect("seed row");
 
-    let err = check_pending_cap_for(&pool, "axon_extract_jobs", "extract", 1)
+    let err = check_pending_cap_for(&pool, JobKind::Extract, 1)
         .await
         .expect_err("should be at capacity");
     let msg = err.to_string();
@@ -361,7 +361,7 @@ async fn ingest_queue_cap_rejects_when_full() {
     .await
     .expect("seed row");
 
-    let err = check_pending_cap_for(&pool, "axon_ingest_jobs", "ingest", 1)
+    let err = check_pending_cap_for(&pool, JobKind::Ingest, 1)
         .await
         .expect_err("should be at capacity");
     let msg = err.to_string();
@@ -388,7 +388,7 @@ async fn embed_queue_cap_zero_disables_limit() {
         .unwrap_or_else(|e| panic!("enqueue {i} failed: {e}"));
     }
     // With 5 pending jobs, limit=0 still allows more.
-    check_pending_cap_for(&pool, "axon_embed_jobs", "embed", 0)
+    check_pending_cap_for(&pool, JobKind::Embed, 0)
         .await
         .expect("limit=0 should be unlimited");
 }
@@ -408,7 +408,7 @@ async fn embed_queue_cap_allows_after_drain() {
     .expect("first enqueue");
 
     // Queue is at cap (1 pending, limit=1) — check should reject.
-    check_pending_cap_for(&pool, "axon_embed_jobs", "embed", 1)
+    check_pending_cap_for(&pool, JobKind::Embed, 1)
         .await
         .expect_err("should be at capacity");
 
@@ -421,7 +421,7 @@ async fn embed_queue_cap_allows_after_drain() {
         .expect("complete");
 
     // Now the cap check should pass (0 pending, limit=1).
-    check_pending_cap_for(&pool, "axon_embed_jobs", "embed", 1)
+    check_pending_cap_for(&pool, JobKind::Embed, 1)
         .await
         .expect("cap check after drain should succeed");
 }

--- a/src/jobs/lite/query.rs
+++ b/src/jobs/lite/query.rs
@@ -270,10 +270,13 @@ pub async fn list_service_jobs(
              END, \
              created_at DESC, \
              updated_at DESC, \
-             id"
+             id ASC"
         }
-        _ => "ORDER BY created_at DESC, updated_at DESC, id",
+        _ => "ORDER BY created_at DESC, updated_at DESC, id ASC",
     };
+    // SAFETY: service_select_from(kind) and order_by are compile-time `&'static
+    // str` from a closed enum dispatch; no caller-controlled values reach this
+    // format!(). Limit/offset are bound parameters.
     let query = format!(
         "{} {} LIMIT ?1 OFFSET ?2",
         service_select_from(kind),

--- a/src/jobs/lite/query.rs
+++ b/src/jobs/lite/query.rs
@@ -258,13 +258,32 @@ pub async fn list_service_jobs(
     limit: i64,
     offset: i64,
 ) -> Result<Vec<ServiceJob>, sqlx::Error> {
+    let order_by = match kind {
+        JobKind::Crawl => {
+            "ORDER BY CASE status \
+                WHEN 'running' THEN 0 \
+                WHEN 'pending' THEN 1 \
+                WHEN 'completed' THEN 2 \
+                WHEN 'failed' THEN 3 \
+                WHEN 'canceled' THEN 4 \
+                ELSE 5 \
+             END, \
+             created_at DESC, \
+             updated_at DESC, \
+             id"
+        }
+        _ => "ORDER BY created_at DESC, updated_at DESC, id",
+    };
     let query = format!(
-        "{} ORDER BY created_at DESC, id LIMIT {} OFFSET {}",
+        "{} {} LIMIT ?1 OFFSET ?2",
         service_select_from(kind),
-        limit,
-        offset
+        order_by,
     );
-    let rows: Vec<ServiceJobTuple> = sqlx::query_as(&query).fetch_all(pool).await?;
+    let rows: Vec<ServiceJobTuple> = sqlx::query_as(&query)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
     Ok(rows.into_iter().map(service_job_from_tuple).collect())
 }
 
@@ -381,6 +400,45 @@ mod tests {
         let id = Uuid::new_v4();
         let row = job_status_row(&pool, JobKind::Crawl, id).await.unwrap();
         assert!(row.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_service_jobs_prioritizes_running_crawl_rows_over_newer_pending_rows() {
+        let pool = open_sqlite_pool(":memory:").await.unwrap();
+        let older_running = Uuid::new_v4().to_string();
+        let newer_pending = Uuid::new_v4().to_string();
+
+        sqlx::query(
+            "INSERT INTO axon_crawl_jobs (id, status, url, config_json, created_at, updated_at, started_at) \
+             VALUES (?, 'running', 'https://running.example', '{}', ?, ?, ?)",
+        )
+        .bind(&older_running)
+        .bind(1_000_i64)
+        .bind(1_000_i64)
+        .bind(1_000_i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO axon_crawl_jobs (id, status, url, config_json, created_at, updated_at) \
+             VALUES (?, 'pending', 'https://pending.example', '{}', ?, ?)",
+        )
+        .bind(&newer_pending)
+        .bind(2_000_i64)
+        .bind(2_000_i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let jobs = list_service_jobs(&pool, JobKind::Crawl, 20, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(jobs[0].id.to_string(), older_running);
+        assert_eq!(jobs[0].status, "running");
+        assert_eq!(jobs[1].id.to_string(), newer_pending);
+        assert_eq!(jobs[1].status, "pending");
     }
 
     #[tokio::test]

--- a/src/jobs/lite/store.rs
+++ b/src/jobs/lite/store.rs
@@ -253,4 +253,84 @@ mod tests {
         assert_eq!(fresh_status, "running");
         assert_eq!(pending_status, "pending");
     }
+
+    #[tokio::test]
+    async fn reclaim_stale_running_jobs_for_table_sets_reclaim_error_text() {
+        let pool = open_sqlite_pool(":memory:").await.expect("pool");
+        let stale_updated_at = now_ms() - 10_000;
+
+        let stale_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO axon_crawl_jobs \
+             (id, status, url, config_json, created_at, updated_at, started_at) \
+             VALUES (?, 'running', 'https://stale.example', '{}', ?, ?, ?)",
+        )
+        .bind(&stale_id)
+        .bind(stale_updated_at)
+        .bind(stale_updated_at)
+        .bind(stale_updated_at)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let fresh_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO axon_crawl_jobs \
+             (id, status, url, config_json, created_at, updated_at) \
+             VALUES (?, 'running', 'https://fresh.example', '{}', ?, ?)",
+        )
+        .bind(&fresh_id)
+        .bind(now_ms())
+        .bind(now_ms())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let pending_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO axon_crawl_jobs \
+             (id, status, url, config_json, created_at, updated_at) \
+             VALUES (?, 'pending', 'https://pending.example', '{}', ?, ?)",
+        )
+        .bind(&pending_id)
+        .bind(stale_updated_at)
+        .bind(stale_updated_at)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let reclaimed = reclaim_stale_running_jobs_for_table(&pool, JobKind::Crawl, 5_000)
+            .await
+            .expect("reclaim");
+
+        assert_eq!(
+            reclaimed, 1,
+            "only the stale running row should be reclaimed"
+        );
+
+        let (status, error_text): (String, Option<String>) =
+            sqlx::query_as("SELECT status, error_text FROM axon_crawl_jobs WHERE id = ?")
+                .bind(&stale_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "pending");
+        assert_eq!(error_text.as_deref(), Some(RECLAIMED_ERROR_TEXT));
+
+        let fresh_status: String =
+            sqlx::query_scalar("SELECT status FROM axon_crawl_jobs WHERE id = ?")
+                .bind(&fresh_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(fresh_status, "running", "fresh row must not be reclaimed");
+
+        let pending_status: String =
+            sqlx::query_scalar("SELECT status FROM axon_crawl_jobs WHERE id = ?")
+                .bind(&pending_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(pending_status, "pending", "pending row must not be touched");
+    }
 }

--- a/src/jobs/lite/store.rs
+++ b/src/jobs/lite/store.rs
@@ -67,7 +67,7 @@ pub async fn open_sqlite_pool(path: &str) -> Result<SqlitePool, sqlx::Error> {
     let opts: SqliteConnectOptions = connect_str.parse()?;
     let opts = opts
         .pragma("journal_mode", "WAL")
-        .pragma("busy_timeout", "5000")
+        .pragma("busy_timeout", "10000")
         .pragma("foreign_keys", "ON");
 
     let pool = SqlitePoolOptions::new()

--- a/src/jobs/lite/store.rs
+++ b/src/jobs/lite/store.rs
@@ -84,6 +84,13 @@ pub async fn open_sqlite_pool(path: &str) -> Result<SqlitePool, sqlx::Error> {
     Ok(pool)
 }
 
+/// Error text written into `error_text` when the watchdog reclaims a stale running job.
+///
+/// All three read sites (`jobs/lite/store.rs`, `cli/commands/status.rs`,
+/// `jobs/lite/ops/tests.rs`) import this constant so a one-character change never
+/// silently breaks the renderer.
+pub(crate) const RECLAIMED_ERROR_TEXT: &str = "reclaimed after unexpected shutdown";
+
 /// Reclaim jobs stuck in `running` state from a previous crashed process.
 pub async fn reclaim_stale_running_jobs(
     pool: &SqlitePool,
@@ -127,10 +134,11 @@ pub async fn reclaim_stale_running_jobs_for_table(
     .fetch_all(pool)
     .await?;
     let result = sqlx::query(&format!(
-        "UPDATE {} SET status='pending', error_text='reclaimed after unexpected shutdown', \
+        "UPDATE {} SET status='pending', error_text=?, \
          updated_at=? WHERE status='running' AND updated_at < ?",
         table
     ))
+    .bind(RECLAIMED_ERROR_TEXT)
     .bind(now_ms())
     .bind(threshold)
     .execute(pool)

--- a/src/jobs/lite/store.rs
+++ b/src/jobs/lite/store.rs
@@ -91,31 +91,58 @@ pub async fn open_sqlite_pool(path: &str) -> Result<SqlitePool, sqlx::Error> {
 /// silently breaks the renderer.
 pub(crate) const RECLAIMED_ERROR_TEXT: &str = "reclaimed after unexpected shutdown";
 
+/// Per-kind reclaim count returned by `reclaim_stale_running_jobs_detailed`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ReclaimCounts {
+    pub crawl: u64,
+    pub embed: u64,
+    pub extract: u64,
+    pub ingest: u64,
+}
+
+impl ReclaimCounts {
+    pub fn total(&self) -> u64 {
+        self.crawl + self.embed + self.extract + self.ingest
+    }
+}
+
 /// Reclaim jobs stuck in `running` state from a previous crashed process.
+/// Returns the total count for backwards compatibility; the watchdog uses
+/// `reclaim_stale_running_jobs_detailed` to drive per-kind worker wakeups.
 pub async fn reclaim_stale_running_jobs(
     pool: &SqlitePool,
     stale_threshold_ms: i64,
 ) -> Result<u64, sqlx::Error> {
-    tracing::debug!(
-        stale_threshold_ms,
-        "watchdog: starting stale-running-job sweep across all tables"
-    );
-    let mut total: u64 = 0;
+    Ok(
+        reclaim_stale_running_jobs_detailed(pool, stale_threshold_ms)
+            .await?
+            .total(),
+    )
+}
+
+pub async fn reclaim_stale_running_jobs_detailed(
+    pool: &SqlitePool,
+    stale_threshold_ms: i64,
+) -> Result<ReclaimCounts, sqlx::Error> {
+    let mut counts = ReclaimCounts::default();
     for kind in JobKind::all() {
-        match reclaim_stale_running_jobs_for_table(pool, *kind, stale_threshold_ms).await {
-            Ok(n) => total += n,
-            Err(e) => {
+        let n = reclaim_stale_running_jobs_for_table(pool, *kind, stale_threshold_ms)
+            .await
+            .inspect_err(|e| {
                 tracing::error!(table = kind.table_name(), error = %e, "watchdog: per-table sweep failed");
-                return Err(e);
-            }
+            })?;
+        match kind {
+            JobKind::Crawl => counts.crawl = n,
+            JobKind::Embed => counts.embed = n,
+            JobKind::Extract => counts.extract = n,
+            JobKind::Ingest => counts.ingest = n,
         }
     }
+    let total = counts.total();
     if total > 0 {
         tracing::info!(reclaimed = total, "watchdog: sweep complete");
-    } else {
-        tracing::debug!("watchdog: sweep complete, no stale jobs");
     }
-    Ok(total)
+    Ok(counts)
 }
 
 pub async fn reclaim_stale_running_jobs_for_table(
@@ -123,8 +150,10 @@ pub async fn reclaim_stale_running_jobs_for_table(
     kind: JobKind,
     stale_threshold_ms: i64,
 ) -> Result<u64, sqlx::Error> {
+    // SAFETY: `kind.table_name()` returns a compile-time `&'static str` from
+    // a closed enum dispatch; no caller-controlled value reaches `format!`.
+    // Status literals come from a closed enum too.
     let table = kind.table_name();
-    tracing::debug!(table, stale_threshold_ms, "watchdog: sweep table start");
     let threshold = now_ms() - stale_threshold_ms;
     let stale_ids = sqlx::query_scalar::<_, String>(&format!(
         "SELECT id FROM {} WHERE status='running' AND updated_at < ?",

--- a/src/jobs/lite/workers.rs
+++ b/src/jobs/lite/workers.rs
@@ -37,7 +37,6 @@ pub(crate) fn resolve_lane_count(env_var: &str, cpu_min: usize, cpu_max: usize) 
 
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 const WORKER_BATCH_LIMIT: usize = 32;
-const WATCHDOG_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Handles to wake specific worker types when new jobs are enqueued.
 pub struct WorkerHandles {
@@ -180,15 +179,13 @@ pub fn spawn_workers(
     }
 }
 
-/// Periodic watchdog: sweeps all job tables every 15s while the process is alive.
+/// Periodic watchdog: sweeps all job tables on a config-driven interval
+/// (`cfg.watchdog_sweep_secs`, default 15s) while the process is alive.
 ///
 /// Pairs with `HeartbeatGuard` — heartbeat keeps `updated_at` fresh for live jobs;
 /// watchdog reclaims rows whose `updated_at` has gone stale (process died, runner
-/// panicked, etc.). After any reclaim, wakes all four worker channels so pending
-/// rows are picked up within milliseconds rather than waiting for `POLL_INTERVAL`.
-///
-/// Uses `match` instead of `if let Err` so reclaimed > 0 can trigger worker wakeups.
-/// `.await?` inside `tokio::spawn` returning `()` is a compile error — do not use it.
+/// panicked, etc.). After a reclaim, wakes the worker channels whose kind had
+/// rows reclaimed — not the others — so untouched lanes stay parked.
 async fn watchdog_loop(
     pool: Arc<SqlitePool>,
     cfg: Arc<Config>,
@@ -200,7 +197,8 @@ async fn watchdog_loop(
 ) {
     let stale_threshold_ms =
         (cfg.watchdog_stale_timeout_secs + cfg.watchdog_confirm_secs).max(0) * 1_000i64;
-    let mut ticker = tokio::time::interval(WATCHDOG_SWEEP_INTERVAL);
+    let sweep_interval = Duration::from_secs(cfg.watchdog_sweep_secs.max(1) as u64);
+    let mut ticker = tokio::time::interval(sweep_interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // Skip immediate tick — startup-time reclaim already ran in LiteBackend::init.
     ticker.tick().await;
@@ -209,25 +207,29 @@ async fn watchdog_loop(
             biased;
             _ = shutdown.cancelled() => break,
             _ = ticker.tick() => {
-                match crate::jobs::lite::store::reclaim_stale_running_jobs(
+                match crate::jobs::lite::store::reclaim_stale_running_jobs_detailed(
                     &pool,
                     stale_threshold_ms,
                 )
                 .await
                 {
-                    Ok(total) if total > 0 => {
-                        tracing::info!(
-                            reclaimed = total,
-                            "watchdog: reclaimed stale jobs, waking workers"
-                        );
+                    Ok(counts) if counts.total() > 0 => {
                         // notify_waiters (not notify_one) so all parked lanes
                         // for each kind wake — a single reclaim sweep can free
                         // multiple jobs of the same kind, and embed/ingest run
                         // multiple lanes that share one Notify handle.
-                        crawl_notify.notify_waiters();
-                        embed_notify.notify_waiters();
-                        extract_notify.notify_waiters();
-                        ingest_notify.notify_waiters();
+                        if counts.crawl > 0 {
+                            crawl_notify.notify_waiters();
+                        }
+                        if counts.embed > 0 {
+                            embed_notify.notify_waiters();
+                        }
+                        if counts.extract > 0 {
+                            extract_notify.notify_waiters();
+                        }
+                        if counts.ingest > 0 {
+                            ingest_notify.notify_waiters();
+                        }
                     }
                     Ok(_) => {}
                     Err(e) => {

--- a/src/jobs/lite/workers.rs
+++ b/src/jobs/lite/workers.rs
@@ -220,10 +220,14 @@ async fn watchdog_loop(
                             reclaimed = total,
                             "watchdog: reclaimed stale jobs, waking workers"
                         );
-                        crawl_notify.notify_one();
-                        embed_notify.notify_one();
-                        extract_notify.notify_one();
-                        ingest_notify.notify_one();
+                        // notify_waiters (not notify_one) so all parked lanes
+                        // for each kind wake — a single reclaim sweep can free
+                        // multiple jobs of the same kind, and embed/ingest run
+                        // multiple lanes that share one Notify handle.
+                        crawl_notify.notify_waiters();
+                        embed_notify.notify_waiters();
+                        extract_notify.notify_waiters();
+                        ingest_notify.notify_waiters();
                     }
                     Ok(_) => {}
                     Err(e) => {

--- a/src/jobs/lite/workers.rs
+++ b/src/jobs/lite/workers.rs
@@ -37,6 +37,7 @@ pub(crate) fn resolve_lane_count(env_var: &str, cpu_min: usize, cpu_max: usize) 
 
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 const WORKER_BATCH_LIMIT: usize = 32;
+const WATCHDOG_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Handles to wake specific worker types when new jobs are enqueued.
 pub struct WorkerHandles {
@@ -158,40 +159,16 @@ pub fn spawn_workers(
         )));
     }
 
-    // Periodic watchdog: re-runs reclaim_stale_running_jobs every 60s while the
-    // process is alive. Pairs with the per-job HeartbeatGuard — heartbeat keeps
-    // updated_at fresh for live jobs; watchdog reclaims rows whose updated_at
-    // has gone stale (process died, runner panicked, etc.).
-    {
-        let pool = Arc::clone(&pool);
-        let cfg_for_watchdog = Arc::clone(&cfg);
-        let shutdown = shutdown.clone();
-        worker_handles.push(tokio::spawn(async move {
-            let stale_threshold_ms = (cfg_for_watchdog.watchdog_stale_timeout_secs
-                + cfg_for_watchdog.watchdog_confirm_secs)
-                .max(0)
-                * 1_000i64;
-            let mut ticker = tokio::time::interval(Duration::from_secs(60));
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            // Skip immediate tick — startup-time reclaim already ran in LiteBackend::init.
-            ticker.tick().await;
-            loop {
-                tokio::select! {
-                    _ = shutdown.cancelled() => break,
-                    _ = ticker.tick() => {
-                        if let Err(e) = crate::jobs::lite::store::reclaim_stale_running_jobs(
-                            &pool,
-                            stale_threshold_ms,
-                        )
-                        .await
-                        {
-                            tracing::warn!(error = %e, "watchdog: periodic reclaim failed");
-                        }
-                    }
-                }
-            }
-        }));
-    }
+    // Periodic watchdog: sweeps all job tables every 15s; wakes workers on reclaim.
+    worker_handles.push(tokio::spawn(watchdog_loop(
+        Arc::clone(&pool),
+        Arc::clone(&cfg),
+        Arc::clone(&crawl_notify),
+        Arc::clone(&embed_notify),
+        Arc::clone(&extract_notify),
+        Arc::clone(&ingest_notify),
+        shutdown.clone(),
+    )));
 
     WorkerHandles {
         crawl: crawl_notify,
@@ -200,6 +177,61 @@ pub fn spawn_workers(
         ingest: ingest_notify,
         shutdown,
         worker_handles,
+    }
+}
+
+/// Periodic watchdog: sweeps all job tables every 15s while the process is alive.
+///
+/// Pairs with `HeartbeatGuard` — heartbeat keeps `updated_at` fresh for live jobs;
+/// watchdog reclaims rows whose `updated_at` has gone stale (process died, runner
+/// panicked, etc.). After any reclaim, wakes all four worker channels so pending
+/// rows are picked up within milliseconds rather than waiting for `POLL_INTERVAL`.
+///
+/// Uses `match` instead of `if let Err` so reclaimed > 0 can trigger worker wakeups.
+/// `.await?` inside `tokio::spawn` returning `()` is a compile error — do not use it.
+async fn watchdog_loop(
+    pool: Arc<SqlitePool>,
+    cfg: Arc<Config>,
+    crawl_notify: Arc<Notify>,
+    embed_notify: Arc<Notify>,
+    extract_notify: Arc<Notify>,
+    ingest_notify: Arc<Notify>,
+    shutdown: CancellationToken,
+) {
+    let stale_threshold_ms =
+        (cfg.watchdog_stale_timeout_secs + cfg.watchdog_confirm_secs).max(0) * 1_000i64;
+    let mut ticker = tokio::time::interval(WATCHDOG_SWEEP_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Skip immediate tick — startup-time reclaim already ran in LiteBackend::init.
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            _ = ticker.tick() => {
+                match crate::jobs::lite::store::reclaim_stale_running_jobs(
+                    &pool,
+                    stale_threshold_ms,
+                )
+                .await
+                {
+                    Ok(total) if total > 0 => {
+                        tracing::info!(
+                            reclaimed = total,
+                            "watchdog: reclaimed stale jobs, waking workers"
+                        );
+                        crawl_notify.notify_one();
+                        embed_notify.notify_one();
+                        extract_notify.notify_one();
+                        ingest_notify.notify_one();
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(error = %e, "watchdog: periodic reclaim failed");
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the [crawl status + watchdog recovery plan](docs/superpowers/plans/2026-05-11-crawl-status-and-watchdog-recovery.md):

- Anchors \`RECLAIMED_ERROR_TEXT\` as a single shared constant so the three usage sites (\`store.rs\` writer, \`status.rs\` renderer, \`ops/tests.rs\` fixture) can't drift.
- Prioritizes active crawl rows in \`axon status\` so running/pending jobs surface before newer completed rows.
- Makes the status output explicitly say when it is truncated (\"showing N of M total\").
- Tightens the in-process watchdog: 60s → 15s sweep interval plus a post-reclaim notify so reclaimed rows are claimed promptly instead of waiting up to a poll cycle.

Also addresses several pre-existing test failures that block the test suite from running parallelized:

- Consolidates two duplicate \`ENV_LOCK\` mutexes (\`parse::tests\` + \`build_config::tests\`) into a single shared lock so parallel tests in different modules don't trample each other's env vars and poison the lock.
- Wraps the pending-queue cap check + INSERT in a \`BEGIN IMMEDIATE\` transaction so concurrent enqueues serialize at the SQLite write lock — previously two callers could observe \`count=0\` simultaneously and double-insert past the cap.
- Bumps SQLite \`busy_timeout\` from 5000ms to 10000ms so enqueue waits through transient lock contention from co-located writers.
- Bumps \`apps/web/package.json\` from 1.9.5 to 1.10.1 to match \`Cargo.toml\`.

## Test plan

- [x] \`cargo test --lib\` (1539 passed)
- [x] \`cargo test --tests\` (1715 passed across 18 suites)
- [x] \`cargo clippy --lib\` clean
- [x] \`cargo clippy --tests\` clean
- [x] Plan regression tests for the reclaim path and status query ordering

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves crawl status visibility and recovery: running and pending crawls are prioritized with a correct “showing N of M” note and reclaimed-job hints. The watchdog now sweeps every 15s (configurable via `AXON_WATCHDOG_SWEEP_SECS`/`--watchdog-sweep-secs`) and wakes all lanes for the affected kinds after a reclaim.

- **New Features**
  - Status: running/pending crawls listed first; truncation note matches the 10-row display cap; reclaimed rows show a friendly hint; anchored `RECLAIMED_ERROR_TEXT`.
  - Watchdog: configurable sweep interval; per-kind wakeups so only lanes with reclaimed jobs are notified.

- **Bug Fixes**
  - Queues: Pending-cap check and INSERT now run under `BEGIN IMMEDIATE` on a dedicated connection; cap check is O(cap) via `SELECT 1 ... LIMIT`; rollback on commit failure; SQLite `busy_timeout` raised to 10000ms.
  - Performance: Added `(status, created_at DESC)` composite indexes on all job tables to keep status and cap checks fast at scale.
  - Tests/infra: Consolidated env var `ENV_LOCK` into a single shared mutex to prevent parallel test flakes; bumped `@axon/admin-panel` to `1.10.1`.

<sup>Written for commit d92fa08717ecee42d10fe3f2a3c8dc6542c77792. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced job status display with truncation notes showing total job counts.
  * Improved job listing to prioritize running jobs.

* **Bug Fixes**
  * Strengthened concurrent job enqueuing with transactional safety.
  * Optimized watchdog interval and conditional worker wakeups.
  * Increased database timeout for better resilience.

* **Chores**
  * Updated admin panel dependency.
  * Centralized error message constants.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/axon/pull/81)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->