### PR TITLE
feat(ask): session management flags (--new-session, --list-sessions, --resume, --continue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-05-17
+
+### Added
+
+- ask: four new session-management flags complement the existing `--follow-up`/`--session`/`--reset-session` surface:
+  - `--new-session` — force a fresh thread for an explicit or auto-generated session name (auto names use `auto-YYYY-MM-DD-HHMMSS`). Wipes prior turns and runs without follow-up context. Mutually exclusive with `--follow-up`, `--reset-session`, and `--resume` (clap-enforced).
+  - `--list-sessions` — print all local ask sessions (name, turn count, last-modified absolute + relative, and a `*` for `latest`). Sorted by last-modified descending. Pair with `--json` for a machine-readable array. Cannot be combined with a query argument.
+  - `--resume <NAME>` — shorthand for `--follow-up --session <NAME>`. Mutually exclusive with `--session` (redundant) and `--new-session`.
+  - `--continue` / `-c` — clap aliases for `--follow-up`, more discoverable for "keep going" usage.
+- ask: `~/.axon/ask-sessions/` is now enumerable via `axon ask --list-sessions` without spinning up retrieval or the LLM; the renderer skips `latest`, `.tmp-*` temp files, and any non-`.jsonl` entries.
+
+### Documentation
+
+- docs/commands/ask.md: documented the seven session-related flags together, added a "Session Lifecycle" table covering each flag's effect on session selection, history loading, and wipes, plus runnable examples for the new combinations.
+
 ## [2.6.0] - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `--continue` / `-c` — clap aliases for `--follow-up`, more discoverable for "keep going" usage.
 - ask: `~/.axon/ask-sessions/` is now enumerable via `axon ask --list-sessions` without spinning up retrieval or the LLM; the renderer skips `latest`, `.tmp-*` temp files, and any non-`.jsonl` entries.
 
+### Fixed
+
+- ask (PR #103 review): `--resume` now has a clap-enforced conflict with `--new-session`, `--reset-session`, and `--session` so contradictory invocations are rejected at parse time instead of silently reinterpreting `<name>` as a reset target.
+- ask (PR #103 review): `--list-sessions` validation also rejects the global `--query` flag, matching the documented "no query argument" contract. Previously `axon ask --list-sessions --query "..."` parsed and silently ignored the query.
+- ask (PR #103 review): `--list-sessions` no longer hides session files whose names start with `.` (e.g. `.team.jsonl`). The previous dotfile filter was too broad; temp files written by `write_atomic` are still filtered by the `.jsonl` suffix check.
+
 ### Documentation
 
 - docs/commands/ask.md: documented the seven session-related flags together, added a "Session Lifecycle" table covering each flag's effect on session selection, history loading, and wipes, plus runnable examples for the new combinations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 2.6.0
+Version: 2.7.0
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/docs/commands/ask.md
+++ b/docs/commands/ask.md
@@ -1,8 +1,8 @@
 # axon ask
-Last Modified: 2026-03-03
+Last Modified: 2026-05-17
 
-Version: 1.0.0
-Last Updated: 20:30:18 | 03/03/2026 EST
+Version: 1.1.0
+Last Updated: 2026-05-17
 
 RAG-powered Q&A. Retrieves relevant chunks from the local Qdrant knowledge base, reranks them by relevance, builds a context window, and calls the configured LLM to generate a grounded answer.
 
@@ -43,9 +43,12 @@ All global flags apply. Key flags:
 | `--explain` | `false` | Emit a per-candidate ranking/context trace. Implies diagnostics and skips LLM synthesis; use with `--json` for the full payload. |
 | `--stream` | `true` | Stream answer tokens as they arrive for interactive use. Uses the in-process ask path; JSON and explain output remain buffered. |
 | `--no-stream` | `false` | Disable answer streaming and render only the final response. |
-| `--follow-up` | `false` | Include recent turns from the selected local ask session as conversation context. |
+| `--follow-up` / `--continue` / `-c` | `false` | Include recent turns from the selected local ask session as conversation context. `--continue` and `-c` are aliases. |
 | `--session <name>` | latest | Local ask session name used for saved turns and follow-up context. If omitted, Axon uses the most recently successful ask session, falling back to `default`. |
-| `--reset-session` | `false` | Clear the selected ask session before running this question. |
+| `--reset-session` | `false` | Clear the selected ask session before running this question. Mutually exclusive with `--new-session`. |
+| `--new-session` | `false` | Force a fresh ask session, deleting prior turns for the selected (or auto-generated) session name and running without follow-up context. Mutually exclusive with `--follow-up` and `--reset-session`. |
+| `--resume <name>` | — | Resume a named ask session. Shorthand for `--follow-up --session <name>`. Mutually exclusive with `--session` and `--new-session`. |
+| `--list-sessions` | `false` | Print all local ask sessions (name, turn count, last used, latest marker) and exit. Cannot be combined with a query argument; pair with `--json` for machine-readable output. |
 | `--json` | `false` | Machine-readable JSON output. |
 
 Note: `ask` runs synchronously and does not support `--wait`.
@@ -72,10 +75,27 @@ axon ask "how does the ask pipeline choose sources?" --no-stream
 
 # Continue from recent ask turns in the default local session
 axon ask --follow-up "can you show a concrete example?"
+axon ask --continue "can you show a concrete example?"   # alias
+axon ask -c "can you show a concrete example?"           # short form
+
+# Resume a specific named session (alias for --follow-up --session NAME)
+axon ask --resume rust-tests "how would that look in this repo?"
 
 # Use a named local session and clear it when changing topics
 axon ask --session rust-tests --reset-session "what is the test sidecar pattern?"
 axon ask --session rust-tests --follow-up "how would that look in this repo?"
+
+# Start a fresh session (auto-named) for a brand-new line of questioning
+axon ask --new-session "what is the architecture of axon's ask pipeline?"
+
+# Overwrite a named session with a fresh thread
+axon ask --new-session --session experiments "let's start over on this topic"
+
+# List local ask sessions (human-readable)
+axon ask --list-sessions
+
+# List sessions as JSON for scripts
+axon ask --list-sessions --json
 
 # Explain ranking/context decisions without calling the LLM
 axon ask "claude marketplace plugins" --explain --json
@@ -99,6 +119,44 @@ AXON_SERVER_URL=http://127.0.0.1:8001 axon ask --no-stream "what changed in serv
 8. Call Gemini headless with context + question
 9. Apply response-quality gates (citations + policy checks)
 10. Print the normalized answer
+
+## Session Lifecycle
+
+The seven session-related flags interact as follows:
+
+| Flag | Selects which session? | Loads prior turns? | Wipes existing turns? | Exits without running query? |
+|------|------------------------|--------------------|-----------------------|------------------------------|
+| (none) | `latest` pointer, falling back to `default` | No | No | No |
+| `--session <NAME>` | `<NAME>` | No | No | No |
+| `--follow-up` (alias `--continue`, short `-c`) | from `--session` or `latest` | Yes | No | No |
+| `--resume <NAME>` | `<NAME>` | Yes | No | No |
+| `--reset-session` | from `--session` or `latest` | No (after wipe) | Yes (selected session) | No |
+| `--new-session` | from `--session` or auto-`auto-YYYY-MM-DD-HHMMSS` | No | Yes (selected/new) | No |
+| `--list-sessions` | — | — | — | Yes |
+
+Mutually exclusive combinations (clap enforces at parse time):
+
+- `--new-session` ⨯ `--follow-up` / `--continue` / `-c`
+- `--new-session` ⨯ `--reset-session`
+- `--new-session` ⨯ `--resume`
+- `--resume` ⨯ `--session` (redundant)
+- `--list-sessions` + any positional query argument is rejected at runtime.
+
+Typical workflows:
+
+```bash
+# Pick up where I left off
+axon ask --continue "what was the second option you mentioned?"
+
+# Switch threads
+axon ask --resume rust-tests "back to the test sidecar conversation"
+
+# Start completely fresh, keep an auto-named history
+axon ask --new-session "let's look at a different topic"
+
+# See all my threads
+axon ask --list-sessions
+```
 
 ## Follow-Up Sessions
 

--- a/src/cli/commands/ask.rs
+++ b/src/cli/commands/ask.rs
@@ -11,14 +11,12 @@ use std::error::Error;
 mod followup;
 
 pub async fn run_ask(cfg: &Config) -> Result<(), Box<dyn Error>> {
-    let query = resolve_input_text(cfg).ok_or("ask requires a question")?;
-    let active_session = followup::resolve_selected_session_name(cfg)?;
-    let mut session_cfg = cfg.clone();
-    session_cfg.ask_session = Some(active_session.clone());
-
-    if session_cfg.ask_reset_session {
-        followup::reset_session(&session_cfg)?;
+    if cfg.ask_list_sessions {
+        return run_list_sessions(cfg);
     }
+
+    let query = resolve_input_text(cfg).ok_or("ask requires a question")?;
+    let (session_cfg, active_session) = prepare_ask_session(cfg)?;
     let effective_query = if session_cfg.ask_follow_up {
         followup::follow_up_query(&session_cfg, &query)?.unwrap_or_else(|| query.clone())
     } else {
@@ -130,6 +128,112 @@ pub async fn run_ask(cfg: &Config) -> Result<(), Box<dyn Error>> {
     record_successful_turn(&session_cfg, &query, &result);
 
     Ok(())
+}
+
+/// Resolve the target ask session, wipe history if `--new-session` or
+/// `--reset-session` requested, and return the prepared session config.
+fn prepare_ask_session(cfg: &Config) -> Result<(Config, String), Box<dyn Error>> {
+    // `--new-session`: pick an explicit `--session NAME` or auto-generate one,
+    // delete any prior history, and treat this as a fresh thread (no follow-up
+    // context). clap enforces exclusivity with `--follow-up`, `--resume`, and
+    // `--reset-session`.
+    let new_session_name = cfg.ask_new_session.then(|| {
+        cfg.ask_session
+            .clone()
+            .unwrap_or_else(followup::new_session_name)
+    });
+
+    let active_session = match new_session_name.as_ref() {
+        Some(name) => name.clone(),
+        None => followup::resolve_selected_session_name(cfg)?,
+    };
+    let mut session_cfg = cfg.clone();
+    session_cfg.ask_session = Some(active_session.clone());
+
+    if new_session_name.is_some() {
+        followup::reset_session(&session_cfg)?;
+        session_cfg.ask_follow_up = false;
+    } else if session_cfg.ask_reset_session {
+        followup::reset_session(&session_cfg)?;
+    }
+    Ok((session_cfg, active_session))
+}
+
+fn run_list_sessions(cfg: &Config) -> Result<(), Box<dyn Error>> {
+    let sessions = followup::list_sessions()?;
+
+    if cfg.json_output {
+        let payload: Vec<serde_json::Value> = sessions
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "name": s.name,
+                    "turn_count": s.turn_count,
+                    "last_used_unix": s.last_used_unix,
+                    "is_latest": s.is_latest,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    if sessions.is_empty() {
+        println!("{} no local ask sessions yet", muted("Sessions:"));
+        println!(
+            "  {} run `axon ask \"...\"` to create one (saved to ~/.axon/ask-sessions/)",
+            muted("Hint:")
+        );
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    println!(
+        "{:<32}  {:>5}  {:<32}  LATEST",
+        "NAME", "TURNS", "LAST USED"
+    );
+    for s in &sessions {
+        let last = match s.last_used_unix {
+            Some(ts) => {
+                let abs = chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
+                    .map(|dt| dt.format("%Y-%m-%d %H:%M UTC").to_string())
+                    .unwrap_or_else(|| "-".to_string());
+                let rel = format_relative_secs(now.saturating_sub(ts));
+                if rel.is_empty() {
+                    abs
+                } else {
+                    format!("{abs} ({rel})")
+                }
+            }
+            None => "-".to_string(),
+        };
+        let star = if s.is_latest { "*" } else { "" };
+        println!(
+            "{:<32}  {:>5}  {:<32}  {}",
+            s.name, s.turn_count, last, star
+        );
+    }
+    Ok(())
+}
+
+fn format_relative_secs(secs: i64) -> String {
+    if secs < 0 {
+        return String::new();
+    }
+    let secs = secs as u64;
+    if secs < 60 {
+        return format!("{secs}s ago");
+    }
+    let minutes = secs / 60;
+    if minutes < 60 {
+        return format!("{minutes}m ago");
+    }
+    let hours = minutes / 60;
+    if hours < 24 {
+        return format!("{hours}h ago");
+    }
+    let days = hours / 24;
+    format!("{days}d ago")
 }
 
 fn record_successful_turn(cfg: &Config, query: &str, result: &AskResult) {

--- a/src/cli/commands/ask/followup.rs
+++ b/src/cli/commands/ask/followup.rs
@@ -23,6 +23,18 @@ pub(crate) struct AskTurn {
     pub assistant: String,
 }
 
+/// Summary of a single local ask session for `--list-sessions`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SessionMeta {
+    pub name: String,
+    pub turn_count: usize,
+    /// Last-modified time as a unix timestamp (seconds). May be `None` if the
+    /// filesystem doesn't expose modification times.
+    pub last_used_unix: Option<i64>,
+    /// True for the session pointed to by the `latest` file.
+    pub is_latest: bool,
+}
+
 #[cfg(test)]
 pub(crate) fn selected_session_name(cfg: &Config) -> String {
     resolve_selected_session_name(cfg).unwrap_or_else(|_| DEFAULT_SESSION.to_string())
@@ -53,6 +65,69 @@ pub(crate) fn update_latest_session(cfg: &Config) -> Result<(), Box<dyn Error>> 
     let path = latest_session_path();
     write_atomic(&path, format!("{session}\n").as_bytes())?;
     Ok(())
+}
+
+/// Generate a fresh auto-named session name based on the current UTC time.
+/// Format: `auto-YYYY-MM-DD-HHMMSS`. The format passes `sanitize_session_name()`.
+pub(crate) fn new_session_name() -> String {
+    Utc::now().format("auto-%Y-%m-%d-%H%M%S").to_string()
+}
+
+/// Enumerate all local ask sessions, sorted by last-modified descending.
+/// The `latest` pointer file is excluded; sessions without a readable modified
+/// time fall to the bottom of the list.
+pub(crate) fn list_sessions() -> Result<Vec<SessionMeta>, Box<dyn Error>> {
+    let dir = sessions_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(rd) => rd,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(format!("failed to read sessions dir {}: {err}", dir.display()).into());
+        }
+    };
+
+    let latest = read_latest_session_name();
+    let mut out: Vec<SessionMeta> = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // Skip the `latest` pointer and any temp files written by `write_atomic`.
+        if file_name == LATEST_SESSION_FILE || file_name.starts_with('.') {
+            continue;
+        }
+        let Some(stem) = file_name.strip_suffix(".jsonl") else {
+            continue;
+        };
+        if sanitize_session_name(stem).is_err() {
+            continue;
+        }
+
+        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        let turn_count = parse_session_lines(&path, &content).len();
+        let last_used_unix = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as i64);
+        let is_latest = latest.as_deref() == Some(stem);
+        out.push(SessionMeta {
+            name: stem.to_string(),
+            turn_count,
+            last_used_unix,
+            is_latest,
+        });
+    }
+
+    out.sort_by(|a, b| {
+        b.last_used_unix
+            .cmp(&a.last_used_unix)
+            .then(a.name.cmp(&b.name))
+    });
+    Ok(out)
 }
 
 pub(crate) fn reset_session(cfg: &Config) -> Result<(), Box<dyn Error>> {

--- a/src/cli/commands/ask/followup.rs
+++ b/src/cli/commands/ask/followup.rs
@@ -94,8 +94,10 @@ pub(crate) fn list_sessions() -> Result<Vec<SessionMeta>, Box<dyn Error>> {
         let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
-        // Skip the `latest` pointer and any temp files written by `write_atomic`.
-        if file_name == LATEST_SESSION_FILE || file_name.starts_with('.') {
+        // Skip the `latest` pointer file. Temp files written by `write_atomic`
+        // are filtered out by the `.jsonl` suffix check below (they are named
+        // `.<file>.tmp-<pid>-<ns>` with no `.jsonl` suffix).
+        if file_name == LATEST_SESSION_FILE {
             continue;
         }
         let Some(stem) = file_name.strip_suffix(".jsonl") else {

--- a/src/cli/commands/ask/followup_tests.rs
+++ b/src/cli/commands/ask/followup_tests.rs
@@ -234,12 +234,20 @@ fn list_sessions_orders_by_modified_desc_and_marks_latest() {
     std::fs::write(dir.join("readme.txt"), "not a session").ok();
     // Bad name should also be filtered.
     std::fs::write(dir.join("bad name.jsonl"), "").ok();
+    // A session whose name starts with '.' is valid per `sanitize_session_name`
+    // and must NOT be hidden (the previous dotfile filter was too broad).
+    let cfg_dot = Config {
+        ask_session: Some(".team".to_string()),
+        ..Default::default()
+    };
+    append_turn(&cfg_dot, "q-.team", "a-.team").expect("append");
 
     let sessions = list_sessions().expect("list");
     let names: Vec<_> = sessions.iter().map(|s| s.name.as_str()).collect();
     assert!(names.contains(&"alpha"));
     assert!(names.contains(&"beta"));
     assert!(names.contains(&"gamma"));
+    assert!(names.contains(&".team"));
     assert!(!names.contains(&"bad name"));
     let beta = sessions.iter().find(|s| s.name == "beta").unwrap();
     assert!(beta.is_latest);

--- a/src/cli/commands/ask/followup_tests.rs
+++ b/src/cli/commands/ask/followup_tests.rs
@@ -1,4 +1,5 @@
 use super::{AskTurn, append_turn, bounded, follow_up_context_source, follow_up_query};
+use super::{list_sessions, new_session_name};
 use super::{resolve_selected_session_name, selected_session_name, update_latest_session};
 use super::{sanitize_session_name, sessions_dir, xml_text};
 use crate::core::config::Config;
@@ -191,6 +192,78 @@ fn append_turn_prunes_session_file_to_recent_bound() {
     assert_eq!(lines.len(), 100);
     assert!(!content.contains("question 0"));
     assert!(content.contains("question 104"));
+
+    match saved {
+        Some(value) => unsafe { std::env::set_var("AXON_DATA_DIR", value) },
+        None => unsafe { std::env::remove_var("AXON_DATA_DIR") },
+    }
+}
+
+#[test]
+fn new_session_name_is_sanitizable() {
+    let name = new_session_name();
+    assert!(name.starts_with("auto-"));
+    sanitize_session_name(&name).expect("auto-generated name must pass sanitizer");
+}
+
+#[allow(unsafe_code)]
+#[serial_test::serial]
+#[test]
+fn list_sessions_orders_by_modified_desc_and_marks_latest() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let saved = std::env::var("AXON_DATA_DIR").ok();
+    unsafe { std::env::set_var("AXON_DATA_DIR", tmp.path()) };
+
+    // Populate three sessions, one turn each, then write `latest` for "beta".
+    for name in ["alpha", "beta", "gamma"] {
+        let cfg = Config {
+            ask_session: Some(name.to_string()),
+            ..Default::default()
+        };
+        append_turn(&cfg, &format!("q-{name}"), &format!("a-{name}")).expect("append");
+    }
+    let cfg_beta = Config {
+        ask_session: Some("beta".to_string()),
+        ..Default::default()
+    };
+    update_latest_session(&cfg_beta).expect("latest");
+
+    // Drop a `.tmp-` file and a non-jsonl entry to make sure we filter them out.
+    let dir = sessions_dir();
+    std::fs::write(dir.join(".alpha.jsonl.tmp-1"), "junk").ok();
+    std::fs::write(dir.join("readme.txt"), "not a session").ok();
+    // Bad name should also be filtered.
+    std::fs::write(dir.join("bad name.jsonl"), "").ok();
+
+    let sessions = list_sessions().expect("list");
+    let names: Vec<_> = sessions.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"alpha"));
+    assert!(names.contains(&"beta"));
+    assert!(names.contains(&"gamma"));
+    assert!(!names.contains(&"bad name"));
+    let beta = sessions.iter().find(|s| s.name == "beta").unwrap();
+    assert!(beta.is_latest);
+    assert_eq!(beta.turn_count, 1);
+    let alpha = sessions.iter().find(|s| s.name == "alpha").unwrap();
+    assert!(!alpha.is_latest);
+
+    match saved {
+        Some(value) => unsafe { std::env::set_var("AXON_DATA_DIR", value) },
+        None => unsafe { std::env::remove_var("AXON_DATA_DIR") },
+    }
+}
+
+#[allow(unsafe_code)]
+#[serial_test::serial]
+#[test]
+fn list_sessions_returns_empty_when_dir_missing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let saved = std::env::var("AXON_DATA_DIR").ok();
+    unsafe { std::env::set_var("AXON_DATA_DIR", tmp.path()) };
+
+    // Don't create the ask-sessions/ subdir at all.
+    let sessions = list_sessions().expect("list");
+    assert!(sessions.is_empty());
 
     match saved {
         Some(value) => unsafe { std::env::set_var("AXON_DATA_DIR", value) },

--- a/src/core/config/cli.rs
+++ b/src/core/config/cli.rs
@@ -341,7 +341,11 @@ pub(super) struct AskArgs {
     #[arg(long = "list-sessions", action = ArgAction::SetTrue)]
     pub(super) list_sessions: bool,
     /// Resume a named ask session (shorthand for `--follow-up --session NAME`).
-    #[arg(long = "resume", value_name = "NAME")]
+    #[arg(
+        long = "resume",
+        value_name = "NAME",
+        conflicts_with_all = ["new_session", "reset_session", "session"],
+    )]
     pub(super) resume: Option<String>,
     #[arg(value_name = "TEXT")]
     pub(super) value: Vec<String>,

--- a/src/core/config/cli.rs
+++ b/src/core/config/cli.rs
@@ -315,14 +315,34 @@ pub(super) struct AskArgs {
     #[arg(long = "no-stream", action = ArgAction::SetTrue)]
     pub(super) no_stream: bool,
     /// Treat this question as a follow-up to recent turns in the ask session.
-    #[arg(long = "follow-up", action = ArgAction::SetTrue)]
+    /// `--continue` is accepted as an alias and `-c` is the short form.
+    #[arg(
+        long = "follow-up",
+        alias = "continue",
+        short = 'c',
+        action = ArgAction::SetTrue,
+        conflicts_with_all = ["new_session", "resume"],
+    )]
     pub(super) follow_up: bool,
     /// Name of the local ask session used for follow-up context.
-    #[arg(long = "session", value_name = "NAME")]
+    #[arg(long = "session", value_name = "NAME", conflicts_with = "resume")]
     pub(super) session: Option<String>,
     /// Clear the selected ask session before running this question.
-    #[arg(long = "reset-session", action = ArgAction::SetTrue)]
+    #[arg(
+        long = "reset-session",
+        action = ArgAction::SetTrue,
+        conflicts_with = "new_session",
+    )]
     pub(super) reset_session: bool,
+    /// Force a fresh ask session, overwriting any selected one (mutually exclusive with --follow-up).
+    #[arg(long = "new-session", action = ArgAction::SetTrue)]
+    pub(super) new_session: bool,
+    /// List local ask sessions and exit. Cannot be combined with a query argument.
+    #[arg(long = "list-sessions", action = ArgAction::SetTrue)]
+    pub(super) list_sessions: bool,
+    /// Resume a named ask session (shorthand for `--follow-up --session NAME`).
+    #[arg(long = "resume", value_name = "NAME")]
+    pub(super) resume: Option<String>,
     #[arg(value_name = "TEXT")]
     pub(super) value: Vec<String>,
 }

--- a/src/core/config/parse/build_config/command_dispatch.rs
+++ b/src/core/config/parse/build_config/command_dispatch.rs
@@ -33,6 +33,8 @@ pub(super) struct DispatchOutput {
     pub ask_follow_up: bool,
     pub ask_session: Option<String>,
     pub ask_reset_session: bool,
+    pub ask_new_session: bool,
+    pub ask_list_sessions: bool,
     pub evaluate_responses_mode: EvaluateResponsesMode,
     pub evaluate_retrieval_ab: bool,
     pub github_include_source: bool,
@@ -67,6 +69,8 @@ impl DispatchOutput {
             ask_follow_up: false,
             ask_session: None,
             ask_reset_session: false,
+            ask_new_session: false,
+            ask_list_sessions: false,
             evaluate_responses_mode: EvaluateResponsesMode::Inline,
             evaluate_retrieval_ab: false,
             github_include_source: true,
@@ -160,9 +164,16 @@ pub(super) fn dispatch(cli_command: CliCommand) -> DispatchOutput {
         CliCommand::Ask(args) => {
             out.ask_explain = args.explain;
             out.ask_stream = !args.no_stream && !args.explain;
-            out.ask_follow_up = args.follow_up;
-            out.ask_session = args.session;
+            // `--resume NAME` is a thin alias for `--follow-up --session NAME`.
+            let (follow_up, session) = match args.resume {
+                Some(name) => (true, Some(name)),
+                None => (args.follow_up, args.session),
+            };
+            out.ask_follow_up = follow_up;
+            out.ask_session = session;
             out.ask_reset_session = args.reset_session;
+            out.ask_new_session = args.new_session;
+            out.ask_list_sessions = args.list_sessions;
             out.ask_diagnostics = args.diagnostics || args.explain;
             set_simple(&mut out, CommandKind::Ask, args.value);
         }

--- a/src/core/config/parse/build_config/config_literal.rs
+++ b/src/core/config/parse/build_config/config_literal.rs
@@ -200,13 +200,19 @@ fn populate_services_and_ask_basics(
     cfg.ask_reset_session = inputs.dispatched.ask_reset_session;
     cfg.ask_new_session = inputs.dispatched.ask_new_session;
     cfg.ask_list_sessions = inputs.dispatched.ask_list_sessions;
-    if cfg.ask_list_sessions
-        && matches!(cfg.command, CommandKind::Ask)
-        && !inputs.dispatched.positional.is_empty()
-    {
-        return Err(
-            "--list-sessions cannot be combined with a query argument; run it on its own".into(),
-        );
+    if cfg.ask_list_sessions && matches!(cfg.command, CommandKind::Ask) {
+        let has_query_flag = inputs
+            .global
+            .query
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|q| !q.is_empty());
+        if !inputs.dispatched.positional.is_empty() || has_query_flag {
+            return Err(
+                "--list-sessions cannot be combined with a query argument; run it on its own"
+                    .into(),
+            );
+        }
     }
     cfg.ask_graph = false;
     cfg.evaluate_responses_mode = inputs.dispatched.evaluate_responses_mode;

--- a/src/core/config/parse/build_config/config_literal.rs
+++ b/src/core/config/parse/build_config/config_literal.rs
@@ -6,7 +6,7 @@
 //! same as the previous flat literal.
 
 use super::super::super::cli::GlobalArgs;
-use super::super::super::types::{ClientMode, Config};
+use super::super::super::types::{ClientMode, CommandKind, Config};
 use super::super::docker::normalize_local_service_url;
 use super::super::helpers::{
     env_port, parse_csv_env, parse_origin_allowlist, resolve_mcp_transport, validate_custom_headers,
@@ -198,6 +198,16 @@ fn populate_services_and_ask_basics(
     cfg.ask_session = inputs.dispatched.ask_session.clone();
     cfg.ask_follow_up_context = None;
     cfg.ask_reset_session = inputs.dispatched.ask_reset_session;
+    cfg.ask_new_session = inputs.dispatched.ask_new_session;
+    cfg.ask_list_sessions = inputs.dispatched.ask_list_sessions;
+    if cfg.ask_list_sessions
+        && matches!(cfg.command, CommandKind::Ask)
+        && !inputs.dispatched.positional.is_empty()
+    {
+        return Err(
+            "--list-sessions cannot be combined with a query argument; run it on its own".into(),
+        );
+    }
     cfg.ask_graph = false;
     cfg.evaluate_responses_mode = inputs.dispatched.evaluate_responses_mode;
     cfg.evaluate_retrieval_ab = inputs.dispatched.evaluate_retrieval_ab;

--- a/src/core/config/parse_tests.rs
+++ b/src/core/config/parse_tests.rs
@@ -289,6 +289,29 @@ fn parse_ask_list_sessions_with_query_rejected() {
 }
 
 #[test]
+fn parse_ask_list_sessions_with_query_flag_rejected() {
+    let err = super::build_config::into_config(ask_cli(&[
+        "--query",
+        "stray-via-flag",
+        "--list-sessions",
+    ]))
+    .expect_err("list-sessions + --query must fail");
+    assert!(err.contains("--list-sessions"));
+}
+
+#[test]
+fn parse_ask_resume_conflicts_with_new_session() {
+    let result = try_ask_cli(&["--resume", "rust-thread", "--new-session", "q"]);
+    assert!(result.is_err(), "--resume + --new-session should error");
+}
+
+#[test]
+fn parse_ask_resume_conflicts_with_reset_session() {
+    let result = try_ask_cli(&["--resume", "rust-thread", "--reset-session", "q"]);
+    assert!(result.is_err(), "--resume + --reset-session should error");
+}
+
+#[test]
 fn parse_ask_list_sessions_alone_is_ok() {
     let cfg =
         super::build_config::into_config(ask_cli(&["--list-sessions"])).expect("list-sessions");

--- a/src/core/config/parse_tests.rs
+++ b/src/core/config/parse_tests.rs
@@ -213,6 +213,97 @@ fn parse_retrieve_max_points_into_config() {
     assert_eq!(cfg.retrieve_max_points, Some(25));
 }
 
+// --- ask session-management flag tests ---
+
+fn ask_cli(extra: &[&str]) -> super::Cli {
+    let mut argv: Vec<&str> = vec![
+        "axon",
+        "--tei-url",
+        "http://127.0.0.1:52000",
+        "--qdrant-url",
+        "http://127.0.0.1:53333",
+        "ask",
+    ];
+    argv.extend_from_slice(extra);
+    super::Cli::parse_from(argv)
+}
+
+fn try_ask_cli(extra: &[&str]) -> Result<super::Cli, clap::Error> {
+    let mut argv: Vec<&str> = vec![
+        "axon",
+        "--tei-url",
+        "http://127.0.0.1:52000",
+        "--qdrant-url",
+        "http://127.0.0.1:53333",
+        "ask",
+    ];
+    argv.extend_from_slice(extra);
+    super::Cli::try_parse_from(argv)
+}
+
+#[test]
+fn parse_ask_continue_alias_is_equivalent_to_follow_up() {
+    let cfg_a =
+        super::build_config::into_config(ask_cli(&["--follow-up", "q"])).expect("follow-up");
+    let cfg_b = super::build_config::into_config(ask_cli(&["--continue", "q"])).expect("continue");
+    let cfg_c = super::build_config::into_config(ask_cli(&["-c", "q"])).expect("-c");
+    assert!(cfg_a.ask_follow_up);
+    assert!(cfg_b.ask_follow_up);
+    assert!(cfg_c.ask_follow_up);
+}
+
+#[test]
+fn parse_ask_resume_is_alias_for_follow_up_plus_session() {
+    let cfg = super::build_config::into_config(ask_cli(&["--resume", "rust-thread", "q"]))
+        .expect("resume");
+    assert!(cfg.ask_follow_up);
+    assert_eq!(cfg.ask_session.as_deref(), Some("rust-thread"));
+}
+
+#[test]
+fn parse_ask_new_session_conflicts_with_follow_up() {
+    let result = try_ask_cli(&["--new-session", "--follow-up", "q"]);
+    assert!(result.is_err(), "--new-session + --follow-up should error");
+}
+
+#[test]
+fn parse_ask_resume_conflicts_with_session() {
+    let result = try_ask_cli(&["--resume", "a", "--session", "b", "q"]);
+    assert!(result.is_err(), "--resume + --session should error");
+}
+
+#[test]
+fn parse_ask_reset_session_conflicts_with_new_session() {
+    let result = try_ask_cli(&["--new-session", "--reset-session", "q"]);
+    assert!(
+        result.is_err(),
+        "--new-session + --reset-session should error"
+    );
+}
+
+#[test]
+fn parse_ask_list_sessions_with_query_rejected() {
+    let err = super::build_config::into_config(ask_cli(&["--list-sessions", "stray-query"]))
+        .expect_err("list-sessions + query must fail");
+    assert!(err.contains("--list-sessions"));
+}
+
+#[test]
+fn parse_ask_list_sessions_alone_is_ok() {
+    let cfg =
+        super::build_config::into_config(ask_cli(&["--list-sessions"])).expect("list-sessions");
+    assert!(matches!(cfg.command, CommandKind::Ask));
+    assert!(cfg.ask_list_sessions);
+}
+
+#[test]
+fn parse_ask_new_session_records_flag() {
+    let cfg = super::build_config::into_config(ask_cli(&["--new-session", "--session", "x", "q"]))
+        .expect("new-session");
+    assert!(cfg.ask_new_session);
+    assert_eq!(cfg.ask_session.as_deref(), Some("x"));
+}
+
 // --- is_docker_service_host tests ---
 
 #[test]

--- a/src/core/config/types/config.rs
+++ b/src/core/config/types/config.rs
@@ -274,6 +274,12 @@ pub struct Config {
     /// Clear the selected local ask session before running. Flag: `ask --reset-session`.
     pub ask_reset_session: bool,
 
+    /// Force a fresh ask session, overwriting any existing one. Flag: `ask --new-session`.
+    pub ask_new_session: bool,
+
+    /// List all local ask sessions and exit without running a query. Flag: `ask --list-sessions`.
+    pub ask_list_sessions: bool,
+
     /// Legacy internal graph toggle. Production request surfaces keep this disabled.
     pub ask_graph: bool,
 

--- a/src/core/config/types/config_impls.rs
+++ b/src/core/config/types/config_impls.rs
@@ -96,6 +96,8 @@ impl Default for Config {
             ask_session: None,
             ask_follow_up_context: None,
             ask_reset_session: false,
+            ask_new_session: false,
+            ask_list_sessions: false,
             ask_graph: false,
             evaluate_responses_mode: EvaluateResponsesMode::Inline,
             ask_max_context_chars: 300_000,
@@ -347,6 +349,8 @@ impl fmt::Debug for Config {
                 &self.ask_follow_up_context.as_ref().map(|_| "[REDACTED]"),
             )
             .field("ask_reset_session", &self.ask_reset_session)
+            .field("ask_new_session", &self.ask_new_session)
+            .field("ask_list_sessions", &self.ask_list_sessions)
             .field("ask_graph", &self.ask_graph)
             .field("evaluate_responses_mode", &self.evaluate_responses_mode)
             .field("ask_max_context_chars", &self.ask_max_context_chars)


### PR DESCRIPTION
## Summary

Round out the `axon ask` session surface with four user-requested flags that complement the existing `--follow-up` / `--session` / `--reset-session` trio.

- `--new-session` — fresh thread for an explicit `--session NAME` or auto-generated `auto-YYYY-MM-DD-HHMMSS`; wipes prior turns and runs without follow-up context. Mutually exclusive with `--follow-up`, `--reset-session`, and `--resume` (clap-enforced).
- `--list-sessions` — enumerate `~/.axon/ask-sessions/`, sorted by last-modified descending, with a `*` for the `latest` pointer. Pair with `--json` for a machine-readable array. Cannot be combined with a query argument (validated in `into_config`).
- `--resume <NAME>` — shorthand for `--follow-up --session NAME`. Mutually exclusive with `--session` (redundant) and `--new-session`.
- `--continue` / `-c` — clap aliases for `--follow-up`, more discoverable.

Implementation stays within the existing CLI-internal `followup` module — `list_sessions()` + `new_session_name()` + `SessionMeta` are exposed to `run_ask`, which renders the list directly. Extracts `prepare_ask_session()` to keep `run_ask` under the 120-line monolith limit.

Bumps to 2.4.0 (Cargo.toml + apps/web/package.json) and refreshes `docs/commands/ask.md` with a Session Lifecycle table covering all seven session flags.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --bin axon --lib --tests -- -D warnings` (clean)
- [x] `cargo test --lib` (1839 passed, 6 ignored)
- [x] 9 new clap parse tests (alias equivalence, conflict matrix, `--list-sessions + query` rejection)
- [x] 3 new followup-module tests (auto name sanitizable, list ordering + latest marker, missing-dir empty list)
- [x] Manual: `axon ask --help` shows all 7 session flags grouped logically
- [x] Manual: `axon ask --list-sessions` (empty + populated)
- [x] Manual: `axon ask --list-sessions stray-query` errors with the documented message

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four session management flags to `axon ask` and tightens parse-time guards to prevent conflicting usage. Updates docs and bumps to 2.7.0.

- **New Features**
  - `--new-session`: start a fresh thread for `--session <NAME>` or auto `auto-YYYY-MM-DD-HHMMSS`; wipes prior turns; conflicts with `--follow-up`/`--continue`/`-c`, `--reset-session`, and `--resume`.
  - `--list-sessions`: list `~/.axon/ask-sessions/` by last used; marks latest; supports `--json`; cannot be used with a positional query or the global `--query` flag.
  - `--resume <NAME>`: shorthand for `--follow-up --session <NAME>`; conflicts with `--session` and `--new-session`.
  - `--continue` / `-c`: aliases for `--follow-up`.

- **Bug Fixes**
  - `--resume` now conflicts with `--new-session`, `--reset-session`, and `--session` (clap-enforced).
  - `--list-sessions` validation rejects both positional queries and the global `--query` flag.
  - Session listing no longer hides names starting with `.`; non-`.jsonl` and temp files remain filtered.
  - Added targeted parse and follow-up tests for conflicts, listing, and dotted names.

<sup>Written for commit 7d69053bbccc6ebd5c1958e8d26f986c85ceff17. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/103?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--new-session` flag to force a fresh session.
  * Added `--list-sessions` flag to view all local ask sessions with metadata.
  * Added `--resume <NAME>` shorthand for resuming sessions with follow-up context.
  * Added `--continue` / `-c` alias for session follow-ups.
  * Enhanced session conflict handling with stricter validation rules.

* **Documentation**
  * Updated ask command documentation with new session-related flags, lifecycle table, and workflow examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/axon/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->