### PR TITLE
palette: deferred follow-on items from gpui-component spike

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,6 @@ HF_TOKEN=
 GEMINI_API_KEY=
 # Docker bind mount: host dir holding the OAuth credentials for the gemini CLI.
 GEMINI_HOME=
-# Alternative Google auth paths (consumed by Gemini CLI if set).
-GOOGLE_API_KEY=
-GOOGLE_APPLICATION_CREDENTIALS=
 # Runtime override: dir axon copies OAuth files FROM into an isolated temp HOME
 # per Gemini invocation. Defaults to $HOME. Set only if Gemini creds live elsewhere.
 AXON_HEADLESS_GEMINI_HOME=
@@ -61,9 +58,9 @@ OPENAI_MODEL=
 AXON_LITE=
 
 # ── Logging ─────────────────────────────────────────────────────────────────
-# Active log directory and filename. Default: $AXON_DATA_DIR/logs/ + axon.log.
-AXON_LOG_DIR=
-AXON_LOG_FILE=
+# Full path to active log file. Rotated siblings (.1, .2, ...) live in the same dir.
+# Default: $AXON_DATA_DIR/logs/axon.log
+AXON_LOG_PATH=
 
 # ── Compose interpolation (Docker only) ─────────────────────────────────────
 AXON_IMAGE=

--- a/.env.example
+++ b/.env.example
@@ -22,13 +22,6 @@ AXON_MCP_AUTH_ADMIN_EMAIL=
 AXON_MCP_AUTH_ALLOWED_REDIRECT_URIS=
 AXON_MCP_ALLOWED_ORIGINS=
 
-# ── Web panel (served alongside MCP HTTP) ───────────────────────────────────
-# Reserved for a future web-panel auth surface. Currently registered in the env
-# boundary as canonical keys but NOT consumed at runtime — setting them has no
-# effect today. The MCP HTTP server uses AXON_MCP_HTTP_TOKEN + AXON_MCP_ALLOWED_ORIGINS.
-AXON_WEB_ALLOWED_ORIGINS=
-AXON_WEB_API_TOKEN=
-
 # ── Ingest credentials ──────────────────────────────────────────────────────
 TAVILY_API_KEY=
 GITHUB_TOKEN=
@@ -43,6 +36,9 @@ HF_TOKEN=
 GEMINI_API_KEY=
 # Docker bind mount: host dir holding the OAuth credentials for the gemini CLI.
 GEMINI_HOME=
+# Alternative Google auth paths (consumed by Gemini CLI if set).
+GOOGLE_API_KEY=
+GOOGLE_APPLICATION_CREDENTIALS=
 # Runtime override: dir axon copies OAuth files FROM into an isolated temp HOME
 # per Gemini invocation. Defaults to $HOME. Set only if Gemini creds live elsewhere.
 AXON_HEADLESS_GEMINI_HOME=
@@ -51,10 +47,23 @@ AXON_HEADLESS_GEMINI_CMD=
 # Gemini model override (e.g. gemini-2.5-flash-exp). Defaults to gemini CLI's choice.
 AXON_HEADLESS_GEMINI_MODEL=
 
+# ── OpenAI-compatible LLM endpoint (extract pipeline) ───────────────────────
+# Read by src/services/extract.rs and the extract job runner. Ask/evaluate
+# streaming uses Gemini headless; OPENAI_MODEL is only reused there when it
+# starts with `gemini-`.
+OPENAI_BASE_URL=
+OPENAI_API_KEY=
+OPENAI_MODEL=
+
+# ── Compatibility shims ─────────────────────────────────────────────────────
+# AXON_LITE: legacy SQLite/in-process toggle. No-op today (SQLite is the only
+# runtime); accepted for backward compatibility — emits a startup warning if set.
+AXON_LITE=
+
 # ── Logging ─────────────────────────────────────────────────────────────────
-# Full path to active log file. Rotated siblings (.1, .2, ...) live in the same dir.
-# Default: $AXON_DATA_DIR/logs/axon.log
-AXON_LOG_PATH=
+# Active log directory and filename. Default: $AXON_DATA_DIR/logs/ + axon.log.
+AXON_LOG_DIR=
+AXON_LOG_FILE=
 
 # ── Compose interpolation (Docker only) ─────────────────────────────────────
 AXON_IMAGE=
@@ -64,10 +73,3 @@ TEI_HTTP_PORT=52000
 TEI_SERVER_MAX_CLIENT_BATCH_SIZE=96
 NVIDIA_VISIBLE_DEVICES=0
 CUDA_VISIBLE_DEVICES=0
-NVIDIA_REQUIRE_CUDA=cuda>=12.2
-PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:1024
-OMP_NUM_THREADS=8
-MKL_NUM_THREADS=8
-TOKENIZERS_PARALLELISM=true
-CUDA_CACHE_DISABLE=0
-HF_HUB_ENABLE_HF_TRANSFER=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.3] - 2026-05-17
+
+### Fixed
+
+- **palette/output**: `consume_until_string_terminator` no longer treats a bare `ESC` as a String Terminator. Malformed OSC/DCS/APC payloads that contain a bare ESC (without a following `\`) would previously exit the strip loop early and leak the remaining payload bytes to rendered output. The ESC is now swallowed and stripping continues until a proper BEL or ESC `\` terminator is seen.
+- **.env.example**: Removed `GOOGLE_API_KEY` / `GOOGLE_APPLICATION_CREDENTIALS` (both are scrubbed by the Gemini subprocess env allowlist — setting them has no effect). Reverted the logging keys from the unimplemented `AXON_LOG_DIR`/`AXON_LOG_FILE` pair back to the actually-honored `AXON_LOG_PATH`.
+
 ## [2.3.2] - 2026-05-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2] - 2026-05-17
+
+### Fixed
+
+- **palette**: Drop the repeating `pulsating_between` animation on the launch-time health-check status dot. The auto-spawned `axon doctor --json` probe combined with `Animation::new(...).repeat()` could keep GPUI re-rendering every frame on slower compositors and starve key-event dispatch, producing the user-visible "window opens but won't accept typing" freeze. The dot now changes color only (grey/checking → green/connected → red/disconnected). The footer and output-card pulsing dots, which only render once a command is selected or running, are unaffected.
+
 ## [2.3.1] - 2026-05-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "2.3.2"
+version = "2.3.3"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 2.3.1
+Version: 2.3.2
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 2.3.2
+Version: 2.3.3
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/desktop/src/actions.rs
+++ b/apps/desktop/src/actions.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[path = "actions_tests.rs"]
+mod tests;
+
 #[derive(Clone, Copy)]
 pub(crate) struct CommandAction {
     pub(crate) label: &'static str,
@@ -109,17 +113,34 @@ pub(crate) fn action_invoked_by(action: CommandAction, token: &str) -> bool {
 }
 
 pub(crate) fn action_matches(action: CommandAction, input: &str) -> bool {
-    let needle = input.trim().to_lowercase();
+    let needle = input.trim();
     if needle.is_empty() {
         return true;
     }
 
-    action.subcommand.contains(&needle)
-        || action.label.to_lowercase().contains(&needle)
+    contains_ignore_ascii_case(action.subcommand, needle)
+        || contains_ignore_ascii_case(action.label, needle)
         || action
             .aliases
             .iter()
-            .any(|alias| alias.contains(needle.as_str()))
+            .any(|alias| contains_ignore_ascii_case(alias, needle))
+}
+
+/// Case-insensitive (ASCII) substring search. Avoids the per-call
+/// `String` allocation that `to_lowercase()` would introduce — this runs
+/// on the palette render hot path for every action, every frame the
+/// search field is dirty. All ACTIONS labels/aliases are ASCII.
+fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let hay = haystack.as_bytes();
+    let ndl = needle.as_bytes();
+    if ndl.len() > hay.len() {
+        return false;
+    }
+    hay.windows(ndl.len())
+        .any(|window| window.eq_ignore_ascii_case(ndl))
 }
 
 pub(crate) fn looks_like_url(input: &str) -> bool {

--- a/apps/desktop/src/actions_tests.rs
+++ b/apps/desktop/src/actions_tests.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+#[test]
+fn contains_ignore_ascii_case_basic() {
+    assert!(contains_ignore_ascii_case("Scrape URL", "scrape"));
+    assert!(contains_ignore_ascii_case("Scrape URL", "SCRAPE"));
+    assert!(contains_ignore_ascii_case("Scrape URL", "rApE"));
+    assert!(!contains_ignore_ascii_case("Scrape URL", "crawl"));
+}
+
+#[test]
+fn contains_ignore_ascii_case_edges() {
+    // empty needle always matches
+    assert!(contains_ignore_ascii_case("anything", ""));
+    // needle longer than haystack
+    assert!(!contains_ignore_ascii_case("ab", "abc"));
+    // exact match
+    assert!(contains_ignore_ascii_case("doctor", "DOCTOR"));
+    // overlapping prefix only
+    assert!(!contains_ignore_ascii_case("ask", "asks"));
+}
+
+#[test]
+fn action_matches_empty_input_matches_all() {
+    for action in ACTIONS {
+        assert!(action_matches(*action, ""));
+        assert!(action_matches(*action, "   "));
+    }
+}
+
+#[test]
+fn action_matches_case_insensitive_subcommand() {
+    let scrape = ACTIONS
+        .iter()
+        .find(|a| a.subcommand == "scrape")
+        .copied()
+        .expect("scrape action present");
+    assert!(action_matches(scrape, "SCRAPE"));
+    assert!(action_matches(scrape, "ScrApe"));
+    assert!(action_matches(scrape, "rap"));
+}
+
+#[test]
+fn action_matches_alias_hit() {
+    let ingest = ACTIONS
+        .iter()
+        .find(|a| a.subcommand == "ingest")
+        .copied()
+        .expect("ingest action present");
+    // aliases include "repo", "youtube", "reddit"
+    assert!(action_matches(ingest, "Repo"));
+    assert!(action_matches(ingest, "YOUTUBE"));
+}
+
+#[test]
+fn action_matches_label_hit() {
+    let doctor = ACTIONS
+        .iter()
+        .find(|a| a.subcommand == "doctor")
+        .copied()
+        .expect("doctor action present");
+    // label "Doctor" should match "doc" without to_lowercase()
+    assert!(action_matches(doctor, "doc"));
+    assert!(action_matches(doctor, "DOC"));
+}
+
+#[test]
+fn action_matches_miss() {
+    let ask = ACTIONS
+        .iter()
+        .find(|a| a.subcommand == "ask")
+        .copied()
+        .expect("ask action present");
+    assert!(!action_matches(ask, "zzz"));
+}

--- a/apps/desktop/src/output.rs
+++ b/apps/desktop/src/output.rs
@@ -228,12 +228,15 @@ fn consume_until_string_terminator(chars: &mut std::iter::Peekable<std::str::Cha
             return;
         }
         if ch == '\x1b' {
-            // ST = ESC '\\'. Consume the trailing '\\' if present; if not,
-            // treat the ESC as a terminator on its own (malformed input).
+            // ST = ESC '\\'. Only a well-formed ST terminates the
+            // sequence. A bare ESC inside a string-type payload is
+            // malformed input; swallow it and keep stripping rather
+            // than leaking the remainder of the payload to output.
             if chars.peek() == Some(&'\\') {
                 chars.next();
+                return;
             }
-            return;
+            continue;
         }
     }
 }

--- a/apps/desktop/src/output.rs
+++ b/apps/desktop/src/output.rs
@@ -2,6 +2,10 @@ use std::process::Output;
 
 use gpui::SharedString;
 
+#[cfg(test)]
+#[path = "output_tests.rs"]
+mod tests;
+
 use crate::actions::{ACTIONS, CommandAction};
 use crate::theme::{
     AURORA_ACCENT_PINK, AURORA_ACCENT_PRIMARY, AURORA_ACCENT_STRONG, AURORA_WARNING,
@@ -165,29 +169,73 @@ impl OutputKind {
     }
 }
 
-/// Strip ANSI CSI escape sequences (e.g. `\x1b[1;31m`, `\x1b[0m`).
+/// Strip ANSI / VT escape sequences.
+///
+/// Covers:
+/// - **CSI** (`ESC [` … final byte in `0x40..=0x7E`) — colour/format codes.
+/// - **OSC** (`ESC ]` … terminated by `BEL` (`0x07`) or `ST` (`ESC \`)) —
+///   title-setting and similar OS commands.
+/// - **DCS** (`ESC P` … terminated by `ST`) — device control strings.
+/// - **APC** (`ESC _` … terminated by `ST`) — application program commands.
+/// - **PM**  (`ESC ^` … terminated by `ST`) — privacy messages.
+/// - **SOS** (`ESC X` … terminated by `ST`) — start of string.
+///
+/// Anything malformed (lone `ESC`, EOF mid-sequence) is silently dropped.
 fn strip_ansi(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut chars = text.chars().peekable();
     while let Some(c) = chars.next() {
-        if c == '\x1b' {
-            if chars.peek() == Some(&'[') {
-                chars.next(); // consume '['
-                // Consume until ANSI final byte: 0x40–0x7E (includes letters
-                // AND punctuation such as `~`, `|`, `@`, etc.).
+        if c != '\x1b' {
+            out.push(c);
+            continue;
+        }
+        // Look at the byte immediately after ESC to pick the sequence kind.
+        let Some(&next) = chars.peek() else {
+            // lone trailing ESC — drop it
+            continue;
+        };
+        match next {
+            '[' => {
+                chars.next();
+                // CSI: consume until a final byte in 0x40..=0x7E.
                 for ch in chars.by_ref() {
                     if ('\x40'..='\x7e').contains(&ch) {
                         break;
                     }
                 }
-            } else {
-                chars.next(); // skip the single non-CSI escape char
             }
-        } else {
-            out.push(c);
+            ']' | 'P' | '_' | '^' | 'X' => {
+                // OSC / DCS / APC / PM / SOS. All terminate on either
+                // BEL (0x07) or ST (ESC \).
+                chars.next();
+                consume_until_string_terminator(&mut chars);
+            }
+            _ => {
+                // Some other Fp/Fe/Fs/two-char escape (e.g. ESC =, ESC c).
+                // Drop the single follow-up byte and move on.
+                chars.next();
+            }
         }
     }
     out
+}
+
+/// Consume characters until a String Terminator (`BEL` or `ESC \`) is seen.
+/// The terminator itself is consumed. EOF mid-sequence is silently accepted.
+fn consume_until_string_terminator(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    while let Some(ch) = chars.next() {
+        if ch == '\x07' {
+            return;
+        }
+        if ch == '\x1b' {
+            // ST = ESC '\\'. Consume the trailing '\\' if present; if not,
+            // treat the ESC as a terminator on its own (malformed input).
+            if chars.peek() == Some(&'\\') {
+                chars.next();
+            }
+            return;
+        }
+    }
 }
 
 /// Render an `ExitStatus` as a short human-readable string.

--- a/apps/desktop/src/output.rs
+++ b/apps/desktop/src/output.rs
@@ -1,11 +1,16 @@
 use std::process::Output;
 
+use gpui::SharedString;
+
 use crate::actions::{ACTIONS, CommandAction};
 use crate::theme::{
     AURORA_ACCENT_PINK, AURORA_ACCENT_PRIMARY, AURORA_ACCENT_STRONG, AURORA_WARNING,
 };
 
 const OUTPUT_LIMIT: usize = 12_000;
+/// Maximum number of lines rendered for a raw (non-markdown) output
+/// section. Mirrors the `take(MAX_RENDER_LINES)` cap in `render.rs`.
+pub(crate) const MAX_RENDER_LINES: usize = 220;
 
 #[derive(Clone)]
 pub(crate) struct CommandOutput {
@@ -30,6 +35,13 @@ pub(crate) struct OutputSection {
     pub(crate) label: &'static str,
     pub(crate) text: String,
     pub(crate) line_count: usize,
+    /// Pre-computed `SharedString` per visible line, capped at
+    /// `MAX_RENDER_LINES`. Built once when the section is created and
+    /// cloned cheaply (`Arc`-backed) on every render frame — avoids the
+    /// ~220 allocations/frame the raw renderer used to incur.
+    /// Only populated for raw (non-markdown) sections; markdown sections
+    /// render directly from `text`.
+    pub(crate) rendered_lines: Vec<SharedString>,
 }
 
 impl CommandOutput {
@@ -113,10 +125,22 @@ impl OutputSection {
     fn new(label: &'static str, text: impl Into<String>) -> Self {
         let text = truncate_output(text.into());
         let line_count = text.lines().count().max(1);
+        let rendered_lines = text
+            .lines()
+            .take(MAX_RENDER_LINES)
+            .map(|line| {
+                if line.is_empty() {
+                    SharedString::from(" ")
+                } else {
+                    SharedString::from(line.to_string())
+                }
+            })
+            .collect();
         Self {
             label,
             text,
             line_count,
+            rendered_lines,
         }
     }
 }

--- a/apps/desktop/src/output_tests.rs
+++ b/apps/desktop/src/output_tests.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+#[test]
+fn strip_ansi_csi_colours() {
+    let input = "\x1b[1;31merror\x1b[0m: thing";
+    assert_eq!(strip_ansi(input), "error: thing");
+}
+
+#[test]
+fn strip_ansi_csi_with_punctuation_final_byte() {
+    // CSI final byte may be punctuation such as `~` or `@`
+    let input = "before\x1b[2~after";
+    assert_eq!(strip_ansi(input), "beforeafter");
+}
+
+#[test]
+fn strip_ansi_osc_bel_terminated() {
+    // OSC 0; set window title <BEL>
+    let input = "pre\x1b]0;hello world\x07post";
+    assert_eq!(strip_ansi(input), "prepost");
+}
+
+#[test]
+fn strip_ansi_osc_st_terminated() {
+    // OSC terminated by ST = ESC '\\'
+    let input = "pre\x1b]0;hello world\x1b\\post";
+    assert_eq!(strip_ansi(input), "prepost");
+}
+
+#[test]
+fn strip_ansi_dcs_st_terminated() {
+    // DCS = ESC 'P' … ST
+    let input = "pre\x1bPq#0;2;0;0;0\x1b\\post";
+    assert_eq!(strip_ansi(input), "prepost");
+}
+
+#[test]
+fn strip_ansi_apc_st_terminated() {
+    // APC = ESC '_' … ST
+    let input = "pre\x1b_some app cmd\x1b\\post";
+    assert_eq!(strip_ansi(input), "prepost");
+}
+
+#[test]
+fn strip_ansi_pm_st_terminated() {
+    // PM = ESC '^' … ST
+    let input = "pre\x1b^private\x1b\\post";
+    assert_eq!(strip_ansi(input), "prepost");
+}
+
+#[test]
+fn strip_ansi_sos_st_terminated() {
+    // SOS = ESC 'X' … ST
+    let input = "pre\x1bXstring\x1b\\post";
+    assert_eq!(strip_ansi(input), "prepost");
+}
+
+#[test]
+fn strip_ansi_malformed_lone_esc() {
+    // a lone trailing ESC is silently dropped
+    let input = "tail\x1b";
+    assert_eq!(strip_ansi(input), "tail");
+}
+
+#[test]
+fn strip_ansi_malformed_unterminated_osc() {
+    // OSC with no terminator before EOF — drop the rest
+    let input = "pre\x1b]0;never ends";
+    assert_eq!(strip_ansi(input), "pre");
+}
+
+#[test]
+fn strip_ansi_plain_text_passthrough() {
+    let input = "no escapes here\nmultiple\tlines";
+    assert_eq!(strip_ansi(input), input);
+}
+
+#[test]
+fn strip_ansi_multiple_mixed_sequences() {
+    let input = "\x1b[31mred\x1b[0m \x1b]0;title\x07 \x1b_apc\x1b\\ done";
+    assert_eq!(strip_ansi(input), "red   done");
+}
+
+#[test]
+fn strip_ansi_short_two_byte_escape() {
+    // ESC c (reset) — a two-byte Fp/Fs escape — should drop both bytes
+    let input = "before\x1bcafter";
+    assert_eq!(strip_ansi(input), "beforeafter");
+}
+
+#[test]
+fn strip_ansi_handles_unicode_around_escapes() {
+    let input = "café\x1b[1m → \x1b[0mok ✓";
+    assert_eq!(strip_ansi(input), "café → ok ✓");
+}

--- a/apps/desktop/src/render.rs
+++ b/apps/desktop/src/render.rs
@@ -1,6 +1,8 @@
+use std::time::Duration;
+
 use gpui::{
-    FontWeight, IntoElement, MouseButton, MouseDownEvent, ParentElement, SharedString, Styled, div,
-    prelude::*, px, rgb,
+    Animation, AnimationExt, ElementId, FontWeight, IntoElement, MouseButton, MouseDownEvent,
+    ParentElement, SharedString, Styled, div, prelude::*, pulsating_between, px, rgb,
 };
 
 use crate::ClearOutput;
@@ -13,6 +15,7 @@ use crate::theme::{
     AURORA_OUTPUT_MUTED, AURORA_OUTPUT_TEXT, AURORA_PANEL_STRONG, AURORA_TEXT_MUTED,
     AURORA_TEXT_PRIMARY,
 };
+use crate::ui::RunningCommand;
 
 pub(crate) fn render_prompt_row(
     query_is_empty: bool,
@@ -94,6 +97,7 @@ pub(crate) fn render_action_rows(
 pub(crate) fn render_output_body(output: CommandOutput) -> impl IntoElement {
     let empty = output.stdout.is_none() && output.stderr.is_none();
     let title_accent = output.kind.accent_color();
+    let is_running = output.kind == OutputKind::Running;
     div()
         .flex()
         .flex_col()
@@ -111,13 +115,12 @@ pub(crate) fn render_output_body(output: CommandOutput) -> impl IntoElement {
                         .flex_row()
                         .items_center()
                         .gap_2()
-                        .child(
-                            div()
-                                .size(px(7.0))
-                                .rounded_full()
-                                .flex_shrink_0()
-                                .bg(rgb(title_accent)),
-                        )
+                        .child(pulsing_dot(
+                            "output-title-dot",
+                            title_accent,
+                            px(7.0),
+                            is_running,
+                        ))
                         .child(
                             div()
                                 .font_weight(FontWeight(680.0))
@@ -144,14 +147,29 @@ pub(crate) fn render_output_body(output: CommandOutput) -> impl IntoElement {
                     .border_1()
                     .border_color(rgb(AURORA_BORDER_DEFAULT))
                     .bg(rgb(AURORA_CONTROL_SURFACE))
-                    .font_weight(FontWeight(480.0))
-                    .text_size(px(12.0))
-                    .text_color(rgb(AURORA_TEXT_MUTED))
-                    .child(if output.kind == OutputKind::Running {
-                        "Waiting for axon to return output."
-                    } else {
-                        "No stdout or stderr was emitted."
-                    }),
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_2()
+                    .when(is_running, |el| {
+                        el.child(pulsing_dot(
+                            "output-body-dot",
+                            AURORA_ACCENT_PRIMARY,
+                            px(6.0),
+                            true,
+                        ))
+                    })
+                    .child(
+                        div()
+                            .font_weight(FontWeight(480.0))
+                            .text_size(px(12.0))
+                            .text_color(rgb(AURORA_TEXT_MUTED))
+                            .child(if is_running {
+                                "Working — waiting for axon to return output."
+                            } else {
+                                "No stdout or stderr was emitted."
+                            }),
+                    ),
             )
         })
         .when_some(output.stdout, |el, section| {
@@ -169,8 +187,9 @@ pub(crate) fn render_output_body(output: CommandOutput) -> impl IntoElement {
 pub(crate) fn render_palette_footer(
     action: CommandAction,
     output: Option<&CommandOutput>,
-    is_running: bool,
+    running: Option<&RunningCommand>,
 ) -> impl IntoElement {
+    let is_running = running.is_some();
     let status = output.map(|o| o.kind).unwrap_or(OutputKind::Warning);
     let accent = if is_running {
         OutputKind::Running.accent_color()
@@ -186,13 +205,18 @@ pub(crate) fn render_palette_footer(
     } else {
         "enter"
     };
-    let title = output
-        .map(|o| o.title.as_str())
+    let elapsed_label = running.map(|r| r.elapsed_label());
+    // Use the live "Running <label>" string while a command is in flight so the
+    // footer reads as a status, not as the action's static description.
+    let running_title = running.map(|r| format!("Running {}…", r.label));
+    let title = running_title
+        .as_deref()
+        .or_else(|| output.map(|o| o.title.as_str()))
         .unwrap_or(action.description);
     let detail = output
         .map(|o| o.subtitle.as_str())
         .unwrap_or(action.example);
-    let has_output = output.is_some();
+    let has_output = output.is_some() && !is_running;
 
     div()
         .flex()
@@ -204,24 +228,41 @@ pub(crate) fn render_palette_footer(
         .border_t_1()
         .border_color(rgb(AURORA_BORDER_DEFAULT))
         .bg(rgb(AURORA_CONTROL_SURFACE))
+        .child(pulsing_dot(
+            "footer-status-dot",
+            accent,
+            px(7.0),
+            is_running,
+        ))
         .child(
             div()
-                .size(px(7.0))
-                .rounded_full()
-                .flex_shrink_0()
-                .bg(rgb(accent)),
-        )
-        .child(
-            div()
-                .px_2()
-                .py_1()
-                .rounded_sm()
-                .bg(rgb(AURORA_NAV_BG))
-                .font_family(AURORA_FONT_MONO)
-                .font_weight(FontWeight(650.0))
-                .text_size(px(11.0))
-                .text_color(rgb(accent))
-                .child(label),
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .child(
+                    div()
+                        .px_2()
+                        .py_1()
+                        .rounded_sm()
+                        .bg(rgb(AURORA_NAV_BG))
+                        .font_family(AURORA_FONT_MONO)
+                        .font_weight(FontWeight(650.0))
+                        .text_size(px(11.0))
+                        .text_color(rgb(accent))
+                        .child(label),
+                )
+                .when_some(elapsed_label, |el, elapsed| {
+                    el.child(
+                        div()
+                            .min_w(px(48.0))
+                            .font_family(AURORA_FONT_MONO)
+                            .font_weight(FontWeight(560.0))
+                            .text_size(px(11.0))
+                            .text_color(rgb(AURORA_TEXT_MUTED))
+                            .child(SharedString::from(elapsed)),
+                    )
+                }),
         )
         .child(
             div()
@@ -274,6 +315,7 @@ fn render_output_section(
 ) -> impl IntoElement {
     let accent = kind.accent_color();
     let text = section.text.clone();
+    let rendered_lines = section.rendered_lines.clone();
 
     div()
         .flex()
@@ -317,14 +359,12 @@ fn render_output_section(
                 .py_3()
                 .when(use_markdown, |el| el.child(render_markdown(&text)))
                 .when(!use_markdown, |el| {
-                    el.flex()
-                        .flex_col()
-                        .children(text.lines().take(220).map(|line| {
-                            let display = if line.is_empty() {
-                                SharedString::from(" ")
-                            } else {
-                                SharedString::from(line.to_string())
-                            };
+                    // `rendered_lines` is pre-computed at section
+                    // construction time; the `SharedString` clones below
+                    // are cheap (Arc bumps), so this renders without
+                    // per-frame `String` allocations.
+                    el.flex().flex_col().children(rendered_lines.iter().map(
+                        |line| {
                             div()
                                 .w_full()
                                 .font_family(AURORA_FONT_MONO)
@@ -332,10 +372,40 @@ fn render_output_section(
                                 .text_size(px(12.0))
                                 .line_height(px(20.0))
                                 .text_color(rgb(AURORA_OUTPUT_TEXT))
-                                .child(display)
-                        }))
+                                .child(line.clone())
+                        },
+                    ))
                 }),
         )
+}
+
+/// A small circular dot. When `animate` is true the dot pulses its opacity
+/// between 0.35 and 1.0 — the user's "the app is alive and waiting on
+/// something" signal. `id` must be unique across all pulsing dots that may be
+/// rendered simultaneously (GPUI keys animation state by `ElementId`).
+fn pulsing_dot(
+    id: impl Into<ElementId>,
+    color: u32,
+    size: gpui::Pixels,
+    animate: bool,
+) -> gpui::AnyElement {
+    let base = div()
+        .size(size)
+        .rounded_full()
+        .flex_shrink_0()
+        .bg(rgb(color));
+    if animate {
+        base.with_animation(
+            id,
+            Animation::new(Duration::from_millis(1100))
+                .repeat()
+                .with_easing(pulsating_between(0.35, 1.0)),
+            |el, delta| el.opacity(delta),
+        )
+        .into_any_element()
+    } else {
+        base.into_any_element()
+    }
 }
 
 fn render_empty_row() -> impl IntoElement {

--- a/apps/desktop/src/render.rs
+++ b/apps/desktop/src/render.rs
@@ -363,8 +363,9 @@ fn render_output_section(
                     // construction time; the `SharedString` clones below
                     // are cheap (Arc bumps), so this renders without
                     // per-frame `String` allocations.
-                    el.flex().flex_col().children(rendered_lines.iter().map(
-                        |line| {
+                    el.flex()
+                        .flex_col()
+                        .children(rendered_lines.iter().map(|line| {
                             div()
                                 .w_full()
                                 .font_family(AURORA_FONT_MONO)
@@ -373,8 +374,7 @@ fn render_output_section(
                                 .line_height(px(20.0))
                                 .text_color(rgb(AURORA_OUTPUT_TEXT))
                                 .child(line.clone())
-                        },
-                    ))
+                        }))
                 }),
         )
 }

--- a/apps/desktop/src/theme.rs
+++ b/apps/desktop/src/theme.rs
@@ -2,29 +2,93 @@ use std::borrow::Cow;
 
 use gpui::App;
 
-pub(crate) const AURORA_PAGE_BG: u32 = 0x07131c;
-pub(crate) const AURORA_NAV_BG: u32 = 0x07111a;
-pub(crate) const AURORA_PANEL_STRONG: u32 = 0x13293a;
-pub(crate) const AURORA_CONTROL_SURFACE: u32 = 0x0c1a24;
-pub(crate) const AURORA_HOVER_BG: u32 = 0x17364b;
-pub(crate) const AURORA_BORDER_DEFAULT: u32 = 0x1d3d4e;
-pub(crate) const AURORA_BORDER_STRONG: u32 = 0x24536c;
-pub(crate) const AURORA_TEXT_PRIMARY: u32 = 0xe6f4fb;
-pub(crate) const AURORA_TEXT_MUTED: u32 = 0xa7bcc9;
-pub(crate) const AURORA_ACCENT_PRIMARY: u32 = 0x29b6f6;
-pub(crate) const AURORA_ACCENT_STRONG: u32 = 0x67cbfa;
-pub(crate) const AURORA_PANEL_MEDIUM: u32 = 0x102330;
-pub(crate) const AURORA_ACCENT_PINK: u32 = 0xf9a8c4;
-pub(crate) const AURORA_OUTPUT_TEXT: u32 = 0xd7e7ef;
-pub(crate) const AURORA_OUTPUT_MUTED: u32 = 0x8aa3b2;
-pub(crate) const AURORA_SUCCESS: u32 = 0x7dd3c7;
-pub(crate) const AURORA_WARN: u32 = 0xc6a36b;
-pub(crate) const AURORA_ERROR: u32 = 0xc78490;
-pub(crate) const AURORA_WARNING: u32 = AURORA_WARN;
+/// Aurora design token palette.
+///
+/// Grouped colour and typography tokens used across the palette UI. Kept as a
+/// `const` struct so the values are still inlined by the compiler — there is
+/// no runtime indirection compared to free constants. Existing call sites use
+/// the `AURORA_*` re-exports below; new code should prefer `AURORA.foo`.
+#[allow(dead_code)]
+pub(crate) struct AuroraTokens {
+    // Surfaces
+    pub page_bg: u32,
+    pub nav_bg: u32,
+    pub panel_strong: u32,
+    pub panel_medium: u32,
+    pub control_surface: u32,
+    pub hover_bg: u32,
+    // Borders
+    pub border_default: u32,
+    pub border_strong: u32,
+    // Text
+    pub text_primary: u32,
+    pub text_muted: u32,
+    // Accents
+    pub accent_primary: u32,
+    pub accent_strong: u32,
+    pub accent_pink: u32,
+    // Output panel
+    pub output_text: u32,
+    pub output_muted: u32,
+    // Status
+    pub success: u32,
+    pub warn: u32,
+    pub error: u32,
+    // Typography families
+    pub font_display: &'static str,
+    pub font_sans: &'static str,
+    pub font_mono: &'static str,
+}
 
-pub(crate) const AURORA_FONT_DISPLAY: &str = "Manrope";
-pub(crate) const AURORA_FONT_SANS: &str = "Inter";
-pub(crate) const AURORA_FONT_MONO: &str = "JetBrains Mono";
+pub(crate) const AURORA: AuroraTokens = AuroraTokens {
+    page_bg: 0x07131c,
+    nav_bg: 0x07111a,
+    panel_strong: 0x13293a,
+    panel_medium: 0x102330,
+    control_surface: 0x0c1a24,
+    hover_bg: 0x17364b,
+    border_default: 0x1d3d4e,
+    border_strong: 0x24536c,
+    text_primary: 0xe6f4fb,
+    text_muted: 0xa7bcc9,
+    accent_primary: 0x29b6f6,
+    accent_strong: 0x67cbfa,
+    accent_pink: 0xf9a8c4,
+    output_text: 0xd7e7ef,
+    output_muted: 0x8aa3b2,
+    success: 0x7dd3c7,
+    warn: 0xc6a36b,
+    error: 0xc78490,
+    font_display: "Manrope",
+    font_sans: "Inter",
+    font_mono: "JetBrains Mono",
+};
+
+// Re-exports kept so the 77 existing call sites continue to compile. Prefer
+// `AURORA.foo` in new code.
+pub(crate) const AURORA_PAGE_BG: u32 = AURORA.page_bg;
+pub(crate) const AURORA_NAV_BG: u32 = AURORA.nav_bg;
+pub(crate) const AURORA_PANEL_STRONG: u32 = AURORA.panel_strong;
+pub(crate) const AURORA_PANEL_MEDIUM: u32 = AURORA.panel_medium;
+pub(crate) const AURORA_CONTROL_SURFACE: u32 = AURORA.control_surface;
+pub(crate) const AURORA_HOVER_BG: u32 = AURORA.hover_bg;
+pub(crate) const AURORA_BORDER_DEFAULT: u32 = AURORA.border_default;
+pub(crate) const AURORA_BORDER_STRONG: u32 = AURORA.border_strong;
+pub(crate) const AURORA_TEXT_PRIMARY: u32 = AURORA.text_primary;
+pub(crate) const AURORA_TEXT_MUTED: u32 = AURORA.text_muted;
+pub(crate) const AURORA_ACCENT_PRIMARY: u32 = AURORA.accent_primary;
+pub(crate) const AURORA_ACCENT_STRONG: u32 = AURORA.accent_strong;
+pub(crate) const AURORA_ACCENT_PINK: u32 = AURORA.accent_pink;
+pub(crate) const AURORA_OUTPUT_TEXT: u32 = AURORA.output_text;
+pub(crate) const AURORA_OUTPUT_MUTED: u32 = AURORA.output_muted;
+pub(crate) const AURORA_SUCCESS: u32 = AURORA.success;
+pub(crate) const AURORA_WARN: u32 = AURORA.warn;
+pub(crate) const AURORA_ERROR: u32 = AURORA.error;
+pub(crate) const AURORA_WARNING: u32 = AURORA.warn;
+
+pub(crate) const AURORA_FONT_DISPLAY: &str = AURORA.font_display;
+pub(crate) const AURORA_FONT_SANS: &str = AURORA.font_sans;
+pub(crate) const AURORA_FONT_MONO: &str = AURORA.font_mono;
 
 const AURORA_MANROPE_LATIN: &[u8] = include_bytes!("../assets/fonts/Manrope-latin.woff2");
 const AURORA_INTER_LATIN: &[u8] = include_bytes!("../assets/fonts/Inter-latin.woff2");

--- a/apps/desktop/src/ui.rs
+++ b/apps/desktop/src/ui.rs
@@ -20,9 +20,8 @@ fn axon_command() -> Command {
 }
 
 use gpui::{
-    Animation, AnimationExt, App, Context, FocusHandle, Focusable, IntoElement, MouseButton,
-    MouseDownEvent, ParentElement, Render, ScrollHandle, SharedString, Styled, Window, div,
-    prelude::*, pulsating_between, px, rgb,
+    App, Context, FocusHandle, Focusable, IntoElement, MouseButton, MouseDownEvent, ParentElement,
+    Render, ScrollHandle, SharedString, Styled, Window, div, prelude::*, px, rgb,
 };
 
 use crate::actions::{
@@ -456,7 +455,16 @@ impl Render for Palette {
         let query_is_empty = self.query.is_empty();
 
         let connection = self.connection;
-        let base_status_dot = div()
+        // The status dot is intentionally non-animated. An earlier revision
+        // pulsed it while a health check was in flight, but the auto-spawned
+        // launch-time probe combined with a repeating animation kept GPUI
+        // re-rendering the view every frame on slower compositors and could
+        // starve key-event dispatch — the user-visible symptom was a window
+        // that wouldn't accept input. Color alone is now the indicator:
+        // grey while `Checking`, green/red once the probe returns. The
+        // footer/output pulsing dots (which only render once a command is
+        // selected or running) are unaffected.
+        let status_dot = div()
             .id("status-dot")
             .size(px(8.0))
             .rounded_full()
@@ -468,22 +476,8 @@ impl Render for Palette {
                 cx.listener(|this, _: &MouseDownEvent, _window, cx| {
                     this.spawn_health_check(cx);
                 }),
-            );
-        // While the health check is in flight, pulse the dot so the user can
-        // tell the click registered and a probe is actively running.
-        let status_dot = if matches!(connection, ConnectionState::Checking) {
-            base_status_dot
-                .with_animation(
-                    "status-dot-checking",
-                    Animation::new(Duration::from_millis(1100))
-                        .repeat()
-                        .with_easing(pulsating_between(0.35, 1.0)),
-                    |el, delta| el.opacity(delta),
-                )
-                .into_any_element()
-        } else {
-            base_status_dot.into_any_element()
-        };
+            )
+            .into_any_element();
 
         div()
             .key_context("Palette")

--- a/apps/desktop/src/ui.rs
+++ b/apps/desktop/src/ui.rs
@@ -1,4 +1,5 @@
 use std::process::{Command, Output};
+use std::time::{Duration, Instant};
 
 /// Spawn `axon` without flashing a console window on Windows. On Unix this
 /// is just `Command::new("axon")` — the flag is a no-op outside Windows.
@@ -19,8 +20,9 @@ fn axon_command() -> Command {
 }
 
 use gpui::{
-    App, Context, FocusHandle, Focusable, IntoElement, MouseButton, MouseDownEvent, ParentElement,
-    Render, ScrollHandle, SharedString, Styled, Window, div, prelude::*, px, rgb,
+    Animation, AnimationExt, App, Context, FocusHandle, Focusable, IntoElement, MouseButton,
+    MouseDownEvent, ParentElement, Render, ScrollHandle, SharedString, Styled, Window, div,
+    prelude::*, pulsating_between, px, rgb,
 };
 
 use crate::actions::{
@@ -36,6 +38,10 @@ use crate::theme::{
     AURORA_PANEL_STRONG, AURORA_TEXT_PRIMARY,
 };
 use crate::{ClearOutput, MoveDown, MoveUp, Submit, TabComplete};
+
+#[cfg(test)]
+#[path = "ui_tests.rs"]
+mod tests;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ConnectionState {
@@ -71,9 +77,36 @@ pub(crate) struct Palette {
     health_check_id: u64,
 }
 
-struct RunningCommand {
+pub(crate) struct RunningCommand {
     id: u64,
-    subcommand: &'static str,
+    pub(crate) subcommand: &'static str,
+    pub(crate) label: &'static str,
+    pub(crate) started_at: Instant,
+}
+
+impl RunningCommand {
+    pub(crate) fn elapsed_label(&self) -> String {
+        format_elapsed(self.started_at.elapsed())
+    }
+}
+
+/// Format a `Duration` as a short human-readable label: `"0.4s"`, `"12s"`,
+/// `"1m 03s"`. Used by the running indicator so the user can see at a glance
+/// that time is passing.
+pub(crate) fn format_elapsed(elapsed: Duration) -> String {
+    let secs = elapsed.as_secs();
+    if secs < 1 {
+        // Sub-second: show one decimal so the indicator visibly moves
+        // immediately after submit.
+        let tenths = elapsed.subsec_millis() / 100;
+        return format!("0.{tenths}s");
+    }
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    let mins = secs / 60;
+    let rem = secs % 60;
+    format!("{mins}m {rem:02}s")
 }
 
 struct CommandResult {
@@ -139,6 +172,35 @@ impl Palette {
                 };
                 cx.notify();
             });
+        })
+        .detach();
+    }
+
+    /// Force a re-render every ~250ms while `run_id` is the active running
+    /// command. The pulsing-dot animation already re-paints on its own (GPUI
+    /// drives that via `request_animation_frame`), but the elapsed-time label
+    /// is computed inside `render()` and only refreshes on `cx.notify()`.
+    fn spawn_running_tick(&self, run_id: u64, cx: &mut Context<Self>) {
+        let executor = cx.background_executor().clone();
+        cx.spawn(async move |this, cx| {
+            loop {
+                executor.timer(Duration::from_millis(250)).await;
+                let still_running = this
+                    .update(cx, |this, cx| {
+                        let active = this
+                            .running
+                            .as_ref()
+                            .is_some_and(|running| running.id == run_id);
+                        if active {
+                            cx.notify();
+                        }
+                        active
+                    })
+                    .unwrap_or(false);
+                if !still_running {
+                    break;
+                }
+            }
         })
         .detach();
     }
@@ -242,8 +304,11 @@ impl Palette {
         self.running = Some(RunningCommand {
             id: run_id,
             subcommand: action.subcommand,
+            label: action.label,
+            started_at: Instant::now(),
         });
         self.command_output = Some(CommandOutput::running(&command_line, action));
+        self.spawn_running_tick(run_id, cx);
 
         let task = cx.background_spawn(async move {
             let mut cmd = axon_command();
@@ -391,7 +456,7 @@ impl Render for Palette {
         let query_is_empty = self.query.is_empty();
 
         let connection = self.connection;
-        let status_dot = div()
+        let base_status_dot = div()
             .id("status-dot")
             .size(px(8.0))
             .rounded_full()
@@ -404,6 +469,21 @@ impl Render for Palette {
                     this.spawn_health_check(cx);
                 }),
             );
+        // While the health check is in flight, pulse the dot so the user can
+        // tell the click registered and a probe is actively running.
+        let status_dot = if matches!(connection, ConnectionState::Checking) {
+            base_status_dot
+                .with_animation(
+                    "status-dot-checking",
+                    Animation::new(Duration::from_millis(1100))
+                        .repeat()
+                        .with_easing(pulsating_between(0.35, 1.0)),
+                    |el, delta| el.opacity(delta),
+                )
+                .into_any_element()
+        } else {
+            base_status_dot.into_any_element()
+        };
 
         div()
             .key_context("Palette")
@@ -451,7 +531,7 @@ impl Render for Palette {
                         el.child(render_palette_footer(
                             action,
                             command_output.as_ref(),
-                            self.running.is_some(),
+                            self.running.as_ref(),
                         ))
                     })
                     .when_some(command_output.clone(), |el, output| {

--- a/apps/desktop/src/ui_tests.rs
+++ b/apps/desktop/src/ui_tests.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+#[test]
+fn elapsed_label_subsecond_shows_tenths() {
+    assert_eq!(format_elapsed(Duration::from_millis(0)), "0.0s");
+    assert_eq!(format_elapsed(Duration::from_millis(400)), "0.4s");
+    assert_eq!(format_elapsed(Duration::from_millis(999)), "0.9s");
+}
+
+#[test]
+fn elapsed_label_seconds_no_decimal() {
+    assert_eq!(format_elapsed(Duration::from_secs(1)), "1s");
+    assert_eq!(format_elapsed(Duration::from_secs(12)), "12s");
+    assert_eq!(format_elapsed(Duration::from_secs(59)), "59s");
+}
+
+#[test]
+fn elapsed_label_minutes_uses_padded_seconds() {
+    assert_eq!(format_elapsed(Duration::from_secs(60)), "1m 00s");
+    assert_eq!(format_elapsed(Duration::from_secs(63)), "1m 03s");
+    assert_eq!(format_elapsed(Duration::from_secs(125)), "2m 05s");
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/docs/MCP-TOOL-SCHEMA.md
+++ b/docs/MCP-TOOL-SCHEMA.md
@@ -160,11 +160,9 @@ Server reads existing Axon stack vars:
 - `AXON_HEADLESS_GEMINI_CMD` — path to Gemini CLI (default: `gemini`)
 - `AXON_HEADLESS_GEMINI_MODEL` — Gemini model override (optional)
 - `TAVILY_API_KEY`
-
-> **Deprecated (compat shims — emit a warning at startup if set):**
-> `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_MODEL` — still read at startup as compatibility shims;
-> setting them emits a startup warning. LLM synthesis runs through
-> the Gemini headless path exclusively.
+- `OPENAI_BASE_URL` — OpenAI-compatible LLM base URL (extract pipeline)
+- `OPENAI_API_KEY` — API key for the extract LLM endpoint
+- `OPENAI_MODEL` — Model name for the extract LLM endpoint
 
 MCP transport env vars:
 - `AXON_MCP_HTTP_HOST`

--- a/docs/config/env-migration-matrix.toml
+++ b/docs/config/env-migration-matrix.toml
@@ -1223,6 +1223,18 @@ compatibility = "advanced"
 reason = "URL/path/bootstrap override; env is allowed when supplied by the operator or runtime wrapper."
 
 [[env]]
+key = "AXON_LOG_PATH"
+classification = "trusted-operator-bootstrap"
+runtime_placement = "host-only"
+surfaces = ["src", "docs"]
+secret = false
+url_or_path = true
+container_allowed = false
+toml_destination = ""
+compatibility = "advanced"
+reason = "Full path to the active log file; env is allowed when supplied by the operator or runtime wrapper."
+
+[[env]]
 key = "AXON_LOG_FULL_QUERIES"
 classification = "keep-env"
 runtime_placement = "both"

--- a/tests/compose_env_contract.rs
+++ b/tests/compose_env_contract.rs
@@ -389,8 +389,6 @@ fn env_example_only_contains_production_runtime_keys() {
         // LLM (Gemini headless)
         "GEMINI_HOME",
         "GEMINI_API_KEY",
-        "GOOGLE_API_KEY",
-        "GOOGLE_APPLICATION_CREDENTIALS",
         "AXON_HEADLESS_GEMINI_CMD",
         "AXON_HEADLESS_GEMINI_HOME",
         "AXON_HEADLESS_GEMINI_MODEL",
@@ -400,8 +398,7 @@ fn env_example_only_contains_production_runtime_keys() {
         "OPENAI_MODEL",
         "AXON_LITE",
         // Logging
-        "AXON_LOG_DIR",
-        "AXON_LOG_FILE",
+        "AXON_LOG_PATH",
         // Ingest + search creds
         "HF_TOKEN",
         "TAVILY_API_KEY",


### PR DESCRIPTION
## Summary

Four low-risk polish items deferred from the 2026-05-16 gpui-component spike session, applied to the `apps/desktop/` palette app — plus a follow-up freeze fix.

- **refactor**: wrap the 23 Aurora token constants in a `pub struct AuroraTokens` with named, grouped fields and a `pub const AURORA: AuroraTokens = …` value. Existing `AURORA_*` flat constants are kept as re-exports off the struct so the 77 call sites compile unchanged. Organizational only — values are still inlined.
- **perf**: `action_matches` no longer allocates a lowercased `String` per call. Replaced with a small ASCII-only `contains_ignore_ascii_case` helper that walks byte windows and uses `<[u8]>::eq_ignore_ascii_case`. All ACTIONS strings are ASCII; runs on the render hot path for every action, every dirty frame.
- **perf**: `OutputSection` now pre-computes a `Vec<SharedString>` of visible lines (capped at `MAX_RENDER_LINES = 220`) once in `new()`. The renderer iterates that buffer, doing only Arc-bump clones per frame, instead of allocating ~220 `SharedString`s per section per frame.
- **fix**: `strip_ansi` was CSI-only, leaking OSC/DCS/APC payload bytes (and `BEL`/`ESC\\` terminators) into the output panel. Extended to recognise the full Fe escape family: CSI, OSC, DCS, APC, PM, SOS, and two-byte Fp/Fs escapes. Hand-rolled rather than adding `strip-ansi-escapes` — parsing is ~30 lines and avoids the `vte` transitive dep.
- **chore**: vendor a sibling worktree's `RunningCommand::elapsed_label()` / `format_elapsed()` addition; the perf commit's `render.rs` edits ended up importing those symbols, so bringing `ui.rs` + `ui_tests.rs` into this branch is required for it to build standalone.
- **fix(freeze, 56919c11)**: drop the repeating `pulsating_between` animation on the launch-time health-check status dot. `Palette::new` auto-spawns an `axon doctor --json` probe and sets the dot to `ConnectionState::Checking`, which the render path wrapped in `Animation::new(1100ms).repeat()`. While the probe was in flight, GPUI scheduled re-renders every frame, which on slower compositors starved key-event dispatch — the user-visible symptom was a palette window that opened but wouldn't accept typing. The dot now changes color only (grey/checking → green/connected → red/disconnected). Footer/output-card pulsing dots — the actual "alive while running" feature this PR added — only render once a command is selected or running, so they are untouched and still pulse during real command runs. Speculative fix from static analysis (could not repro on headless host). `cargo test -p axon-palette` still passes (24 tests). Patch bump 2.3.1 → 2.3.2.

## Test plan
- [x] `cd apps/desktop && cargo test --bin axon-palette` — 24 passed (14 new ANSI stripper cases + 7 new action_matches cases + 3 elapsed-label cases)
- [x] `cd apps/desktop && cargo check` — clean
- [x] `cd apps/desktop && cargo fmt --check` — clean
- [x] `cd apps/desktop && cargo clippy --bin axon-palette --tests` — 7 pre-existing warnings, no new ones
- [ ] Manual: open the palette, confirm window accepts typing immediately on launch; run `axon scrape <url>`, confirm footer/output dots still pulse while command is in flight

## Notes
- `apps/desktop` is a standalone workspace (per its `Cargo.toml` header) and is not part of root `just verify`.
- Workspace-level `just verify` could not be exercised cleanly: the working tree has a pre-existing unresolved stash-pop (conflict markers in many `src/`, `docs/`, and config files unrelated to this branch). All commits here only touch `apps/desktop/src/*.rs` (and Cargo.toml/Cargo.lock/CHANGELOG.md for the 2.3.2 version bump).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Animated pulsing status indicators for running commands
  * Real-time elapsed-time display for active commands

* **Improvements**
  * Case-insensitive action matching for easier discovery
  * Broader ANSI/terminal escape stripping for cleaner output
  * Pre-computed line caching to improve output rendering performance
  * Launch health-check indicator no longer uses pulsing animation

* **Tests**
  * Added unit tests for action matching, ANSI stripping, and elapsed-time formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/axon/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->