### PR TITLE
feat: GitLab code chunking + Reddit extra fields

### DIFF
--- a/src/extract/verticals/reddit.rs
+++ b/src/extract/verticals/reddit.rs
@@ -139,6 +139,30 @@ async fn wait_for_rate_slot() {
     state.last_request_at = Some(Instant::now());
 }
 
+// ── Extra payload ─────────────────────────────────────────────────────────────
+
+/// Build the flat `reddit_*` extra payload for embedding.
+///
+/// Mirrors `build_reddit_post_extra_payload` in `src/ingest/reddit/meta.rs`.
+/// `post_data` is the `post["data"]` object from the Reddit API JSON response.
+fn build_extra(post_data: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "reddit_author": post_data["author"].as_str().unwrap_or("[deleted]"),
+        // Reddit API returns `created_utc` as a float (e.g. 1710000000.0).
+        // `as_u64()` returns `None` for JSON floats, so parse as f64 then cast.
+        "reddit_created_utc": post_data["created_utc"].as_f64().map(|f| f as u64).unwrap_or(0),
+        "reddit_score": post_data["score"].as_i64().unwrap_or(0),
+        "reddit_num_comments": post_data["num_comments"].as_u64().unwrap_or(0),
+        "reddit_upvote_ratio": post_data["upvote_ratio"].as_f64().unwrap_or(0.0),
+        "reddit_subreddit": post_data["subreddit"].as_str().unwrap_or(""),
+        "reddit_domain": post_data["domain"].as_str().unwrap_or(""),
+        "reddit_is_video": post_data["is_video"].as_bool().unwrap_or(false),
+        "reddit_distinguished": post_data["distinguished"].as_str(),
+        "reddit_gilded": post_data["gilded"].as_u64().unwrap_or(0),
+        "reddit_flair": post_data["link_flair_text"].as_str(),
+    })
+}
+
 // ── URL matching ─────────────────────────────────────────────────────────────
 
 pub fn matches(url: &str) -> bool {
@@ -211,7 +235,7 @@ pub async fn extract(url: &str, _ctx: &VerticalContext) -> Result<ScrapedDoc, Ve
         extractor_version: 2,
         structured: Some(data),
         follow_crawl_urls: vec![],
-        extra: None,
+        extra: Some(build_extra(&post_data)),
     })
 }
 
@@ -284,3 +308,7 @@ fn parse_retry_after(resp: &reqwest::Response) -> Option<Duration> {
         .and_then(|s| s.parse::<u64>().ok())?;
     Some(Duration::from_secs(secs.min(120)))
 }
+
+#[cfg(test)]
+#[path = "reddit_tests.rs"]
+mod tests;

--- a/src/extract/verticals/reddit.rs
+++ b/src/extract/verticals/reddit.rs
@@ -21,6 +21,7 @@ use crate::core::http::http_client;
 use crate::extract::context::VerticalContext;
 use crate::extract::error::VerticalError;
 use crate::extract::types::{ExtractorInfo, ScrapedDoc};
+use crate::ingest::reddit::meta::build_reddit_post_extra_payload;
 
 pub const INFO: ExtractorInfo = ExtractorInfo {
     name: "reddit",
@@ -139,29 +140,7 @@ async fn wait_for_rate_slot() {
     state.last_request_at = Some(Instant::now());
 }
 
-// ── Extra payload ─────────────────────────────────────────────────────────────
-
-/// Build the flat `reddit_*` extra payload for embedding.
-///
-/// Mirrors `build_reddit_post_extra_payload` in `src/ingest/reddit/meta.rs`.
-/// `post_data` is the `post["data"]` object from the Reddit API JSON response.
-fn build_extra(post_data: &serde_json::Value) -> serde_json::Value {
-    serde_json::json!({
-        "reddit_author": post_data["author"].as_str().unwrap_or("[deleted]"),
-        // Reddit API returns `created_utc` as a float (e.g. 1710000000.0).
-        // `as_u64()` returns `None` for JSON floats, so parse as f64 then cast.
-        "reddit_created_utc": post_data["created_utc"].as_f64().map(|f| f as u64).unwrap_or(0),
-        "reddit_score": post_data["score"].as_i64().unwrap_or(0),
-        "reddit_num_comments": post_data["num_comments"].as_u64().unwrap_or(0),
-        "reddit_upvote_ratio": post_data["upvote_ratio"].as_f64().unwrap_or(0.0),
-        "reddit_subreddit": post_data["subreddit"].as_str().unwrap_or(""),
-        "reddit_domain": post_data["domain"].as_str().unwrap_or(""),
-        "reddit_is_video": post_data["is_video"].as_bool().unwrap_or(false),
-        "reddit_distinguished": post_data["distinguished"].as_str(),
-        "reddit_gilded": post_data["gilded"].as_u64().unwrap_or(0),
-        "reddit_flair": post_data["link_flair_text"].as_str(),
-    })
-}
+// ── Extra payload — delegates to the shared ingest helper to prevent drift ─────
 
 // ── URL matching ─────────────────────────────────────────────────────────────
 
@@ -235,7 +214,7 @@ pub async fn extract(url: &str, _ctx: &VerticalContext) -> Result<ScrapedDoc, Ve
         extractor_version: 2,
         structured: Some(data),
         follow_crawl_urls: vec![],
-        extra: Some(build_extra(&post_data)),
+        extra: Some(build_reddit_post_extra_payload(&post_data)),
     })
 }
 

--- a/src/extract/verticals/reddit_tests.rs
+++ b/src/extract/verticals/reddit_tests.rs
@@ -1,0 +1,64 @@
+use serde_json::json;
+
+use super::build_extra;
+
+#[test]
+fn build_extra_all_fields_present() {
+    let post_data = json!({
+        "author": "testuser",
+        "created_utc": 1_710_000_000.0_f64,
+        "score": 42,
+        "num_comments": 7,
+        "upvote_ratio": 0.95,
+        "subreddit": "rust",
+        "domain": "self.rust",
+        "is_video": false,
+        "distinguished": null,
+        "gilded": 0,
+        "link_flair_text": "Discussion"
+    });
+    let extra = build_extra(&post_data);
+    assert_eq!(extra["reddit_author"], json!("testuser"));
+    assert_eq!(extra["reddit_created_utc"], json!(1_710_000_000_u64));
+    assert_eq!(extra["reddit_score"], json!(42_i64));
+    assert_eq!(extra["reddit_num_comments"], json!(7_u64));
+    assert_eq!(extra["reddit_upvote_ratio"], json!(0.95_f64));
+    assert_eq!(extra["reddit_subreddit"], json!("rust"));
+    assert_eq!(extra["reddit_domain"], json!("self.rust"));
+    assert_eq!(extra["reddit_is_video"], json!(false));
+    assert_eq!(extra["reddit_gilded"], json!(0_u64));
+    assert_eq!(extra["reddit_flair"], json!("Discussion"));
+}
+
+#[test]
+fn build_extra_missing_fields_use_defaults() {
+    let post_data = json!({});
+    let extra = build_extra(&post_data);
+    assert_eq!(extra["reddit_author"], json!("[deleted]"));
+    assert_eq!(extra["reddit_created_utc"], json!(0_u64));
+    assert_eq!(extra["reddit_score"], json!(0_i64));
+    assert_eq!(extra["reddit_num_comments"], json!(0_u64));
+    assert_eq!(extra["reddit_upvote_ratio"], json!(0.0_f64));
+    assert_eq!(extra["reddit_subreddit"], json!(""));
+    assert_eq!(extra["reddit_domain"], json!(""));
+    assert_eq!(extra["reddit_is_video"], json!(false));
+    assert_eq!(extra["reddit_gilded"], json!(0_u64));
+    // nullable fields should be JSON null when absent
+    assert!(extra["reddit_distinguished"].is_null());
+    assert!(extra["reddit_flair"].is_null());
+}
+
+#[test]
+fn build_extra_distinguished_field() {
+    let post_data = json!({
+        "distinguished": "moderator"
+    });
+    let extra = build_extra(&post_data);
+    assert_eq!(extra["reddit_distinguished"], json!("moderator"));
+}
+
+#[test]
+fn build_extra_returns_object() {
+    let extra = build_extra(&json!({}));
+    assert!(extra.is_object(), "build_extra must return a JSON object");
+}

--- a/src/extract/verticals/reddit_tests.rs
+++ b/src/extract/verticals/reddit_tests.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use super::build_extra;
+use crate::ingest::reddit::meta::build_reddit_post_extra_payload as build_extra;
 
 #[test]
 fn build_extra_all_fields_present() {

--- a/src/ingest/gitlab/files.rs
+++ b/src/ingest/gitlab/files.rs
@@ -7,6 +7,7 @@ use crate::core::config::Config;
 use crate::ingest::github::{is_indexable_doc_path, is_indexable_source_path};
 use crate::ingest::progress::PhaseReporter;
 use crate::ingest::subprocess::{SUBPROCESS_TIMEOUT, run_command_with_timeout};
+use crate::vector::ops::input::code::chunk_code;
 use crate::vector::ops::{PreparedDoc, chunk_text};
 
 use super::embed::{embed_docs, gitlab_payload};
@@ -116,7 +117,23 @@ pub(crate) async fn embed_files(
         let Ok(content) = tokio::fs::read_to_string(&file).await else {
             continue;
         };
-        let chunks = chunk_text(&content);
+        let ext = Path::new(&rel)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let chunks = {
+            let content_clone = content.clone();
+            let ext_clone = ext.clone();
+            match tokio::task::spawn_blocking(move || {
+                chunk_code(&content_clone, &ext_clone).unwrap_or_else(|| chunk_text(&content_clone))
+            })
+            .await
+            {
+                Ok(chunks) => chunks,
+                Err(_) => chunk_text(&content),
+            }
+        };
         if !chunks.is_empty() {
             docs.push(PreparedDoc {
                 url: format!("{}/-/blob/{}/{}", target.web_url, branch, rel),

--- a/src/ingest/gitlab/files.rs
+++ b/src/ingest/gitlab/files.rs
@@ -124,9 +124,8 @@ pub(crate) async fn embed_files(
             .to_ascii_lowercase();
         let chunks = {
             let content_clone = content.clone();
-            let ext_clone = ext.clone();
             match tokio::task::spawn_blocking(move || {
-                chunk_code(&content_clone, &ext_clone).unwrap_or_else(|| chunk_text(&content_clone))
+                chunk_code(&content_clone, &ext).unwrap_or_else(|| chunk_text(&content_clone))
             })
             .await
             {

--- a/src/ingest/gitlab/files.rs
+++ b/src/ingest/gitlab/files.rs
@@ -122,15 +122,17 @@ pub(crate) async fn embed_files(
             .and_then(|e| e.to_str())
             .unwrap_or("")
             .to_ascii_lowercase();
-        let chunks = {
-            let content_clone = content.clone();
-            match tokio::task::spawn_blocking(move || {
-                chunk_code(&content_clone, &ext).unwrap_or_else(|| chunk_text(&content_clone))
-            })
-            .await
-            {
-                Ok(chunks) => chunks,
-                Err(_) => chunk_text(&content),
+        // Move content into spawn_blocking — avoids cloning large files.
+        // On JoinError (panic/cancellation) log a warning and skip the file.
+        let chunks = match tokio::task::spawn_blocking(move || {
+            chunk_code(&content, &ext).unwrap_or_else(|| chunk_text(&content))
+        })
+        .await
+        {
+            Ok(chunks) => chunks,
+            Err(e) => {
+                tracing::warn!(path = %rel, error = %e, "spawn_blocking panicked during code chunking; skipping file");
+                vec![]
             }
         };
         if !chunks.is_empty() {

--- a/src/ingest/reddit.rs
+++ b/src/ingest/reddit.rs
@@ -1,6 +1,6 @@
 mod client;
 mod comments;
-mod meta;
+pub(crate) mod meta;
 mod types;
 
 pub use client::get_access_token;


### PR DESCRIPTION
## Summary

- **GitLab file ingest**: replace `chunk_text()` with `chunk_code(&content, &ext).unwrap_or_else(|| chunk_text(&content))` wrapped in `tokio::task::spawn_blocking`, matching the existing GitHub ingest pattern. AST-aware chunking (Rust, Python, JS, JSX, TS, TSX, Go, Bash) produces semantically coherent chunks at structural boundaries; unsupported extensions fall back gracefully to prose chunking.

- **Reddit vertical extractor**: add `build_extra(post_data: &Value) -> Value` that emits the same 11 flat `reddit_*` Qdrant payload fields as the ingest path's `build_reddit_post_extra_payload`: `reddit_author`, `reddit_created_utc`, `reddit_score`, `reddit_num_comments`, `reddit_upvote_ratio`, `reddit_subreddit`, `reddit_domain`, `reddit_is_video`, `reddit_distinguished`, `reddit_gilded`, `reddit_flair`. Wire into `extract()` as `extra: Some(build_extra(&post_data))`. Add sidecar tests in `reddit_tests.rs`.

## Files changed

- `src/ingest/gitlab/files.rs` — tree-sitter code chunking + spawn_blocking
- `src/extract/verticals/reddit.rs` — `build_extra()` function + `extra` field wired
- `src/extract/verticals/reddit_tests.rs` — new sidecar test file (4 tests)

## Test plan

- [x] `cargo test --lib verticals::reddit::tests` — 4 new tests pass
- [x] `cargo test --lib extract` — 214 tests pass, no regressions
- [x] `cargo test --lib gitlab` — 9 tests pass, no regressions
- [x] `cargo test --lib chunk_code` — code chunking tests pass
- [x] `cargo test --lib` — full suite: 2121 passed, 6 ignored
- [x] `cargo clippy --bin axon` — no errors or warnings on changed files
- [x] Pre-commit hooks: monolith policy, rustfmt, clippy, no-mod-rs, secrets — all pass

## Base branch

This PR targets `feature/vertical-extractor-metadata` (not `main`) because it depends on `ScrapedDoc.extra: Option<serde_json::Value>` added in that branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AST-aware code chunking to GitLab ingest and plugs the Reddit extractor into a shared `extra` payload helper. Improves code chunk quality and keeps Reddit metadata consistent across ingest and extract.

- **New Features**
  - GitLab ingest: use `chunk_code(&content, &ext)` with fallback to `chunk_text()` inside `tokio::task::spawn_blocking`; logs and skips files if the blocking task panics; supports Rust, Python, JS/TS/JSX/TSX, Go, Bash.
  - Reddit extractor: emit 11 flat `reddit_*` fields via `build_reddit_post_extra_payload()`; `ingest::reddit::meta` exposed for reuse; tests updated to cover defaults and types.

<sup>Written for commit 6fe21eb312ec4246ae556d7951a9db4379044f5e. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/120?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

