### PR TITLE
Work/desktop ci docs release

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -45,6 +45,9 @@ jobs:
             libxcb-randr0-dev libxcb-xkb-dev libxcb-cursor-dev libxcb-shape0-dev \
             libxcb-xfixes0-dev libxcb-keysyms1-dev libxcb-image0-dev
 
+      - name: cargo test
+        run: cargo test --locked --manifest-path apps/desktop/Cargo.toml
+
       - name: cargo build --release
         run: cargo build --release --locked --manifest-path apps/desktop/Cargo.toml
 
@@ -82,6 +85,11 @@ jobs:
           cargo config get build.rustflags --merged
           if ($LASTEXITCODE -ne 0) { "build.rustflags not set" }
           exit 0
+        env:
+          RUSTFLAGS: ${{ env.WINDOWS_PORTABLE_RUSTFLAGS }}
+
+      - name: cargo test
+        run: cargo test --locked --manifest-path apps/desktop/Cargo.toml
         env:
           RUSTFLAGS: ${{ env.WINDOWS_PORTABLE_RUSTFLAGS }}
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -17,6 +17,9 @@ env:
   CARGO_TERM_COLOR: always
   # apps/desktop is its own workspace (see apps/desktop/Cargo.toml).
   CARGO_MANIFEST_PATH: apps/desktop/Cargo.toml
+  WINDOWS_PORTABLE_RUSTFLAGS: >-
+    -C target-cpu=x86-64
+    -C target-feature=-avx512f,-avx512vl,-avx512bw,-avx512dq,-avx512cd,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vnni,-avx512bitalg,-avx512vpopcntdq
 
 jobs:
   build-linux:
@@ -69,8 +72,23 @@ jobs:
           workspaces: apps/desktop
           shared-key: axon-palette-windows
 
+      - name: Show Windows Rust CPU flags
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          rustc -vV
+          "RUSTFLAGS=$env:RUSTFLAGS"
+          rustc --print cfg | Select-String 'target_feature'
+          cargo config get build.rustflags --merged
+          if ($LASTEXITCODE -ne 0) { "build.rustflags not set" }
+          exit 0
+        env:
+          RUSTFLAGS: ${{ env.WINDOWS_PORTABLE_RUSTFLAGS }}
+
       - name: cargo build --release
         run: cargo build --release --locked --manifest-path apps/desktop/Cargo.toml
+        env:
+          RUSTFLAGS: ${{ env.WINDOWS_PORTABLE_RUSTFLAGS }}
 
       - name: Upload Windows binary
         uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  WINDOWS_PORTABLE_RUSTFLAGS: >-
+    -C target-cpu=x86-64
+    -C target-feature=-avx512f,-avx512vl,-avx512bw,-avx512dq,-avx512cd,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vnni,-avx512bitalg,-avx512vpopcntdq
 
 jobs:
   axon-linux:
@@ -124,8 +127,22 @@ jobs:
         with:
           workspaces: apps/desktop
           shared-key: release-palette-windows
+      - name: Show Windows Rust CPU flags
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          rustc -vV
+          "RUSTFLAGS=$env:RUSTFLAGS"
+          rustc --print cfg | Select-String 'target_feature'
+          cargo config get build.rustflags --merged
+          if ($LASTEXITCODE -ne 0) { "build.rustflags not set" }
+          exit 0
+        env:
+          RUSTFLAGS: ${{ env.WINDOWS_PORTABLE_RUSTFLAGS }}
       - name: cargo build --release
         run: cargo build --release --locked --manifest-path apps/desktop/Cargo.toml
+        env:
+          RUSTFLAGS: ${{ env.WINDOWS_PORTABLE_RUSTFLAGS }}
       - name: Package
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **palette/ci**: desktop CI now runs the `apps/desktop` unit test suite on
+  Linux and Windows before producing release binaries.
+- **palette/docs**: added dedicated desktop build, run, platform, hotkey,
+  binary-resolution, smoke-test, and markdown-link behavior documentation.
+
 ## [3.0.0] - 2026-05-17
 
 ### BREAKING CHANGES

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,0 +1,75 @@
+# Axon Palette
+
+`axon-palette` is the desktop command palette for the `axon` CLI. It opens from a global hotkey, filters common Axon actions, and shells out to the `axon` binary.
+
+## Platforms
+
+- Linux and FreeBSD use the GPUI Linux backend. Linux builds link X11, Wayland, xcb, OpenSSL, and fontconfig development packages.
+- Windows uses the native GPUI Windows backend and is built on a native Windows runner.
+- macOS is not currently enabled; unsupported platforms fail at compile time.
+- Wayland global-hotkey support depends on the compositor and desktop portal behavior. X11 is the most predictable Linux path today.
+
+## Build
+
+The desktop app is intentionally its own Cargo workspace under `apps/desktop`.
+
+```bash
+cargo build --manifest-path apps/desktop/Cargo.toml
+cargo build --release --locked --manifest-path apps/desktop/Cargo.toml
+```
+
+Release artifacts are written under `apps/desktop/target/release/`:
+
+- Linux/FreeBSD: `axon-palette`
+- Windows: `axon-palette.exe`
+
+## Test
+
+```bash
+cargo test --locked --manifest-path apps/desktop/Cargo.toml
+```
+
+The dedicated desktop CI workflow runs this command before release builds on both Linux and Windows.
+
+## Run
+
+```bash
+cargo run --manifest-path apps/desktop/Cargo.toml
+```
+
+or run the built binary directly:
+
+```bash
+apps/desktop/target/release/axon-palette
+```
+
+The palette resolves `axon` through `PATH` and executes it as a subprocess. Install or symlink the intended Axon CLI binary before launching the palette:
+
+```bash
+which axon
+axon --version
+```
+
+If the wrong binary is found, fix the shell or desktop-session `PATH` before testing the palette. The palette forces local CLI execution for its actions, so a configured `AXON_SERVER_URL` should not redirect palette commands to a remote server.
+
+## Hotkey
+
+The default global hotkey is `Ctrl+Shift+Space`. The hotkey manager is kept alive for the life of the process; dropping it unregisters the binding.
+
+If the palette starts but the hotkey does not focus the window, check whether another app already owns the shortcut or whether the compositor blocks global hotkeys.
+
+## Smoke Test
+
+Before packaging a desktop release:
+
+1. Build the release binary for the target platform.
+2. Ensure `which axon` points at the expected Axon CLI.
+3. Launch `axon-palette`.
+4. Confirm the window accepts typing immediately after launch.
+5. Type `doctor`, press Enter, and confirm output appears.
+6. Press `Ctrl+Shift+Space` from another focused app and confirm the palette activates.
+7. Run an `ask` command, close and reopen the palette within 30 minutes, then confirm the next ask continues the restored conversation.
+
+## Output Links
+
+Markdown output renders links as their destination URL, not hidden label text. Clicks are user initiated and only `http://` and `https://` destinations are opened; other URI schemes are ignored.

--- a/apps/desktop/src/anim.rs
+++ b/apps/desktop/src/anim.rs
@@ -18,16 +18,6 @@ use std::time::Duration;
 /// setting); flip locally to test.
 pub(crate) const REDUCE_MOTION: bool = false;
 
-/// Resize tick interval for the window-height lerp. ~60 FPS is overkill for
-/// a window resize; 16ms keeps the motion smooth without flooding the GPUI
-/// runloop with notifications.
-pub(crate) const RESIZE_TICK_MS: u64 = 16;
-
-/// How close `current_height` has to get to `target_height` before the
-/// resize tick self-terminates and snaps to the target. Under one pixel is
-/// indistinguishable from "done" on any DPI.
-pub(crate) const RESIZE_SNAP_EPSILON: f32 = 0.75;
-
 /// Linear interpolation between `from` and `to` at progress `t` (clamped to
 /// `[0.0, 1.0]`).
 pub(crate) fn lerp_f32(from: f32, to: f32, t: f32) -> f32 {

--- a/apps/desktop/src/conversation.rs
+++ b/apps/desktop/src/conversation.rs
@@ -2,11 +2,13 @@
 //!
 //! The palette auto-continues `axon ask` conversations: the first ask starts a
 //! conversation, every subsequent ask while the conversation is "live" prepends
-//! `--follow-up` to the shell-out. Conversations are in-memory only — they
-//! survive across other (non-ask) actions but not across palette restarts.
+//! `--follow-up` to the shell-out. Conversations are restored across palette
+//! restarts when the latest CLI ask session is still inside the idle window;
+//! only turn timestamps are parsed, never prompt or answer text.
 //!
 //! Lifecycle:
-//! - Created on the first **successful** `axon ask`
+//! - Restored on startup from `~/.axon/ask-sessions/latest` when fresh
+//! - Created on the first **successful** `axon ask` when nothing is restored
 //! - Bumped on each subsequent successful `axon ask`
 //! - NOT modified on failed asks (so a transient CLI error doesn't reset the
 //!   user's chain)

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -49,7 +49,15 @@ fn build_application() -> Application {
 
 actions!(
     palette,
-    [Submit, MoveDown, MoveUp, TabComplete, ClearOutput]
+    [
+        Submit,
+        MoveDown,
+        MoveUp,
+        TabComplete,
+        ClearOutput,
+        ToggleActionMenu,
+        ToggleErrors
+    ]
 );
 
 fn main() -> Result<()> {
@@ -86,6 +94,8 @@ fn main() -> Result<()> {
             KeyBinding::new("down", MoveDown, Some("Palette")),
             KeyBinding::new("up", MoveUp, Some("Palette")),
             KeyBinding::new("tab", TabComplete, Some("Palette")),
+            KeyBinding::new("ctrl+k", ToggleActionMenu, Some("Palette")),
+            KeyBinding::new("ctrl+e", ToggleErrors, Some("Palette")),
         ]);
 
         // Launch height is the prompt-only minimum from `layout::MIN_WINDOW_HEIGHT`.

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -17,7 +17,7 @@ mod render;
 mod theme;
 mod ui;
 
-use std::thread;
+use std::{mem::ManuallyDrop, thread};
 
 use anyhow::Result;
 use global_hotkey::{
@@ -142,9 +142,11 @@ fn main() -> Result<()> {
         })
         .detach();
 
-        // Keep the GlobalHotKeyManager alive for the lifetime of the app.
-        // Without this, dropping the manager would unregister the hotkey.
-        std::mem::forget(manager);
+        // Keep the GlobalHotKeyManager alive for the lifetime of the process.
+        // The crate unregisters the hotkey on Drop, while GPUI does not expose
+        // a simple process-lifetime state slot here. This intentionally leaks
+        // one manager so Ctrl+Shift+Space remains registered until exit.
+        let _hotkey_manager = ManuallyDrop::new(manager);
     });
 
     Ok(())

--- a/apps/desktop/src/output.rs
+++ b/apps/desktop/src/output.rs
@@ -92,20 +92,27 @@ impl CommandOutput {
 
     pub(crate) fn from_process(command_line: &str, subcommand: &str, output: Output) -> Self {
         let stdout = OutputSection::from_bytes_for_command("stdout", subcommand, &output.stdout);
-        let stderr = OutputSection::from_bytes("stderr", &output.stderr);
-        let kind = if output.status.success() {
+        let success = output.status.success();
+        let stderr = OutputSection::from_bytes("stderr", &output.stderr).map(|section| {
+            if success {
+                section
+            } else {
+                section.with_text(actionable_error_text(&section.text))
+            }
+        });
+        let kind = if success {
             OutputKind::Success
         } else {
             OutputKind::Error
         };
-        let title = if output.status.success() {
+        let title = if success {
             format!("{} completed", command_title(subcommand))
         } else {
             format!("{} failed", command_title(subcommand))
         };
         let subtitle = format!("{command_line} · {}", format_exit_status(&output.status));
         let use_markdown = matches!(subcommand, "scrape" | "ask" | "research");
-        let compact_stdout = output.status.success() && stderr.is_none();
+        let compact_stdout = success && stderr.is_none();
 
         Self {
             kind,
@@ -189,6 +196,34 @@ fn map_url_listing(text: &str) -> String {
         text.to_string()
     } else {
         urls.join("\n")
+    }
+}
+
+fn actionable_error_text(text: &str) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    if let Some(index) = lines
+        .iter()
+        .position(|line| line.trim_start().starts_with("Error:"))
+    {
+        return lines[index..].join("\n");
+    }
+
+    let non_log_lines: Vec<&str> = lines
+        .iter()
+        .copied()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            !(trimmed.contains(" WARN ")
+                || trimmed.contains(" INFO ")
+                || trimmed.contains(" DEBUG ")
+                || trimmed.contains(" TRACE "))
+        })
+        .collect();
+
+    if non_log_lines.is_empty() {
+        text.to_string()
+    } else {
+        non_log_lines.join("\n")
     }
 }
 

--- a/apps/desktop/src/output_tests.rs
+++ b/apps/desktop/src/output_tests.rs
@@ -156,3 +156,25 @@ fn map_url_listing_keeps_non_map_output_when_no_urls_found() {
     let input = "Map failed before producing URLs";
     assert_eq!(map_url_listing(input), input);
 }
+
+#[test]
+fn actionable_error_text_prefers_final_error_line() {
+    let input = "\
+02:50:24  WARN  tei_embed retry transport_error attempt=1/6
+02:50:27  WARN  tei_embed retry transport_error attempt=2/6
+Error: ServiceError { message: \"TEI unavailable\" }";
+
+    assert_eq!(
+        actionable_error_text(input),
+        "Error: ServiceError { message: \"TEI unavailable\" }"
+    );
+}
+
+#[test]
+fn actionable_error_text_drops_log_lines_when_no_error_prefix() {
+    let input = "\
+02:50:24  WARN  tei_embed retry transport_error
+failed to connect to service";
+
+    assert_eq!(actionable_error_text(input), "failed to connect to service");
+}

--- a/apps/desktop/src/render.rs
+++ b/apps/desktop/src/render.rs
@@ -1,28 +1,33 @@
 use std::time::Duration;
 
 mod action_rows;
+mod output_body;
 pub(crate) use action_rows::render_action_rows_interactive;
+pub(crate) use output_body::render_output_body;
 
 use gpui::{
-    Animation, AnimationExt, ElementId, FontWeight, IntoElement, MouseButton, MouseDownEvent,
-    ParentElement, SharedString, Styled, div, prelude::*, pulsating_between, px, rgb,
+    Animation, AnimationExt, ElementId, FocusHandle, FontWeight, IntoElement, MouseButton,
+    MouseDownEvent, ParentElement, SharedString, Styled, div, prelude::*, pulsating_between, px,
+    rgb,
 };
 
-use crate::ClearOutput;
 use crate::actions::CommandAction;
-use crate::markdown::render_markdown;
-use crate::output::{CommandOutput, OutputKind, OutputSection};
+use crate::output::{CommandOutput, OutputKind};
 use crate::theme::{
-    AURORA_ACCENT_PRIMARY, AURORA_ACCENT_STRONG, AURORA_BORDER_DEFAULT, AURORA_BORDER_STRONG,
-    AURORA_CONTROL_SURFACE, AURORA_FONT_DISPLAY, AURORA_FONT_MONO, AURORA_NAV_BG,
-    AURORA_OUTPUT_MUTED, AURORA_OUTPUT_TEXT, AURORA_TEXT_MUTED, AURORA_TEXT_PRIMARY,
+    AURORA_ACCENT_STRONG, AURORA_BORDER_DEFAULT, AURORA_BORDER_STRONG, AURORA_CONTROL_SURFACE,
+    AURORA_FONT_DISPLAY, AURORA_FONT_MONO, AURORA_HOVER_BG, AURORA_NAV_BG, AURORA_TEXT_MUTED,
+    AURORA_TEXT_PRIMARY,
 };
 use crate::ui::RunningCommand;
+use crate::{ClearOutput, Submit, ToggleActionMenu};
 
 pub(crate) fn render_prompt_row(
     query_is_empty: bool,
     locked_command: Option<CommandAction>,
     prompt: SharedString,
+    input_active: bool,
+    focus_handle: FocusHandle,
+    action_menu_open: bool,
     status_dot: impl IntoElement,
 ) -> impl IntoElement {
     div()
@@ -34,14 +39,30 @@ pub(crate) fn render_prompt_row(
         .px_4()
         .border_b_1()
         .border_color(rgb(AURORA_BORDER_DEFAULT))
+        .cursor_text()
+        .on_mouse_down(MouseButton::Left, move |_: &MouseDownEvent, window, cx| {
+            window.focus(&focus_handle, cx);
+        })
         .child(status_dot)
         .child(
             div()
+                .cursor_pointer()
+                .rounded_sm()
+                .px_1()
+                .py_1()
+                .hover(|el| el.bg(rgb(AURORA_NAV_BG)))
+                .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, window, cx| {
+                    window.dispatch_action(Box::new(ToggleActionMenu), cx);
+                })
                 .font_family(AURORA_FONT_DISPLAY)
                 .font_weight(FontWeight(760.0))
                 .text_size(px(15.0))
-                .text_color(rgb(AURORA_TEXT_PRIMARY))
-                .child("axon"),
+                .text_color(if action_menu_open {
+                    rgb(AURORA_ACCENT_STRONG)
+                } else {
+                    rgb(AURORA_TEXT_PRIMARY)
+                })
+                .child("axon ▾"),
         )
         .when_some(locked_command, |el, action| {
             el.child(
@@ -62,115 +83,58 @@ pub(crate) fn render_prompt_row(
         .child(
             div()
                 .flex_1()
-                .font_weight(FontWeight(480.0))
-                .text_size(px(14.0))
-                .text_color(if query_is_empty {
-                    rgb(AURORA_TEXT_MUTED)
-                } else {
-                    rgb(AURORA_TEXT_PRIMARY)
-                })
-                .child(prompt),
-        )
-}
-
-pub(crate) fn render_output_body(output: CommandOutput) -> impl IntoElement {
-    let empty = output.stdout.is_none() && output.stderr.is_none();
-    let title_accent = output.kind.accent_color();
-    let is_running = output.kind == OutputKind::Running;
-    let show_subtitle = is_running || output.kind == OutputKind::Error;
-    let compact_stdout = output.compact_stdout;
-    div()
-        .flex()
-        .flex_col()
-        .gap_2()
-        .px_4()
-        .py_2()
-        .child(
-            div()
                 .flex()
-                .flex_col()
-                .gap_px()
+                .flex_row()
+                .items_center()
+                .gap_1()
                 .child(
                     div()
-                        .flex()
-                        .flex_row()
-                        .items_center()
-                        .gap_2()
-                        .child(pulsing_dot(
-                            "output-title-dot",
-                            title_accent,
-                            px(7.0),
-                            is_running,
-                        ))
-                        .child(
-                            div()
-                                .font_weight(FontWeight(680.0))
-                                .text_size(px(13.0))
-                                .text_color(rgb(AURORA_TEXT_PRIMARY))
-                                .child(SharedString::from(output.title)),
-                        ),
+                        .font_weight(FontWeight(480.0))
+                        .text_size(px(14.0))
+                        .text_color(if query_is_empty {
+                            rgb(AURORA_TEXT_MUTED)
+                        } else {
+                            rgb(AURORA_TEXT_PRIMARY)
+                        })
+                        .child(prompt),
                 )
-                .when(show_subtitle, |el| {
+                .when(input_active, |el| {
                     el.child(
                         div()
-                            .font_family(AURORA_FONT_MONO)
-                            .font_weight(FontWeight(500.0))
-                            .text_size(px(11.0))
-                            .text_color(rgb(AURORA_OUTPUT_MUTED))
-                            .child(SharedString::from(output.subtitle)),
+                            .id("prompt-caret")
+                            .w(px(1.5))
+                            .h(px(18.0))
+                            .rounded_sm()
+                            .bg(rgb(AURORA_ACCENT_STRONG))
+                            .with_animation(
+                                "prompt-caret-blink",
+                                Animation::new(Duration::from_millis(1000))
+                                    .repeat()
+                                    .with_easing(pulsating_between(0.12, 1.0)),
+                                |el, delta| el.opacity(delta),
+                            ),
                     )
                 }),
         )
-        .when(empty, |el| {
-            el.child(
-                div()
-                    .px_3()
-                    .py_3()
-                    .rounded_sm()
-                    .border_1()
-                    .border_color(rgb(AURORA_BORDER_DEFAULT))
-                    .bg(rgb(AURORA_CONTROL_SURFACE))
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .gap_2()
-                    .when(is_running, |el| {
-                        el.child(pulsing_dot(
-                            "output-body-dot",
-                            AURORA_ACCENT_PRIMARY,
-                            px(6.0),
-                            true,
-                        ))
-                    })
-                    .child(
-                        div()
-                            .font_weight(FontWeight(480.0))
-                            .text_size(px(12.0))
-                            .text_color(rgb(AURORA_TEXT_MUTED))
-                            .child(if is_running {
-                                "Working — waiting for axon to return output."
-                            } else {
-                                "No stdout or stderr was emitted."
-                            }),
-                    ),
-            )
-        })
-        .when_some(output.stdout, |el, section| {
-            el.child(render_output_section(
-                section,
-                OutputKind::Success,
-                output.use_markdown,
-                compact_stdout,
-            ))
-        })
-        .when_some(output.stderr, |el, section| {
-            el.child(render_output_section(
-                section,
-                OutputKind::Error,
-                false,
-                false,
-            ))
-        })
+        .child(
+            div()
+                .cursor_pointer()
+                .rounded_sm()
+                .px_2()
+                .py_1()
+                .border_1()
+                .border_color(rgb(AURORA_BORDER_STRONG))
+                .bg(rgb(AURORA_NAV_BG))
+                .hover(|el| el.bg(rgb(AURORA_HOVER_BG)))
+                .font_family(AURORA_FONT_MONO)
+                .font_weight(FontWeight(700.0))
+                .text_size(px(12.0))
+                .text_color(rgb(AURORA_ACCENT_STRONG))
+                .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, window, cx| {
+                    window.dispatch_action(Box::new(Submit), cx);
+                })
+                .child("send"),
+        )
 }
 
 pub(crate) fn render_palette_footer(
@@ -310,82 +274,6 @@ pub(crate) fn render_palette_footer(
 }
 
 // ── private helpers ───────────────────────────────────────────────────────────
-
-fn render_output_section(
-    section: OutputSection,
-    kind: OutputKind,
-    use_markdown: bool,
-    compact: bool,
-) -> impl IntoElement {
-    let accent = kind.accent_color();
-    let text = section.text.clone();
-    let rendered_lines = section.rendered_lines.clone();
-
-    div()
-        .flex()
-        .flex_col()
-        .rounded_sm()
-        .when(!compact, |el| {
-            el.border_1()
-                .border_color(rgb(AURORA_BORDER_DEFAULT))
-                .bg(rgb(AURORA_CONTROL_SURFACE))
-        })
-        // section header
-        .when(!compact, |el| {
-            el.child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .justify_between()
-                    .px_3()
-                    .py_2()
-                    .border_b_1()
-                    .border_color(rgb(AURORA_BORDER_DEFAULT))
-                    .child(
-                        div()
-                            .font_family(AURORA_FONT_MONO)
-                            .font_weight(FontWeight(650.0))
-                            .text_size(px(11.0))
-                            .text_color(rgb(accent))
-                            .child(section.label),
-                    )
-                    .child(
-                        div()
-                            .font_family(AURORA_FONT_MONO)
-                            .font_weight(FontWeight(480.0))
-                            .text_size(px(11.0))
-                            .text_color(rgb(AURORA_OUTPUT_MUTED))
-                            .child(SharedString::from(format!("{} lines", section.line_count))),
-                    ),
-            )
-        })
-        // section body — markdown or raw monospace
-        .child(
-            div()
-                .px_3()
-                .py_2()
-                .when(use_markdown, |el| el.child(render_markdown(&text)))
-                .when(!use_markdown, |el| {
-                    // `rendered_lines` is pre-computed at section
-                    // construction time; the `SharedString` clones below
-                    // are cheap (Arc bumps), so this renders without
-                    // per-frame `String` allocations.
-                    el.flex()
-                        .flex_col()
-                        .children(rendered_lines.iter().map(|line| {
-                            div()
-                                .w_full()
-                                .font_family(AURORA_FONT_MONO)
-                                .font_weight(FontWeight(480.0))
-                                .text_size(px(12.0))
-                                .line_height(px(20.0))
-                                .text_color(rgb(AURORA_OUTPUT_TEXT))
-                                .child(line.clone())
-                        }))
-                }),
-        )
-}
 
 /// A small circular dot. When `animate` is true the dot pulses its opacity
 /// between 0.35 and 1.0 — the user's "the app is alive and waiting on

--- a/apps/desktop/src/render/output_body.rs
+++ b/apps/desktop/src/render/output_body.rs
@@ -1,0 +1,258 @@
+use gpui::{
+    Div, FontWeight, IntoElement, MouseButton, MouseDownEvent, ParentElement, SharedString, Styled,
+    div, prelude::*, px, rgb,
+};
+
+use super::pulsing_dot;
+use crate::ToggleErrors;
+use crate::markdown::render_markdown;
+use crate::output::{CommandOutput, OutputKind, OutputSection};
+use crate::theme::{
+    AURORA_ACCENT_PRIMARY, AURORA_ACCENT_STRONG, AURORA_BORDER_DEFAULT, AURORA_CONTROL_SURFACE,
+    AURORA_FONT_MONO, AURORA_NAV_BG, AURORA_OUTPUT_MUTED, AURORA_OUTPUT_TEXT, AURORA_TEXT_MUTED,
+    AURORA_TEXT_PRIMARY,
+};
+
+pub(crate) fn render_output_body(output: CommandOutput, errors_open: bool) -> impl IntoElement {
+    let empty = output.stdout.is_none() && output.stderr.is_none();
+    let title_accent = output.kind.accent_color();
+    let is_running = output.kind == OutputKind::Running;
+    let show_subtitle = is_running || output.kind == OutputKind::Error;
+    let compact_stdout = output.compact_stdout;
+    let has_stdout = output.stdout.is_some();
+    let has_stderr = output.stderr.is_some();
+    let show_errors = has_stderr && (!has_stdout || errors_open);
+    let stdout = output.stdout.clone();
+    let stderr = output.stderr.clone();
+
+    div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .px_4()
+        .py_2()
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap_px()
+                .child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_2()
+                        .child(pulsing_dot(
+                            "output-title-dot",
+                            title_accent,
+                            px(7.0),
+                            is_running,
+                        ))
+                        .child(
+                            div()
+                                .font_weight(FontWeight(680.0))
+                                .text_size(px(13.0))
+                                .text_color(rgb(AURORA_TEXT_PRIMARY))
+                                .child(SharedString::from(output.title)),
+                        ),
+                )
+                .when(show_subtitle, |el| {
+                    el.child(
+                        div()
+                            .font_family(AURORA_FONT_MONO)
+                            .font_weight(FontWeight(500.0))
+                            .text_size(px(11.0))
+                            .text_color(rgb(AURORA_OUTPUT_MUTED))
+                            .child(SharedString::from(output.subtitle)),
+                    )
+                }),
+        )
+        .when(has_stdout && has_stderr, |el| {
+            el.child(render_output_tabs(
+                errors_open,
+                stderr.as_ref().map_or(0, |s| s.line_count),
+            ))
+        })
+        .when(empty, |el| {
+            el.child(
+                div()
+                    .px_3()
+                    .py_3()
+                    .rounded_sm()
+                    .border_1()
+                    .border_color(rgb(AURORA_BORDER_DEFAULT))
+                    .bg(rgb(AURORA_CONTROL_SURFACE))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_2()
+                    .when(is_running, |el| {
+                        el.child(pulsing_dot(
+                            "output-body-dot",
+                            AURORA_ACCENT_PRIMARY,
+                            px(6.0),
+                            true,
+                        ))
+                    })
+                    .child(
+                        div()
+                            .font_weight(FontWeight(480.0))
+                            .text_size(px(12.0))
+                            .text_color(rgb(AURORA_TEXT_MUTED))
+                            .child(if is_running {
+                                "Working - waiting for axon to return output."
+                            } else {
+                                "No stdout or stderr was emitted."
+                            }),
+                    ),
+            )
+        })
+        .when_some(stdout.filter(|_| !show_errors), |el, section| {
+            el.child(render_output_section(
+                section,
+                OutputKind::Success,
+                output.use_markdown,
+                compact_stdout,
+            ))
+        })
+        .when_some(stderr.filter(|_| show_errors), |el, section| {
+            el.child(render_output_section(
+                section,
+                OutputKind::Error,
+                false,
+                false,
+            ))
+        })
+}
+
+fn render_output_section(
+    section: OutputSection,
+    kind: OutputKind,
+    use_markdown: bool,
+    compact: bool,
+) -> impl IntoElement {
+    let accent = kind.accent_color();
+    let text = section.text.clone();
+    let rendered_lines = section.rendered_lines.clone();
+
+    div()
+        .flex()
+        .flex_col()
+        .rounded_sm()
+        .when(!compact, |el| {
+            el.border_1()
+                .border_color(rgb(AURORA_BORDER_DEFAULT))
+                .bg(rgb(AURORA_CONTROL_SURFACE))
+        })
+        .when(!compact, |el| {
+            el.child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .justify_between()
+                    .px_3()
+                    .py_2()
+                    .border_b_1()
+                    .border_color(rgb(AURORA_BORDER_DEFAULT))
+                    .child(
+                        div()
+                            .font_family(AURORA_FONT_MONO)
+                            .font_weight(FontWeight(650.0))
+                            .text_size(px(11.0))
+                            .text_color(rgb(accent))
+                            .child(section.label),
+                    )
+                    .child(
+                        div()
+                            .font_family(AURORA_FONT_MONO)
+                            .font_weight(FontWeight(480.0))
+                            .text_size(px(11.0))
+                            .text_color(rgb(AURORA_OUTPUT_MUTED))
+                            .child(SharedString::from(format!("{} lines", section.line_count))),
+                    ),
+            )
+        })
+        .child(
+            div()
+                .px_3()
+                .py_2()
+                .when(use_markdown, |el| el.child(render_markdown(&text)))
+                .when(!use_markdown, |el| {
+                    el.flex()
+                        .flex_col()
+                        .children(rendered_lines.iter().map(|line| {
+                            div()
+                                .w_full()
+                                .font_family(AURORA_FONT_MONO)
+                                .font_weight(FontWeight(480.0))
+                                .text_size(px(12.0))
+                                .line_height(px(20.0))
+                                .text_color(rgb(AURORA_OUTPUT_TEXT))
+                                .child(line.clone())
+                        }))
+                }),
+        )
+}
+
+fn render_output_tabs(errors_open: bool, error_lines: usize) -> impl IntoElement {
+    div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap_2()
+        .px_3()
+        .py_1()
+        .rounded_sm()
+        .bg(rgb(AURORA_CONTROL_SURFACE))
+        .child(
+            render_output_tab("stdout", !errors_open, None).on_mouse_down(
+                MouseButton::Left,
+                move |_: &MouseDownEvent, window, cx| {
+                    if errors_open {
+                        window.dispatch_action(Box::new(ToggleErrors), cx);
+                    }
+                },
+            ),
+        )
+        .child(
+            render_output_tab("errors", errors_open, Some(error_lines)).on_mouse_down(
+                MouseButton::Left,
+                |_: &MouseDownEvent, window, cx| {
+                    window.dispatch_action(Box::new(ToggleErrors), cx);
+                },
+            ),
+        )
+}
+
+fn render_output_tab(label: &'static str, active: bool, count: Option<usize>) -> Div {
+    let text = count
+        .map(|count| format!("{label} {count}"))
+        .unwrap_or_else(|| label.to_string());
+
+    div()
+        .px_2()
+        .py_1()
+        .rounded_sm()
+        .cursor_pointer()
+        .border_1()
+        .border_color(rgb(if active {
+            AURORA_ACCENT_PRIMARY
+        } else {
+            AURORA_BORDER_DEFAULT
+        }))
+        .bg(rgb(if active {
+            AURORA_NAV_BG
+        } else {
+            AURORA_CONTROL_SURFACE
+        }))
+        .font_family(AURORA_FONT_MONO)
+        .font_weight(FontWeight(650.0))
+        .text_size(px(11.0))
+        .text_color(rgb(if active {
+            AURORA_ACCENT_STRONG
+        } else {
+            AURORA_TEXT_MUTED
+        }))
+        .child(SharedString::from(text))
+}

--- a/apps/desktop/src/theme.rs
+++ b/apps/desktop/src/theme.rs
@@ -73,7 +73,6 @@ pub(crate) const AURORA: AuroraTokens = AuroraTokens {
 pub(crate) const AURORA_PAGE_BG: u32 = AURORA.page_bg;
 pub(crate) const AURORA_NAV_BG: u32 = AURORA.nav_bg;
 pub(crate) const AURORA_PANEL_STRONG: u32 = AURORA.panel_strong;
-pub(crate) const AURORA_PANEL_MEDIUM: u32 = AURORA.panel_medium;
 pub(crate) const AURORA_CONTROL_SURFACE: u32 = AURORA.control_surface;
 pub(crate) const AURORA_HOVER_BG: u32 = AURORA.hover_bg;
 pub(crate) const AURORA_ROW_HOVER_BG: u32 = AURORA.row_hover_bg;
@@ -87,9 +86,6 @@ pub(crate) const AURORA_ACCENT_STRONG: u32 = AURORA.accent_strong;
 pub(crate) const AURORA_ACCENT_PINK: u32 = AURORA.accent_pink;
 pub(crate) const AURORA_OUTPUT_TEXT: u32 = AURORA.output_text;
 pub(crate) const AURORA_OUTPUT_MUTED: u32 = AURORA.output_muted;
-pub(crate) const AURORA_SUCCESS: u32 = AURORA.success;
-pub(crate) const AURORA_WARN: u32 = AURORA.warn;
-pub(crate) const AURORA_ERROR: u32 = AURORA.error;
 pub(crate) const AURORA_WARNING: u32 = AURORA.warn;
 
 pub(crate) const AURORA_FONT_DISPLAY: &str = AURORA.font_display;

--- a/apps/desktop/src/ui.rs
+++ b/apps/desktop/src/ui.rs
@@ -1,4 +1,4 @@
-use std::process::{Command, Output};
+use std::process::Command;
 use std::time::{Duration, Instant};
 
 /// Spawn `axon` without flashing a console window on Windows. On Unix this
@@ -19,19 +19,16 @@ fn axon_command() -> Command {
     cmd
 }
 
-use gpui::{
-    App, Context, FocusHandle, Focusable, ScrollHandle, SharedString, Size, Window, prelude::*, px,
-};
+use gpui::{App, Context, FocusHandle, Focusable, ScrollHandle, SharedString, Size, Window, px};
 
 use crate::actions::{
-    ACTIONS, ArgMode, CommandAction, action_invoked_by, action_matches, build_axon_args,
-    display_command_line, looks_like_url,
+    ACTIONS, ArgMode, CommandAction, action_invoked_by, action_matches, looks_like_url,
 };
-use crate::conversation::{AskConversation, inject_follow_up, restore_from_latest};
+use crate::conversation::{AskConversation, restore_from_latest};
 use crate::layout::{HeightSnapshot, MIN_WINDOW_HEIGHT};
-use crate::output::{CommandOutput, OutputKind};
+use crate::output::CommandOutput;
 use crate::theme::AURORA_BORDER_STRONG;
-use crate::{ClearOutput, MoveDown, MoveUp, Submit, TabComplete};
+use crate::{ClearOutput, MoveDown, MoveUp, TabComplete, ToggleActionMenu, ToggleErrors};
 
 #[cfg(test)]
 #[path = "ui_tests.rs"]
@@ -42,6 +39,9 @@ mod tests;
 // to `Palette`'s private fields. See the project monolith policy.
 #[path = "ui_render.rs"]
 mod ui_render;
+
+#[path = "ui_commands.rs"]
+mod ui_commands;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ConnectionState {
@@ -70,6 +70,8 @@ pub(crate) struct Palette {
     next_run_id: u64,
     output_scroll: ScrollHandle,
     locked_command: Option<CommandAction>,
+    action_menu_open: bool,
+    errors_open: bool,
     connection: ConnectionState,
     /// Monotonic id for in-flight health checks. Each spawn increments this;
     /// completions only apply when their captured id still matches the latest,
@@ -121,17 +123,6 @@ pub(crate) fn format_elapsed(elapsed: Duration) -> String {
     format!("{mins}m {rem:02}s")
 }
 
-struct CommandResult {
-    id: u64,
-    subcommand: &'static str,
-    command_line: String,
-    result: Result<Output, String>,
-}
-
-struct HealthResult {
-    ok: bool,
-}
-
 impl Palette {
     pub(crate) fn new(cx: &mut Context<Self>) -> Self {
         // Restore any live `axon ask` conversation from the CLI's session
@@ -149,6 +140,8 @@ impl Palette {
             next_run_id: 1,
             output_scroll: ScrollHandle::new(),
             locked_command: None,
+            action_menu_open: false,
+            errors_open: false,
             connection: ConnectionState::Unknown,
             health_check_id: 0,
             current_window_height: None,
@@ -158,74 +151,10 @@ impl Palette {
         palette
     }
 
-    fn spawn_health_check(&mut self, cx: &mut Context<Self>) {
-        self.health_check_id = self.health_check_id.wrapping_add(1);
-        let my_id = self.health_check_id;
-        self.connection = ConnectionState::Checking;
-        cx.notify();
-
-        let task = cx.background_spawn(async move {
-            let ok = axon_command()
-                .args(["doctor", "--json"])
-                .output()
-                .map(|o| {
-                    let stdout = String::from_utf8_lossy(&o.stdout);
-                    // Check for "all_ok":true with or without a space after the colon.
-                    stdout.contains(r#""all_ok":true"#) || stdout.contains(r#""all_ok": true"#)
-                })
-                .unwrap_or(false);
-            HealthResult { ok }
-        });
-
-        cx.spawn(async move |this, cx| {
-            let result = task.await;
-            let _ = this.update(cx, |this, cx| {
-                // Ignore stale completions — a newer probe has been spawned and
-                // its result is authoritative.
-                if this.health_check_id != my_id {
-                    return;
-                }
-                this.connection = if result.ok {
-                    ConnectionState::Connected
-                } else {
-                    ConnectionState::Disconnected
-                };
-                cx.notify();
-            });
-        })
-        .detach();
-    }
-
-    /// Force a re-render every ~250ms while `run_id` is the active running
-    /// command. The pulsing-dot animation already re-paints on its own (GPUI
-    /// drives that via `request_animation_frame`), but the elapsed-time label
-    /// is computed inside `render()` and only refreshes on `cx.notify()`.
-    fn spawn_running_tick(&self, run_id: u64, cx: &mut Context<Self>) {
-        let executor = cx.background_executor().clone();
-        cx.spawn(async move |this, cx| {
-            loop {
-                executor.timer(Duration::from_millis(250)).await;
-                let still_running = this
-                    .update(cx, |this, cx| {
-                        let active = this
-                            .running
-                            .as_ref()
-                            .is_some_and(|running| running.id == run_id);
-                        if active {
-                            cx.notify();
-                        }
-                        active
-                    })
-                    .unwrap_or(false);
-                if !still_running {
-                    break;
-                }
-            }
-        })
-        .detach();
-    }
-
     fn matches(&self) -> Vec<CommandAction> {
+        if self.action_menu_open {
+            return ACTIONS.to_vec();
+        }
         if self.locked_command.is_some() {
             return vec![];
         }
@@ -249,156 +178,50 @@ impl Palette {
 
     fn clear_output(&mut self, _: &ClearOutput, _window: &mut Window, cx: &mut Context<Self>) {
         self.command_output = None;
+        self.errors_open = false;
+        cx.notify();
+    }
+
+    fn toggle_errors(&mut self, _: &ToggleErrors, _window: &mut Window, cx: &mut Context<Self>) {
+        self.errors_open = !self.errors_open;
+        cx.notify();
+    }
+
+    fn toggle_action_menu(
+        &mut self,
+        _: &ToggleActionMenu,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.action_menu_open = !self.action_menu_open;
+        self.selected = self.selected_for_locked_action();
         cx.notify();
     }
 
     fn tab_complete(&mut self, _: &TabComplete, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.query.trim().is_empty() {
+            self.action_menu_open = true;
+            self.selected = self.selected_for_locked_action();
+            cx.notify();
+            return;
+        }
         if self.locked_command.is_some() {
             return;
         }
         let actions = self.matches();
         if let Some(action) = actions.get(self.selected).copied() {
-            self.locked_command = Some(action);
-            // Strip the command token from the query if the user typed it exactly
-            // OR if the head matches a fuzzy prefix the palette used to surface
-            // this action — otherwise a fragment like "scra" would stay in
-            // self.query and leak into argv when the locked command is submitted.
-            let input = self.query.trim();
-            let mut parts = input.splitn(2, char::is_whitespace);
-            let head = parts.next().unwrap_or("");
-            let tail = parts.next().map(str::trim).unwrap_or("");
-            if action_invoked_by(action, head) || action_matches(action, head) {
-                self.query = tail.to_string();
-            }
-            self.selected = 0;
-            cx.notify();
+            self.select_action_mode(action, true, cx);
         }
-    }
-
-    fn submit(&mut self, _: &Submit, _window: &mut Window, cx: &mut Context<Self>) {
-        let (action, arg) = if let Some(locked) = self.locked_command {
-            (locked, self.query.trim().to_string())
-        } else {
-            let actions = self.matches();
-            let Some(action) = actions.get(self.selected).copied() else {
-                return;
-            };
-            (action, self.argument_for(action).to_string())
-        };
-
-        // Palette-internal sentinel: "Reset ask conversation" never shells
-        // out. Handle inline and return — but only when no command is
-        // currently running, otherwise an in-flight `ask` that finishes
-        // after the reset would recreate the conversation we just cleared.
-        if action.subcommand == "ask-reset" {
-            if self.running.is_some() {
-                self.command_output = Some(CommandOutput::notice(
-                    OutputKind::Warning,
-                    "Command already running",
-                    "Wait for the current axon command to finish.",
-                ));
-                cx.notify();
-                return;
-            }
-            self.handle_reset_conversation(cx);
-            return;
-        }
-
-        // Idle-timeout sweep: drop stale conversation before any submit runs.
-        // Checked on submit (not render) so we avoid continuous redraws. Runs on
-        // every submit — not gated to `ask` — so a non-ask command after a long
-        // idle still clears the stale conversation state.
-        if self
-            .ask_conversation
-            .is_some_and(|c| c.is_stale(Instant::now()))
-        {
-            self.ask_conversation = None;
-        }
-
-        if action.arg_mode != ArgMode::None && arg.is_empty() {
-            self.command_output = Some(CommandOutput::notice(
-                OutputKind::Warning,
-                "Argument required",
-                action.example,
-            ));
-            cx.notify();
-            return;
-        }
-
-        if self.running.is_some() {
-            self.command_output = Some(CommandOutput::notice(
-                OutputKind::Warning,
-                "Command already running",
-                "Wait for the current axon command to finish.",
-            ));
-            cx.notify();
-            return;
-        }
-
-        let mut args = match build_axon_args(action, &arg) {
-            Ok(args) => args,
-            Err(error) => {
-                self.command_output = Some(CommandOutput::notice(
-                    OutputKind::Error,
-                    "Invalid input",
-                    error,
-                ));
-                cx.notify();
-                return;
-            }
-        };
-        // For `axon ask`, auto-prepend `--follow-up` when a live conversation
-        // exists so the CLI threads this turn onto the same session.
-        inject_follow_up(action.subcommand, &mut args, self.ask_conversation.as_ref());
-        let command_line = display_command_line(&args);
-        let run_id = self.next_run_id;
-        self.next_run_id += 1;
-        self.running = Some(RunningCommand {
-            id: run_id,
-            subcommand: action.subcommand,
-            label: action.label,
-            started_at: Instant::now(),
-        });
-        self.command_output = Some(CommandOutput::running(&command_line, action));
-        self.spawn_running_tick(run_id, cx);
-
-        let task = cx.background_spawn(async move {
-            let mut cmd = axon_command();
-            cmd.args(&args);
-            let result = cmd.output().map_err(|error| error.to_string());
-            CommandResult {
-                id: run_id,
-                subcommand: action.subcommand,
-                command_line,
-                result,
-            }
-        });
-        cx.spawn(async move |this, cx| {
-            let result = task.await;
-            let _ = this.update(cx, |this, cx| {
-                if this
-                    .running
-                    .as_ref()
-                    .map(|running| running.id)
-                    .is_some_and(|running_id| running_id == result.id)
-                {
-                    this.running = None;
-                }
-
-                this.command_output = Some(this.finalize_result(result));
-                cx.notify();
-            });
-        })
-        .detach();
-
-        self.locked_command = None;
-        self.query.clear();
-        self.selected = 0;
-        cx.notify();
     }
 
     fn move_down(&mut self, _: &MoveDown, _w: &mut Window, cx: &mut Context<Self>) {
         let n = self.matches().len();
+        if n == 0 && self.query.trim().is_empty() {
+            self.action_menu_open = true;
+            self.selected = self.selected_for_locked_action();
+            cx.notify();
+            return;
+        }
         if n > 0 {
             self.selected = (self.selected + 1) % n;
             cx.notify();
@@ -428,7 +251,9 @@ impl Palette {
                 }
             }
             "escape" => {
-                if self.locked_command.is_some() {
+                if self.action_menu_open {
+                    self.action_menu_open = false;
+                } else if self.locked_command.is_some() {
                     // Unlock but preserve typed argument so user can reselect a command.
                     self.locked_command = None;
                 } else if self.command_output.is_some() {
@@ -443,6 +268,7 @@ impl Palette {
                 let m = &ev.keystroke.modifiers;
                 if !m.control && !m.alt && !m.platform && !m.function {
                     if let Some(ch) = ev.keystroke.key_char.as_deref() {
+                        self.action_menu_open = false;
                         self.query.push_str(ch);
                     }
                 }
@@ -498,42 +324,6 @@ impl Palette {
         }
     }
 
-    /// Handle the palette-internal "Reset ask conversation" action — clear
-    /// the live conversation and surface a transient notice.
-    fn handle_reset_conversation(&mut self, cx: &mut Context<Self>) {
-        self.ask_conversation = None;
-        self.command_output = Some(CommandOutput::notice(
-            OutputKind::Success,
-            "Conversation reset",
-            "Next ask will start a fresh session.",
-        ));
-        self.locked_command = None;
-        self.query.clear();
-        self.selected = 0;
-        cx.notify();
-    }
-
-    /// Map a completed background command into a `CommandOutput` and update
-    /// conversation state on success.
-    fn finalize_result(&mut self, result: CommandResult) -> CommandOutput {
-        match result.result {
-            Ok(output) => {
-                // Conversation lifecycle: only successful `axon ask` turns
-                // count. A failed ask leaves the previous conversation
-                // untouched so a transient CLI error doesn't reset the chain.
-                if result.subcommand == "ask" && output.status.success() {
-                    let now = Instant::now();
-                    match self.ask_conversation.as_mut() {
-                        Some(c) => c.bump(now),
-                        None => self.ask_conversation = Some(AskConversation::new(now)),
-                    }
-                }
-                CommandOutput::from_process(&result.command_line, result.subcommand, output)
-            }
-            Err(error) => CommandOutput::spawn_error(&result.command_line, error),
-        }
-    }
-
     /// Compact footer-status string describing the live ask conversation,
     /// or `None` when no conversation is active. Rendered in the footer so
     /// the user sees at a glance that follow-up mode is engaged.
@@ -561,6 +351,41 @@ impl Palette {
         } else {
             input
         }
+    }
+
+    fn select_action_mode(
+        &mut self,
+        action: CommandAction,
+        strip_query_command: bool,
+        cx: &mut Context<Self>,
+    ) {
+        self.locked_command = Some(action);
+        self.action_menu_open = false;
+        if strip_query_command {
+            // Strip the command token from the query if the user typed it exactly
+            // OR if the head matches a fuzzy prefix the palette used to surface
+            // this action — otherwise a fragment like "scra" would stay in
+            // self.query and leak into argv when the locked command is submitted.
+            let input = self.query.trim();
+            let mut parts = input.splitn(2, char::is_whitespace);
+            let head = parts.next().unwrap_or("");
+            let tail = parts.next().map(str::trim).unwrap_or("");
+            if action_invoked_by(action, head) || action_matches(action, head) {
+                self.query = tail.to_string();
+            }
+        }
+        self.selected = 0;
+        cx.notify();
+    }
+
+    fn selected_for_locked_action(&self) -> usize {
+        self.locked_command
+            .and_then(|locked| {
+                ACTIONS
+                    .iter()
+                    .position(|action| action.subcommand == locked.subcommand)
+            })
+            .unwrap_or(0)
     }
 }
 

--- a/apps/desktop/src/ui_commands.rs
+++ b/apps/desktop/src/ui_commands.rs
@@ -1,0 +1,233 @@
+use std::process::Output;
+use std::time::{Duration, Instant};
+
+use gpui::{Context, Window, prelude::*};
+
+use super::{ConnectionState, Palette, RunningCommand, axon_command};
+use crate::Submit;
+use crate::actions::{ArgMode, build_axon_args, display_command_line};
+use crate::conversation::{AskConversation, inject_follow_up};
+use crate::output::{CommandOutput, OutputKind};
+
+struct CommandResult {
+    id: u64,
+    subcommand: &'static str,
+    command_line: String,
+    result: Result<Output, String>,
+}
+
+struct HealthResult {
+    ok: bool,
+}
+
+impl Palette {
+    pub(super) fn spawn_health_check(&mut self, cx: &mut Context<Self>) {
+        self.health_check_id = self.health_check_id.wrapping_add(1);
+        let my_id = self.health_check_id;
+        self.connection = ConnectionState::Checking;
+        cx.notify();
+
+        let task = cx.background_spawn(async move {
+            let ok = axon_command()
+                .args(["doctor", "--json"])
+                .output()
+                .map(|o| {
+                    let stdout = String::from_utf8_lossy(&o.stdout);
+                    stdout.contains(r#""all_ok":true"#) || stdout.contains(r#""all_ok": true"#)
+                })
+                .unwrap_or(false);
+            HealthResult { ok }
+        });
+
+        cx.spawn(async move |this, cx| {
+            let result = task.await;
+            let _ = this.update(cx, |this, cx| {
+                if this.health_check_id != my_id {
+                    return;
+                }
+                this.connection = if result.ok {
+                    ConnectionState::Connected
+                } else {
+                    ConnectionState::Disconnected
+                };
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    pub(super) fn submit(&mut self, _: &Submit, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.action_menu_open {
+            let actions = self.matches();
+            if let Some(action) = actions.get(self.selected).copied() {
+                self.select_action_mode(action, false, cx);
+            }
+            return;
+        }
+
+        let (action, arg) = if let Some(locked) = self.locked_command {
+            (locked, self.query.trim().to_string())
+        } else {
+            let actions = self.matches();
+            let Some(action) = actions.get(self.selected).copied() else {
+                return;
+            };
+            (action, self.argument_for(action).to_string())
+        };
+
+        if action.subcommand == "ask-reset" {
+            if self.running.is_some() {
+                self.command_output = Some(CommandOutput::notice(
+                    OutputKind::Warning,
+                    "Command already running",
+                    "Wait for the current axon command to finish.",
+                ));
+                cx.notify();
+                return;
+            }
+            self.handle_reset_conversation(cx);
+            return;
+        }
+
+        if self
+            .ask_conversation
+            .is_some_and(|c| c.is_stale(Instant::now()))
+        {
+            self.ask_conversation = None;
+        }
+
+        if action.arg_mode != ArgMode::None && arg.is_empty() {
+            self.command_output = Some(CommandOutput::notice(
+                OutputKind::Warning,
+                "Argument required",
+                action.example,
+            ));
+            cx.notify();
+            return;
+        }
+
+        if self.running.is_some() {
+            self.command_output = Some(CommandOutput::notice(
+                OutputKind::Warning,
+                "Command already running",
+                "Wait for the current axon command to finish.",
+            ));
+            cx.notify();
+            return;
+        }
+
+        let mut args = match build_axon_args(action, &arg) {
+            Ok(args) => args,
+            Err(error) => {
+                self.command_output = Some(CommandOutput::notice(
+                    OutputKind::Error,
+                    "Invalid input",
+                    error,
+                ));
+                cx.notify();
+                return;
+            }
+        };
+        inject_follow_up(action.subcommand, &mut args, self.ask_conversation.as_ref());
+        let command_line = display_command_line(&args);
+        let run_id = self.next_run_id;
+        self.next_run_id += 1;
+        self.running = Some(RunningCommand {
+            id: run_id,
+            subcommand: action.subcommand,
+            label: action.label,
+            started_at: Instant::now(),
+        });
+        self.command_output = Some(CommandOutput::running(&command_line, action));
+        self.errors_open = false;
+        self.spawn_running_tick(run_id, cx);
+
+        let task = cx.background_spawn(async move {
+            let mut cmd = axon_command();
+            cmd.args(&args);
+            let result = cmd.output().map_err(|error| error.to_string());
+            CommandResult {
+                id: run_id,
+                subcommand: action.subcommand,
+                command_line,
+                result,
+            }
+        });
+        cx.spawn(async move |this, cx| {
+            let result = task.await;
+            let _ = this.update(cx, |this, cx| {
+                if this
+                    .running
+                    .as_ref()
+                    .map(|running| running.id)
+                    .is_some_and(|running_id| running_id == result.id)
+                {
+                    this.running = None;
+                }
+
+                let output = this.finalize_result(result);
+                this.errors_open = output.stdout.is_none() && output.stderr.is_some();
+                this.command_output = Some(output);
+                cx.notify();
+            });
+        })
+        .detach();
+
+        self.query.clear();
+        self.selected = 0;
+        cx.notify();
+    }
+
+    fn spawn_running_tick(&self, run_id: u64, cx: &mut Context<Self>) {
+        let executor = cx.background_executor().clone();
+        cx.spawn(async move |this, cx| {
+            loop {
+                executor.timer(Duration::from_millis(250)).await;
+                let still_running = this
+                    .update(cx, |this, cx| {
+                        let active = this
+                            .running
+                            .as_ref()
+                            .is_some_and(|running| running.id == run_id);
+                        if active {
+                            cx.notify();
+                        }
+                        active
+                    })
+                    .unwrap_or(false);
+                if !still_running {
+                    break;
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn handle_reset_conversation(&mut self, cx: &mut Context<Self>) {
+        self.ask_conversation = None;
+        self.command_output = Some(CommandOutput::notice(
+            OutputKind::Success,
+            "Conversation reset",
+            "Next ask will start a fresh session.",
+        ));
+        self.query.clear();
+        self.selected = 0;
+        cx.notify();
+    }
+
+    fn finalize_result(&mut self, result: CommandResult) -> CommandOutput {
+        match result.result {
+            Ok(output) => {
+                if result.subcommand == "ask" && output.status.success() {
+                    let now = Instant::now();
+                    match self.ask_conversation.as_mut() {
+                        Some(c) => c.bump(now),
+                        None => self.ask_conversation = Some(AskConversation::new(now)),
+                    }
+                }
+                CommandOutput::from_process(&result.command_line, result.subcommand, output)
+            }
+            Err(error) => CommandOutput::spawn_error(&result.command_line, error),
+        }
+    }
+}

--- a/apps/desktop/src/ui_render.rs
+++ b/apps/desktop/src/ui_render.rs
@@ -4,11 +4,12 @@
 
 use gpui::{
     AnyElement, Context, IntoElement, MouseButton, MouseDownEvent, ParentElement, Render,
-    SharedString, Styled, Window, div, prelude::*, px, rgb,
+    ScrollHandle, SharedString, Styled, Window, div, prelude::*, px, rgb,
 };
 
 use super::Palette;
 use crate::layout::compute_desired_height;
+use crate::output::CommandOutput;
 use crate::render::{
     render_action_rows_interactive, render_output_body, render_palette_footer, render_prompt_row,
 };
@@ -25,7 +26,8 @@ impl Render for Palette {
         let running_subcommand = self.running.as_ref().map(|running| running.subcommand);
         let command_output = self.command_output.clone();
         let locked = self.locked_command;
-        let hide_list = self.query.is_empty() || locked.is_some();
+        let action_menu_open = self.action_menu_open;
+        let hide_list = !action_menu_open && (self.query.is_empty() || locked.is_some());
 
         // Drive the content-driven window resize. This runs every render
         // pass but `sync_window_height` is idempotent — it only calls
@@ -60,6 +62,8 @@ impl Render for Palette {
             .on_action(cx.listener(Palette::move_up))
             .on_action(cx.listener(Palette::tab_complete))
             .on_action(cx.listener(Palette::clear_output))
+            .on_action(cx.listener(Palette::toggle_action_menu))
+            .on_action(cx.listener(Palette::toggle_errors))
             .on_key_down(cx.listener(Palette::on_key))
             .flex()
             .flex_col()
@@ -86,6 +90,9 @@ impl Render for Palette {
                         query_is_empty,
                         locked,
                         prompt,
+                        self.focus.is_focused(window),
+                        self.focus.clone(),
+                        action_menu_open,
                         status_dot,
                     ))
                     .child(render_action_rows_interactive(
@@ -96,7 +103,13 @@ impl Render for Palette {
                         |i| {
                             cx.listener(move |this, _: &MouseDownEvent, window, cx| {
                                 this.selected = i;
-                                this.submit(&crate::Submit, window, cx);
+                                if this.action_menu_open {
+                                    if let Some(action) = this.matches().get(i).copied() {
+                                        this.select_action_mode(action, false, cx);
+                                    }
+                                } else {
+                                    this.submit(&crate::Submit, window, cx);
+                                }
                             })
                         },
                         |i| {
@@ -116,25 +129,16 @@ impl Render for Palette {
                             self.conversation_hint(),
                         ))
                     })
-                    .when_some(command_output.clone(), |el, output| {
-                        if output.has_body() {
-                            el.child(
-                                div()
-                                    .id("palette-output")
-                                    .max_h(px(320.0))
-                                    .overflow_scroll()
-                                    .scrollbar_width(px(12.0))
-                                    .track_scroll(&self.output_scroll)
-                                    .block_mouse_except_scroll()
-                                    .border_t_1()
-                                    .border_color(rgb(AURORA_BORDER_DEFAULT))
-                                    .bg(rgb(AURORA_NAV_BG))
-                                    .child(render_output_body(output)),
-                            )
-                        } else {
-                            el
-                        }
-                    }),
+                    .when_some(
+                        command_output.clone().filter(|o| o.has_body()),
+                        |el, output| {
+                            el.child(render_output_panel(
+                                output,
+                                self.errors_open,
+                                &self.output_scroll,
+                            ))
+                        },
+                    ),
             )
     }
 }
@@ -156,4 +160,22 @@ fn render_status_dot(connection: super::ConnectionState, cx: &mut Context<Palett
             }),
         )
         .into_any_element()
+}
+
+fn render_output_panel(
+    output: CommandOutput,
+    errors_open: bool,
+    output_scroll: &ScrollHandle,
+) -> impl IntoElement {
+    div()
+        .id("palette-output")
+        .max_h(px(320.0))
+        .overflow_scroll()
+        .scrollbar_width(px(12.0))
+        .track_scroll(output_scroll)
+        .block_mouse_except_scroll()
+        .border_t_1()
+        .border_color(rgb(AURORA_BORDER_DEFAULT))
+        .bg(rgb(AURORA_NAV_BG))
+        .child(render_output_body(output, errors_open))
 }

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -9,6 +9,8 @@ use crate::services::types::SearchOptions as ServiceSearchOptions;
 use serde_json::Value;
 use std::error::Error;
 
+const HUMAN_SNIPPET_LIMIT: usize = 240;
+
 pub async fn run_search(
     cfg: &Config,
     service_context: &ServiceContext,
@@ -110,10 +112,22 @@ fn print_search_results(query: &str, results: &[Value]) {
         println!("{}. {}", position, primary(title));
         println!("   {}", muted(url));
         if let Some(s) = result["snippet"].as_str() {
-            println!("   {s}");
+            println!("   {}", summarize_snippet(s));
         }
         println!();
     }
+}
+
+fn summarize_snippet(snippet: &str) -> String {
+    let compact = snippet.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.len() <= HUMAN_SNIPPET_LIMIT {
+        return compact;
+    }
+
+    let boundary = compact.floor_char_boundary(HUMAN_SNIPPET_LIMIT);
+    let mut truncated = compact[..boundary].trim_end().to_string();
+    truncated.push_str("...");
+    truncated
 }
 
 #[cfg(test)]

--- a/src/cli/commands/search_tests.rs
+++ b/src/cli/commands/search_tests.rs
@@ -59,3 +59,19 @@ async fn run_search_rejects_empty_tavily_key() {
         "expected TAVILY_API_KEY error, got: {err}"
     );
 }
+
+#[test]
+fn summarize_snippet_collapses_whitespace_and_truncates() {
+    let snippet = format!("first\n\nsecond\t{}", "word ".repeat(80));
+    let got = summarize_snippet(&snippet);
+
+    assert!(!got.contains('\n'));
+    assert!(!got.contains('\t'));
+    assert!(got.len() <= HUMAN_SNIPPET_LIMIT + 3);
+    assert!(got.ends_with("..."));
+}
+
+#[test]
+fn summarize_snippet_keeps_short_text() {
+    assert_eq!(summarize_snippet("short\nsnippet"), "short snippet");
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preps the desktop palette for release with a cleaner UX (action menu, stdout/error tabs, clearer errors), restored ask conversations across restarts, and a reliable global hotkey. CI now runs `apps/desktop` tests and builds portable Windows binaries; new docs cover build/run, hotkeys, and smoke tests.

- **New Features**
  - Action menu: open via Ctrl+K or click “axon ▾”; Tab on empty query opens it; Esc closes it.
  - Output panel: stdout/errors tabs with Ctrl+E; defaults to errors when stdout is empty; errors show only actionable lines.
  - Prompt QoL: click-to-focus, blinking caret, and a clickable “send” button.
  - Ask conversations: restore across palette restarts when the latest CLI session is still fresh; only timestamps are read.
  - CLI search: human-readable snippets are collapsed and truncated to 240 chars with ellipsis.
  - Internal refactor: extracted `render/output_body.rs` and `ui_commands.rs`; removed dead code.

- **CI and Docs**
  - CI runs `cargo test --locked --manifest-path apps/desktop/Cargo.toml` on Linux and Windows before building.
  - Windows builds use portable `RUSTFLAGS` (target `x86-64`, AVX-512 disabled) in desktop and release workflows.
  - Added `apps/desktop/README.md` with platforms, build/test/run, hotkey, smoke test, and link handling notes.
  - CHANGELOG updated to reflect CI and docs changes.

<sup>Written for commit 7a57017523211156fbe0c9df9d30a1c729437ed3. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/111?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

