### PR TITLE
Harden retrieval quality diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-15
+
+### Added
+
+- retrieval: add typed corpus-health diagnostics and richer `ask --explain` selection metadata so ranking, full-document selection, and corpus coverage failures can be separated without scraping logs.
+- eval: add a tracked retrieval fixture harness for repeatable domain-quality sweeps, including strict expected-domain matching and regression coverage for script pass/fail semantics.
+
+### Fixed
+
+- retrieval: keep explain selection metadata attached to the right candidate after rerank reordering or duplicate URLs by using stable candidate keys instead of kept-index ordinals.
+- retrieval: harden full-document selection with URL dedupe, configurable per-domain diversity, and fallback fill when a single domain is the only available source.
+
 ## [2.0.0] - 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2026-05-15
+## [2.1.0] - 2026-05-16
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/docs/ASK.md
+++ b/docs/ASK.md
@@ -16,6 +16,24 @@ Benchmarking:
 - Quality set: `docs/eval/README.md`
 - Parity report: `docs/perf/quality-parity-2026-05-07.md`
 
+### Retrieval Quality Gates
+
+Fast gates:
+- token policy unit tests
+- explain/schema unit tests
+- selection unit tests
+
+Medium gates:
+- `scripts/evaluate-retrieval.sh`
+- `ALLOW_MISS=1 scripts/evaluate-retrieval.sh` for exploratory sweeps with known misses
+
+Slow gates:
+- `axon evaluate`
+- `scripts/evaluate-ask-golden.sh`
+- `scripts/bench-ask.sh`
+
+Use slow gates for release signoff, not for every small retrieval tuning loop.
+
 Explain mode:
 
 - `axon ask --explain --json "<question>"` runs retrieval, reranking, and context assembly, then skips Gemini synthesis.

--- a/docs/commands/ask.md
+++ b/docs/commands/ask.md
@@ -27,7 +27,7 @@ axon ask --query "<question>" [FLAGS]
 | `QDRANT_URL` | Qdrant base URL. Searched for relevant chunks. |
 | `AXON_HEADLESS_GEMINI_CMD` | Optional Gemini CLI command. Defaults to `gemini`. |
 | `AXON_HEADLESS_GEMINI_MODEL` | Optional Gemini model override for answer generation. |
-| `AXON_SERVER_URL` | Optional generic server endpoint. If set, server-mode capable commands use `axon serve`; `ask` uses the same server URL. |
+| `AXON_SERVER_URL` | Optional generic server endpoint. If set, buffered `ask` requests use `axon serve`; streaming requests stay in-process. |
 
 `ask` uses Qdrant + TEI retrieval and Gemini headless synthesis.
 
@@ -83,8 +83,8 @@ axon ask "claude marketplace plugins" --explain --json
 # JSON output
 axon ask "what is the max crawl depth?" --json
 
-# Ask through a running server
-AXON_SERVER_URL=http://127.0.0.1:8001 axon ask "what changed in server mode?"
+# Ask through a running server with buffered output
+AXON_SERVER_URL=http://127.0.0.1:8001 axon ask --no-stream "what changed in server mode?"
 ```
 
 ## RAG Pipeline
@@ -116,6 +116,30 @@ topics.
 ## Explain Trace
 
 Use `--diagnostics` for aggregate health counters. Use `--explain --json` when a ranking result looks wrong and you need the per-candidate math and context decisions. Explain mode returns the normal `AskResult` shape with `answer: ""`, `timing_ms.llm: 0`, `explain.llm_skipped: true`, and no Gemini call.
+
+```text
+query
+  |
+  v
+TEI embedding + Qdrant dense/BM42/RRF retrieval
+  |
+  v
+rerank/filter + token/authority policy
+  |
+  v
+corpus-health classification
+  |
+  v
+context selection + bounded full-doc fetch
+  |
+  v
+ask --explain retrieval harness
+  |
+  +--> ranking bug? tune scoring/filtering
+  +--> selection bug? tune context selection
+  +--> corpus gap? crawl/index better docs
+  +--> fixture mismatch? update tracked fixture notes
+```
 
 Compact example:
 

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -24,3 +24,19 @@ Update rules:
 `axon evaluate --json` emits a `scores` object with `status`, per-axis `axes`,
 `rag_total`, `baseline_total`, and `winner`. Report consumers must treat
 `parse_failed` and `partial` as explicit statuses, not as zero scores.
+
+## Retrieval Fixture Sweep
+
+`scripts/evaluate-retrieval.sh` runs `axon ask --explain --diagnostics --json`
+over `docs/eval/retrieval-fixtures.jsonl`. It checks whether the expected
+domain appears in top domains and selected context without invoking Gemini
+answer synthesis or judge analysis.
+
+Use it before and after retrieval ranking, token-policy, or context-selection
+changes:
+
+```bash
+cargo build --bin axon
+scripts/evaluate-retrieval.sh
+ALLOW_MISS=1 scripts/evaluate-retrieval.sh
+```

--- a/docs/eval/retrieval-fixtures.jsonl
+++ b/docs/eval/retrieval-fixtures.jsonl
@@ -1,0 +1,9 @@
+{"id":"top20-docsrs-rust-crate-docs","domain":"docs.rs","query":"How do I use docs.rs to find Rust crate API documentation?","expected":"selected","notes":"top20 baseline"}
+{"id":"top20-openai-chatgpt-tools","domain":"developers.openai.com","query":"How do ChatGPT Apps expose tools to the model?","expected":"selected","notes":"top20 baseline"}
+{"id":"top20-postgresql-create-view","domain":"www.postgresql.org","query":"How do I create a PostgreSQL view with CHECK OPTION?","expected":"selected","notes":"top20 baseline"}
+{"id":"top20-qdrant-collection","domain":"qdrant.tech","query":"How do I create a Qdrant collection with vectors?","expected":"selected","notes":"top20 baseline"}
+{"id":"popular-uv-dependencies","domain":"docs.astral.sh","query":"How do I use uv to manage Python dependencies?","expected":"selected","notes":"short product token regression"}
+{"id":"popular-claude-hooks","domain":"code.claude.com","query":"How do Claude Code hooks work?","expected":"selected","notes":"configured authority regression"}
+{"id":"popular-pypi-publish","domain":"pypi.org","query":"How do I publish a Python package to PyPI?","expected":"top_domain","notes":"known corpus mismatch: pypi appears but publish docs may not be selected"}
+{"id":"popular-effective-rust-errors","domain":"effective-rust.com","query":"How should I structure error handling in Rust?","expected":"known_miss","notes":"known thin corpus/broad query miss"}
+{"id":"popular-shuttle-deploy","domain":"www.shuttle.dev","query":"How do I deploy a Rust app with Shuttle?","expected":"known_miss","notes":"known not indexed in active collection at planning time"}

--- a/scripts/evaluate-retrieval.sh
+++ b/scripts/evaluate-retrieval.sh
@@ -93,12 +93,17 @@ jq -s --arg output "$OUT" '
     pass: (map(select(.pass)) | length),
     top_pass: (map(select(.top_pass)) | length),
     selected_pass: (map(select(.selected_pass)) | length),
+    runtime_failures: map(select(.status != "ok")),
     failures: map(select(.pass | not)),
     output: $output
   }
 ' "$OUT" > "$SUMMARY"
 
 cat "$SUMMARY"
+
+if jq -e '.runtime_failures | length > 0' "$SUMMARY" >/dev/null; then
+  exit 1
+fi
 
 if [ "$ALLOW_MISS" != "1" ] && jq -e '.failures | length > 0' "$SUMMARY" >/dev/null; then
   exit 1

--- a/scripts/evaluate-retrieval.sh
+++ b/scripts/evaluate-retrieval.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+FIXTURES="${1:-$REPO/docs/eval/retrieval-fixtures.jsonl}"
+OUT="${OUT:-$REPO/.cache/axon-rust/evals/retrieval-$(date +%Y%m%d%H%M%S).jsonl}"
+SUMMARY="${SUMMARY:-${OUT%.jsonl}.summary.json}"
+AXON_BIN="${AXON_BIN:-$REPO/target/debug/axon}"
+ALLOW_MISS="${ALLOW_MISS:-0}"
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 2
+  }
+}
+
+need jq
+mkdir -p "$(dirname "$OUT")"
+mkdir -p "$(dirname "$SUMMARY")"
+: > "$OUT"
+
+jq -s -e '
+  length > 0 and
+  all(.[]; type == "object"
+    and ((.id // "") != "")
+    and ((.domain // "") != "")
+    and ((.query // "") != "")
+    and (.expected as $expected
+      | $expected == "selected"
+        or $expected == "top_domain"
+        or $expected == "known_miss"))
+' "$FIXTURES" >/dev/null
+
+while IFS= read -r row; do
+  id="$(jq -r '.id' <<<"$row")"
+  domain="$(jq -r '.domain' <<<"$row")"
+  query="$(jq -r '.query' <<<"$row")"
+  expected="$(jq -r '.expected' <<<"$row")"
+
+  if ! payload="$("$AXON_BIN" --local ask --explain --diagnostics --json "$query" 2> >(sed "s/^/[axon:$id] /" >&2))"; then
+    jq -n -c --arg id "$id" --arg domain "$domain" --arg query "$query" --arg expected "$expected" \
+      '{id:$id,domain:$domain,query:$query,expected:$expected,status:"axon_failed",top_pass:false,selected_pass:false,pass:false}' >> "$OUT"
+    continue
+  fi
+
+  jq -c \
+    --arg id "$id" \
+    --arg domain "$domain" \
+    --arg query "$query" \
+    --arg expected "$expected" \
+    '
+    def selected_urls:
+      [.explain.candidates[]?
+       | select(.selected_context_rank != null)
+       | .url];
+    def url_host:
+      capture("^https?://(?<host>[^/:?#]+)")?.host | ascii_downcase;
+    def domain_match($domain):
+      ascii_downcase as $host
+      | ($domain | ascii_downcase) as $expected
+      | ($host == $expected or ($host | endswith("." + $expected)));
+    def top_domain_host:
+      split(":")[0] | ascii_downcase;
+    . as $payload
+    | {
+        id: $id,
+        domain: $domain,
+        query: $query,
+        expected: $expected,
+        status: "ok",
+        top_domains: ($payload.diagnostics.top_domains // []),
+        selected_urls: (selected_urls[0:20]),
+        top_pass: (($payload.diagnostics.top_domains // []) | any(top_domain_host | domain_match($domain))),
+        selected_pass: (selected_urls | map(url_host) | any(. != null and domain_match($domain))),
+        corpus_health: ($payload.diagnostics.corpus_health // null),
+        timing_ms: ($payload.timing_ms // {})
+      }
+    | .pass = (
+        if $expected == "selected" then (.top_pass and .selected_pass)
+        elif $expected == "top_domain" then .top_pass
+        elif $expected == "known_miss" then true
+        else false
+        end
+      )
+    ' <<<"$payload" >> "$OUT"
+done < <(jq -c '.' "$FIXTURES")
+
+jq -s --arg output "$OUT" '
+  {
+    total: length,
+    pass: (map(select(.pass)) | length),
+    top_pass: (map(select(.top_pass)) | length),
+    selected_pass: (map(select(.selected_pass)) | length),
+    failures: map(select(.pass | not)),
+    output: $output
+  }
+' "$OUT" > "$SUMMARY"
+
+cat "$SUMMARY"
+
+if [ "$ALLOW_MISS" != "1" ] && jq -e '.failures | length > 0' "$SUMMARY" >/dev/null; then
+  exit 1
+fi

--- a/scripts/test-evaluate-retrieval.sh
+++ b/scripts/test-evaluate-retrieval.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cat >"$TMP/fake-axon" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+query="${@: -1}"
+case "$query" in
+  "selected")
+    cat <<'JSON'
+{"diagnostics":{"top_domains":["docs.example.com:2"]},"explain":{"candidates":[{"url":"https://docs.example.com/page","selected_context_rank":1}]},"timing_ms":{}}
+JSON
+    ;;
+  "top-only")
+    cat <<'JSON'
+{"diagnostics":{"top_domains":["docs.example.com:2"]},"explain":{"candidates":[{"url":"https://other.example.com/page","selected_context_rank":1}]},"timing_ms":{}}
+JSON
+    ;;
+  "known-miss" | "miss")
+    cat <<'JSON'
+{"diagnostics":{"top_domains":["other.example.com:2"]},"explain":{"candidates":[{"url":"https://other.example.com/page","selected_context_rank":1}]},"timing_ms":{}}
+JSON
+    ;;
+  *)
+    exit 9
+    ;;
+esac
+FAKE
+chmod +x "$TMP/fake-axon"
+
+cat >"$TMP/fixtures.jsonl" <<'JSONL'
+{"id":"selected","domain":"docs.example.com","query":"selected","expected":"selected"}
+{"id":"top","domain":"docs.example.com","query":"top-only","expected":"top_domain"}
+{"id":"known","domain":"docs.example.com","query":"known-miss","expected":"known_miss"}
+{"id":"miss","domain":"docs.example.com","query":"miss","expected":"selected"}
+JSONL
+
+if AXON_BIN="$TMP/fake-axon" OUT="$TMP/default.jsonl" "$REPO/scripts/evaluate-retrieval.sh" "$TMP/fixtures.jsonl" >"$TMP/default-summary.json"; then
+  echo "expected default run to fail on miss" >&2
+  exit 1
+fi
+
+ALLOW_MISS=1 AXON_BIN="$TMP/fake-axon" OUT="$TMP/allow-miss.jsonl" "$REPO/scripts/evaluate-retrieval.sh" "$TMP/fixtures.jsonl" >"$TMP/summary.json"
+jq -e '.total == 4 and .pass == 3 and (.failures | length == 1)' "$TMP/summary.json" >/dev/null
+
+: >"$TMP/empty.jsonl"
+if ALLOW_MISS=1 AXON_BIN="$TMP/fake-axon" OUT="$TMP/empty-output.jsonl" "$REPO/scripts/evaluate-retrieval.sh" "$TMP/empty.jsonl" >/dev/null 2>&1; then
+  echo "expected empty fixture file to fail validation" >&2
+  exit 1
+fi

--- a/scripts/test-evaluate-retrieval.sh
+++ b/scripts/test-evaluate-retrieval.sh
@@ -46,7 +46,29 @@ if AXON_BIN="$TMP/fake-axon" OUT="$TMP/default.jsonl" "$REPO/scripts/evaluate-re
 fi
 
 ALLOW_MISS=1 AXON_BIN="$TMP/fake-axon" OUT="$TMP/allow-miss.jsonl" "$REPO/scripts/evaluate-retrieval.sh" "$TMP/fixtures.jsonl" >"$TMP/summary.json"
-jq -e '.total == 4 and .pass == 3 and (.failures | length == 1)' "$TMP/summary.json" >/dev/null
+jq -e '
+  .total == 4
+  and .pass == 3
+  and (.runtime_failures | length == 0)
+  and (.failures | length == 1)
+  and .failures[0].id == "miss"
+' "$TMP/summary.json" >/dev/null
+
+cat >"$TMP/runtime-failure.jsonl" <<'JSONL'
+{"id":"infra","domain":"docs.example.com","query":"infra-failure","expected":"known_miss"}
+JSONL
+
+if ALLOW_MISS=1 AXON_BIN="$TMP/fake-axon" OUT="$TMP/runtime-output.jsonl" "$REPO/scripts/evaluate-retrieval.sh" "$TMP/runtime-failure.jsonl" >"$TMP/runtime-summary.json"; then
+  echo "expected runtime failures to fail even with ALLOW_MISS=1" >&2
+  exit 1
+fi
+jq -e '
+  .total == 1
+  and .pass == 0
+  and (.runtime_failures | length == 1)
+  and .runtime_failures[0].id == "infra"
+  and .runtime_failures[0].status == "axon_failed"
+' "$TMP/runtime-summary.json" >/dev/null
 
 : >"$TMP/empty.jsonl"
 if ALLOW_MISS=1 AXON_BIN="$TMP/fake-axon" OUT="$TMP/empty-output.jsonl" "$REPO/scripts/evaluate-retrieval.sh" "$TMP/empty.jsonl" >/dev/null 2>&1; then

--- a/src/cli/commands/ask.rs
+++ b/src/cli/commands/ask.rs
@@ -292,6 +292,16 @@ fn print_diagnostics(diag: &Option<crate::services::types::AskDiagnostics>) {
             diag.top_domains.join(", ")
         );
     }
+    if let Some(health) = &diag.corpus_health {
+        println!(
+            "  {} {:?} selected_domains={} top_domains={} reason={}",
+            muted("Corpus health:"),
+            health.kind,
+            health.selected_domain_count,
+            health.top_domain_count,
+            health.reason
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/commands/watch.rs
+++ b/src/cli/commands/watch.rs
@@ -261,7 +261,9 @@ mod tests {
 
     #[tokio::test]
     async fn run_watch_rejects_unknown_subcommand() {
+        let tmp = tempfile::tempdir().expect("tempdir");
         let mut cfg = Config::test_default();
+        cfg.sqlite_path = tmp.path().join("jobs.db");
         cfg.positional = vec!["bogus".to_string()];
         let service_context = test_service_context(&cfg).await;
         let err = run_watch(&cfg, &service_context)
@@ -272,7 +274,9 @@ mod tests {
 
     #[tokio::test]
     async fn run_watch_lists_in_lite_mode() -> Result<(), Box<dyn Error>> {
-        let cfg = Config::default_lite();
+        let tmp = tempfile::tempdir()?;
+        let mut cfg = Config::default_lite();
+        cfg.sqlite_path = tmp.path().join("jobs.db");
         let service_context = test_service_context(&cfg).await;
         run_watch(&cfg, &service_context).await?;
         Ok(())

--- a/src/services/query/tests.rs
+++ b/src/services/query/tests.rs
@@ -282,7 +282,9 @@ fn ask_explain_candidate_deserializes_without_rank_fields() {
     });
     let parsed: AskExplainCandidate = serde_json::from_value(value).unwrap();
     assert_eq!(parsed.raw_rerank_rank, None);
+    assert_eq!(parsed.planned_full_doc_rank, None);
     assert_eq!(parsed.selected_context_rank, None);
+    assert_eq!(parsed.insertion_mode, None);
 }
 
 #[test]

--- a/src/services/query/tests.rs
+++ b/src/services/query/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::services::types::{
-    AskExplainFilterDecisionKind, AskExplainMode, AskExplainScoreComponentStatus,
-    AskExplainScoreKind, AskExplainSelectionDecisionKind, AskTiming,
+    AskExplainCandidate, AskExplainFilterDecisionKind, AskExplainMode,
+    AskExplainScoreComponentStatus, AskExplainScoreKind, AskExplainSelectionDecisionKind,
+    AskTiming, CorpusHealthKind,
 };
 use serde_json::json;
 
@@ -190,6 +191,10 @@ fn map_ask_payload_preserves_explain_contract() {
                 "id": "c0",
                 "url": "https://docs.widget.dev/docs/en/discover-plugins",
                 "chunk_index": 2,
+                "raw_rerank_rank": 1,
+                "planned_full_doc_rank": 1,
+                "selected_context_rank": 1,
+                "insertion_mode": "top_chunk",
                 "retrieval_score": 0.7,
                 "rerank_score": 1.18,
                 "score_kind": "cosine",
@@ -256,7 +261,28 @@ fn map_ask_payload_preserves_explain_contract() {
         candidate.selection_decisions[0].kind,
         AskExplainSelectionDecisionKind::SelectedTopChunk
     );
+    assert_eq!(candidate.raw_rerank_rank, Some(1));
+    assert_eq!(candidate.selected_context_rank, Some(1));
     assert!(explain.llm_skipped);
+}
+
+#[test]
+fn ask_explain_candidate_deserializes_without_rank_fields() {
+    let value = serde_json::json!({
+        "id": "candidate-1",
+        "url": "https://docs.example.com/page",
+        "chunk_index": null,
+        "retrieval_score": 0.5,
+        "rerank_score": 0.5,
+        "score_kind": "cosine",
+        "score_components": [],
+        "filter_decisions": [],
+        "selection_decisions": [],
+        "snippet": "example"
+    });
+    let parsed: AskExplainCandidate = serde_json::from_value(value).unwrap();
+    assert_eq!(parsed.raw_rerank_rank, None);
+    assert_eq!(parsed.selected_context_rank, None);
 }
 
 #[test]
@@ -283,7 +309,13 @@ fn map_ask_payload_preserves_adaptive_diagnostics() {
             "top_domains": ["docs.example.com"],
             "authority_ratio": 0.75,
             "configured_authority_ratio": 0.25,
-            "product_authority_ratio": 0.75
+            "product_authority_ratio": 0.75,
+            "corpus_health": {
+                "kind": "healthy",
+                "reason": "retrieval produced selected context",
+                "selected_domain_count": 2,
+                "top_domain_count": 5
+            }
         },
         "timing_ms": {
             "retrieval": 1,
@@ -302,6 +334,9 @@ fn map_ask_payload_preserves_adaptive_diagnostics() {
     assert_eq!(diagnostics.full_docs_source, "adaptive");
     assert_eq!(diagnostics.configured_authority_ratio, 0.25);
     assert_eq!(diagnostics.product_authority_ratio, 0.75);
+    let health = diagnostics.corpus_health.expect("corpus health");
+    assert_eq!(health.kind, CorpusHealthKind::Healthy);
+    assert_eq!(health.selected_domain_count, 2);
 }
 
 #[test]

--- a/src/services/types/service.rs
+++ b/src/services/types/service.rs
@@ -445,6 +445,27 @@ pub struct AskDiagnostics {
     pub configured_authority_ratio: f64,
     #[serde(default)]
     pub product_authority_ratio: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus_health: Option<CorpusHealthDiagnostic>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CorpusHealthKind {
+    Healthy,
+    NoRetrievalCandidates,
+    ThinDomain,
+    RetrievedNotSelected,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct CorpusHealthDiagnostic {
+    pub kind: CorpusHealthKind,
+    pub reason: String,
+    pub selected_domain_count: usize,
+    pub top_domain_count: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -531,12 +552,32 @@ pub struct AskExplainSelectionDecision {
     pub reason: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AskExplainInsertionMode {
+    TopChunk,
+    PlannedFullDoc,
+    InsertedFullDoc,
+    Supplemental,
+    NotSelected,
+    #[serde(other)]
+    Unknown,
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AskExplainCandidate {
     pub id: String,
     pub url: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chunk_index: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_rerank_rank: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub planned_full_doc_rank: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_context_rank: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub insertion_mode: Option<AskExplainInsertionMode>,
     pub retrieval_score: f64,
     pub rerank_score: f64,
     pub score_kind: AskExplainScoreKind,

--- a/src/vector/CLAUDE.md
+++ b/src/vector/CLAUDE.md
@@ -127,6 +127,20 @@ The ask reranker has two score-scale contracts:
 
 On RRF mode, Qdrant's fusion order remains the base ranking signal, then `score_and_filter_candidates` applies small lexical URL/chunk, docs-path, phrase, configured-authority, and docs-like URL product-token boosts before context selection. `AXON_ASK_MIN_RELEVANCE_SCORE` is still skipped on RRF because that threshold is calibrated to cosine `[0, 1]`, not rank-fusion output; the topical-overlap gate still applies and rejects generic-only matches when a query includes a salient product/library token. Diagnostics expose `authority_ratio` as the effective max of configured-authority and product-authority matches, plus `configured_authority_ratio` and `product_authority_ratio` separately. Run `axon evaluate --no-hybrid-search` to compare RRF against dense-only behavior on Named collections.
 
+### Retrieval Tuning Rule
+
+Do not tune retrieval from a single query. Before changing scoring, token policy,
+authority handling, or context selection, run the tracked retrieval fixture sweep.
+Classify every miss first:
+
+- ranking bug: relevant candidates exist but score/filter order is wrong
+- selection bug: relevant candidates rank well but do not enter context
+- corpus-health gap: expected source is not indexed or indexed too thinly
+- fixture mismatch: the fixture expectation does not match indexed content
+
+Hard-coded product/domain allowlists are not allowed in code. User-configured
+authoritative domains are allowed through config.
+
 The **adaptive full-doc fetch skip gate** (bd axon_rust-30y) elides `fetch_full_docs(...)` when the reranked top-K already covers >= `ask_fulldoc_skip_min_urls` unique URLs, >= `ask_fulldoc_skip_min_chars` chunk-text bytes, and every score satisfies the mode-specific floor above. The gate defaults to **disabled** because `ask` is normally a Gemini-backed one-shot synthesis path with a large context window, so recall is more valuable than minimizing context assembly. It can be enabled with `[ask.adaptive] fulldoc-skip-enabled = true` in `~/.axon/config.toml` after `axon evaluate` proves no quality regression on the target corpus. The decision is exposed in ask diagnostics as `full_doc_fetch_skipped: bool` and `full_doc_fetch_skip_reason: "ok_skip" | "disabled" | "insufficient_urls" | "insufficient_chars" | "low_top_scores" | "empty_top_k"`. The cosine `score_delta` knob is intentionally ignored on the RRF row because rank-fusion output is unitless — the rank-based gate uses P75 across the full reranked set instead.
 
 ### Collection Naming

--- a/src/vector/ops.rs
+++ b/src/vector/ops.rs
@@ -6,6 +6,7 @@ pub mod source_display;
 pub mod sparse;
 pub mod stats;
 pub mod tei;
+pub(crate) mod token_policy;
 
 // Re-export public API — no passthrough wrappers needed.
 pub use input::{chunk_markdown, chunk_text, url_lookup_candidates};

--- a/src/vector/ops/commands/ask.rs
+++ b/src/vector/ops/commands/ask.rs
@@ -36,31 +36,7 @@ pub async fn ask_payload(cfg: &Config, query: &str) -> anyhow::Result<serde_json
         return Ok(serde_json::json!({
             "query": query,
             "answer": "",
-            "diagnostics": if diagnostics_enabled {
-                serde_json::json!({
-                    "candidate_pool": ctx.candidate_count,
-                    "reranked_pool": ctx.reranked_count,
-                    "chunks_selected": ctx.chunks_selected,
-                    "full_docs_selected": ctx.full_docs_selected,
-                    "supplemental_selected": ctx.supplemental_count,
-                    "context_chars": ctx.context.len(),
-                    "graph_entities": ctx.graph_entities_found,
-                    "graph_context_chars": ctx.graph_context_text.len(),
-                    "min_relevance_score": cfg.ask_min_relevance_score,
-                    "doc_fetch_concurrency": cfg.ask_doc_fetch_concurrency,
-                    "top_domains": ctx.top_domains,
-                    "authority_ratio": ctx.authoritative_ratio,
-                    "configured_authority_ratio": ctx.configured_authority_ratio,
-                    "product_authority_ratio": ctx.product_authority_ratio,
-                    "full_doc_fetch_skipped": ctx.full_doc_fetch_skipped,
-                    "full_doc_fetch_skip_reason": ctx.full_doc_fetch_skip_reason,
-                    "detected_complexity": ctx.detected_complexity,
-                    "resolved_full_docs": ctx.resolved_full_docs,
-                    "full_docs_source": ctx.full_docs_source,
-                })
-            } else {
-                serde_json::Value::Null
-            },
+            "diagnostics": build_diagnostics_json(diagnostics_enabled, cfg, &ctx),
             "explain": ctx.explain,
             "timing_ms": build_timing_json(
                 ctx.retrieval_elapsed_ms,
@@ -111,31 +87,7 @@ pub async fn ask_payload(cfg: &Config, query: &str) -> anyhow::Result<serde_json
     Ok(serde_json::json!({
         "query": query,
         "answer": answer,
-        "diagnostics": if diagnostics_enabled {
-            serde_json::json!({
-                "candidate_pool": ctx.candidate_count,
-                "reranked_pool": ctx.reranked_count,
-                "chunks_selected": ctx.chunks_selected,
-                "full_docs_selected": ctx.full_docs_selected,
-                "supplemental_selected": ctx.supplemental_count,
-                "context_chars": ctx.context.len(),
-                "graph_entities": ctx.graph_entities_found,
-                "graph_context_chars": ctx.graph_context_text.len(),
-                "min_relevance_score": cfg.ask_min_relevance_score,
-                "doc_fetch_concurrency": cfg.ask_doc_fetch_concurrency,
-                "top_domains": ctx.top_domains,
-                "authority_ratio": ctx.authoritative_ratio,
-                "configured_authority_ratio": ctx.configured_authority_ratio,
-                "product_authority_ratio": ctx.product_authority_ratio,
-                "full_doc_fetch_skipped": ctx.full_doc_fetch_skipped,
-                "full_doc_fetch_skip_reason": ctx.full_doc_fetch_skip_reason,
-                "detected_complexity": ctx.detected_complexity,
-                "resolved_full_docs": ctx.resolved_full_docs,
-                "full_docs_source": ctx.full_docs_source,
-            })
-        } else {
-            serde_json::Value::Null
-        },
+        "diagnostics": build_diagnostics_json(diagnostics_enabled, cfg, &ctx),
         "explain": serde_json::Value::Null,
         "timing_ms": build_timing_json(
             ctx.retrieval_elapsed_ms,
@@ -146,6 +98,34 @@ pub async fn ask_payload(cfg: &Config, query: &str) -> anyhow::Result<serde_json
             &timing,
         ),
     }))
+}
+
+fn build_diagnostics_json(enabled: bool, cfg: &Config, ctx: &AskContext) -> serde_json::Value {
+    if !enabled {
+        return serde_json::Value::Null;
+    }
+    serde_json::json!({
+        "candidate_pool": ctx.candidate_count,
+        "reranked_pool": ctx.reranked_count,
+        "chunks_selected": ctx.chunks_selected,
+        "full_docs_selected": ctx.full_docs_selected,
+        "supplemental_selected": ctx.supplemental_count,
+        "context_chars": ctx.context.len(),
+        "graph_entities": ctx.graph_entities_found,
+        "graph_context_chars": ctx.graph_context_text.len(),
+        "min_relevance_score": cfg.ask_min_relevance_score,
+        "doc_fetch_concurrency": cfg.ask_doc_fetch_concurrency,
+        "top_domains": ctx.top_domains,
+        "authority_ratio": ctx.authoritative_ratio,
+        "configured_authority_ratio": ctx.configured_authority_ratio,
+        "product_authority_ratio": ctx.product_authority_ratio,
+        "corpus_health": ctx.corpus_health,
+        "full_doc_fetch_skipped": ctx.full_doc_fetch_skipped,
+        "full_doc_fetch_skip_reason": ctx.full_doc_fetch_skip_reason,
+        "detected_complexity": ctx.detected_complexity,
+        "resolved_full_docs": ctx.resolved_full_docs,
+        "full_docs_source": ctx.full_docs_source,
+    })
 }
 
 /// Back-compat: legacy 5-bucket shape always present; sub-stage fields populate

--- a/src/vector/ops/commands/ask/context.rs
+++ b/src/vector/ops/commands/ask/context.rs
@@ -10,10 +10,11 @@ mod retrieval;
 mod tests;
 
 use super::AskTiming;
-use crate::services::types::AskExplainTrace;
+use crate::services::types::{AskExplainTrace, CorpusHealthDiagnostic, CorpusHealthKind};
 use build::build_context_from_candidates;
 use query_rewrite::{QueryComplexity, build_query_forms};
 use retrieval::retrieve_ask_candidates;
+use spider::url::Url;
 
 const ASK_EXPLAIN_CANDIDATE_TRACE_LIMIT: usize = 50;
 
@@ -75,6 +76,7 @@ pub(crate) struct AskContext {
     pub authoritative_ratio: f64,
     pub configured_authority_ratio: f64,
     pub product_authority_ratio: f64,
+    pub corpus_health: CorpusHealthDiagnostic,
     /// True when the adaptive skip gate elided full-doc fetch.
     /// (bd axon_rust-30y)
     pub full_doc_fetch_skipped: bool,
@@ -135,6 +137,13 @@ pub(crate) async fn build_ask_context(
     let graph_entities_found = 0usize;
     let graph_elapsed_ms = 0u128;
     let context = built.context;
+    let selected_urls = selected_context_urls(&built.selection_decisions);
+    let corpus_health = classify_corpus_health(
+        &retrieval.top_domains,
+        &selected_urls,
+        retrieval.candidates.len(),
+        context.len(),
+    );
 
     if cfg.ask_graph {
         log_warn(
@@ -159,6 +168,7 @@ pub(crate) async fn build_ask_context(
         authoritative_ratio: retrieval.authoritative_ratio,
         configured_authority_ratio: retrieval.configured_authority_ratio,
         product_authority_ratio: retrieval.product_authority_ratio,
+        corpus_health,
         full_doc_fetch_skipped: built.full_doc_fetch_skipped,
         full_doc_fetch_skip_reason: built.full_doc_fetch_skip_reason,
         detected_complexity,
@@ -167,6 +177,7 @@ pub(crate) async fn build_ask_context(
         explain: if cfg.ask_explain {
             build_explain_trace(
                 query,
+                &retrieval.reranked,
                 retrieval.explain_retrieval,
                 retrieval.candidate_traces,
                 built.explain_context,
@@ -180,6 +191,7 @@ pub(crate) async fn build_ask_context(
 
 fn build_explain_trace(
     query: &str,
+    reranked: &[crate::vector::ops::ranking::AskCandidate],
     retrieval: Option<crate::services::types::AskExplainRetrieval>,
     candidate_traces: Vec<crate::vector::ops::commands::retrieval::CandidateRankingTrace>,
     context: crate::services::types::AskExplainContext,
@@ -187,38 +199,53 @@ fn build_explain_trace(
 ) -> Option<AskExplainTrace> {
     use crate::services::types::{AskExplainCandidate, AskExplainMode};
     use crate::vector::ops::ranking;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, VecDeque};
 
     let retrieval = retrieval?;
-    let mut selections_by_kept_index = selections
-        .into_iter()
-        .map(|selection| (selection.candidate_index, selection.decisions))
-        .collect::<HashMap<_, _>>();
+    let mut selections_by_key: HashMap<_, VecDeque<_>> = HashMap::new();
+    for selection in selections {
+        selections_by_key
+            .entry(selection.key)
+            .or_default()
+            .push_back((selection.decisions, selection.metadata));
+    }
+    let mut raw_rerank_ranks: HashMap<_, VecDeque<_>> = HashMap::new();
+    for (idx, candidate) in reranked.iter().enumerate() {
+        raw_rerank_ranks
+            .entry(build::candidate_selection_key(candidate))
+            .or_default()
+            .push_back(idx + 1);
+    }
     let query_tokens = ranking::tokenize_query(query);
     let total_candidate_traces = candidate_traces.len();
-    let mut kept_candidate_index = 0usize;
     let candidates = candidate_traces
         .into_iter()
         .take(ASK_EXPLAIN_CANDIDATE_TRACE_LIMIT)
         .enumerate()
         .map(|(idx, trace)| {
-            let selection_decisions = if trace.filter_decisions.iter().any(|decision| {
-                decision.kind == crate::services::types::AskExplainFilterDecisionKind::Kept
-            }) {
-                let decisions = selections_by_kept_index
-                    .remove(&kept_candidate_index)
-                    .unwrap_or_else(default_not_selected_decision);
-                kept_candidate_index += 1;
-                decisions
-            } else {
-                default_not_selected_decision()
-            };
+            let (selection_decisions, selection_metadata) =
+                if trace.filter_decisions.iter().any(|decision| {
+                    decision.kind == crate::services::types::AskExplainFilterDecisionKind::Kept
+                }) {
+                    pop_front_for_key(
+                        &mut selections_by_key,
+                        &build::candidate_selection_key(&trace.candidate.candidate),
+                    )
+                    .unwrap_or_else(default_not_selected_selection)
+                } else {
+                    default_not_selected_selection()
+                };
             let candidate = trace.candidate.candidate;
             let snippet = ranking::get_meaningful_snippet(&candidate.chunk_text, &query_tokens);
+            let candidate_key = build::candidate_selection_key(&candidate);
             AskExplainCandidate {
                 id: format!("candidate-{}", idx + 1),
                 url: candidate.url,
                 chunk_index: trace.candidate.chunk_index,
+                raw_rerank_rank: pop_front_for_key(&mut raw_rerank_ranks, &candidate_key),
+                planned_full_doc_rank: selection_metadata.planned_full_doc_rank,
+                selected_context_rank: selection_metadata.selected_context_rank,
+                insertion_mode: selection_metadata.insertion_mode,
                 retrieval_score: candidate.score,
                 rerank_score: candidate.rerank_score,
                 score_kind: trace.score_kind,
@@ -240,9 +267,100 @@ fn build_explain_trace(
     })
 }
 
-fn default_not_selected_decision() -> Vec<crate::services::types::AskExplainSelectionDecision> {
-    vec![crate::services::types::AskExplainSelectionDecision {
-        kind: crate::services::types::AskExplainSelectionDecisionKind::NotSelected,
-        reason: None,
-    }]
+fn pop_front_for_key<K, V>(
+    values_by_key: &mut std::collections::HashMap<K, std::collections::VecDeque<V>>,
+    key: &K,
+) -> Option<V>
+where
+    K: Eq + std::hash::Hash,
+{
+    let values = values_by_key.get_mut(key)?;
+    let value = values.pop_front();
+    if values.is_empty() {
+        values_by_key.remove(key);
+    }
+    value
+}
+
+fn selected_context_urls(selections: &[build::ContextCandidateSelection]) -> Vec<String> {
+    selections
+        .iter()
+        .filter(|selection| {
+            matches!(
+                selection.metadata.insertion_mode,
+                Some(
+                    crate::services::types::AskExplainInsertionMode::TopChunk
+                        | crate::services::types::AskExplainInsertionMode::InsertedFullDoc
+                        | crate::services::types::AskExplainInsertionMode::Supplemental
+                )
+            )
+        })
+        .map(|selection| selection.url.clone())
+        .collect()
+}
+
+fn classify_corpus_health(
+    top_domains: &[String],
+    selected_urls: &[String],
+    candidate_pool: usize,
+    context_chars: usize,
+) -> CorpusHealthDiagnostic {
+    let top_domain_count = top_domains.len();
+    let selected_domain_count = selected_urls
+        .iter()
+        .filter_map(|url| Url::parse(url).ok())
+        .filter_map(|url| url.host_str().map(str::to_string))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    let (kind, reason) = if candidate_pool == 0 {
+        (
+            CorpusHealthKind::NoRetrievalCandidates,
+            "retrieval returned no candidates".to_string(),
+        )
+    } else if selected_urls.is_empty() {
+        (
+            CorpusHealthKind::RetrievedNotSelected,
+            "retrieval returned candidates but none reached selected context".to_string(),
+        )
+    } else if context_chars < 2_000 {
+        (
+            CorpusHealthKind::ThinDomain,
+            "selected context is very small; indexed coverage may be thin".to_string(),
+        )
+    } else if top_domain_count == 0 {
+        (
+            CorpusHealthKind::Unknown,
+            "top-domain diagnostics were unavailable".to_string(),
+        )
+    } else {
+        (
+            CorpusHealthKind::Healthy,
+            "retrieval produced selected context".to_string(),
+        )
+    };
+
+    CorpusHealthDiagnostic {
+        kind,
+        reason,
+        selected_domain_count,
+        top_domain_count,
+    }
+}
+
+fn default_not_selected_selection() -> (
+    Vec<crate::services::types::AskExplainSelectionDecision>,
+    build::CandidateSelectionMetadata,
+) {
+    (
+        vec![crate::services::types::AskExplainSelectionDecision {
+            kind: crate::services::types::AskExplainSelectionDecisionKind::NotSelected,
+            reason: None,
+        }],
+        build::CandidateSelectionMetadata {
+            planned_full_doc_rank: None,
+            selected_context_rank: None,
+            insertion_mode: Some(crate::services::types::AskExplainInsertionMode::NotSelected),
+        },
+    )
 }

--- a/src/vector/ops/commands/ask/context/build.rs
+++ b/src/vector/ops/commands/ask/context/build.rs
@@ -22,13 +22,14 @@ pub(super) use diagnostics::build_diagnostic_sources;
 pub(super) use fetchers::ask_doc_cache;
 pub(super) use fetchers::fetch_full_docs;
 pub(super) use selection::{
-    collect_supplemental_candidate_indices, planned_full_doc_urls, select_context_indices,
+    SelectionPolicy, collect_supplemental_candidate_indices, planned_full_doc_urls,
+    select_context_indices,
 };
 use selection::{dominant_retrieval_hosts, full_doc_selection_score};
 pub(super) use trace::{
-    ContextCandidateSelection, ContextSelectionInputs, build_context_selection_decisions,
-    context_source_candidate_count, final_source_order_from_context, selected_top_chunk_indices,
-    sorted_urls,
+    CandidateSelectionMetadata, ContextCandidateSelection, ContextSelectionInputs,
+    build_context_selection_decisions, candidate_selection_key, context_source_candidate_count,
+    final_source_order_from_context, selected_top_chunk_indices, sorted_urls,
 };
 
 pub(super) struct BuiltAskContext {
@@ -328,6 +329,7 @@ fn finalize_built_context(mut inputs: FinalizeContextInputs<'_>) -> Result<Final
         supplemental_indices: inputs.supplemental,
         supplemental_count: inputs.supplemental_count,
         full_doc_fetch_skipped: inputs.skip_decision.skip,
+        final_source_order: &explain_context.final_source_order,
     });
 
     Ok(FinalizedAskContext {

--- a/src/vector/ops/commands/ask/context/build/selection.rs
+++ b/src/vector/ops/commands/ask/context/build/selection.rs
@@ -2,11 +2,27 @@ use crate::vector::ops::ranking;
 use spider::url::Url;
 use std::collections::HashSet;
 
+#[derive(Debug, Clone, Copy)]
+pub(in crate::vector::ops::commands::ask::context) struct SelectionPolicy {
+    pub prefer_authoritative: bool,
+    pub max_docs_per_domain: usize,
+}
+
+impl Default for SelectionPolicy {
+    fn default() -> Self {
+        Self {
+            prefer_authoritative: true,
+            max_docs_per_domain: 3,
+        }
+    }
+}
+
 pub fn select_context_indices(
     reranked: &[ranking::AskCandidate],
     query_tokens: &[String],
     chunk_limit: usize,
     full_doc_limit: usize,
+    policy: SelectionPolicy,
 ) -> (Vec<usize>, Vec<usize>) {
     let top_chunk_indices = ranking::select_diverse_candidates(reranked, chunk_limit, 1);
     // Full-doc indices are selected independently from the full reranked pool.
@@ -18,11 +34,11 @@ pub fn select_context_indices(
     // Enable ask_fulldoc_skip_enabled to restore fast-path when top chunks
     // already provide sufficient coverage.
     let full_doc_candidate_indices = full_doc_candidate_indices(reranked, query_tokens);
-    let mut top_full_doc_indices = ranking::select_diverse_candidates_from_indices(
+    let mut top_full_doc_indices = select_full_doc_indices_with_policy(
         reranked,
         &full_doc_candidate_indices,
         full_doc_limit,
-        1,
+        policy,
     );
     include_preferred_top_chunk_docs(
         reranked,
@@ -31,8 +47,91 @@ pub fn select_context_indices(
         &top_chunk_indices,
         &mut top_full_doc_indices,
         full_doc_limit,
+        policy,
     );
     (top_chunk_indices, top_full_doc_indices)
+}
+
+fn select_full_doc_indices_with_policy(
+    reranked: &[ranking::AskCandidate],
+    candidate_indices: &[usize],
+    full_doc_limit: usize,
+    policy: SelectionPolicy,
+) -> Vec<usize> {
+    if full_doc_limit == 0 {
+        return Vec::new();
+    }
+    let max_docs_per_domain = policy.max_docs_per_domain.max(1);
+    let mut selected = Vec::new();
+    let mut deferred = Vec::new();
+    for &idx in candidate_indices {
+        if selected.len() >= full_doc_limit {
+            break;
+        }
+        if url_already_selected(reranked, &selected, idx) {
+            continue;
+        }
+        if domain_count_for_selected(reranked, &selected, idx) >= max_docs_per_domain {
+            deferred.push(idx);
+            continue;
+        }
+        selected.push(idx);
+    }
+    for idx in deferred {
+        if selected.len() >= full_doc_limit {
+            break;
+        }
+        if !url_already_selected(reranked, &selected, idx) {
+            selected.push(idx);
+        }
+    }
+    selected
+}
+
+fn url_already_selected(
+    reranked: &[ranking::AskCandidate],
+    selected: &[usize],
+    candidate_idx: usize,
+) -> bool {
+    url_already_selected_except(reranked, selected, None, candidate_idx)
+}
+
+fn url_already_selected_except(
+    reranked: &[ranking::AskCandidate],
+    selected: &[usize],
+    exclude_selected_at: Option<usize>,
+    candidate_idx: usize,
+) -> bool {
+    selected.iter().enumerate().any(|(selected_at, &idx)| {
+        Some(selected_at) != exclude_selected_at && reranked[idx].url == reranked[candidate_idx].url
+    })
+}
+
+fn domain_count_for_selected(
+    reranked: &[ranking::AskCandidate],
+    selected: &[usize],
+    candidate_idx: usize,
+) -> usize {
+    domain_count_for_selected_except(reranked, selected, None, candidate_idx)
+}
+
+fn domain_count_for_selected_except(
+    reranked: &[ranking::AskCandidate],
+    selected: &[usize],
+    exclude_selected_at: Option<usize>,
+    candidate_idx: usize,
+) -> usize {
+    let Some(candidate_host) = host_from_url(&reranked[candidate_idx].url) else {
+        return 0;
+    };
+    selected
+        .iter()
+        .enumerate()
+        .filter(|(selected_at, _)| Some(*selected_at) != exclude_selected_at)
+        .filter(|&(_, &idx)| {
+            host_from_url(&reranked[idx].url).as_deref() == Some(candidate_host.as_str())
+        })
+        .count()
 }
 
 fn full_doc_candidate_indices(
@@ -133,8 +232,9 @@ fn include_preferred_top_chunk_docs(
     top_chunk_indices: &[usize],
     top_full_doc_indices: &mut Vec<usize>,
     full_doc_limit: usize,
+    policy: SelectionPolicy,
 ) {
-    if full_doc_limit == 0 {
+    if full_doc_limit == 0 || !policy.prefer_authoritative {
         return;
     }
     let entity_tokens = full_doc_entity_tokens(query_tokens);
@@ -171,6 +271,9 @@ fn include_preferred_top_chunk_docs(
             continue;
         }
         if top_full_doc_indices.len() < full_doc_limit {
+            if !can_add_full_doc_index(reranked, top_full_doc_indices, idx, policy) {
+                continue;
+            }
             top_full_doc_indices.push(idx);
             continue;
         }
@@ -179,6 +282,8 @@ fn include_preferred_top_chunk_docs(
             query_tokens,
             dominant_hosts,
             top_full_doc_indices,
+            idx,
+            policy,
         ) {
             top_full_doc_indices[replace_at] = idx;
         }
@@ -190,12 +295,23 @@ fn replacement_slot_for_preferred_doc(
     query_tokens: &[String],
     dominant_hosts: &HashSet<String>,
     top_full_doc_indices: &[usize],
+    candidate_idx: usize,
+    policy: SelectionPolicy,
 ) -> Option<usize> {
     let entity_tokens = full_doc_entity_tokens(query_tokens);
     top_full_doc_indices
         .iter()
         .enumerate()
-        .filter(|(_, idx_ref)| {
+        .filter(|(replace_at, idx_ref)| {
+            if !can_replace_full_doc_index(
+                reranked,
+                top_full_doc_indices,
+                *replace_at,
+                candidate_idx,
+                policy,
+            ) {
+                return false;
+            }
             let idx = **idx_ref;
             let candidate = &reranked[idx];
             !host_from_url(&candidate.url).is_some_and(|host| dominant_hosts.contains(&host))
@@ -215,6 +331,29 @@ fn replacement_slot_for_preferred_doc(
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
         .map(|(replace_at, _)| replace_at)
+}
+
+fn can_add_full_doc_index(
+    reranked: &[ranking::AskCandidate],
+    selected: &[usize],
+    candidate_idx: usize,
+    policy: SelectionPolicy,
+) -> bool {
+    !url_already_selected(reranked, selected, candidate_idx)
+        && domain_count_for_selected(reranked, selected, candidate_idx)
+            < policy.max_docs_per_domain.max(1)
+}
+
+fn can_replace_full_doc_index(
+    reranked: &[ranking::AskCandidate],
+    selected: &[usize],
+    replace_at: usize,
+    candidate_idx: usize,
+    policy: SelectionPolicy,
+) -> bool {
+    !url_already_selected_except(reranked, selected, Some(replace_at), candidate_idx)
+        && domain_count_for_selected_except(reranked, selected, Some(replace_at), candidate_idx)
+            < policy.max_docs_per_domain.max(1)
 }
 
 fn host_from_url(url: &str) -> Option<String> {

--- a/src/vector/ops/commands/ask/context/build/trace.rs
+++ b/src/vector/ops/commands/ask/context/build/trace.rs
@@ -1,15 +1,41 @@
 use crate::services::types::{
-    AskExplainContextSource, AskExplainSelectionDecision, AskExplainSelectionDecisionKind,
+    AskExplainContextSource, AskExplainInsertionMode, AskExplainSelectionDecision,
+    AskExplainSelectionDecisionKind,
 };
 use crate::vector::ops::ranking;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(in crate::vector::ops::commands::ask::context) struct CandidateSelectionKey {
+    url: String,
+    chunk_text: String,
+}
+
+pub(in crate::vector::ops::commands::ask::context) fn candidate_selection_key(
+    candidate: &ranking::AskCandidate,
+) -> CandidateSelectionKey {
+    CandidateSelectionKey {
+        url: candidate.url.clone(),
+        chunk_text: candidate.chunk_text.clone(),
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)]
 pub(in crate::vector::ops::commands::ask::context) struct ContextCandidateSelection {
     pub(in crate::vector::ops::commands::ask::context) candidate_index: usize,
+    pub(in crate::vector::ops::commands::ask::context) key: CandidateSelectionKey,
     pub(in crate::vector::ops::commands::ask::context) url: String,
     pub(in crate::vector::ops::commands::ask::context) decisions: Vec<AskExplainSelectionDecision>,
+    pub(in crate::vector::ops::commands::ask::context) metadata: CandidateSelectionMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::vector::ops::commands::ask::context) struct CandidateSelectionMetadata {
+    pub(in crate::vector::ops::commands::ask::context) planned_full_doc_rank: Option<usize>,
+    pub(in crate::vector::ops::commands::ask::context) selected_context_rank: Option<usize>,
+    pub(in crate::vector::ops::commands::ask::context) insertion_mode:
+        Option<AskExplainInsertionMode>,
 }
 
 pub(crate) struct ContextSelectionInputs<'a> {
@@ -22,6 +48,7 @@ pub(crate) struct ContextSelectionInputs<'a> {
     pub(crate) supplemental_indices: &'a [usize],
     pub(crate) supplemental_count: usize,
     pub(crate) full_doc_fetch_skipped: bool,
+    pub(crate) final_source_order: &'a [AskExplainContextSource],
 }
 
 pub(crate) fn build_context_selection_decisions(
@@ -30,6 +57,8 @@ pub(crate) fn build_context_selection_decisions(
     let top_chunk_set = index_set(inputs.top_chunk_indices);
     let selected_top_chunk_set = index_set(inputs.selected_top_chunk_indices);
     let top_full_doc_set = index_set(inputs.top_full_doc_indices);
+    let planned_full_doc_ranks = index_rank_map(inputs.top_full_doc_indices);
+    let selected_context_ranks = selected_context_rank_map(inputs.final_source_order);
     let supplemental_selected = inputs
         .supplemental_indices
         .iter()
@@ -60,9 +89,19 @@ pub(crate) fn build_context_selection_decisions(
                 supplemental_budget_skipped: &supplemental_budget_skipped,
                 full_doc_fetch_skipped: inputs.full_doc_fetch_skipped,
             });
+            let insertion_mode = insertion_mode_for_decisions(&decisions);
+            let selected_context_rank = selected_context_ranks
+                .get(&(candidate.url.clone(), insertion_mode))
+                .copied();
             ContextCandidateSelection {
                 candidate_index: idx,
+                key: candidate_selection_key(candidate),
                 url: candidate.url.clone(),
+                metadata: CandidateSelectionMetadata {
+                    planned_full_doc_rank: planned_full_doc_ranks.get(&idx).copied(),
+                    selected_context_rank,
+                    insertion_mode: Some(insertion_mode),
+                },
                 decisions,
             }
         })
@@ -181,6 +220,34 @@ fn selection_decision(
     }
 }
 
+fn insertion_mode_for_decisions(
+    decisions: &[AskExplainSelectionDecision],
+) -> AskExplainInsertionMode {
+    if decisions
+        .iter()
+        .any(|decision| decision.kind == AskExplainSelectionDecisionKind::SelectedTopChunk)
+    {
+        AskExplainInsertionMode::TopChunk
+    } else if decisions
+        .iter()
+        .any(|decision| decision.kind == AskExplainSelectionDecisionKind::InsertedFullDoc)
+    {
+        AskExplainInsertionMode::InsertedFullDoc
+    } else if decisions
+        .iter()
+        .any(|decision| decision.kind == AskExplainSelectionDecisionKind::PlannedFullDoc)
+    {
+        AskExplainInsertionMode::PlannedFullDoc
+    } else if decisions
+        .iter()
+        .any(|decision| decision.kind == AskExplainSelectionDecisionKind::SelectedSupplemental)
+    {
+        AskExplainInsertionMode::Supplemental
+    } else {
+        AskExplainInsertionMode::NotSelected
+    }
+}
+
 pub(crate) fn selected_top_chunk_indices(
     reranked: &[ranking::AskCandidate],
     top_chunk_indices: &[usize],
@@ -252,6 +319,36 @@ fn parse_source_header(line: &str) -> Option<AskExplainContextSource> {
 
 fn index_set(indices: &[usize]) -> HashSet<usize> {
     indices.iter().copied().collect()
+}
+
+fn index_rank_map(indices: &[usize]) -> HashMap<usize, usize> {
+    indices
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(rank, idx)| (idx, rank + 1))
+        .collect()
+}
+
+fn selected_context_rank_map(
+    sources: &[AskExplainContextSource],
+) -> HashMap<(String, AskExplainInsertionMode), usize> {
+    let mut ranks = HashMap::new();
+    for (idx, source) in sources.iter().enumerate() {
+        if let Some(mode) = insertion_mode_for_context_tier(&source.tier) {
+            ranks.entry((source.url.clone(), mode)).or_insert(idx + 1);
+        }
+    }
+    ranks
+}
+
+fn insertion_mode_for_context_tier(tier: &str) -> Option<AskExplainInsertionMode> {
+    match tier {
+        "top_chunk" => Some(AskExplainInsertionMode::TopChunk),
+        "full_doc" => Some(AskExplainInsertionMode::InsertedFullDoc),
+        "supplemental" => Some(AskExplainInsertionMode::Supplemental),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/src/vector/ops/commands/ask/context/build/trace.rs
+++ b/src/vector/ops/commands/ask/context/build/trace.rs
@@ -235,14 +235,14 @@ fn insertion_mode_for_decisions(
         AskExplainInsertionMode::InsertedFullDoc
     } else if decisions
         .iter()
-        .any(|decision| decision.kind == AskExplainSelectionDecisionKind::PlannedFullDoc)
-    {
-        AskExplainInsertionMode::PlannedFullDoc
-    } else if decisions
-        .iter()
         .any(|decision| decision.kind == AskExplainSelectionDecisionKind::SelectedSupplemental)
     {
         AskExplainInsertionMode::Supplemental
+    } else if decisions
+        .iter()
+        .any(|decision| decision.kind == AskExplainSelectionDecisionKind::PlannedFullDoc)
+    {
+        AskExplainInsertionMode::PlannedFullDoc
     } else {
         AskExplainInsertionMode::NotSelected
     }

--- a/src/vector/ops/commands/ask/context/build/trace/tests.rs
+++ b/src/vector/ops/commands/ask/context/build/trace/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::services::types::AskExplainSelectionDecisionKind;
+use crate::services::types::{
+    AskExplainContextSource, AskExplainInsertionMode, AskExplainSelectionDecisionKind,
+};
 
 fn candidate(url: &str, score: f64) -> ranking::AskCandidate {
     ranking::AskCandidate {
@@ -36,6 +38,7 @@ fn context_trace_marks_full_doc_skip_without_suppressing_top_chunk() {
         supplemental_indices: &[],
         supplemental_count: 0,
         full_doc_fetch_skipped: true,
+        final_source_order: &[],
     });
 
     let kinds = decision_kinds(&decisions[0]);
@@ -63,6 +66,7 @@ fn context_trace_marks_planned_suppression_and_budget_skips() {
         supplemental_indices: &[2],
         supplemental_count: 0,
         full_doc_fetch_skipped: false,
+        final_source_order: &[],
     });
 
     assert!(
@@ -89,4 +93,115 @@ fn context_trace_final_source_order_matches_prompt_order() {
     assert_eq!(order[1].source_id, "S2");
     assert_eq!(order[1].url, "https://a.test/docs");
     assert_eq!(order[1].tier, "full_doc");
+}
+
+#[test]
+fn context_trace_emits_selection_metadata() {
+    let reranked = vec![
+        candidate("https://a.test/top", 0.90),
+        candidate("https://b.test/full", 0.80),
+        candidate("https://c.test/planned", 0.70),
+        candidate("https://d.test/supplemental", 0.60),
+        candidate("https://e.test/not-selected", 0.50),
+    ];
+    let planned = HashSet::from([
+        "https://b.test/full".to_string(),
+        "https://c.test/planned".to_string(),
+    ]);
+    let inserted = HashSet::from(["https://b.test/full".to_string()]);
+    let final_source_order = vec![
+        AskExplainContextSource {
+            source_id: "S1".to_string(),
+            url: "https://a.test/top".to_string(),
+            tier: "top_chunk".to_string(),
+        },
+        AskExplainContextSource {
+            source_id: "S2".to_string(),
+            url: "https://b.test/full".to_string(),
+            tier: "full_doc".to_string(),
+        },
+        AskExplainContextSource {
+            source_id: "S3".to_string(),
+            url: "https://d.test/supplemental".to_string(),
+            tier: "supplemental".to_string(),
+        },
+    ];
+
+    let decisions = build_context_selection_decisions(ContextSelectionInputs {
+        reranked: &reranked,
+        top_chunk_indices: &[0],
+        selected_top_chunk_indices: &[0],
+        planned_full_doc_urls: &planned,
+        top_full_doc_indices: &[1, 2],
+        inserted_full_doc_urls: &inserted,
+        supplemental_indices: &[3],
+        supplemental_count: 1,
+        full_doc_fetch_skipped: false,
+        final_source_order: &final_source_order,
+    });
+
+    assert_eq!(
+        decisions[0].metadata.insertion_mode,
+        Some(AskExplainInsertionMode::TopChunk)
+    );
+    assert_eq!(decisions[0].metadata.selected_context_rank, Some(1));
+    assert_eq!(
+        decisions[1].metadata.insertion_mode,
+        Some(AskExplainInsertionMode::InsertedFullDoc)
+    );
+    assert_eq!(decisions[1].metadata.planned_full_doc_rank, Some(1));
+    assert_eq!(decisions[1].metadata.selected_context_rank, Some(2));
+    assert_eq!(
+        decisions[2].metadata.insertion_mode,
+        Some(AskExplainInsertionMode::PlannedFullDoc)
+    );
+    assert_eq!(decisions[2].metadata.planned_full_doc_rank, Some(2));
+    assert_eq!(decisions[2].metadata.selected_context_rank, None);
+    assert_eq!(
+        decisions[3].metadata.insertion_mode,
+        Some(AskExplainInsertionMode::Supplemental)
+    );
+    assert_eq!(decisions[3].metadata.selected_context_rank, Some(3));
+    assert_eq!(
+        decisions[4].metadata.insertion_mode,
+        Some(AskExplainInsertionMode::NotSelected)
+    );
+}
+
+#[test]
+fn context_trace_ranks_duplicate_url_by_context_tier() {
+    let reranked = vec![
+        candidate("https://a.test/docs", 0.90),
+        candidate("https://a.test/docs", 0.80),
+    ];
+    let planned = HashSet::from(["https://a.test/docs".to_string()]);
+    let inserted = HashSet::from(["https://a.test/docs".to_string()]);
+    let final_source_order = vec![
+        AskExplainContextSource {
+            source_id: "S1".to_string(),
+            url: "https://a.test/docs".to_string(),
+            tier: "top_chunk".to_string(),
+        },
+        AskExplainContextSource {
+            source_id: "S2".to_string(),
+            url: "https://a.test/docs".to_string(),
+            tier: "full_doc".to_string(),
+        },
+    ];
+
+    let decisions = build_context_selection_decisions(ContextSelectionInputs {
+        reranked: &reranked,
+        top_chunk_indices: &[0],
+        selected_top_chunk_indices: &[0],
+        planned_full_doc_urls: &planned,
+        top_full_doc_indices: &[1],
+        inserted_full_doc_urls: &inserted,
+        supplemental_indices: &[],
+        supplemental_count: 0,
+        full_doc_fetch_skipped: false,
+        final_source_order: &final_source_order,
+    });
+
+    assert_eq!(decisions[0].metadata.selected_context_rank, Some(1));
+    assert_eq!(decisions[1].metadata.selected_context_rank, Some(2));
 }

--- a/src/vector/ops/commands/ask/context/build/trace/tests.rs
+++ b/src/vector/ops/commands/ask/context/build/trace/tests.rs
@@ -169,6 +169,37 @@ fn context_trace_emits_selection_metadata() {
 }
 
 #[test]
+fn context_trace_prioritizes_supplemental_mode_over_planned_only() {
+    let reranked = vec![candidate("https://a.test/docs", 0.90)];
+    let planned = HashSet::from(["https://a.test/docs".to_string()]);
+    let final_source_order = vec![AskExplainContextSource {
+        source_id: "S1".to_string(),
+        url: "https://a.test/docs".to_string(),
+        tier: "supplemental".to_string(),
+    }];
+
+    let decisions = build_context_selection_decisions(ContextSelectionInputs {
+        reranked: &reranked,
+        top_chunk_indices: &[],
+        selected_top_chunk_indices: &[],
+        planned_full_doc_urls: &planned,
+        top_full_doc_indices: &[0],
+        inserted_full_doc_urls: &HashSet::new(),
+        supplemental_indices: &[0],
+        supplemental_count: 1,
+        full_doc_fetch_skipped: false,
+        final_source_order: &final_source_order,
+    });
+
+    assert_eq!(
+        decisions[0].metadata.insertion_mode,
+        Some(AskExplainInsertionMode::Supplemental)
+    );
+    assert_eq!(decisions[0].metadata.planned_full_doc_rank, Some(1));
+    assert_eq!(decisions[0].metadata.selected_context_rank, Some(1));
+}
+
+#[test]
 fn context_trace_ranks_duplicate_url_by_context_tier() {
     let reranked = vec![
         candidate("https://a.test/docs", 0.90),

--- a/src/vector/ops/commands/ask/context/heuristics.rs
+++ b/src/vector/ops/commands/ask/context/heuristics.rs
@@ -228,6 +228,7 @@ pub(super) fn authoritative_ratio(candidates: &[AskCandidate], domains: &[String
 fn candidate_topical_overlap_count(candidate: &AskCandidate, query_tokens: &[String]) -> usize {
     query_tokens
         .iter()
+        .filter(|token| token.len() >= 3)
         .filter(|token| {
             candidate.url_tokens.contains(token.as_str())
                 || candidate.chunk_tokens.contains(token.as_str())
@@ -243,9 +244,13 @@ pub(super) fn candidate_has_topical_overlap(
     if query_tokens.is_empty() {
         return true;
     }
+    let topical_token_count = query_tokens.iter().filter(|token| token.len() >= 3).count();
+    if topical_token_count == 0 {
+        return true;
+    }
     let overlap = candidate_topical_overlap_count(candidate, query_tokens);
-    let coverage = overlap as f64 / query_tokens.len() as f64;
-    match query_tokens.len() {
+    let coverage = overlap as f64 / topical_token_count as f64;
+    match topical_token_count {
         0 => true,
         1 | 2 => overlap >= 1,
         3 | 4 => overlap >= 1 || coverage >= 0.5,

--- a/src/vector/ops/commands/ask/context/retrieval.rs
+++ b/src/vector/ops/commands/ask/context/retrieval.rs
@@ -196,6 +196,7 @@ pub(super) async fn retrieve_ask_candidates(
         query_tokens,
         ask_tuning.ask_chunk_limit,
         ask_tuning.ask_full_docs,
+        super::build::SelectionPolicy::default(),
     );
     timing.record(AskTimingSlot::TopSelect, top_select_started);
 

--- a/src/vector/ops/commands/ask/context/tests.rs
+++ b/src/vector/ops/commands/ask/context/tests.rs
@@ -1,5 +1,6 @@
 use super::build::{
-    collect_supplemental_candidate_indices, planned_full_doc_urls, select_context_indices,
+    SelectionPolicy, collect_supplemental_candidate_indices, planned_full_doc_urls,
+    select_context_indices,
 };
 use super::heuristics::{
     candidate_has_topical_overlap, query_requests_low_signal_sources, should_inject_supplemental,
@@ -10,8 +11,9 @@ use super::retrieval::{RerankParams, apply_mode_aware_rerank, is_rrf_mode};
 use super::{FullDocsSource, resolve_ask_full_docs};
 use crate::core::config::Config;
 use crate::services::types::{
-    AskExplainContext, AskExplainFilterDecision, AskExplainFilterDecisionKind, AskExplainRetrieval,
-    AskExplainScoreKind, AskExplainSelectionDecision, AskExplainSelectionDecisionKind,
+    AskExplainContext, AskExplainFilterDecision, AskExplainFilterDecisionKind,
+    AskExplainInsertionMode, AskExplainRetrieval, AskExplainScoreKind, AskExplainSelectionDecision,
+    AskExplainSelectionDecisionKind, CorpusHealthKind,
 };
 use crate::vector::ops::commands::retrieval::{CandidateRankingTrace, RetrievedCandidate};
 use crate::vector::ops::ranking::AskCandidate;
@@ -83,18 +85,22 @@ fn explain_context() -> AskExplainContext {
     }
 }
 
+fn trace_candidate(url: &str, chunk_index: i64, score: f64, rerank_score: f64) -> AskCandidate {
+    AskCandidate {
+        score,
+        url: url.to_string(),
+        path: url.to_string(),
+        chunk_text: format!("rust docs candidate chunk {chunk_index} long enough"),
+        url_tokens: HashSet::new(),
+        chunk_tokens: HashSet::new(),
+        rerank_score,
+    }
+}
+
 fn kept_trace(url: &str, chunk_index: i64) -> CandidateRankingTrace {
     CandidateRankingTrace {
         candidate: RetrievedCandidate {
-            candidate: AskCandidate {
-                score: 0.7,
-                url: url.to_string(),
-                path: url.to_string(),
-                chunk_text: format!("rust docs candidate chunk {chunk_index} long enough"),
-                url_tokens: HashSet::new(),
-                chunk_tokens: HashSet::new(),
-                rerank_score: 0.8,
-            },
+            candidate: trace_candidate(url, chunk_index, 0.7, 0.8),
             chunk_index: Some(chunk_index),
         },
         score_kind: AskExplainScoreKind::Cosine,
@@ -106,15 +112,37 @@ fn kept_trace(url: &str, chunk_index: i64) -> CandidateRankingTrace {
     }
 }
 
+fn reranked_from_traces(traces: &[CandidateRankingTrace]) -> Vec<AskCandidate> {
+    traces
+        .iter()
+        .map(|trace| trace.candidate.candidate.clone())
+        .collect()
+}
+
 fn selection(
     candidate_index: usize,
     url: &str,
     kind: AskExplainSelectionDecisionKind,
 ) -> super::build::ContextCandidateSelection {
+    selection_for_chunk(candidate_index, url, candidate_index as i64, kind)
+}
+
+fn selection_for_chunk(
+    candidate_index: usize,
+    url: &str,
+    chunk_index: i64,
+    kind: AskExplainSelectionDecisionKind,
+) -> super::build::ContextCandidateSelection {
     super::build::ContextCandidateSelection {
         candidate_index,
+        key: super::build::candidate_selection_key(&trace_candidate(url, chunk_index, 0.0, 0.0)),
         url: url.to_string(),
         decisions: vec![AskExplainSelectionDecision { kind, reason: None }],
+        metadata: super::build::CandidateSelectionMetadata {
+            planned_full_doc_rank: None,
+            selected_context_rank: None,
+            insertion_mode: None::<AskExplainInsertionMode>,
+        },
     }
 }
 
@@ -138,6 +166,7 @@ fn ask_explain_trace_caps_candidate_output() {
     let traces = (0..51)
         .map(|idx| kept_trace(&format!("https://docs.example.com/{idx}"), idx))
         .collect::<Vec<_>>();
+    let reranked = reranked_from_traces(&traces);
     let selections = (0..51)
         .map(|idx| {
             selection(
@@ -150,6 +179,7 @@ fn ask_explain_trace_caps_candidate_output() {
 
     let trace = super::build_explain_trace(
         "rust docs",
+        &reranked,
         Some(explain_retrieval()),
         traces,
         explain_context(),
@@ -165,16 +195,20 @@ fn ask_explain_trace_caps_candidate_output() {
 #[test]
 fn ask_explain_trace_maps_duplicate_url_selections_by_kept_order() {
     let url = "https://docs.example.com/rust";
+    let traces = vec![kept_trace(url, 1), kept_trace(url, 2)];
+    let reranked = reranked_from_traces(&traces);
     let trace = super::build_explain_trace(
         "rust docs",
+        &reranked,
         Some(explain_retrieval()),
-        vec![kept_trace(url, 1), kept_trace(url, 2)],
+        traces,
         explain_context(),
         vec![
-            selection(0, url, AskExplainSelectionDecisionKind::SelectedTopChunk),
-            selection(
+            selection_for_chunk(0, url, 1, AskExplainSelectionDecisionKind::SelectedTopChunk),
+            selection_for_chunk(
                 1,
                 url,
+                2,
                 AskExplainSelectionDecisionKind::SelectedSupplemental,
             ),
         ],
@@ -189,6 +223,101 @@ fn ask_explain_trace_maps_duplicate_url_selections_by_kept_order() {
         trace.candidates[1].selection_decisions[0].kind,
         AskExplainSelectionDecisionKind::SelectedSupplemental
     );
+}
+
+#[test]
+fn ask_explain_trace_maps_reordered_kept_traces_by_candidate_key() {
+    let first_url = "https://docs.example.com/first";
+    let boosted_url = "https://docs.example.com/boosted";
+    let traces = vec![kept_trace(first_url, 1), kept_trace(boosted_url, 2)];
+    let reranked = vec![
+        traces[1].candidate.candidate.clone(),
+        traces[0].candidate.candidate.clone(),
+    ];
+    let trace = super::build_explain_trace(
+        "rust docs",
+        &reranked,
+        Some(explain_retrieval()),
+        traces,
+        explain_context(),
+        vec![
+            selection_for_chunk(
+                0,
+                boosted_url,
+                2,
+                AskExplainSelectionDecisionKind::SelectedTopChunk,
+            ),
+            selection_for_chunk(
+                1,
+                first_url,
+                1,
+                AskExplainSelectionDecisionKind::SelectedSupplemental,
+            ),
+        ],
+    )
+    .expect("trace");
+
+    assert_eq!(
+        trace.candidates[0].selection_decisions[0].kind,
+        AskExplainSelectionDecisionKind::SelectedSupplemental
+    );
+    assert_eq!(trace.candidates[0].raw_rerank_rank, Some(2));
+    assert_eq!(
+        trace.candidates[1].selection_decisions[0].kind,
+        AskExplainSelectionDecisionKind::SelectedTopChunk
+    );
+    assert_eq!(trace.candidates[1].raw_rerank_rank, Some(1));
+}
+
+#[test]
+fn corpus_health_classifies_no_candidates() {
+    let health = super::classify_corpus_health(&[], &[], 0, 0);
+    assert_eq!(health.kind, CorpusHealthKind::NoRetrievalCandidates);
+    assert_eq!(health.selected_domain_count, 0);
+    assert_eq!(health.top_domain_count, 0);
+}
+
+#[test]
+fn corpus_health_classifies_retrieved_not_selected() {
+    let health = super::classify_corpus_health(&["docs.example.com:3".to_string()], &[], 3, 0);
+    assert_eq!(health.kind, CorpusHealthKind::RetrievedNotSelected);
+}
+
+#[test]
+fn corpus_health_counts_unique_selected_domains_and_ignores_bad_urls() {
+    let selected = vec![
+        "https://docs.example.com/a".to_string(),
+        "https://docs.example.com/b".to_string(),
+        "not a url".to_string(),
+        "https://api.example.com/c".to_string(),
+    ];
+    let health = super::classify_corpus_health(
+        &[
+            "docs.example.com:2".to_string(),
+            "api.example.com:1".to_string(),
+        ],
+        &selected,
+        4,
+        3_000,
+    );
+    assert_eq!(health.kind, CorpusHealthKind::Healthy);
+    assert_eq!(health.selected_domain_count, 2);
+    assert_eq!(health.top_domain_count, 2);
+}
+
+#[test]
+fn corpus_health_classifies_thin_and_unknown_context() {
+    let thin = super::classify_corpus_health(
+        &["docs.example.com:1".to_string()],
+        &["https://docs.example.com/a".to_string()],
+        1,
+        100,
+    );
+    assert_eq!(thin.kind, CorpusHealthKind::ThinDomain);
+
+    let unknown =
+        super::classify_corpus_health(&[], &["https://docs.example.com/a".to_string()], 1, 3_000);
+    assert_eq!(unknown.kind, CorpusHealthKind::Unknown);
 }
 
 #[test]
@@ -290,7 +419,7 @@ fn context_full_doc_selection_is_independent_of_chunk_urls() {
 
     let query_tokens = Vec::new();
     let (chunk_indices, full_doc_indices) =
-        select_context_indices(&candidates, &query_tokens, 2, 2);
+        select_context_indices(&candidates, &query_tokens, 2, 2, SelectionPolicy::default());
     assert_eq!(chunk_indices.len(), 2, "should select 2 top chunks");
     assert_eq!(full_doc_indices.len(), 2, "should select 2 full docs");
 
@@ -335,7 +464,8 @@ fn full_doc_selection_prefers_url_entity_matches() {
     let query_tokens =
         crate::vector::ops::ranking::tokenize_query("setup agents not inherit mcp servers skills");
 
-    let (_, full_doc_indices) = select_context_indices(&candidates, &query_tokens, 2, 2);
+    let (_, full_doc_indices) =
+        select_context_indices(&candidates, &query_tokens, 2, 2, SelectionPolicy::default());
     let full_doc_urls = full_doc_indices
         .iter()
         .map(|&idx| candidates[idx].url.as_str())
@@ -348,13 +478,126 @@ fn full_doc_selection_prefers_url_entity_matches() {
 }
 
 #[test]
+fn selection_limits_full_docs_per_domain_when_alternatives_exist() {
+    let candidates = vec![
+        test_candidate("https://a.dev/docs/one", 0.99),
+        test_candidate("https://a.dev/docs/two", 0.98),
+        test_candidate("https://a.dev/docs/three", 0.97),
+        test_candidate("https://b.dev/docs/one", 0.90),
+        test_candidate("https://b.dev/docs/two", 0.89),
+    ];
+    let policy = SelectionPolicy {
+        max_docs_per_domain: 2,
+        ..SelectionPolicy::default()
+    };
+
+    let (_, full_doc_indices) = select_context_indices(&candidates, &[], 2, 4, policy);
+    let full_doc_urls = full_doc_indices
+        .iter()
+        .map(|&idx| candidates[idx].url.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        full_doc_urls
+            .iter()
+            .filter(|url| url.contains("https://a.dev/"))
+            .count(),
+        2
+    );
+    assert!(
+        full_doc_urls
+            .iter()
+            .any(|url| url.contains("https://b.dev/")),
+        "selection should admit alternate domains after the per-domain cap: {full_doc_urls:?}"
+    );
+}
+
+#[test]
+fn selection_deduplicates_full_doc_urls() {
+    let candidates = vec![
+        test_candidate("https://a.dev/docs/one", 0.99),
+        test_candidate("https://a.dev/docs/one", 0.98),
+        test_candidate("https://a.dev/docs/one", 0.97),
+        test_candidate("https://b.dev/docs/two", 0.90),
+    ];
+
+    let (_, full_doc_indices) =
+        select_context_indices(&candidates, &[], 2, 3, SelectionPolicy::default());
+    let full_doc_urls = full_doc_indices
+        .iter()
+        .map(|&idx| candidates[idx].url.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        full_doc_urls,
+        vec!["https://a.dev/docs/one", "https://b.dev/docs/two"]
+    );
+}
+
+#[test]
+fn selection_fills_from_single_domain_when_no_alternatives_exist() {
+    let candidates = vec![
+        test_candidate("https://a.dev/docs/one", 0.99),
+        test_candidate("https://a.dev/docs/two", 0.98),
+        test_candidate("https://a.dev/docs/three", 0.97),
+        test_candidate("https://a.dev/docs/four", 0.96),
+        test_candidate("https://a.dev/docs/five", 0.95),
+    ];
+
+    let (_, full_doc_indices) =
+        select_context_indices(&candidates, &[], 2, 5, SelectionPolicy::default());
+
+    assert_eq!(full_doc_indices.len(), 5);
+}
+
+#[test]
+fn selection_preserves_non_authoritative_high_signal_example() {
+    let candidates = vec![
+        test_candidate("https://blog.example.com/deep-topic", 0.99),
+        test_candidate("https://docs.example.com/reference", 0.70),
+        test_candidate("https://docs.example.com/reference-two", 0.69),
+    ];
+    let policy = SelectionPolicy {
+        prefer_authoritative: false,
+        ..SelectionPolicy::default()
+    };
+
+    let (chunk_indices, full_doc_indices) = select_context_indices(&candidates, &[], 1, 1, policy);
+
+    assert_eq!(
+        candidates[chunk_indices[0]].url,
+        "https://blog.example.com/deep-topic"
+    );
+    assert_eq!(
+        candidates[full_doc_indices[0]].url,
+        "https://blog.example.com/deep-topic"
+    );
+}
+
+#[test]
+fn selection_without_authority_signal_preserves_existing_diversity() {
+    let candidates = vec![
+        test_candidate("https://a.dev/docs/one", 0.99),
+        test_candidate("https://b.dev/docs/two", 0.98),
+        test_candidate("https://c.dev/docs/three", 0.97),
+    ];
+
+    let (chunk_indices, full_doc_indices) =
+        select_context_indices(&candidates, &[], 2, 2, SelectionPolicy::default());
+
+    assert_eq!(chunk_indices, vec![0, 1]);
+    assert_eq!(full_doc_indices, vec![0, 1]);
+}
+
+#[test]
 fn planned_full_doc_urls_are_empty_when_fetch_is_skipped() {
     let candidates = vec![
         test_candidate("https://a.dev/docs/one", 0.90),
         test_candidate("https://b.dev/docs/two", 0.80),
     ];
     let query_tokens = Vec::new();
-    let (_, full_doc_indices) = select_context_indices(&candidates, &query_tokens, 2, 2);
+    let (_, full_doc_indices) =
+        select_context_indices(&candidates, &query_tokens, 2, 2, SelectionPolicy::default());
 
     let skipped = planned_full_doc_urls(&candidates, &full_doc_indices, true);
     let fetched = planned_full_doc_urls(&candidates, &full_doc_indices, false);

--- a/src/vector/ops/commands/retrieval/product_authority_tests.rs
+++ b/src/vector/ops/commands/retrieval/product_authority_tests.rs
@@ -1,0 +1,171 @@
+use super::*;
+
+#[test]
+fn product_authority_ratio_counts_docs_like_urls_with_query_product_token() {
+    let candidates = vec![
+        make_candidate(
+            "https://docs.widget.dev/docs/en/plugins",
+            "Widget plugins marketplace official docs",
+            0.8,
+        )
+        .candidate,
+        make_candidate(
+            "https://docs.other.dev/cli/plugins",
+            "Other plugins marketplace commands install list inspect",
+            0.7,
+        )
+        .candidate,
+    ];
+    let query_tokens = vec!["widget".to_string(), "plugins".to_string()];
+
+    let ratio = product_authority_ratio(&candidates, &query_tokens, 0.35);
+
+    assert!((ratio - 0.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn product_authority_boost_ignores_malformed_urls() {
+    let query_tokens = vec!["uv".to_string()];
+    assert_eq!(
+        product_authority_boost_for_url("not a url", &query_tokens, 0.35),
+        0.0
+    );
+}
+
+#[test]
+fn product_authority_ratio_is_zero_without_matching_product_token() {
+    let candidates = vec![
+        make_candidate(
+            "https://docs.widget.dev/docs/en/plugins",
+            "Widget plugins marketplace official docs",
+            0.8,
+        )
+        .candidate,
+    ];
+    let query_tokens = vec!["plugins".to_string()];
+
+    assert_eq!(
+        product_authority_ratio(&candidates, &query_tokens, 0.35),
+        0.0
+    );
+}
+
+#[test]
+fn product_authority_ratio_ignores_generic_package_publish_tokens() {
+    let candidates = vec![
+        make_candidate(
+            "https://docs.astral.sh/uv/guides/package",
+            "Publish your package with uv publish",
+            0.8,
+        )
+        .candidate,
+    ];
+    let query_tokens = vec![
+        "publish".to_string(),
+        "python".to_string(),
+        "package".to_string(),
+        "pypi".to_string(),
+    ];
+
+    assert_eq!(
+        product_authority_ratio(&candidates, &query_tokens, 0.35),
+        0.0
+    );
+}
+
+#[test]
+fn product_authority_ratio_ignores_language_tokens_as_product_identity() {
+    let candidates = vec![
+        make_candidate(
+            "https://playwright.dev/python/docs/ci",
+            "Python continuous integration guide",
+            0.8,
+        )
+        .candidate,
+    ];
+    let query_tokens = vec![
+        "uv".to_string(),
+        "python".to_string(),
+        "dependencies".to_string(),
+    ];
+
+    assert_eq!(
+        product_authority_ratio(&candidates, &query_tokens, 0.35),
+        0.0
+    );
+}
+
+#[test]
+fn product_authority_ratio_requires_host_or_early_path_identity_match() {
+    let candidates = vec![
+        make_candidate(
+            "https://www.postgresql.org/docs/current/runtime-config-error-handling.html",
+            "PostgreSQL runtime error handling docs",
+            0.8,
+        )
+        .candidate,
+    ];
+    let query_tokens = vec![
+        "rust".to_string(),
+        "error".to_string(),
+        "handling".to_string(),
+    ];
+
+    assert_eq!(
+        product_authority_ratio(&candidates, &query_tokens, 0.35),
+        0.0
+    );
+}
+
+#[test]
+fn product_authority_ratio_counts_early_path_identity_match() {
+    let candidates = vec![
+        make_candidate(
+            "https://docs.astral.sh/uv/concepts/projects/dependencies",
+            "uv Python dependency management",
+            0.8,
+        )
+        .candidate,
+    ];
+    let query_tokens = vec![
+        "uv".to_string(),
+        "python".to_string(),
+        "dependencies".to_string(),
+    ];
+
+    assert_eq!(
+        product_authority_ratio(&candidates, &query_tokens, 0.35),
+        1.0
+    );
+}
+
+#[test]
+fn score_policy_boosts_docs_rs_crate_page_for_crate_queries() {
+    let candidates = vec![
+        make_candidate(
+            "https://docs.other.dev/docs/layout",
+            "Other layout documentation with rendering concepts",
+            0.30,
+        ),
+        make_candidate(
+            "https://docs.rs/gpui/latest/gpui/",
+            "GPUI crate documentation application views windows render",
+            0.20,
+        ),
+    ];
+    let query_tokens = vec!["gpui".to_string(), "views".to_string()];
+    let policy = CandidateScorePolicy {
+        authoritative_domains: &[],
+        authoritative_boost: 0.0,
+        product_authority_boost: 0.35,
+        min_relevance_score: None,
+        require_topical_overlap: true,
+    };
+
+    let selected = score_and_filter_candidates(&candidates, &query_tokens, &policy);
+
+    assert_eq!(
+        selected[0].candidate.url,
+        "https://docs.rs/gpui/latest/gpui/"
+    );
+}

--- a/src/vector/ops/commands/retrieval/tests.rs
+++ b/src/vector/ops/commands/retrieval/tests.rs
@@ -6,6 +6,9 @@ use crate::vector::ops::qdrant::{QdrantPayload, QdrantSearchHit};
 use serde_json::Value;
 use std::collections::HashSet;
 
+#[path = "product_authority_tests.rs"]
+mod product_authority_tests;
+
 fn make_candidate(url: &str, chunk: &str, score: f64) -> RetrievedCandidate {
     RetrievedCandidate {
         candidate: ranking::AskCandidate {
@@ -167,6 +170,19 @@ fn candidate_has_topical_overlap_chunk_tokens_count_toward_overlap() {
 }
 
 #[test]
+fn candidate_has_topical_overlap_ignores_short_query_tokens_for_topical_gate() {
+    let candidate = make_candidate(
+        "https://docs.astral.sh/uv/concepts/projects/dependencies",
+        "Python dependency management guide",
+        0.4,
+    )
+    .candidate;
+    let query_tokens = vec!["uv".to_string(), "dependencies".to_string()];
+
+    assert!(candidate_has_topical_overlap(&candidate, &query_tokens));
+}
+
+#[test]
 fn candidate_has_topical_overlap_rejects_generic_only_matches_when_product_named() {
     let candidate = make_candidate(
         "https://www.postgresql.org/docs/current/sql-createview.html",
@@ -266,145 +282,6 @@ fn score_policy_boosts_docs_like_url_with_query_product_token() {
     assert_eq!(
         selected[0].candidate.url,
         "https://docs.widget.dev/docs/en/plugins"
-    );
-}
-
-#[test]
-fn product_authority_ratio_counts_docs_like_urls_with_query_product_token() {
-    let candidates = vec![
-        make_candidate(
-            "https://docs.widget.dev/docs/en/plugins",
-            "Widget plugins marketplace official docs",
-            0.8,
-        )
-        .candidate,
-        make_candidate(
-            "https://docs.other.dev/cli/plugins",
-            "Other plugins marketplace commands install list inspect",
-            0.7,
-        )
-        .candidate,
-    ];
-    let query_tokens = vec!["widget".to_string(), "plugins".to_string()];
-
-    let ratio = product_authority_ratio(&candidates, &query_tokens, 0.35);
-
-    assert!((ratio - 0.5).abs() < f64::EPSILON);
-}
-
-#[test]
-fn product_authority_boost_ignores_malformed_urls() {
-    let query_tokens = vec!["uv".to_string()];
-    assert_eq!(
-        product_authority_boost_for_url("not a url", &query_tokens, 0.35),
-        0.0
-    );
-}
-
-#[test]
-fn product_authority_ratio_is_zero_without_matching_product_token() {
-    let candidates = vec![
-        make_candidate(
-            "https://docs.widget.dev/docs/en/plugins",
-            "Widget plugins marketplace official docs",
-            0.8,
-        )
-        .candidate,
-    ];
-    let query_tokens = vec!["plugins".to_string()];
-
-    assert_eq!(
-        product_authority_ratio(&candidates, &query_tokens, 0.35),
-        0.0
-    );
-}
-
-#[test]
-fn product_authority_ratio_ignores_generic_package_publish_tokens() {
-    let candidates = vec![
-        make_candidate(
-            "https://docs.astral.sh/uv/guides/package",
-            "Publish your package with uv publish",
-            0.8,
-        )
-        .candidate,
-    ];
-    let query_tokens = vec![
-        "publish".to_string(),
-        "python".to_string(),
-        "package".to_string(),
-        "pypi".to_string(),
-    ];
-
-    assert_eq!(
-        product_authority_ratio(&candidates, &query_tokens, 0.35),
-        0.0
-    );
-}
-
-#[test]
-fn product_authority_ratio_ignores_language_tokens_as_product_identity() {
-    let candidates = vec![
-        make_candidate(
-            "https://playwright.dev/python/docs/ci",
-            "Python continuous integration guide",
-            0.8,
-        )
-        .candidate,
-    ];
-    let query_tokens = vec![
-        "uv".to_string(),
-        "python".to_string(),
-        "dependencies".to_string(),
-    ];
-
-    assert_eq!(
-        product_authority_ratio(&candidates, &query_tokens, 0.35),
-        0.0
-    );
-}
-
-#[test]
-fn product_authority_ratio_requires_host_or_early_path_identity_match() {
-    let candidates = vec![
-        make_candidate(
-            "https://www.postgresql.org/docs/current/runtime-config-error-handling.html",
-            "PostgreSQL runtime error handling docs",
-            0.8,
-        )
-        .candidate,
-    ];
-    let query_tokens = vec![
-        "rust".to_string(),
-        "error".to_string(),
-        "handling".to_string(),
-    ];
-
-    assert_eq!(
-        product_authority_ratio(&candidates, &query_tokens, 0.35),
-        0.0
-    );
-}
-
-#[test]
-fn product_authority_ratio_counts_early_path_identity_match() {
-    let candidates = vec![
-        make_candidate(
-            "https://docs.astral.sh/uv/concepts/projects/dependencies",
-            "uv Python dependency management",
-            0.8,
-        )
-        .candidate,
-    ];
-    let query_tokens = vec![
-        "uv".to_string(),
-        "python".to_string(),
-        "dependencies".to_string(),
-    ];
-
-    assert_eq!(
-        product_authority_ratio(&candidates, &query_tokens, 0.35),
-        1.0
     );
 }
 
@@ -567,36 +444,5 @@ fn rrf_score_trace_applies_lexical_boosts_without_min_relevance() {
                 && component.value > 0.0
         }),
         "RRF trace path should apply lexical URL boosts during final ask context reranking"
-    );
-}
-
-#[test]
-fn score_policy_boosts_docs_rs_crate_page_for_crate_queries() {
-    let candidates = vec![
-        make_candidate(
-            "https://docs.other.dev/docs/layout",
-            "Other layout documentation with rendering concepts",
-            0.30,
-        ),
-        make_candidate(
-            "https://docs.rs/gpui/latest/gpui/",
-            "GPUI crate documentation application views windows render",
-            0.20,
-        ),
-    ];
-    let query_tokens = vec!["gpui".to_string(), "views".to_string()];
-    let policy = CandidateScorePolicy {
-        authoritative_domains: &[],
-        authoritative_boost: 0.0,
-        product_authority_boost: 0.35,
-        min_relevance_score: None,
-        require_topical_overlap: true,
-    };
-
-    let selected = score_and_filter_candidates(&candidates, &query_tokens, &policy);
-
-    assert_eq!(
-        selected[0].candidate.url,
-        "https://docs.rs/gpui/latest/gpui/"
     );
 }

--- a/src/vector/ops/commands/retrieval/tests.rs
+++ b/src/vector/ops/commands/retrieval/tests.rs
@@ -293,6 +293,15 @@ fn product_authority_ratio_counts_docs_like_urls_with_query_product_token() {
 }
 
 #[test]
+fn product_authority_boost_ignores_malformed_urls() {
+    let query_tokens = vec!["uv".to_string()];
+    assert_eq!(
+        product_authority_boost_for_url("not a url", &query_tokens, 0.35),
+        0.0
+    );
+}
+
+#[test]
 fn product_authority_ratio_is_zero_without_matching_product_token() {
     let candidates = vec![
         make_candidate(

--- a/src/vector/ops/commands/retrieval/tests.rs
+++ b/src/vector/ops/commands/retrieval/tests.rs
@@ -183,6 +183,14 @@ fn candidate_has_topical_overlap_ignores_short_query_tokens_for_topical_gate() {
 }
 
 #[test]
+fn candidate_has_topical_overlap_allows_all_short_identity_query_tokens() {
+    let candidate = make_candidate("https://docs.rs/axum", "router guide", 0.4).candidate;
+    let query_tokens = vec!["ui".to_string(), "rs".to_string()];
+
+    assert!(candidate_has_topical_overlap(&candidate, &query_tokens));
+}
+
+#[test]
 fn candidate_has_topical_overlap_rejects_generic_only_matches_when_product_named() {
     let candidate = make_candidate(
         "https://www.postgresql.org/docs/current/sql-createview.html",

--- a/src/vector/ops/commands/retrieval/tokens.rs
+++ b/src/vector/ops/commands/retrieval/tokens.rs
@@ -77,6 +77,7 @@ fn candidate_topical_overlap_count(
 ) -> usize {
     query_tokens
         .iter()
+        .filter(|token| token.len() >= 3)
         .filter(|token| {
             candidate.url_tokens.contains(token.as_str())
                 || candidate.chunk_tokens.contains(token.as_str())
@@ -85,7 +86,7 @@ fn candidate_topical_overlap_count(
 }
 
 fn candidate_matches_any_token(candidate: &ranking::AskCandidate, tokens: &[&String]) -> bool {
-    tokens.iter().any(|token| {
+    tokens.iter().filter(|token| token.len() >= 3).any(|token| {
         candidate.url_tokens.contains(token.as_str())
             || candidate.chunk_tokens.contains(token.as_str())
     })
@@ -98,16 +99,24 @@ pub(crate) fn candidate_has_topical_overlap(
     if query_tokens.is_empty() {
         return true;
     }
-    let salient_tokens = query_tokens
+    let topical_tokens = query_tokens
         .iter()
+        .filter(|token| token.len() >= 3)
+        .collect::<Vec<_>>();
+    if topical_tokens.is_empty() {
+        return true;
+    }
+    let salient_tokens = topical_tokens
+        .iter()
+        .copied()
         .filter(|token| !token_policy::is_generic_topical_token(token.as_str()))
         .collect::<Vec<_>>();
     if !salient_tokens.is_empty() && !candidate_matches_any_token(candidate, &salient_tokens) {
         return false;
     }
     let overlap = candidate_topical_overlap_count(candidate, query_tokens);
-    let coverage = overlap as f64 / query_tokens.len() as f64;
-    match query_tokens.len() {
+    let coverage = overlap as f64 / topical_tokens.len() as f64;
+    match topical_tokens.len() {
         0 => true,
         1 | 2 => overlap >= 1,
         3 | 4 => overlap >= 1 || coverage >= 0.5,

--- a/src/vector/ops/commands/retrieval/tokens.rs
+++ b/src/vector/ops/commands/retrieval/tokens.rs
@@ -1,4 +1,5 @@
 use crate::vector::ops::ranking;
+use crate::vector::ops::token_policy;
 use spider::url::Url;
 use std::collections::HashSet;
 
@@ -19,7 +20,8 @@ pub(crate) fn product_authority_boost_for_url(
 
     let identity_tokens = product_identity_tokens(url);
     let product_token_match = query_tokens.iter().any(|token| {
-        !is_generic_authority_token(token.as_str()) && identity_tokens.contains(token.as_str())
+        !token_policy::is_generic_authority_token(token.as_str())
+            && identity_tokens.contains(token.as_str())
     });
     if product_token_match {
         product_authority_boost
@@ -55,7 +57,7 @@ fn product_identity_tokens(url: &str) -> HashSet<String> {
     };
     let mut tokens = HashSet::new();
     if let Some(host) = parsed.host_str() {
-        tokens.extend(tokenize_identity_segment(host));
+        tokens.extend(token_policy::identity_tokens(host));
     }
     for segment in parsed
         .path_segments()
@@ -64,123 +66,9 @@ fn product_identity_tokens(url: &str) -> HashSet<String> {
         .filter(|segment| !segment.is_empty())
         .take(2)
     {
-        tokens.extend(tokenize_identity_segment(segment));
+        tokens.extend(token_policy::identity_tokens(segment));
     }
     tokens
-}
-
-fn tokenize_identity_segment(text: &str) -> HashSet<String> {
-    text.to_ascii_lowercase()
-        .split(|c: char| !c.is_ascii_alphanumeric())
-        .filter(|token| token.len() >= 2)
-        .map(str::to_string)
-        .collect()
-}
-
-fn is_generic_authority_token(token: &str) -> bool {
-    matches!(
-        token,
-        "api"
-            | "app"
-            | "book"
-            | "build"
-            | "cli"
-            | "code"
-            | "command"
-            | "commands"
-            | "config"
-            | "create"
-            | "documentation"
-            | "error"
-            | "errors"
-            | "find"
-            | "docs"
-            | "guide"
-            | "guides"
-            | "handling"
-            | "install"
-            | "java"
-            | "javascript"
-            | "js"
-            | "dependency"
-            | "dependencies"
-            | "go"
-            | "manage"
-            | "management"
-            | "marketplace"
-            | "node"
-            | "nodejs"
-            | "package"
-            | "packages"
-            | "plugin"
-            | "plugins"
-            | "publish"
-            | "publishing"
-            | "py"
-            | "python"
-            | "reference"
-            | "registry"
-            | "rs"
-            | "rust"
-            | "setup"
-            | "structure"
-            | "structured"
-            | "structuring"
-            | "tool"
-            | "tools"
-            | "ts"
-            | "typescript"
-            | "using"
-            | "view"
-            | "views"
-    )
-}
-
-fn is_generic_topical_token(token: &str) -> bool {
-    matches!(
-        token,
-        "api"
-            | "app"
-            | "book"
-            | "build"
-            | "cli"
-            | "code"
-            | "command"
-            | "commands"
-            | "config"
-            | "create"
-            | "documentation"
-            | "error"
-            | "errors"
-            | "find"
-            | "docs"
-            | "guide"
-            | "guides"
-            | "handling"
-            | "install"
-            | "dependency"
-            | "dependencies"
-            | "manage"
-            | "management"
-            | "marketplace"
-            | "package"
-            | "packages"
-            | "plugin"
-            | "plugins"
-            | "publish"
-            | "publishing"
-            | "reference"
-            | "registry"
-            | "setup"
-            | "structure"
-            | "structured"
-            | "structuring"
-            | "tool"
-            | "tools"
-            | "using"
-            | "view"
-            | "views"
-    )
 }
 
 fn candidate_topical_overlap_count(
@@ -212,7 +100,7 @@ pub(crate) fn candidate_has_topical_overlap(
     }
     let salient_tokens = query_tokens
         .iter()
-        .filter(|token| !is_generic_topical_token(token.as_str()))
+        .filter(|token| !token_policy::is_generic_topical_token(token.as_str()))
         .collect::<Vec<_>>();
     if !salient_tokens.is_empty() && !candidate_matches_any_token(candidate, &salient_tokens) {
         return false;

--- a/src/vector/ops/ranking.rs
+++ b/src/vector/ops/ranking.rs
@@ -53,11 +53,7 @@ impl AskScoreBreakdown {
 }
 
 pub fn tokenize_query(text: &str) -> Vec<String> {
-    text.to_ascii_lowercase()
-        .split(|c: char| !c.is_ascii_alphanumeric())
-        .filter(|t| t.len() >= 2 && !STOP_WORDS.contains(*t))
-        .map(str::to_string)
-        .collect()
+    super::token_policy::query_tokens(text)
 }
 
 pub fn tokenize_text_set(text: &str) -> HashSet<String> {

--- a/src/vector/ops/token_policy.rs
+++ b/src/vector/ops/token_policy.rs
@@ -1,0 +1,88 @@
+use std::collections::HashSet;
+
+const GENERIC_TOPICAL_TOKENS: &[&str] = &[
+    "api",
+    "app",
+    "book",
+    "build",
+    "cli",
+    "code",
+    "command",
+    "commands",
+    "config",
+    "create",
+    "documentation",
+    "error",
+    "errors",
+    "find",
+    "docs",
+    "guide",
+    "guides",
+    "handling",
+    "install",
+    "dependency",
+    "dependencies",
+    "manage",
+    "management",
+    "marketplace",
+    "package",
+    "packages",
+    "plugin",
+    "plugins",
+    "publish",
+    "publishing",
+    "reference",
+    "registry",
+    "setup",
+    "structure",
+    "structured",
+    "structuring",
+    "tool",
+    "tools",
+    "using",
+    "view",
+    "views",
+];
+
+const LANGUAGE_IDENTITY_TOKENS: &[&str] = &[
+    "java",
+    "javascript",
+    "js",
+    "go",
+    "node",
+    "nodejs",
+    "py",
+    "python",
+    "rs",
+    "rust",
+    "ts",
+    "typescript",
+];
+
+pub fn query_tokens(text: &str) -> Vec<String> {
+    text.to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|token| token.len() >= 2 && !is_query_stop_word(token))
+        .map(str::to_string)
+        .collect()
+}
+
+pub fn identity_tokens(text: &str) -> HashSet<String> {
+    text.to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|token| token.len() >= 2)
+        .map(str::to_string)
+        .collect()
+}
+
+pub fn is_generic_authority_token(token: &str) -> bool {
+    is_generic_topical_token(token) || LANGUAGE_IDENTITY_TOKENS.contains(&token)
+}
+
+pub fn is_generic_topical_token(token: &str) -> bool {
+    GENERIC_TOPICAL_TOKENS.contains(&token)
+}
+
+fn is_query_stop_word(token: &str) -> bool {
+    super::sparse::STOP_WORDS.contains(token)
+}


### PR DESCRIPTION
## Summary
- add typed corpus-health diagnostics and richer ask explain selection metadata
- add fixture-backed retrieval eval harness with strict host matching
- harden full-document selection with URL dedupe and domain diversity fallback

## Verification
- cargo fmt --check
- git diff --check
- cargo test vector::ops::commands::retrieval::tests --lib
- cargo test vector::ops::ranking::tests --lib
- cargo test services::query::tests --lib
- cargo test vector::ops::commands::ask::context --lib
- cargo check --bin axon
- scripts/test-evaluate-retrieval.sh
- scripts/evaluate-retrieval.sh
- pre-commit hook suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens retrieval quality and debugging with typed corpus-health diagnostics, richer `ask --explain` metadata, a fast retrieval sweep harness, and hardened full-doc selection. Adds a unified token policy that filters short tokens for topical coverage while preserving identity matching.

- **New Features**
  - Corpus-health diagnostics with kind/reason and domain counts; shown in CLI and JSON.
  - `ask --explain` adds `raw_rerank_rank`, `planned_full_doc_rank`, `selected_context_rank`, and `insertion_mode`.
  - Retrieval sweep via `docs/eval/retrieval-fixtures.jsonl`, `scripts/evaluate-retrieval.sh` (+ `scripts/test-evaluate-retrieval.sh`); strict expected-domain checks with summary output. Runtime failures are always fatal; `ALLOW_MISS=1` only ignores known misses.
  - Centralized token policy for query/identity tokens; docs updated with retrieval gates and workflow.

- **Bug Fixes**
  - Stable candidate keys keep selection metadata aligned after rerank reordering and duplicate URLs.
  - Full-doc selection: URL de-duplication plus per-domain cap, with fallback fill when only one domain is available; supplemental insertion is prioritized and ranks reflect final context order.
  - Topical-overlap gate ignores very short tokens for coverage while preserving short identity tokens for ranking/authority; product authority boost ignores malformed URLs; explain traces are more robust.

<sup>Written for commit e85a0270cd38ad615f431473e47b44e06fe04182. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/90?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Corpus health diagnostics now available in explain mode output.
  * Enhanced explain trace with detailed selection metadata including rank information and insertion modes.
  * Improved full-document selection with per-domain diversity caps, URL deduplication, and fallback fill support.
  * Retrieval evaluation framework with fixture-based quality gates for incremental tuning vs. release signoff.

* **Documentation**
  * Added retrieval quality gates guidance and evaluation fixture harness documentation.
  * Expanded ask command server configuration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/axon/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->