### PR TITLE
ci: drop duplicate AXON_DATA_DIR env keys in mcp-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,6 @@ jobs:
           AXON_DATA_DIR: .cache/axon-ci
           TEI_URL: http://127.0.0.1:52000
           QDRANT_URL: http://127.0.0.1:53333
-          AXON_DATA_DIR: .cache/axon-ci
           AXON_LOG_DIR: .cache/axon-ci/logs
           AXON_SQLITE_PATH: .cache/axon-ci/jobs.db
           AXON_EMBED_STRICT_PREDELETE: "false"
@@ -456,7 +455,6 @@ jobs:
           AXON_DATA_DIR: .cache/axon-ci
           TEI_URL: http://127.0.0.1:52000
           QDRANT_URL: http://127.0.0.1:53333
-          AXON_DATA_DIR: .cache/axon-ci
           AXON_LOG_DIR: .cache/axon-ci/logs
           AXON_SQLITE_PATH: .cache/axon-ci/jobs.db
         run: |


### PR DESCRIPTION
## Summary

Two-line fix: removes a duplicate `AXON_DATA_DIR` env key from each of two steps in the `mcp-smoke` job in `.github/workflows/ci.yml`. GitHub Actions rejects workflows that contain duplicate map keys at the parse stage, so the entire CI workflow has been failing to load on every push — no jobs (check, clippy, fmt, test, etc.) ever execute. The screenshot from the Actions UI confirms the parse error at lines 448 and 459 of the main-branch copy.

This is a clean cherry-pick of `38e0225` from PR #87 onto main so the fix can land independently of that larger PR and unblock CI for every open branch.

## Test plan

- [ ] After merge, the next push to main (or any open PR) should produce a queued CI run instead of a parse-error failure.
- [ ] The kept declarations in each `env:` block are identical to the removed ones, so runtime behavior of `mcp-smoke` is unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code/session_01Rea7xss2zW5YUrvwq5P69Z)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rea7xss2zW5YUrvwq5P69Z)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI workflow parse errors by removing duplicate `AXON_DATA_DIR` env keys in the `mcp-smoke` job. This unblocks all CI jobs; behavior of `mcp-smoke` is unchanged.

<sup>Written for commit 8bfdfcbd3804fa05cce144108e9fb87af51a9b2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

