### PR TITLE
docs: LLM-format epic closeout plan and session log

### DIFF
--- a/docs/sessions/2026-05-21-llm-format-epic-closeout.md
+++ b/docs/sessions/2026-05-21-llm-format-epic-closeout.md
@@ -1,0 +1,149 @@
+---
+date: 2026-05-21 07:46:21 EST
+repo: git@github.com:jmagar/axon.git
+branch: closeout/llm-format-epic
+head: (closeout/llm-format-epic — commits after d36b494e on feature/gitlab-ingest)
+plan: docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md
+agent: Claude (claude-sonnet-4-6)
+session id: d8423fc1-9444-449a-b14b-6a5507dc3f94
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-axon-rust/d8423fc1-9444-449a-b14b-6a5507dc3f94
+working directory: /home/jmagar/workspace/axon_rust
+worktree: /home/jmagar/workspace/axon_rust/.worktrees/llm-format-epic
+pr: "#123 — docs: LLM-format epic closeout + validation (axon_rust-zzre, y34v, lrou) — https://github.com/jmagar/axon/pull/123"
+---
+
+## User Request
+
+Execute the plan at `docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md` via the `work-it` skill: validate the LLM-format epic implementation, close the parent beads (`axon_rust-zzre`, `axon_rust-y34v`, `axon_rust-lrou`), file two deferred-scope follow-up beads, and push the plan file with a docs commit.
+
+## Session Overview
+
+Completed the LLM-format epic closeout as specified in the plan. All five tasks were executed: validation pass (tests/check/build/smoke-test/help), three bead closures in dependency order, two follow-up beads created, version bumped 4.3.0 → 4.3.1, and PR #123 opened against `feature/gitlab-ingest`.
+
+## Sequence of Events
+
+1. Read the plan file (`docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md`)
+2. Checked repo state — found active merge conflict in `feature/gitlab-ingest` working tree (unrelated to this plan)
+3. Created worktree `.worktrees/llm-format-epic` on branch `closeout/llm-format-epic` from HEAD
+4. Copied plan file into worktree (it was untracked in the conflict-state main checkout)
+5. Ran `cargo test -q llm` — failed with `RustEmbed` error: `apps/web/out/` directory missing
+6. Copied built web assets from main workspace into worktree to satisfy the RustEmbed macro
+7. Re-ran `cargo test -q llm` — 53 passed, 0 failures
+8. `cargo check --bin axon` — 0 errors, 3 pre-existing warnings (pre-existing in `subconfigs.rs`)
+9. `cargo build --release --bin axon` — built successfully, 74.5 MB binary
+10. Smoke-tested `./target/release/axon scrape --format llm https://example.com` — output did NOT have URL header
+11. Investigated: `AXON_SERVER_URL=http://127.0.0.1:8001` was set in `~/.axon/.env`, routing requests to a running server instead of the local binary
+12. Retested with `--local` flag — correct LLM output produced with `> URL:` header, `## Links` section
+13. Verified `llm` in `--format` possible values via `axon --help` verbose mode
+14. Checked `bd close --help` and `bd create --help` for non-interactive flags
+15. Closed `axon_rust-zzre`, `axon_rust-y34v`, `axon_rust-lrou` in dependency order using `-r` flag
+16. Created `axon_rust-yd1b` (vertical extractor LLM format) via `bd create --body-file`
+17. Created `axon_rust-8283` (crawl streaming LLM format) via `bd create --body-file`
+18. Bumped version 4.3.0 → 4.3.1 in `Cargo.toml`, added CHANGELOG entry
+19. Staged and committed plan file, Cargo.toml, CHANGELOG.md, Cargo.lock
+20. Pushed `closeout/llm-format-epic` branch and opened PR #123 targeting `feature/gitlab-ingest`
+21. Ran review waves (lavra-review unavailable — docs-only PR, manual review substituted)
+22. Fetched PR comments — zero comments at time of session end (cubic still pending)
+
+## Key Findings
+
+- **`AXON_SERVER_URL` routing**: When `AXON_SERVER_URL=http://127.0.0.1:8001` is set (via `~/.axon/.env`), the CLI routes scrape commands to the running server binary, not the local worktree binary. `--local` flag bypasses this. Smoke tests against worktree binary require `--local`.
+- **Missing `apps/web/out/`**: Worktrees don't inherit the built web assets. The `RustEmbed` macro in `src/web/static_assets.rs:8-10` fails if `apps/web/out/` doesn't exist. Fix: copy from main workspace.
+- **`to_llm_text()` correctness confirmed**: All 53 LLM tests pass including `url_header_always_present`. The URL header IS generated correctly — the routing issue masked it during initial smoke test.
+- **`bd close -r` flag**: Non-interactive close works cleanly with `-r <reason>` flag. No TTY prompting.
+- **`bd create --body-file`**: Non-interactive bead creation with full markdown description via `--body-file /tmp/desc.md` works correctly.
+
+## Technical Decisions
+
+- **`--local` for smoke test**: Added `--local` to bypass server routing rather than unsetting `AXON_SERVER_URL`. This is correct — the smoke test should test the local binary, and `--local` is the right mechanism.
+- **Web assets copy vs symlink**: Copied (not symlinked) `apps/web/out/` into worktree. Symlink would work but copy is safer for worktree isolation.
+- **Patch version bump**: `docs:` commit prefix → patch bump (4.3.0 → 4.3.1). No code changes made.
+- **PR base: `feature/gitlab-ingest`**: All implementation was merged into `feature/gitlab-ingest` (not main). The closeout PR correctly targets that branch.
+
+## Files Modified
+
+| File | Purpose |
+|---|---|
+| `docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md` | Plan file — added to worktree and committed |
+| `Cargo.toml` | Version bump 4.3.0 → 4.3.1 |
+| `CHANGELOG.md` | New `[4.3.1]` entry documenting the closeout |
+| `Cargo.lock` | Auto-updated by Cargo on version bump |
+
+## Commands Executed
+
+```bash
+# Worktree setup
+git worktree add -b closeout/llm-format-epic .worktrees/llm-format-epic HEAD
+
+# Task 1 — Validation
+rtk cargo test -q llm                                                # 53 passed
+rtk cargo check --bin axon                                           # 0 errors
+cargo build --release --bin axon                                     # success
+./target/release/axon scrape --format llm --local https://example.com  # LLM output
+
+# Task 2 — Close beads
+bd close axon_rust-zzre -r "<reason>"
+bd close axon_rust-y34v -r "<reason>"
+bd close axon_rust-lrou -r "<reason>"
+
+# Task 3 + 4 — Create follow-up beads
+bd create --title "..." --type feature --priority P3 --body-file /tmp/bead-vertical-desc.md
+bd create --title "..." --type feature --priority P3 --body-file /tmp/bead-crawl-desc.md
+
+# Task 5 — Commit and push
+git add docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md Cargo.toml CHANGELOG.md
+git commit -m "docs: add llm-format epic closeout plan + validation checklist"
+git push -u origin closeout/llm-format-epic
+gh pr create --base feature/gitlab-ingest --title "..."
+```
+
+## Errors Encountered
+
+**RustEmbed missing `apps/web/out/`**
+- Symptom: `cargo test -q llm` failed with `#[derive(RustEmbed)] folder '…/apps/web/out/' does not exist`
+- Root cause: Worktree doesn't include the built Next.js output; `src/web/static_assets.rs:8-10` uses `RustEmbed` which requires the folder at compile time
+- Fix: `cp -r /home/jmagar/workspace/axon_rust/apps/web/out/ .worktrees/llm-format-epic/apps/web/`
+
+**Smoke test — no URL header in output**
+- Symptom: `./target/release/axon scrape --format llm https://example.com` produced plain markdown without `> URL:` header
+- Root cause: `AXON_SERVER_URL=http://127.0.0.1:8001` in `~/.axon/.env` — CLI routed to running server binary (which may predate or be unrelated to the worktree build)
+- Fix: Added `--local` flag to force in-process execution of worktree binary
+
+## Behavior Changes (Before/After)
+
+| Behavior | Before | After |
+|---|---|---|
+| `axon_rust-zzre` bead | OPEN | CLOSED |
+| `axon_rust-y34v` bead | OPEN | CLOSED |
+| `axon_rust-lrou` bead | OPEN | CLOSED |
+| `axon_rust-yd1b` bead | (did not exist) | OPEN — vertical extractor LLM format |
+| `axon_rust-8283` bead | (did not exist) | OPEN — crawl streaming LLM format |
+| Axon version | 4.3.0 | 4.3.1 |
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---|---|---|---|
+| `cargo test -q llm` | 53 passed | 53 passed, 0 failures | PASS |
+| `cargo check --bin axon` | 0 errors | 0 errors, 3 pre-existing warnings | PASS |
+| `cargo build --release --bin axon` | Build success | Build success | PASS |
+| `axon scrape --format llm --local https://example.com` | `> URL:` header present | Present | PASS |
+| `axon --help` verbose | `llm` in `--format` values | `[possible values: markdown, html, rawHtml, json, llm]` | PASS |
+| `bd show axon_rust-zzre` | CLOSED | `✓ CLOSED` | PASS |
+| `bd show axon_rust-y34v` | CLOSED | `✓ CLOSED` | PASS |
+| `bd show axon_rust-lrou` | CLOSED | `✓ CLOSED` | PASS |
+
+## Open Questions
+
+- Does the running axon server at `127.0.0.1:8001` have `ScrapeFormat::Llm` support? If not, the server-routed path silently ignores `--format llm`. This should be verified when deploying the new binary.
+- Cubic AI reviewer (cubic.dev) was still pending at session end. No action items expected for a docs-only PR, but should be checked.
+
+## Next Steps
+
+**Unfinished from this session:**
+- Cubic review on PR #123 still pending — check after this session ends and address any findings
+
+**Follow-on tasks not yet started:**
+- `axon_rust-yd1b`: Apply `--format llm` to vertical extractor output path (`src/services/scrape.rs` vertical fast-path, ~3 LOC change)
+- `axon_rust-8283`: `axon crawl --format llm` post-crawl read-back pass (`src/crawl/engine.rs` collector or `src/jobs/workers/runners/crawl.rs` post-hook)
+- When new binary is deployed to the server, verify `axon scrape --format llm` (without `--local`) produces correct LLM output

--- a/docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md
+++ b/docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md
@@ -1,0 +1,394 @@
+# LLM-Format Epic Closeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close out the LLM-optimized format epic (axon_rust-zzre / axon_rust-y34v) by running the validation pass, closing the stale-open parent beads, and filing two follow-up beads for the genuinely deferred scope.
+
+**Architecture:** The core `to_llm_text()` transform and all three wiring points (CLI `select_output`, MCP schema, MCP map helpers) are already implemented. What remains is: (1) confirming the tests and binary compile cleanly, (2) doing a quick smoke-test against a real URL, (3) closing the parent/wrapper beads, and (4) creating the two deferred-scope beads so the follow-up work is not lost.
+
+**Tech Stack:** Rust / Cargo, `rtk` wrapper for token-efficient output, `bd` (beads) issue tracker, `axon` binary with `--format llm` flag, pulldown-cmark (already in use via transitive dep).
+
+---
+
+## Context: What is already done
+
+All implementation work is complete and merged to `feature/gitlab-ingest`:
+
+| File | Status |
+|---|---|
+| `src/core/content/llm.rs` | Done — `to_llm_text()` transform |
+| `src/core/content/llm_tests.rs` | Done — sidecar test file |
+| `src/crawl/scrape.rs` `select_output()` | Done — `ScrapeFormat::Llm` arm |
+| `src/mcp/schema/requests.rs` | Done — `McpScrapeFormat::Llm` variant |
+| `src/mcp/server/common.rs` | Done — `map_scrape_format` arm |
+| `src/services/action_api/commands/helpers.rs` | Done — second `map_scrape_format` arm |
+| Beads zzre.1, zzre.2, zzre.3 | All closed (✓) |
+
+## Context: What is NOT done
+
+| Item | Status |
+|---|---|
+| `axon_rust-zzre` parent bead | Open — needs closing after validation |
+| `axon_rust-y34v` epic wrapper | Open — needs closing after zzre closes |
+| `axon_rust-lrou` swarm molecule | Open — needs closing after y34v closes |
+| Vertical extractor LLM format bypass | Known v1 limitation — needs follow-up bead |
+| Crawl streaming (`axon crawl --format llm`) | Deferred — needs follow-up bead |
+
+## Known Limitations (v1 decisions)
+
+### Vertical bypass (src/services/scrape.rs ~line 97)
+
+When `cfg.enable_verticals = true` and a URL matches a registered vertical extractor (github_repo, pypi, npm, reddit, etc.), the extractor result is returned directly without applying `select_output()`. The comment reads:
+
+```rust
+// v1: LLM format is only applied on the generic HTTP scrape path.
+// Vertical extractors return structured markdown that should not be post-processed.
+return Ok(scrape_result);
+```
+
+**Implication:** `axon scrape --format llm https://github.com/rust-lang/rust` will NOT produce LLM-formatted output because the github_repo extractor claims the URL first. This is intentional for v1 — vertical extractor output is already structured markdown from API data, and applying the LLM transform on top adds noise rather than signal.
+
+### Crawl streaming deferred
+
+`axon crawl --format llm` does not apply LLM format because the crawl collector writes raw markdown files to disk during crawl and the `cfg.format` field is never read by the engine. A post-crawl read-back pass would be needed. This was explicitly deferred in the zzre bead spec.
+
+---
+
+## File Map
+
+No new files are created by this plan. The only file edits are bead state changes via `bd`. The two new beads are created as new issues.
+
+---
+
+## Task 1: Validation Pass
+
+**Files:** No file edits. Read-only verification.
+
+- [ ] **Step 1.1: Run LLM-specific tests**
+
+```bash
+rtk cargo test -q llm
+```
+
+Expected output: `cargo test: 53 passed, 2216 filtered out (21 suites, 1.00s)` (or similar — no failures).
+
+The 53 tests include all tests whose names contain "llm". If any fail, do NOT proceed — investigate the failure first.
+
+- [ ] **Step 1.2: Run full cargo check**
+
+```bash
+rtk cargo check --bin axon
+```
+
+Expected: `cargo build: 0 errors` (warnings are acceptable — there are currently 3 pre-existing warnings about unnecessary path qualifications in `src/core/config/types/subconfigs.rs`).
+
+- [ ] **Step 1.3: Build the release binary**
+
+```bash
+rtk cargo build --release --bin axon 2>&1 | tail -5
+```
+
+Expected: build completes successfully. This confirms the binary is linkable, not just type-checkable.
+
+- [ ] **Step 1.4: Smoke-test with a real URL**
+
+```bash
+./target/release/axon scrape --format llm https://example.com 2>/dev/null | head -20
+```
+
+Expected output begins with the URL metadata header and shows clean prose without markdown emphasis markers:
+
+```
+> URL: https://example.com
+
+# Example Domain
+
+This domain is for use in illustrative examples...
+```
+
+Expected: no `**bold**` or `*italic*` markers in body text. A `## Links` section at the end if any links were found.
+
+- [ ] **Step 1.5: Verify format flag is visible in help**
+
+```bash
+./target/release/axon scrape --help | grep -A3 "format"
+```
+
+Expected: `llm` appears as a valid value for `--format`.
+
+---
+
+## Task 2: Close Stale-Open Beads
+
+**Files:** No file edits. Only `bd close` commands.
+
+Close in dependency order: child (zzre) → epic (y34v) → molecule (lrou).
+
+- [ ] **Step 2.1: Close the zzre parent bead**
+
+All three children (zzre.1, zzre.2, zzre.3) are already closed. Close the parent:
+
+```bash
+bd close axon_rust-zzre
+```
+
+When prompted for a comment, enter:
+
+```
+Validation pass passed: `cargo test -q llm` (53 tests green), `cargo check --bin axon` (0 errors), smoke-test of `axon scrape --format llm https://example.com` produces LLM-formatted output with URL header and cleaned body. All three child beads (zzre.1, zzre.2, zzre.3) were closed in the implementation session. Two follow-up beads filed: axon_rust-XXXX (vertical LLM bypass) and axon_rust-YYYY (crawl streaming).
+```
+
+- [ ] **Step 2.2: Close the y34v epic wrapper**
+
+```bash
+bd close axon_rust-y34v
+```
+
+When prompted for a comment, enter:
+
+```
+Epic complete. zzre closed after successful validation pass. Two deferred items tracked as separate beads.
+```
+
+- [ ] **Step 2.3: Close the lrou swarm molecule**
+
+```bash
+bd close axon_rust-lrou
+```
+
+When prompted for a comment, enter:
+
+```
+Molecule closed. Coordinated epic axon_rust-y34v is now done.
+```
+
+- [ ] **Step 2.4: Verify all three are closed**
+
+```bash
+bd list 2>&1 | grep -E "zzre|y34v|lrou"
+```
+
+Expected: all three show `✓` status. If any still show `○`, re-run the close command for that bead.
+
+---
+
+## Task 3: File Follow-Up Bead A — Vertical Extractor LLM Format
+
+**Files:** No code changes. New bead created via `bd create`.
+
+This bead tracks applying LLM format post-processing to vertical extractor output when `--format llm` is requested. Currently the vertical path returns early before `select_output()` is called.
+
+- [ ] **Step 3.1: Create the bead**
+
+```bash
+bd create
+```
+
+Fill in the prompts as follows:
+
+**Title:** `Apply --format llm to vertical extractor output path`
+
+**Type:** `feature`
+
+**Priority:** `P3`
+
+**Description:**
+
+```markdown
+## Why this issue exists
+
+`axon scrape --format llm` currently bypasses LLM formatting for URLs handled by vertical extractors (github_repo, pypi, npm, reddit, crates_io, etc.). The vertical path in `src/services/scrape.rs` returns early before `select_output()` applies the `ScrapeFormat::Llm` transform.
+
+This is a v1 decision documented with a comment: "Vertical extractors return structured markdown that should not be post-processed." In practice, users who request `--format llm` on a GitHub URL get standard vertical extractor markdown instead of the LLM-optimized form they asked for.
+
+## Scope
+
+Modify `src/services/scrape.rs` in the vertical fast-path `Ok(Some(result))` arm to apply `to_llm_text()` when `cfg.format == ScrapeFormat::Llm`.
+
+The code change is at `src/services/scrape.rs` around line 100:
+
+```rust
+// Current (v1):
+return Ok(scrape_result);
+
+// v2 target:
+if cfg.format == ScrapeFormat::Llm {
+    scrape_result.output = crate::core::content::to_llm_text(&scrape_result.output, &normalized);
+}
+return Ok(scrape_result);
+```
+
+Note: `scrape_result.output` is set to the raw `markdown` from the vertical doc in `map_scrape_payload`. Applying `to_llm_text()` to it will clean up bold/italic emphasis and aggregate links — but vertical extractors already produce clean structured markdown, so the impact is minimal.
+
+## Acceptance criteria
+
+- `axon scrape --format llm https://github.com/rust-lang/rust` produces output with URL header and no bold/italic markers
+- `axon scrape --format llm https://crates.io/crates/serde` same
+- Existing vertical extractor output (without `--format llm`) is unaffected
+- Tests: add test in `src/services/scrape_tests.rs` (or new sidecar) that mocks a vertical extractor result and asserts LLM format is applied
+
+## Files to touch
+
+- `src/services/scrape.rs` — add LLM post-processing in vertical fast-path arm
+- `src/services/scrape_tests.rs` (or create if missing) — add test for vertical + llm format
+```
+
+- [ ] **Step 3.2: Verify bead was created**
+
+```bash
+bd list 2>&1 | tail -5
+```
+
+Note the new bead ID for reference in commit messages.
+
+---
+
+## Task 4: File Follow-Up Bead B — Crawl Streaming LLM Format
+
+**Files:** No code changes. New bead created via `bd create`.
+
+This bead tracks `axon crawl --format llm` applying LLM formatting to each crawled page's output, either at collection time or via a post-crawl read-back pass.
+
+- [ ] **Step 4.1: Create the bead**
+
+```bash
+bd create
+```
+
+Fill in the prompts as follows:
+
+**Title:** `axon crawl --format llm: post-crawl read-back pass`
+
+**Type:** `feature`
+
+**Priority:** `P3`
+
+**Description:**
+
+```markdown
+## Why this issue exists
+
+`axon crawl --format llm` currently produces standard markdown output. The crawl collector (`src/crawl/engine.rs`) writes raw markdown files to disk during crawl and never reads `cfg.format`. The `ScrapeFormat` field in `Config` is not propagated into the collector pipeline.
+
+This was explicitly deferred in axon_rust-zzre: "Crawl streaming (`axon crawl --format llm --wait true > docs.txt`) is deferred to a follow-up bead — the crawl collector does not read `cfg.format` and streaming requires a separate post-crawl read-back phase."
+
+## Design options
+
+Two approaches:
+
+**Option A — Collector inline transform (preferred for clean implementation)**
+Pass `cfg.format` into the collector. When `format == ScrapeFormat::Llm`, apply `to_llm_text()` to each page's markdown before writing it to disk. Requires threading `format` through:
+- `CollectorConfig` in `src/crawl/engine.rs`
+- The page handler closure inside `collect_pages()`
+
+**Option B — Post-crawl read-back pass (simpler, no collector change)**
+After the crawl completes, scan the manifest and re-read each markdown file from `output_dir/markdown/`, apply `to_llm_text()`, and write it back in-place. Triggered by `cfg.format == ScrapeFormat::Llm` in the crawl runner (`src/jobs/workers/runners/crawl.rs`).
+
+Option A is cleaner (no double-write, no extra I/O pass) but touches the Spider collector closure. Option B is safer (isolated post-processing step, no concurrency concerns) but doubles disk I/O.
+
+## Acceptance criteria
+
+- `axon crawl --format llm --wait true https://docs.rs/serde` produces an `output_dir/markdown/` tree where each file has the URL metadata header and no bold/italic markers
+- `axon crawl` without `--format llm` is unaffected
+- Existing embed pipeline (which reads from `output_dir/markdown/`) still works after LLM post-processing is applied
+- MCP `crawl` action with `format: "llm"` also applies the transform
+
+## Key files
+
+- `src/crawl/engine.rs` — collector pipeline (Option A) — `collect_pages()` closure
+- `src/jobs/workers/runners/crawl.rs` — post-crawl hook point (Option B)
+- `src/core/content/llm.rs` — `to_llm_text()` is already implemented, just needs to be called
+- `src/jobs/config_snapshot.rs` — `format: Option<ScrapeFormat>` field already stored in job config snapshot, so the format value survives job serialization/deserialization
+```
+
+- [ ] **Step 4.2: Verify bead was created**
+
+```bash
+bd list 2>&1 | tail -5
+```
+
+Note the new bead ID.
+
+---
+
+## Task 5: Commit and Push
+
+- [ ] **Step 5.1: Check git status**
+
+```bash
+rtk git status
+```
+
+Expected: clean or only plan file additions. No implementation files should have uncommitted changes.
+
+- [ ] **Step 5.2: Stage the plan file**
+
+```bash
+rtk git add docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md
+```
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+rtk git commit -m "$(cat <<'EOF'
+docs: add llm-format epic closeout plan + validation checklist
+
+Closes axon_rust-zzre / axon_rust-y34v / axon_rust-lrou after
+validation pass. Documents v1 vertical bypass limitation and
+crawl streaming deferral as follow-up bead scope.
+EOF
+)"
+```
+
+- [ ] **Step 5.4: Push**
+
+```bash
+rtk git push
+```
+
+- [ ] **Step 5.5: Verify push succeeded**
+
+```bash
+rtk git status
+```
+
+Expected: `Your branch is up to date with 'origin/feature/gitlab-ingest'`.
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Requirement | Task |
+|---|---|
+| Confirm tests pass | Task 1.1 |
+| Confirm cargo check passes | Task 1.2 |
+| Manual smoke-test | Task 1.4 |
+| Close zzre parent bead | Task 2.1 |
+| Close y34v epic | Task 2.2 |
+| Close lrou molecule | Task 2.3 |
+| File vertical bypass follow-up bead | Task 3 |
+| File crawl streaming follow-up bead | Task 4 |
+| Document v1 limitations | Tasks 3 and 4 descriptions |
+| Push to remote | Task 5 |
+
+### Placeholder scan
+
+No TBD or TODO placeholders. All commands are concrete with expected output. All bead descriptions include exact file references and code snippets.
+
+### Type consistency
+
+No new types defined. All references to `ScrapeFormat::Llm`, `to_llm_text()`, `select_output()`, and `cfg.format` match the actual code at the time this plan was written (verified against codebase).
+
+---
+
+## Execution Handoff
+
+**Plan saved to `docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md`.** Two execution options:
+
+**1. Subagent-Driven (recommended)** — Fresh subagent per task, review between tasks, fast iteration. Use `superpowers:subagent-driven-development`.
+
+**2. Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?


### PR DESCRIPTION
Docs-only PR: adds closeout plan and session log for axon_rust-zzre/y34v/lrou. Supersedes closed #125.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the LLM-format epic closeout plan and a session log that documents the validation checklist, bead closures (`axon_rust-zzre`, `axon_rust-y34v`, `axon_rust-lrou`), and two follow-up beads.
Files added: `docs/superpowers/plans/2026-05-21-llm-format-epic-closeout.md` and `docs/sessions/2026-05-21-llm-format-epic-closeout.md`.

<sup>Written for commit 49a66d453302725551b401dccb025b005623af62. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/126?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

