### PR TITLE
fix: batch server-mode session uploads to respect prepared-docs cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.6.1] - 2026-05-26
+
+### Fixed
+
+- `axon sessions` in server mode no longer fails with `too many prepared
+  session docs: N > 256` when a local history exceeds the per-request cap on
+  `/v1/ingest/sessions/prepared`. The client now splits prepared session docs
+  into batches that each satisfy the endpoint's doc-count and cumulative-text
+  limits and uploads one ingest job per batch
+  (`src/ingest/sessions/prepared.rs`, `src/cli/server_mode.rs`).
+
 ## [4.6.0] - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "4.6.0"
+version = "4.6.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "4.6.0"
+version = "4.6.1"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 4.6.0
+Version: 4.6.1
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "4.5.0"
+    "version": "4.6.1"
   },
   "paths": {
     "/v1/ask": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "4.5.0",
+  "version": "4.6.1",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/cli/server_mode.rs
+++ b/src/cli/server_mode.rs
@@ -66,8 +66,8 @@ async fn run_server_mode_sessions(
     server_url: reqwest::Url,
 ) -> Result<(), Box<dyn Error>> {
     let client = cli::client::ServerClient::new(server_url)?;
-    let request = crate::ingest::sessions::prepare_sessions_request(cfg).await?;
-    if request.docs.is_empty() {
+    let batches = crate::ingest::sessions::prepare_sessions_request_batches(cfg).await?;
+    if batches.is_empty() {
         if cfg.json_output {
             println!(
                 "{}",
@@ -82,18 +82,48 @@ async fn run_server_mode_sessions(
         }
         return Ok(());
     }
-    let result = client
-        .post_json(
-            "/v1/ingest/sessions/prepared",
-            &serde_json::to_value(request)?,
-            "sessions",
-        )
-        .await
-        .map_err(|err| server_client_error("sessions", err))?;
+
+    // Large session histories exceed the per-request doc/byte caps on
+    // `/v1/ingest/sessions/prepared`, so upload one bounded job per batch.
+    let mut results: Vec<serde_json::Value> = Vec::with_capacity(batches.len());
+    for request in batches {
+        let result = client
+            .post_json(
+                "/v1/ingest/sessions/prepared",
+                &serde_json::to_value(request)?,
+                "sessions",
+            )
+            .await
+            .map_err(|err| server_client_error("sessions", err))?;
+        results.push(result);
+    }
+
+    if results.len() == 1 {
+        let result = &results[0];
+        return if cfg.wait {
+            poll_server_jobs(cfg, &client, ServerJobFamily::Ingest, result).await
+        } else {
+            render::render_server_result(cfg, "sessions", result)
+        };
+    }
+
+    let combined = serde_json::json!({ "jobs": results });
     if cfg.wait {
-        poll_server_jobs(cfg, &client, ServerJobFamily::Ingest, &result).await
+        poll_server_jobs(cfg, &client, ServerJobFamily::Ingest, &combined).await
+    } else if cfg.json_output {
+        println!("{}", serde_json::to_string_pretty(&combined)?);
+        Ok(())
     } else {
-        render::render_server_result(cfg, "sessions", &result)
+        eprintln!(
+            "sessions: queued {} ingest jobs (history exceeded single-request limit)",
+            results.len()
+        );
+        for result in &results {
+            if let Some(job_id) = result.get("job_id").and_then(serde_json::Value::as_str) {
+                println!("Job ID: {job_id}");
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/ingest/sessions.rs
+++ b/src/ingest/sessions.rs
@@ -147,9 +147,9 @@ pub async fn ingest_sessions(
     Ok(total_chunks)
 }
 
-pub async fn prepare_sessions_request(
+async fn collect_prepared_session_docs(
     cfg: &Config,
-) -> Result<IngestSessionsPreparedRequest, Box<dyn Error>> {
+) -> Result<(Vec<PreparedSessionDoc>, Option<String>), Box<dyn Error>> {
     let multi = MultiProgress::new();
     let all_platforms = !cfg.sessions_claude && !cfg.sessions_codex && !cfg.sessions_gemini;
     let mut all_docs: Vec<SessionDoc> = Vec::new();
@@ -174,6 +174,13 @@ pub async fn prepare_sessions_request(
         .map(prepared_session_doc_from_session_doc)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|err| -> Box<dyn Error> { err.into() })?;
+    Ok((docs, collection))
+}
+
+pub async fn prepare_sessions_request(
+    cfg: &Config,
+) -> Result<IngestSessionsPreparedRequest, Box<dyn Error>> {
+    let (docs, collection) = collect_prepared_session_docs(cfg).await?;
     let request = IngestSessionsPreparedRequest {
         docs,
         project: cfg.sessions_project.clone(),
@@ -185,6 +192,34 @@ pub async fn prepare_sessions_request(
             .map_err(|err| -> Box<dyn Error> { err.into() })?;
     }
     Ok(request)
+}
+
+/// Scan local session exports and split them into validated batches, each within
+/// the per-request limits of `/v1/ingest/sessions/prepared`. Used by server-mode
+/// `axon sessions` so large histories upload as several jobs instead of failing
+/// the doc-count cap. Returns an empty vec when no session docs match.
+pub async fn prepare_sessions_request_batches(
+    cfg: &Config,
+) -> Result<Vec<IngestSessionsPreparedRequest>, Box<dyn Error>> {
+    let (docs, collection) = collect_prepared_session_docs(cfg).await?;
+    if docs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let project = cfg.sessions_project.clone();
+    prepared::split_prepared_session_docs(docs, cfg)
+        .into_iter()
+        .map(|batch| {
+            let request = IngestSessionsPreparedRequest {
+                docs: batch,
+                project: project.clone(),
+                collection: collection.clone(),
+            };
+            request
+                .validate(cfg)
+                .map(|()| request)
+                .map_err(|err| -> Box<dyn Error> { err.into() })
+        })
+        .collect()
 }
 
 fn prepared_session_doc_from_session_doc(

--- a/src/ingest/sessions/prepared.rs
+++ b/src/ingest/sessions/prepared.rs
@@ -3,7 +3,7 @@ use crate::core::content::url_to_domain;
 use crate::vector::ops::{PreparedDoc, chunk_text};
 use serde::{Deserialize, Serialize};
 
-const MAX_PREPARED_SESSION_DOCS: usize = 256;
+pub(crate) const MAX_PREPARED_SESSION_DOCS: usize = 256;
 const MAX_PREPARED_SESSION_METADATA_BYTES: usize = 64 * 1024;
 const RESERVED_EXTRA_KEYS: &[&str] = &[
     "agent",
@@ -184,6 +184,36 @@ impl PreparedSessionDoc {
             .unwrap_or(self.session_platform.as_str())
             .to_string()
     }
+}
+
+/// Split prepared session docs into batches that each satisfy the per-request
+/// limits enforced by [`IngestSessionsPreparedRequest::validate`] (doc count and
+/// cumulative text size). A single oversized doc is left in its own batch — its
+/// per-doc validation is the caller's responsibility.
+pub(crate) fn split_prepared_session_docs(
+    docs: Vec<PreparedSessionDoc>,
+    cfg: &Config,
+) -> Vec<Vec<PreparedSessionDoc>> {
+    let total_limit = super::session_ingest_max_bytes_for_config(cfg).saturating_mul(4);
+    let mut batches: Vec<Vec<PreparedSessionDoc>> = Vec::new();
+    let mut current: Vec<PreparedSessionDoc> = Vec::new();
+    let mut current_bytes = 0usize;
+    for doc in docs {
+        let doc_bytes = doc.text.len();
+        let exceeds_count = current.len() >= MAX_PREPARED_SESSION_DOCS;
+        let exceeds_bytes =
+            !current.is_empty() && current_bytes.saturating_add(doc_bytes) > total_limit;
+        if exceeds_count || exceeds_bytes {
+            batches.push(std::mem::take(&mut current));
+            current_bytes = 0;
+        }
+        current_bytes = current_bytes.saturating_add(doc_bytes);
+        current.push(doc);
+    }
+    if !current.is_empty() {
+        batches.push(current);
+    }
+    batches
 }
 
 fn validate_collection_name(value: &str) -> Result<(), String> {

--- a/src/ingest/sessions_tests.rs
+++ b/src/ingest/sessions_tests.rs
@@ -68,3 +68,57 @@ fn prepared_session_request_rejects_oversized_total_text() {
     let err = request.validate(&cfg).expect_err("oversized request");
     assert!(err.contains("total prepared session text exceeds"));
 }
+
+fn small_doc(idx: usize) -> PreparedSessionDoc {
+    PreparedSessionDoc {
+        url: format!("file:///tmp/{idx}.jsonl"),
+        title: None,
+        text: "hello world".to_string(),
+        session_platform: "claude".to_string(),
+        session_project: None,
+        session_date: None,
+        session_turn_count: None,
+        session_file: format!("/tmp/{idx}.jsonl"),
+        extra: serde_json::json!({}),
+    }
+}
+
+#[test]
+fn split_prepared_session_docs_chunks_by_count_and_validates() {
+    let cfg = Config::test_default();
+    let docs: Vec<PreparedSessionDoc> = (0..600).map(small_doc).collect();
+
+    let batches = prepared::split_prepared_session_docs(docs, &cfg);
+
+    assert_eq!(batches.len(), 3);
+    assert_eq!(batches[0].len(), prepared::MAX_PREPARED_SESSION_DOCS);
+    assert_eq!(batches[1].len(), prepared::MAX_PREPARED_SESSION_DOCS);
+    assert_eq!(
+        batches[2].len(),
+        600 - 2 * prepared::MAX_PREPARED_SESSION_DOCS
+    );
+    for batch in &batches {
+        let request = IngestSessionsPreparedRequest {
+            docs: batch.clone(),
+            project: None,
+            collection: None,
+        };
+        request.validate(&cfg).expect("batch within limits");
+    }
+}
+
+#[test]
+fn split_prepared_session_docs_chunks_by_total_bytes() {
+    let cfg = Config::test_default();
+    let total_limit = session_ingest_max_bytes_for_config(&cfg).saturating_mul(4);
+    // Each doc holds ~40% of the per-request byte budget, so only two fit per batch.
+    let mut doc = small_doc(0);
+    doc.text = "x".repeat(total_limit * 2 / 5);
+    let docs = vec![doc.clone(), doc.clone(), doc.clone()];
+
+    let batches = prepared::split_prepared_session_docs(docs, &cfg);
+
+    assert_eq!(batches.len(), 2);
+    assert_eq!(batches[0].len(), 2);
+    assert_eq!(batches[1].len(), 1);
+}


### PR DESCRIPTION
## Summary

`axon sessions` in **server mode** (`AXON_SERVER_URL` set) failed outright with:

```
Error: "too many prepared session docs: 3385 > 256"
```

whenever a local history exceeded the per-request cap on `/v1/ingest/sessions/prepared`. The CLI scanned all Claude/Codex/Gemini exports into one `IngestSessionsPreparedRequest` and validated the whole thing against `MAX_PREPARED_SESSION_DOCS = 256` (and the cumulative-text limit) before posting — so any sizable history was unusable over server mode.

That cap is a deliberate hardening bound on an untrusted HTTP endpoint (`deny_unknown_fields`, per-doc/metadata/total-text limits), so raising it would weaken the guard. Instead, the client now **batches** the upload.

## Changes

- `src/ingest/sessions/prepared.rs`: add `split_prepared_session_docs()`, which greedily packs prepared docs into batches bounded by **both** the doc-count cap (256) and the cumulative-text budget (`per_doc_limit * 4`) — exactly the limits `validate()` enforces. Expose `MAX_PREPARED_SESSION_DOCS` as `pub(crate)`.
- `src/ingest/sessions.rs`: factor doc collection out of `prepare_sessions_request` into `collect_prepared_session_docs`, and add `prepare_sessions_request_batches()` that returns one validated request per batch.
- `src/cli/server_mode.rs`: `run_server_mode_sessions` now uploads one ingest job per batch. Single-batch behavior is unchanged; multi-batch runs print/poll all job IDs (and emit a combined `{ "jobs": [...] }` JSON payload).
- Patch version bump to `4.6.1` (`Cargo.toml`, `Cargo.lock`, `README.md`, `CHANGELOG.md`).

Local-mode `axon sessions` is unaffected — it never went through the prepared-docs path.

## Test plan

- [x] `cargo test --lib sessions::` — 62 passed, including two new splitter tests:
  - `split_prepared_session_docs_chunks_by_count_and_validates` (600 docs → 3 batches of 256/256/88, each passing `validate`)
  - `split_prepared_session_docs_chunks_by_total_bytes` (byte-budget split)
- [x] `cargo check --bin axon` clean (pre-existing `apps/web/out/` rust-embed error worked around locally with an empty, gitignored dir)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin axon` clean
- [ ] Manual end-to-end against a live `axon serve` with a >256-doc history (not run in this environment — no live server/Qdrant/TEI)

https://claude.ai/code/session_015gZ9NcpmkZjCenWJzimweX

---
_Generated by [Claude Code](https://claude.ai/code/session_015gZ9NcpmkZjCenWJzimweX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes server‑mode `axon sessions` uploads by batching prepared session docs to meet per‑request doc and byte caps. Large histories now ingest as multiple jobs instead of failing, and web artifact versions are synced to 4.6.1.

- **Bug Fixes**
  - Batch prepared docs by count (256) and cumulative text; add `split_prepared_session_docs()` and validate each batch.
  - Server mode uploads one job per batch to `/v1/ingest/sessions/prepared`; multi-batch prints/polls all job IDs and supports `--json`.
  - Factor doc collection; add `prepare_sessions_request_batches()` and expose `MAX_PREPARED_SESSION_DOCS`. Add tests for count/byte splits.

- **Dependencies**
  - Bump crate to `4.6.1` with changelog/README updates; sync `@axon/admin-panel` and OpenAPI spec versions in apps/web to `4.6.1`.

<sup>Written for commit b119ea550c97df1dfc2eb46ba366139aabc19eef. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/138?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**v4.6.1**

* **Bug Fixes**
  * Fixed `axon sessions` in server mode: prepared-session uploads no longer fail when local session history exceeds per-request limits. Session documents are now automatically batched for upload, with each batch sized to satisfy the ingest endpoint's document count and cumulative text constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/axon/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->