### PR TITLE
Centralize MCP ingest target parsing in services

### DIFF
--- a/src/mcp/server/handlers_embed_ingest.rs
+++ b/src/mcp/server/handlers_embed_ingest.rs
@@ -3,137 +3,18 @@ use super::common::{
     InlineHint, invalid_params, logged_internal_error, parse_job_id, parse_limit, parse_offset,
     respond_with_mode, validate_mcp_embed_input,
 };
-use crate::core::config::Config;
 use crate::mcp::schema::{
-    AxonToolResponse, EmbedRequest, EmbedSubaction, IngestRequest, IngestSourceType,
-    IngestSubaction, ResponseMode, SessionsIngestOptions,
+    AxonToolResponse, EmbedRequest, EmbedSubaction, IngestRequest, IngestSubaction, ResponseMode,
 };
 use crate::services::embed::{
     embed_cancel, embed_cleanup, embed_clear, embed_list, embed_recover, embed_start_with_context,
     embed_status,
 };
 use crate::services::ingest::{
-    IngestSource, ingest_cancel, ingest_cleanup, ingest_clear, ingest_list, ingest_recover,
-    ingest_start_with_context, ingest_status,
+    ingest_cancel, ingest_cleanup, ingest_clear, ingest_list, ingest_recover,
+    ingest_start_with_context, ingest_status, source_from_mcp_request,
 };
 use rmcp::ErrorData;
-
-fn parse_ingest_source(
-    source_type: Option<IngestSourceType>,
-    target: Option<String>,
-    sessions: Option<SessionsIngestOptions>,
-    include_source: Option<bool>,
-    cfg: &Config,
-) -> Result<IngestSource, ErrorData> {
-    let source_type =
-        source_type.ok_or_else(|| invalid_params("source_type is required for ingest.start"))?;
-    match source_type {
-        IngestSourceType::Github => {
-            let repo = target
-                .ok_or_else(|| invalid_params("target repo is required for github ingest"))?;
-            let (owner, name) =
-                crate::ingest::github::parse_github_repo(&repo).ok_or_else(|| {
-                    invalid_params(
-                        "invalid GitHub target; expected owner/repo or github.com/owner/repo",
-                    )
-                })?;
-            Ok(IngestSource::Github {
-                repo: format!("{owner}/{name}"),
-                include_source: include_source.unwrap_or(cfg.github_include_source),
-            })
-        }
-        IngestSourceType::Gitlab => {
-            let target = target
-                .ok_or_else(|| invalid_params("target project is required for gitlab ingest"))?;
-            let target = crate::ingest::gitlab::normalize_gitlab_target(&target)
-                .map_err(|e| invalid_params(format!("invalid GitLab target: {e}")))?;
-            Ok(IngestSource::Gitlab {
-                target,
-                include_source: include_source.unwrap_or(cfg.github_include_source),
-            })
-        }
-        IngestSourceType::Gitea => {
-            let target =
-                target.ok_or_else(|| invalid_params("target repo is required for gitea ingest"))?;
-            let target = crate::ingest::gitea::normalize_gitea_target(&target)
-                .map_err(|e| invalid_params(format!("invalid Gitea target: {e}")))?;
-            Ok(IngestSource::Gitea {
-                target,
-                include_source: include_source.unwrap_or(cfg.github_include_source),
-            })
-        }
-        IngestSourceType::Git => {
-            let target =
-                target.ok_or_else(|| invalid_params("target repo is required for git ingest"))?;
-            let target = crate::ingest::generic_git::normalize_generic_git_target(&target)
-                .map_err(|e| invalid_params(format!("invalid git target: {e}")))?;
-            Ok(IngestSource::GenericGit {
-                target,
-                include_source: include_source.unwrap_or(cfg.github_include_source),
-            })
-        }
-        IngestSourceType::Reddit => {
-            let target =
-                target.ok_or_else(|| invalid_params("target is required for reddit ingest"))?;
-            validate_mcp_reddit_target(&target)?;
-            Ok(IngestSource::Reddit { target })
-        }
-        IngestSourceType::Youtube => {
-            let target =
-                target.ok_or_else(|| invalid_params("target is required for youtube ingest"))?;
-            if crate::ingest::youtube::extract_video_id(&target).is_none()
-                && !crate::ingest::youtube::is_playlist_or_channel_url(&target)
-            {
-                return Err(invalid_params(
-                    "invalid YouTube target; expected video URL, bare video ID, playlist URL, or channel URL",
-                ));
-            }
-            Ok(IngestSource::Youtube { target })
-        }
-        IngestSourceType::Sessions => {
-            let sessions = sessions.unwrap_or(SessionsIngestOptions {
-                claude: None,
-                codex: None,
-                gemini: None,
-                project: None,
-            });
-            Ok(IngestSource::Sessions {
-                sessions_claude: sessions.claude.unwrap_or(false),
-                sessions_codex: sessions.codex.unwrap_or(false),
-                sessions_gemini: sessions.gemini.unwrap_or(false),
-                sessions_project: sessions.project,
-            })
-        }
-    }
-}
-
-fn validate_mcp_reddit_target(target: &str) -> Result<(), ErrorData> {
-    match crate::ingest::reddit::classify_target(target)
-        .map_err(|e| invalid_params(e.to_string()))?
-    {
-        crate::ingest::reddit::RedditTarget::Subreddit(name) => {
-            let len = name.len();
-            let valid = (3..=21).contains(&len)
-                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
-            if valid {
-                Ok(())
-            } else {
-                Err(invalid_params(
-                    "invalid subreddit target; expected 3-21 ASCII letters, digits, or '_'",
-                ))
-            }
-        }
-        crate::ingest::reddit::RedditTarget::Thread(url) => {
-            if url.starts_with("/r/") && url.contains("/comments/") {
-                Ok(())
-            } else {
-                Err(invalid_params(
-                    "invalid Reddit thread target; expected reddit.com comments URL or canonical /r/... permalink",
-                ))
-            }
-        }
-    }
-}
 
 impl AxonMcpServer {
     async fn handle_embed_start(
@@ -277,17 +158,8 @@ impl AxonMcpServer {
         }
     }
 
-    async fn handle_ingest_start(
-        &self,
-        mut req: IngestRequest,
-    ) -> Result<AxonToolResponse, ErrorData> {
-        let source = parse_ingest_source(
-            req.source_type.take(),
-            req.target.take(),
-            req.sessions.take(),
-            req.include_source,
-            self.cfg.as_ref(),
-        )?;
+    async fn handle_ingest_start(&self, req: IngestRequest) -> Result<AxonToolResponse, ErrorData> {
+        let source = source_from_mcp_request(&req, self.cfg.as_ref()).map_err(invalid_params)?;
         let service_context = self
             .base_service_context()
             .await

--- a/src/mcp/server/handlers_embed_ingest_tests.rs
+++ b/src/mcp/server/handlers_embed_ingest_tests.rs
@@ -1,125 +1,17 @@
 use super::*;
 
-#[test]
-fn parse_ingest_source_normalizes_github_url() {
-    let cfg = Config::default();
-    let source = parse_ingest_source(
-        Some(IngestSourceType::Github),
-        Some("https://github.com/owner/repo.git".to_string()),
-        None,
-        Some(false),
-        &cfg,
-    )
-    .expect("valid github target");
-    assert!(matches!(
-        source,
-        IngestSource::Github {
-            repo,
-            include_source: false,
-        } if repo == "owner/repo"
-    ));
-}
+#[tokio::test]
+async fn mcp_ingest_start_maps_service_parser_errors_to_invalid_params() {
+    let server = AxonMcpServer::new(crate::core::config::Config::default());
+    let req = IngestRequest {
+        source_type: Some(crate::mcp::schema::IngestSourceType::Github),
+        target: Some("owner/repo/extra".to_string()),
+        ..Default::default()
+    };
 
-#[test]
-fn parse_ingest_source_rejects_invalid_github_target() {
-    let cfg = Config::default();
-    let err = parse_ingest_source(
-        Some(IngestSourceType::Github),
-        Some("owner/repo/extra".to_string()),
-        None,
-        None,
-        &cfg,
-    )
-    .expect_err("invalid target should fail");
+    let result = server.handle_ingest(req).await;
+    assert!(result.is_err(), "invalid target should fail");
+    let err = result.unwrap_err();
+
     assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
-}
-
-#[test]
-fn parse_ingest_source_normalizes_gitlab_url() {
-    let cfg = Config::default();
-    let source = parse_ingest_source(
-        Some(IngestSourceType::Gitlab),
-        Some("https://gitlab.com/group/subgroup/project/-/issues/1".to_string()),
-        None,
-        Some(false),
-        &cfg,
-    )
-    .expect("valid gitlab target");
-    assert!(matches!(
-        source,
-        IngestSource::Gitlab {
-            target,
-            include_source: false,
-        } if target == "gitlab.com/group/subgroup/project"
-    ));
-}
-
-#[test]
-fn parse_ingest_source_normalizes_gitea_target() {
-    let cfg = Config::default();
-    let source = parse_ingest_source(
-        Some(IngestSourceType::Gitea),
-        Some("gitea:gitea.example.com/org/repo.git".to_string()),
-        None,
-        Some(false),
-        &cfg,
-    )
-    .expect("valid gitea target");
-    assert!(matches!(
-        source,
-        IngestSource::Gitea {
-            target,
-            include_source: false,
-        } if target == "gitea.example.com/org/repo"
-    ));
-}
-
-#[test]
-fn parse_ingest_source_normalizes_generic_git_target() {
-    let cfg = Config::default();
-    let source = parse_ingest_source(
-        Some(IngestSourceType::Git),
-        Some("git:https://example.com/org/repo.git".to_string()),
-        None,
-        Some(false),
-        &cfg,
-    )
-    .expect("valid generic git target");
-    assert!(matches!(
-        source,
-        IngestSource::GenericGit {
-            target,
-            include_source: false,
-        } if target == "https://example.com/org/repo.git"
-    ));
-}
-
-#[test]
-fn parse_ingest_source_rejects_non_reddit_comments_url() {
-    let cfg = Config::default();
-    let err = parse_ingest_source(
-        Some(IngestSourceType::Reddit),
-        Some("https://example.com/r/rust/comments/abc/title".to_string()),
-        None,
-        None,
-        &cfg,
-    )
-    .expect_err("non-reddit thread URL should fail");
-    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
-}
-
-#[test]
-fn parse_ingest_source_accepts_youtube_handle() {
-    let cfg = Config::default();
-    let source = parse_ingest_source(
-        Some(IngestSourceType::Youtube),
-        Some("https://www.youtube.com/@SpaceinvaderOne".to_string()),
-        None,
-        None,
-        &cfg,
-    )
-    .expect("valid youtube channel target");
-    assert!(
-        matches!(source, IngestSource::Youtube { target } if target.contains("@SpaceinvaderOne"))
-    );
 }

--- a/src/services/ingest_tests.rs
+++ b/src/services/ingest_tests.rs
@@ -149,6 +149,177 @@ fn source_from_mcp_request_rejects_invalid_youtube_target() {
     assert!(err.contains("YouTube"));
 }
 
+#[test]
+fn source_from_mcp_request_normalizes_supported_git_targets() {
+    let cfg = Config::test_default();
+
+    let gitlab = source_from_mcp_request(
+        &ingest_req(
+            IngestSourceType::Gitlab,
+            "https://gitlab.com/group/subgroup/project/-/issues/1",
+        ),
+        &cfg,
+    )
+    .expect("valid gitlab target");
+    assert!(matches!(
+        gitlab,
+        IngestSource::Gitlab {
+            target,
+            include_source,
+        } if target == "gitlab.com/group/subgroup/project"
+            && include_source == cfg.github_include_source
+    ));
+
+    let gitea = source_from_mcp_request(
+        &ingest_req(
+            IngestSourceType::Gitea,
+            "gitea:gitea.example.com/org/repo.git",
+        ),
+        &cfg,
+    )
+    .expect("valid gitea target");
+    assert!(matches!(
+        gitea,
+        IngestSource::Gitea {
+            target,
+            include_source,
+        } if target == "gitea.example.com/org/repo"
+            && include_source == cfg.github_include_source
+    ));
+
+    let generic = source_from_mcp_request(
+        &ingest_req(
+            IngestSourceType::Git,
+            "git:https://example.com/org/repo.git",
+        ),
+        &cfg,
+    )
+    .expect("valid generic git target");
+    assert!(matches!(
+        generic,
+        IngestSource::GenericGit {
+            target,
+            include_source,
+        } if target == "https://example.com/org/repo.git"
+            && include_source == cfg.github_include_source
+    ));
+}
+
+#[test]
+fn source_from_mcp_request_respects_include_source_override() {
+    let mut cfg = Config::test_default();
+    cfg.github_include_source = true;
+    let mut req = ingest_req(
+        IngestSourceType::Github,
+        "https://github.com/owner/repo.git",
+    );
+    req.include_source = Some(false);
+
+    let source = source_from_mcp_request(&req, &cfg).expect("valid github target");
+
+    assert!(matches!(
+        source,
+        IngestSource::Github {
+            repo,
+            include_source: false,
+        } if repo == "owner/repo"
+    ));
+}
+
+#[test]
+fn source_from_mcp_request_accepts_youtube_handle() {
+    let cfg = Config::test_default();
+    let source = source_from_mcp_request(
+        &ingest_req(
+            IngestSourceType::Youtube,
+            "https://www.youtube.com/@SpaceinvaderOne",
+        ),
+        &cfg,
+    )
+    .expect("valid youtube channel target");
+
+    assert!(
+        matches!(source, IngestSource::Youtube { target } if target.contains("@SpaceinvaderOne"))
+    );
+}
+
+#[test]
+fn source_from_mcp_request_accepts_youtube_playlist_url() {
+    let cfg = Config::test_default();
+    let source = source_from_mcp_request(
+        &ingest_req(
+            IngestSourceType::Youtube,
+            "https://www.youtube.com/playlist?list=PL1234567890abcdef",
+        ),
+        &cfg,
+    )
+    .expect("valid youtube playlist target");
+
+    assert!(matches!(source, IngestSource::Youtube { target } if target.contains("playlist")));
+}
+
+#[test]
+fn source_from_mcp_request_rejects_non_reddit_comments_url() {
+    let cfg = Config::test_default();
+    let err = source_from_mcp_request(
+        &ingest_req(
+            IngestSourceType::Reddit,
+            "https://example.com/r/rust/comments/abc/title",
+        ),
+        &cfg,
+    )
+    .expect_err("non-reddit thread URL should fail");
+
+    assert!(err.contains("Reddit") || err.contains("reddit"));
+}
+
+#[test]
+fn source_from_mcp_request_requires_source_type() {
+    let cfg = Config::test_default();
+    let req = IngestRequest {
+        target: Some("owner/repo".to_string()),
+        ..Default::default()
+    };
+
+    let err = source_from_mcp_request(&req, &cfg).expect_err("missing source type");
+
+    assert!(err.contains("source_type is required"));
+}
+
+#[test]
+fn source_from_mcp_request_requires_target_for_github() {
+    let cfg = Config::test_default();
+    let req = IngestRequest {
+        source_type: Some(IngestSourceType::Github),
+        ..Default::default()
+    };
+
+    let err = source_from_mcp_request(&req, &cfg).expect_err("missing github target");
+
+    assert!(err.contains("target repo is required"));
+}
+
+#[test]
+fn source_from_mcp_request_maps_default_sessions_options() {
+    let cfg = Config::test_default();
+    let req = IngestRequest {
+        source_type: Some(IngestSourceType::Sessions),
+        ..Default::default()
+    };
+
+    let source = source_from_mcp_request(&req, &cfg).expect("default sessions options");
+
+    assert!(matches!(
+        source,
+        IngestSource::Sessions {
+            sessions_claude: false,
+            sessions_codex: false,
+            sessions_gemini: false,
+            sessions_project: None,
+        }
+    ));
+}
+
 #[tokio::test]
 async fn ingest_start_with_context_enqueues_sessions_jobs_with_sqlite_backend() {
     let mut cfg = Config::test_default();


### PR DESCRIPTION
## Summary
- Route MCP ingest.start target parsing through services::ingest::source_from_mcp_request before service context initialization.
- Remove duplicated MCP ingest parser and Reddit validator from handlers_embed_ingest.rs.
- Move parser behavior coverage to service tests and keep a handler-level MCP INVALID_PARAMS mapping test.
- Make required_scope_for public so existing integration contract tests compile under all-target checks.

## Test Plan
- cargo fmt
- cargo test source_from_mcp_request --lib
- cargo test handlers_embed_ingest --lib
- cargo check
- cargo check --tests
- pre-commit hook: monolith, rustfmt, env/secrets/symlink checks, full lib test suite (2154 passed, 6 ignored), clippy

## Notes
- apps/web/out was copied into the isolated worktree from the main checkout only to satisfy rust-embed during local checks; it is ignored and not committed.
- Post-implementation security review found no ingest-refactor issues.
- Separate pre-existing note from review: endpoints scope expectations appear inconsistent in an individual test, but this PR does not change endpoint scope mapping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes MCP ingest target parsing in the service layer to remove duplicate logic and keep validation consistent. Simplifies the embed/ingest handler and keeps MCP error mapping unchanged.

- **Refactors**
  - Route `ingest.start` through `services::ingest::source_from_mcp_request` before context init; map service parser errors to `INVALID_PARAMS`.
  - Remove duplicate parser and Reddit validator from `handlers_embed_ingest.rs`.
  - Move parsing tests to `services::ingest_tests.rs` with broader coverage (gitlab/gitea/generic git normalization, `include_source` override, YouTube handle/playlist, Reddit validation, Sessions defaults, required fields).
  - Keep one handler test asserting `INVALID_PARAMS` mapping.

<sup>Written for commit f13510b77a2ac509a6364f63b2abd4aca4b63d79. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/131?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

