### PR TITLE
feat(palette): restore ask conversation across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-05-17
+
 ### Added
 
 - palette: cross-restart persistence for the in-memory ask conversation. On startup the palette reads `~/.axon/ask-sessions/latest` and the pointed-to JSONL; if the last turn is within the 30-minute idle window, the live conversation (turn count + last-turn timestamp) is restored so reopening the palette picks up the existing `--follow-up` chain instead of starting fresh. Only turn timestamps are deserialized — prompt/answer content never enters palette memory. Stale, missing, corrupt, or path-traversal-y session pointers fall back to a fresh state without crashing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- palette: cross-restart persistence for the in-memory ask conversation. On startup the palette reads `~/.axon/ask-sessions/latest` and the pointed-to JSONL; if the last turn is within the 30-minute idle window, the live conversation (turn count + last-turn timestamp) is restored so reopening the palette picks up the existing `--follow-up` chain instead of starting fresh. Only turn timestamps are deserialized — prompt/answer content never enters palette memory. Stale, missing, corrupt, or path-traversal-y session pointers fall back to a fresh state without crashing.
+
 ## [2.5.0] - 2026-05-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 2.5.0
+Version: 2.6.0
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -482,12 +482,16 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
+ "chrono",
  "global-hotkey",
  "gpui",
  "gpui_linux",
  "gpui_windows",
  "open",
  "pulldown-cmark",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -24,12 +24,18 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 async-channel = "2"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 global-hotkey = "0.7"
 open = "5"
 pulldown-cmark = { version = "0.10", default-features = false }
 gpui = { git = "https://github.com/zed-industries/zed", rev = "5f5dd7ae301dd265e5020fd65cd20769a81d0d5b" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile = "3"
 
 # We depend on the platform backends directly rather than the gpui_platform
 # convenience crate because gpui_platform transitively pulls in gpui_web,

--- a/apps/desktop/src/conversation.rs
+++ b/apps/desktop/src/conversation.rs
@@ -15,6 +15,8 @@
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -108,8 +110,8 @@ pub(crate) fn restore_from_latest_at(
 
     let session_name = read_latest_session_name(&dir)?;
     let session_path = dir.join(format!("{session_name}.jsonl"));
-    let content = match std::fs::read_to_string(&session_path) {
-        Ok(c) => c,
+    let file = match File::open(&session_path) {
+        Ok(f) => f,
         Err(err) => {
             tracing::debug!(
                 target = "palette::conversation",
@@ -121,13 +123,31 @@ pub(crate) fn restore_from_latest_at(
         }
     };
 
+    // Stream the file line-by-line rather than loading it all into memory.
+    // Each line is parsed into `TurnHeader`, which only captures `created_at` —
+    // user/assistant text is dropped as soon as the line buffer is reused, so
+    // conversation content never accumulates in palette memory.
+    let reader = BufReader::new(file);
     let mut turn_count: u32 = 0;
     let mut last_created_at: Option<DateTime<Utc>> = None;
-    for (idx, line) in content.lines().enumerate() {
+    for (idx, line) in reader.lines().enumerate() {
+        let line = match line {
+            Ok(l) => l,
+            Err(err) => {
+                tracing::debug!(
+                    target = "palette::conversation",
+                    path = %session_path.display(),
+                    line = idx + 1,
+                    error = %err,
+                    "I/O error reading ask-session line; stopping at last good turn"
+                );
+                break;
+            }
+        };
         if line.trim().is_empty() {
             continue;
         }
-        match serde_json::from_str::<TurnHeader>(line) {
+        match serde_json::from_str::<TurnHeader>(&line) {
             Ok(header) => {
                 turn_count = turn_count.saturating_add(1);
                 last_created_at = Some(header.created_at);
@@ -144,10 +164,10 @@ pub(crate) fn restore_from_latest_at(
         }
     }
 
+    // `last_created_at` is `Some` iff at least one turn parsed successfully, so
+    // it also gates `turn_count >= 1`. No separate `turn_count == 0` check is
+    // needed.
     let last_created_at = last_created_at?;
-    if turn_count == 0 {
-        return None;
-    }
 
     // Gate staleness in wall-clock space (robust to system-clock skew between
     // the CLI write and the palette read).
@@ -167,9 +187,7 @@ pub(crate) fn restore_from_latest_at(
 
     // Reconstruct the monotonic `Instant` so the in-memory idle-timeout check
     // continues to work the same way for restored and fresh conversations.
-    let last_turn_at = now_instant
-        .checked_sub(elapsed_wall)
-        .unwrap_or(now_instant);
+    let last_turn_at = now_instant.checked_sub(elapsed_wall).unwrap_or(now_instant);
 
     Some(AskConversation::from_persisted(turn_count, last_turn_at))
 }

--- a/apps/desktop/src/conversation.rs
+++ b/apps/desktop/src/conversation.rs
@@ -13,11 +13,17 @@
 //! - Cleared by the explicit "Reset ask conversation" action
 //! - Cleared by idle timeout (30 minutes since last successful turn)
 
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 /// Idle window after which a conversation is implicitly reset. Matches the
 /// ACP session cache TTL for consistency.
 pub(crate) const CONVERSATION_IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+const LATEST_SESSION_FILE: &str = "latest";
+const MAX_SESSION_NAME_LEN: usize = 64;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct AskConversation {
@@ -36,6 +42,15 @@ impl AskConversation {
         }
     }
 
+    /// Build an `AskConversation` from previously-persisted state recovered
+    /// from a CLI session file. Used only by `restore_from_latest`.
+    pub(crate) fn from_persisted(turn_count: u32, last_turn_at: Instant) -> Self {
+        Self {
+            turn_count: turn_count.max(1),
+            last_turn_at,
+        }
+    }
+
     pub(crate) fn bump(&mut self, now: Instant) {
         self.turn_count = self.turn_count.saturating_add(1);
         self.last_turn_at = now;
@@ -44,6 +59,153 @@ impl AskConversation {
     pub(crate) fn is_stale(&self, now: Instant) -> bool {
         now.saturating_duration_since(self.last_turn_at) >= CONVERSATION_IDLE_TIMEOUT
     }
+}
+
+/// Minimal projection of a CLI `AskTurn` JSONL record. We only need the
+/// timestamp — `user`/`assistant` text is deliberately NOT deserialized so
+/// conversation content never enters palette memory.
+#[derive(Debug, Deserialize)]
+struct TurnHeader {
+    created_at: DateTime<Utc>,
+}
+
+/// Try to restore the palette's `AskConversation` state by reading the most
+/// recent CLI ask session file under `<home>/.axon/ask-sessions/`.
+///
+/// Returns `None` (and the palette starts with no live conversation) when:
+/// - `<home>/.axon/ask-sessions/latest` does not exist or is empty/malformed
+/// - the pointed-to `<name>.jsonl` does not exist (e.g. user ran `axon ask
+///   --reset-session` from a terminal)
+/// - the file has zero successfully-parsed turns
+/// - the last successful turn is older than `CONVERSATION_IDLE_TIMEOUT`
+/// - any I/O error occurs while reading
+///
+/// Returns `Some(AskConversation)` with the recovered turn count and a
+/// reconstructed monotonic `last_turn_at` when the latest session is fresh.
+///
+/// Notes:
+/// - The `latest` pointer is sanitized the same way the CLI does; a path-
+///   traversal pointer (e.g. `../../etc/passwd`) is rejected as if `latest`
+///   did not exist.
+/// - Corrupt JSON lines are skipped (matching the CLI's tolerant loader),
+///   so a file with valid lines followed by one trailing partial write is
+///   recovered up to the last valid turn.
+/// - Only the timestamp of each turn is parsed — `user`/`assistant` content
+///   never crosses into palette memory.
+pub(crate) fn restore_from_latest(home: &Path) -> Option<AskConversation> {
+    restore_from_latest_at(home, Utc::now(), Instant::now())
+}
+
+/// Test seam: pure function with injected clocks so tests don't depend on
+/// `Utc::now()` / `Instant::now()`. Production callers use
+/// `restore_from_latest`.
+pub(crate) fn restore_from_latest_at(
+    home: &Path,
+    now_utc: DateTime<Utc>,
+    now_instant: Instant,
+) -> Option<AskConversation> {
+    let dir = sessions_dir(home);
+
+    let session_name = read_latest_session_name(&dir)?;
+    let session_path = dir.join(format!("{session_name}.jsonl"));
+    let content = match std::fs::read_to_string(&session_path) {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::debug!(
+                target = "palette::conversation",
+                path = %session_path.display(),
+                error = %err,
+                "ask session file missing or unreadable; starting fresh"
+            );
+            return None;
+        }
+    };
+
+    let mut turn_count: u32 = 0;
+    let mut last_created_at: Option<DateTime<Utc>> = None;
+    for (idx, line) in content.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<TurnHeader>(line) {
+            Ok(header) => {
+                turn_count = turn_count.saturating_add(1);
+                last_created_at = Some(header.created_at);
+            }
+            Err(err) => {
+                tracing::debug!(
+                    target = "palette::conversation",
+                    path = %session_path.display(),
+                    line = idx + 1,
+                    error = %err,
+                    "skipping malformed ask-session line"
+                );
+            }
+        }
+    }
+
+    let last_created_at = last_created_at?;
+    if turn_count == 0 {
+        return None;
+    }
+
+    // Gate staleness in wall-clock space (robust to system-clock skew between
+    // the CLI write and the palette read).
+    let elapsed_wall = now_utc
+        .signed_duration_since(last_created_at)
+        .to_std()
+        .unwrap_or(Duration::ZERO);
+    if elapsed_wall >= CONVERSATION_IDLE_TIMEOUT {
+        tracing::debug!(
+            target = "palette::conversation",
+            path = %session_path.display(),
+            elapsed_secs = elapsed_wall.as_secs(),
+            "latest ask session is stale; not restoring"
+        );
+        return None;
+    }
+
+    // Reconstruct the monotonic `Instant` so the in-memory idle-timeout check
+    // continues to work the same way for restored and fresh conversations.
+    let last_turn_at = now_instant
+        .checked_sub(elapsed_wall)
+        .unwrap_or(now_instant);
+
+    Some(AskConversation::from_persisted(turn_count, last_turn_at))
+}
+
+fn sessions_dir(home: &Path) -> PathBuf {
+    home.join(".axon").join("ask-sessions")
+}
+
+fn read_latest_session_name(dir: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(dir.join(LATEST_SESSION_FILE)).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    sanitize_session_name(trimmed)
+}
+
+/// Mirrors `src/cli/commands/ask/followup.rs::sanitize_session_name`. Returns
+/// `None` for any name that fails validation rather than substituting a
+/// default — a corrupt `latest` pointer should not silently fall back to
+/// `default.jsonl`.
+fn sanitize_session_name(name: &str) -> Option<String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_SESSION_NAME_LEN {
+        return None;
+    }
+    if trimmed == "." || trimmed == ".." {
+        return None;
+    }
+    let safe = trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'));
+    if !safe {
+        return None;
+    }
+    Some(trimmed.to_string())
 }
 
 /// Build the argv vector for an `axon` shell-out.

--- a/apps/desktop/src/conversation_tests.rs
+++ b/apps/desktop/src/conversation_tests.rs
@@ -1,5 +1,9 @@
 use super::*;
+use chrono::{DateTime, Utc};
+use std::fs;
+use std::path::Path;
 use std::time::Duration;
+use tempfile::TempDir;
 
 fn ask_argv(arg: &str) -> Vec<String> {
     vec!["--local".to_string(), "ask".to_string(), arg.to_string()]
@@ -68,6 +72,152 @@ fn is_stale_returns_false_within_idle_window() {
     let convo = AskConversation::new(t0);
     let later = t0 + Duration::from_secs(60);
     assert!(!convo.is_stale(later));
+}
+
+// ---- restore_from_latest tests -----------------------------------------
+
+fn sessions_dir(home: &Path) -> std::path::PathBuf {
+    home.join(".axon").join("ask-sessions")
+}
+
+fn write_latest(home: &Path, name: &str) {
+    let dir = sessions_dir(home);
+    fs::create_dir_all(&dir).expect("create ask-sessions dir");
+    fs::write(dir.join("latest"), format!("{name}\n")).expect("write latest");
+}
+
+fn write_session(home: &Path, name: &str, body: &str) {
+    let dir = sessions_dir(home);
+    fs::create_dir_all(&dir).expect("create ask-sessions dir");
+    fs::write(dir.join(format!("{name}.jsonl")), body).expect("write jsonl");
+}
+
+fn turn_line(ts: DateTime<Utc>, user: &str, assistant: &str) -> String {
+    let v = serde_json::json!({
+        "schema": "axon.ask.turn.v1",
+        "created_at": ts.to_rfc3339(),
+        "collection": "axon",
+        "user": user,
+        "assistant": assistant,
+    });
+    serde_json::to_string(&v).expect("serialize turn")
+}
+
+#[test]
+fn restore_from_latest_returns_none_when_latest_missing() {
+    let tmp = TempDir::new().unwrap();
+    let got = restore_from_latest_at(tmp.path(), Utc::now(), Instant::now());
+    assert!(got.is_none());
+}
+
+#[test]
+fn restore_from_latest_returns_none_when_session_file_missing() {
+    let tmp = TempDir::new().unwrap();
+    write_latest(tmp.path(), "ghost");
+    let got = restore_from_latest_at(tmp.path(), Utc::now(), Instant::now());
+    assert!(got.is_none(), "missing <name>.jsonl should yield None");
+}
+
+#[test]
+fn restore_from_latest_returns_none_when_session_file_empty() {
+    let tmp = TempDir::new().unwrap();
+    write_latest(tmp.path(), "empty");
+    write_session(tmp.path(), "empty", "");
+    let got = restore_from_latest_at(tmp.path(), Utc::now(), Instant::now());
+    assert!(got.is_none(), "zero turns should yield None");
+}
+
+#[test]
+fn restore_from_latest_returns_none_when_last_turn_stale() {
+    let tmp = TempDir::new().unwrap();
+    let now = Utc::now();
+    let stale = now - chrono::Duration::from_std(CONVERSATION_IDLE_TIMEOUT).unwrap()
+        - chrono::Duration::seconds(5);
+    write_latest(tmp.path(), "stale");
+    write_session(tmp.path(), "stale", &(turn_line(stale, "hi", "yo") + "\n"));
+    let got = restore_from_latest_at(tmp.path(), now, Instant::now());
+    assert!(got.is_none(), "turn older than idle window should not restore");
+}
+
+#[test]
+fn restore_from_latest_returns_some_with_correct_turn_count_when_fresh() {
+    let tmp = TempDir::new().unwrap();
+    let now = Utc::now();
+    let t0 = now - chrono::Duration::seconds(120);
+    let t1 = now - chrono::Duration::seconds(60);
+    let t2 = now - chrono::Duration::seconds(10);
+    write_latest(tmp.path(), "live");
+    let body = format!(
+        "{}\n{}\n{}\n",
+        turn_line(t0, "q1", "a1"),
+        turn_line(t1, "q2", "a2"),
+        turn_line(t2, "q3", "a3"),
+    );
+    write_session(tmp.path(), "live", &body);
+    let now_instant = Instant::now();
+    let convo = restore_from_latest_at(tmp.path(), now, now_instant)
+        .expect("fresh session should restore");
+    assert_eq!(convo.turn_count, 3);
+    // last_turn_at should be ~10s before now_instant, well inside the idle window.
+    assert!(!convo.is_stale(now_instant));
+    let reconstructed_age = now_instant.saturating_duration_since(convo.last_turn_at);
+    assert!(
+        reconstructed_age >= Duration::from_secs(5)
+            && reconstructed_age <= Duration::from_secs(20),
+        "reconstructed Instant should reflect ~10s wall-clock age, got {reconstructed_age:?}"
+    );
+}
+
+#[test]
+fn restore_from_latest_recovers_valid_lines_when_last_line_corrupt() {
+    let tmp = TempDir::new().unwrap();
+    let now = Utc::now();
+    let t0 = now - chrono::Duration::seconds(45);
+    let t1 = now - chrono::Duration::seconds(30);
+    write_latest(tmp.path(), "partial");
+    // Two valid turns + a truncated trailing line (no newline, not valid JSON).
+    let body = format!(
+        "{}\n{}\n{{\"schema\":\"axon.ask.turn.v1\",\"created_a",
+        turn_line(t0, "q1", "a1"),
+        turn_line(t1, "q2", "a2"),
+    );
+    write_session(tmp.path(), "partial", &body);
+    let convo = restore_from_latest_at(tmp.path(), now, Instant::now())
+        .expect("partial corruption should still recover the valid prefix");
+    assert_eq!(convo.turn_count, 2);
+}
+
+#[test]
+fn restore_from_latest_returns_none_when_latest_pointer_is_empty() {
+    let tmp = TempDir::new().unwrap();
+    let dir = sessions_dir(tmp.path());
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("latest"), "   \n").unwrap();
+    let got = restore_from_latest_at(tmp.path(), Utc::now(), Instant::now());
+    assert!(got.is_none());
+}
+
+#[test]
+fn restore_from_latest_rejects_path_traversal_in_latest_pointer() {
+    let tmp = TempDir::new().unwrap();
+    let dir = sessions_dir(tmp.path());
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("latest"), "../../etc/passwd").unwrap();
+    let got = restore_from_latest_at(tmp.path(), Utc::now(), Instant::now());
+    assert!(got.is_none(), "unsafe session name must not resolve");
+}
+
+#[test]
+fn restore_from_latest_does_not_panic_on_garbage_file() {
+    let tmp = TempDir::new().unwrap();
+    write_latest(tmp.path(), "garbage");
+    write_session(
+        tmp.path(),
+        "garbage",
+        "this is not json\nneither is this\n{not even close}\n",
+    );
+    let got = restore_from_latest_at(tmp.path(), Utc::now(), Instant::now());
+    assert!(got.is_none(), "all-corrupt file should yield None, not panic");
 }
 
 #[test]

--- a/apps/desktop/src/ui.rs
+++ b/apps/desktop/src/ui.rs
@@ -27,7 +27,7 @@ use crate::actions::{
     ACTIONS, ArgMode, CommandAction, action_invoked_by, action_matches, build_axon_args,
     display_command_line, looks_like_url,
 };
-use crate::conversation::{AskConversation, inject_follow_up};
+use crate::conversation::{AskConversation, inject_follow_up, restore_from_latest};
 use crate::layout::{HeightSnapshot, MIN_WINDOW_HEIGHT};
 use crate::output::{CommandOutput, OutputKind};
 use crate::theme::AURORA_BORDER_STRONG;
@@ -134,6 +134,12 @@ struct HealthResult {
 
 impl Palette {
     pub(crate) fn new(cx: &mut Context<Self>) -> Self {
+        // Restore any live `axon ask` conversation from the CLI's session
+        // file so reopening the palette picks up where the user left off
+        // (within the idle window). Sync local-file read — small JSONL, no
+        // need to defer to a background task. See `conversation::restore_from_latest`.
+        let ask_conversation = std::env::home_dir().and_then(|home| restore_from_latest(&home));
+
         let mut palette = Self {
             query: String::new(),
             selected: 0,
@@ -146,7 +152,7 @@ impl Palette {
             connection: ConnectionState::Unknown,
             health_check_id: 0,
             current_window_height: None,
-            ask_conversation: None,
+            ask_conversation,
         };
         palette.spawn_health_check(cx);
         palette

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
## Summary

Adds cross-restart persistence for the in-memory `axon ask` conversation state in `axon-palette`. Building on PR #100 (which introduced the in-memory `AskConversation` and `--follow-up` injection), this PR restores the live conversation from disk on `Palette::new` when the CLI's most recent ask session is still fresh.

Concretely:

- On startup, read `~/.axon/ask-sessions/latest` and the pointed-to `<name>.jsonl`.
- Count successfully-parsed turns; take the timestamp of the last successful turn.
- If the last turn is within the existing 30-minute idle window, build an `AskConversation { turn_count, last_turn_at }` with `last_turn_at` reconstructed from the wall-clock age via `Instant::checked_sub`.
- Otherwise (stale, missing pointer, missing file, empty file, corrupt-only file, or unsafe pointer like `../../`), start with `None` — same as today.

## Design decisions

- **Restoration policy**: 30-minute idle window, matching the in-memory `CONVERSATION_IDLE_TIMEOUT` and the ACP session cache TTL. A `axon ask` run from a terminal 5 minutes ago is treated the same as one from the palette — picking it up is a feature, not a bug.
- **Privacy**: only the `created_at` timestamp from each `AskTurn` JSONL line is deserialized into a minimal `TurnHeader` projection. Prompt and answer content never enters palette memory.
- **Clock model**: staleness is gated in wall-clock (`DateTime<Utc>`) before any `Instant` math. The reconstructed `last_turn_at: Instant` is only used for the in-memory idle-timeout check going forward and is computed via `checked_sub` so clock skew can't panic.
- **Defensive parsing**: corrupt JSONL lines are skipped (matching the CLI's tolerant loader) — a file with N valid turns followed by one trailing partial write recovers up to the last valid turn. Path-traversal-y `latest` pointers (`..`, `.`, characters outside `[A-Za-z0-9._-]`) are rejected.
- **No new state**: the palette does not write to the session file. The CLI already appends a turn after each successful ask; the palette just trusts whatever the CLI wrote last.

## Test plan

- [x] `cargo test --bin axon-palette` — 17 tests pass (8 prior + 9 new for `restore_from_latest_at`).
- [x] `cargo clippy --bin axon-palette --tests` — no new warnings on the added code.
- New tests cover: missing `latest`, missing session file, empty session file, stale last turn, fresh restore with correct turn_count, corrupt trailing line recoverable, empty/whitespace `latest`, path-traversal pointer rejected, all-garbage file.

## Boot responsiveness

`Palette::new` does a single synchronous local file read (`~/.axon/ask-sessions/latest`, then the pointed-to JSONL). On a typical home dir this is sub-millisecond — well inside the budget that PR #99 protected. Not deferred to `cx.background_spawn` because: (a) `Palette::new` is sync; (b) deferring would require making `ask_conversation` async-settable and would defeat the "footer hint shows immediately on launch" goal.

## Version + CHANGELOG

- `apps/desktop/Cargo.toml`: `0.2.0` → `0.2.1` (patch; small additive feature).
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Deferred / out of scope

- Multi-machine session sync: explicitly out of scope. The palette trusts the local `latest` pointer.
- Restoration metrics / telemetry: not added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the in-memory `axon ask` conversation in `axon-palette` across restarts so reopening the palette continues the existing `--follow-up` chain when the last turn was within 30 minutes. The session file is streamed and only timestamps are read; prompt/answer text never enters memory.

- **New Features**
  - On startup, read `~/.axon/ask-sessions/latest` and the pointed JSONL; sanitize the pointer, skip corrupt lines, and fall back to a fresh state if stale or missing.
  - Stream JSONL lines and deserialize only `created_at`; content is never loaded. Staleness is checked via wall-clock time, and the monotonic `Instant` is reconstructed for idle-timeout tracking.
  - Synchronous local-file read in `Palette::new`; negligible overhead.

- **Dependencies**
  - Add `chrono`, `serde`, `serde_json`; dev `tempfile` to `apps/desktop`.
  - Bump repo version to `2.6.0` and update `CHANGELOG.md`, `README.md`, and `apps/web/package.json`.

<sup>Written for commit b37c3a51fe54df0cbf273b55027a8c2c23630c2f. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/102?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

