### PR TITLE
feat(palette): stream ask responses

### DIFF
--- a/apps/palette-tauri/package.json
+++ b/apps/palette-tauri/package.json
@@ -22,6 +22,7 @@
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "streamdown": "^2.5.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18"
   },

--- a/apps/palette-tauri/pnpm-lock.yaml
+++ b/apps/palette-tauri/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      streamdown:
+        specifier: ^2.5.0
+        version: 2.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.6.0
@@ -75,6 +78,9 @@ importers:
         version: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -216,6 +222,12 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@dotenvx/dotenvx@1.67.0':
     resolution: {integrity: sha512-KBfIx5OrAG6giqSkHCkQWynZmT47XkSTuuYIcvjHxlKoVRlYbxNrJmyIPaefnszU8MCvMwrrB+viJQzPqzgpcg==}
@@ -389,6 +401,12 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -439,6 +457,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -555,66 +576,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -691,24 +725,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -769,30 +807,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.2':
     resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
     resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.2':
     resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.2':
     resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
     resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
@@ -835,8 +878,119 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
@@ -855,8 +1009,23 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -905,6 +1074,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -961,12 +1133,27 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1004,6 +1191,9 @@ packages:
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
@@ -1011,6 +1201,14 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -1043,6 +1241,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig@9.0.1:
     resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
@@ -1064,9 +1268,168 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.4:
+    resolution: {integrity: sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1076,6 +1439,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -1101,17 +1467,30 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dompurify@3.4.5:
+    resolution: {integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -1149,6 +1528,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1168,6 +1551,9 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1180,10 +1566,17 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -1214,6 +1607,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1336,6 +1732,9 @@ packages:
     resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -1344,12 +1743,42 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   hono@4.12.22:
     resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1367,6 +1796,10 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -1379,12 +1812,25 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -1394,8 +1840,17 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -1413,6 +1868,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -1516,6 +1974,13 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -1523,6 +1988,12 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1559,24 +2030,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1597,9 +2072,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1612,9 +2093,67 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -1630,6 +2169,93 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1759,9 +2385,15 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -1775,12 +2407,18 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1815,6 +2453,12 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -1834,6 +2478,9 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -1871,6 +2518,30 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  rehype-harden@1.1.8:
+    resolution: {integrity: sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remend@1.3.0:
+    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -1894,10 +2565,16 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.60.4:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -1909,6 +2586,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1980,6 +2660,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -1987,6 +2670,12 @@ packages:
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
+
+  streamdown@2.5.0:
+    resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -1998,6 +2687,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -2023,6 +2715,15 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -2043,6 +2744,10 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -2066,6 +2771,16 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -2101,6 +2816,24 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2124,6 +2857,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2131,6 +2868,15 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
@@ -2171,6 +2917,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -2231,7 +2980,15 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.2.2
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2429,6 +3186,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
+
   '@dotenvx/dotenvx@1.67.0':
     dependencies:
       commander: 11.1.0
@@ -2529,6 +3290,14 @@ snapshots:
     dependencies:
       hono: 4.12.22
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@inquirer/ansi@2.0.5': {}
 
   '@inquirer/confirm@6.0.13(@types/node@25.9.1)':
@@ -2574,6 +3343,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
@@ -2902,7 +3675,144 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@25.9.1':
     dependencies:
@@ -2922,7 +3832,21 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@ungap/structured-clone@1.3.1': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
@@ -2969,6 +3893,8 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
@@ -3030,9 +3956,19 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  ccount@2.0.1: {}
+
   chalk@5.6.2: {}
 
   change-case@5.4.4: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -3064,9 +4000,15 @@ snapshots:
 
   colorette@1.4.0: {}
 
+  comma-separated-tokens@2.0.3: {}
+
   commander@11.1.0: {}
 
   commander@14.0.3: {}
+
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
 
   content-disposition@1.1.0: {}
 
@@ -3087,6 +4029,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
@@ -3106,13 +4056,203 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.4):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.4
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.4):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.4
+
+  cytoscape@3.33.4: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-uri-to-buffer@4.0.1: {}
+
+  dayjs@1.11.20: {}
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 10.2.2
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   dedent@1.7.2: {}
 
@@ -3127,11 +4267,25 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   diff@8.0.4: {}
+
+  dompurify@3.4.5:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.4.2: {}
 
@@ -3168,6 +4322,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@6.0.1: {}
+
   env-paths@2.2.1: {}
 
   error-ex@1.3.4:
@@ -3181,6 +4337,8 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.47.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -3215,7 +4373,11 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@5.0.0: {}
+
   esprima@4.0.1: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
 
   etag@1.8.1: {}
 
@@ -3289,6 +4451,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3408,11 +4572,92 @@ snapshots:
 
   graphql@16.14.0: {}
 
+  hachure-fill@0.5.2: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.1
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.1
+      unist-util-position: 5.0.0
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   headers-polyfill@5.0.1:
     dependencies:
@@ -3420,6 +4665,10 @@ snapshots:
       set-cookie-parser: 3.1.0
 
   hono@4.12.22: {}
+
+  html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -3440,6 +4689,10 @@ snapshots:
 
   human-signals@8.0.1: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -3451,15 +4704,32 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
+
+  inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arrayish@0.2.1: {}
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -3470,6 +4740,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -3535,9 +4807,19 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3590,10 +4872,14 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lodash-es@4.18.1: {}
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
+
+  longest-streak@3.1.0: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -3607,7 +4893,166 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
+
+  marked@17.0.6: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   media-typer@1.1.0: {}
 
@@ -3616,6 +5061,221 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.4
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.4)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.4)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.4.5
+      es-toolkit: 1.47.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 14.0.0
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3(supports-color@10.2.2)
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -3755,9 +5415,21 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  package-manager-detector@1.6.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse-json@5.2.0:
     dependencies:
@@ -3774,9 +5446,15 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
+
+  path-data-parser@0.1.0: {}
 
   path-key@3.1.1: {}
 
@@ -3795,6 +5473,13 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   pluralize@8.0.0: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -3817,6 +5502,8 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  property-information@7.1.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -3855,6 +5542,57 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  rehype-harden@1.1.8:
+    dependencies:
+      unist-util-visit: 5.1.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remend@1.3.0: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -3869,6 +5607,8 @@ snapshots:
   rettime@0.11.11: {}
 
   reusify@1.1.0: {}
+
+  robust-predicates@3.0.3: {}
 
   rollup@4.60.4:
     dependencies:
@@ -3901,6 +5641,13 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -3916,6 +5663,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
 
@@ -4039,9 +5788,34 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   statuses@2.0.2: {}
 
   stdin-discarder@0.2.2: {}
+
+  streamdown@2.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      clsx: 2.1.1
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      marked: 17.0.6
+      mermaid: 11.15.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      rehype-harden: 1.1.8
+      rehype-raw: 7.0.0
+      rehype-sanitize: 6.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remend: 1.3.0
+      tailwind-merge: 3.6.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   strict-event-emitter@0.5.1: {}
 
@@ -4056,6 +5830,11 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   stringify-object@5.0.0:
     dependencies:
@@ -4077,6 +5856,16 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
+  stylis@4.4.0: {}
+
   supports-color@10.2.2: {}
 
   tagged-tag@1.0.0: {}
@@ -4088,6 +5877,8 @@ snapshots:
   tapable@2.3.3: {}
 
   tiny-invariant@1.3.3: {}
+
+  tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -4109,6 +5900,12 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  ts-dedent@2.2.0: {}
 
   ts-morph@26.0.0:
     dependencies:
@@ -4141,6 +5938,39 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -4157,9 +5987,26 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@14.0.0: {}
+
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
@@ -4174,6 +6021,8 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+
+  web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
 
@@ -4227,3 +6076,5 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}

--- a/apps/palette-tauri/src-tauri/Cargo.lock
+++ b/apps/palette-tauri/src-tauri/Cargo.lock
@@ -88,6 +88,7 @@ version = "4.8.0"
 dependencies = [
  "anyhow",
  "dirs",
+ "futures-util",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2733,6 +2734,7 @@ dependencies = [
  "cookie_store",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2754,12 +2756,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -2794,7 +2798,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4372,6 +4376,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/apps/palette-tauri/src-tauri/Cargo.toml
+++ b/apps/palette-tauri/src-tauri/Cargo.toml
@@ -23,7 +23,12 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 anyhow = "1"
 dirs = "6"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+  "stream",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = ["image-png", "tray-icon"] }

--- a/apps/palette-tauri/src-tauri/src/lib.rs
+++ b/apps/palette-tauri/src-tauri/src/lib.rs
@@ -8,6 +8,10 @@ use tauri::{
 };
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 
+mod stream;
+
+use stream::axon_http_stream_request;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PaletteSettings {
@@ -447,7 +451,8 @@ pub fn run() {
             hide_palette,
             show_palette,
             resize_palette,
-            axon_http_request
+            axon_http_request,
+            axon_http_stream_request
         ])
         .setup(|app| {
             let _ = install_tray(app);

--- a/apps/palette-tauri/src-tauri/src/stream.rs
+++ b/apps/palette-tauri/src-tauri/src/stream.rs
@@ -1,0 +1,144 @@
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use tauri::Emitter;
+
+use super::normalize_server_url;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PaletteStreamRequest {
+    base_url: String,
+    token: Option<String>,
+    path: String,
+    body: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum PaletteStreamEvent {
+    Started { path: String },
+    Delta { text: String },
+    Done { answer: Option<String> },
+    Error { message: String },
+}
+
+#[tauri::command]
+pub(crate) async fn axon_http_stream_request(
+    window: tauri::Window,
+    request: PaletteStreamRequest,
+) -> Result<(), String> {
+    let base_url = normalize_server_url(&request.base_url);
+    let url = format!("{}{}", base_url.trim_end_matches('/'), request.path);
+    window
+        .emit(
+            "palette://stream",
+            PaletteStreamEvent::Started {
+                path: request.path.clone(),
+            },
+        )
+        .map_err(|err| err.to_string())?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .user_agent("Axon Palette/4.5")
+        .build()
+        .map_err(|err| err.to_string())?;
+    let mut builder = client
+        .post(url)
+        .header(reqwest::header::ACCEPT, "text/event-stream")
+        .json(&request.body);
+    if let Some(token) = request
+        .token
+        .as_deref()
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    {
+        builder = builder.bearer_auth(token).header("x-api-key", token);
+    }
+
+    let response = builder.send().await.map_err(|err| err.to_string())?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("stream request failed with HTTP {status}: {text}"));
+    }
+
+    let mut pending = String::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|err| err.to_string())?;
+        pending.push_str(&String::from_utf8_lossy(&chunk));
+        while let Some(pos) = pending.find('\n') {
+            let line = pending[..pos].trim_end_matches('\r').to_string();
+            pending.drain(..=pos);
+            handle_palette_sse_line(&window, &line)?;
+        }
+    }
+    if !pending.trim().is_empty() {
+        handle_palette_sse_line(&window, pending.trim_end_matches('\r'))?;
+    }
+    Ok(())
+}
+
+fn parse_sse_data_line(line: &str) -> Option<String> {
+    line.strip_prefix("data:")
+        .map(|value| value.trim().to_string())
+}
+
+fn handle_palette_sse_line(window: &tauri::Window, line: &str) -> Result<(), String> {
+    let Some(data) = parse_sse_data_line(line) else {
+        return Ok(());
+    };
+    let value: serde_json::Value = serde_json::from_str(&data).map_err(|err| err.to_string())?;
+    match value.get("type").and_then(|kind| kind.as_str()) {
+        Some("delta") => {
+            let text = value
+                .get("text")
+                .and_then(|text| text.as_str())
+                .unwrap_or_default();
+            window.emit(
+                "palette://stream",
+                PaletteStreamEvent::Delta {
+                    text: text.to_string(),
+                },
+            )
+        }
+        Some("done") => {
+            let answer = value
+                .get("answer")
+                .and_then(|answer| answer.as_str())
+                .map(str::to_string);
+            window.emit("palette://stream", PaletteStreamEvent::Done { answer })
+        }
+        Some("error") => {
+            let message = value
+                .get("message")
+                .and_then(|message| message.as_str())
+                .unwrap_or("stream error")
+                .to_string();
+            window.emit("palette://stream", PaletteStreamEvent::Error { message })
+        }
+        _ => Ok(()),
+    }
+    .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod stream_tests {
+    use super::parse_sse_data_line as parse_data_line;
+
+    #[test]
+    fn parse_sse_data_line() {
+        assert_eq!(
+            parse_data_line("data: {\"type\":\"delta\",\"text\":\"hi\"}"),
+            Some("{\"type\":\"delta\",\"text\":\"hi\"}".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_non_data_sse_line() {
+        assert_eq!(parse_data_line("event: delta"), None);
+    }
+}

--- a/apps/palette-tauri/src-tauri/src/stream.rs
+++ b/apps/palette-tauri/src-tauri/src/stream.rs
@@ -11,17 +11,34 @@ use super::normalize_server_url;
 pub(crate) struct PaletteStreamRequest {
     base_url: String,
     token: Option<String>,
+    request_id: String,
     path: String,
     body: serde_json::Value,
 }
 
 #[derive(Debug, Serialize, Clone)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 enum PaletteStreamEvent {
-    Started { path: String },
-    Delta { text: String },
-    Done { answer: Option<String> },
-    Error { message: String },
+    Started {
+        request_id: String,
+        path: String,
+    },
+    Delta {
+        request_id: String,
+        text: String,
+    },
+    Done {
+        request_id: String,
+        answer: Option<String>,
+    },
+    Error {
+        request_id: String,
+        message: String,
+    },
 }
 
 #[tauri::command]
@@ -35,6 +52,7 @@ pub(crate) async fn axon_http_stream_request(
         .emit(
             "palette://stream",
             PaletteStreamEvent::Started {
+                request_id: request.request_id.clone(),
                 path: request.path.clone(),
             },
         )
@@ -65,21 +83,53 @@ pub(crate) async fn axon_http_stream_request(
         return Err(format!("stream request failed with HTTP {status}: {text}"));
     }
 
-    let mut pending = String::new();
+    let mut pending = Vec::new();
+    let mut terminal = false;
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|err| err.to_string())?;
-        pending.push_str(&String::from_utf8_lossy(&chunk));
-        while let Some(pos) = pending.find('\n') {
-            let line = pending[..pos].trim_end_matches('\r').to_string();
-            pending.drain(..=pos);
-            handle_palette_sse_line(&window, &line)?;
+        for line in drain_sse_lines(&mut pending, &chunk)? {
+            terminal |= handle_palette_sse_line(&window, &request.request_id, &line)?;
         }
     }
-    if !pending.trim().is_empty() {
-        handle_palette_sse_line(&window, pending.trim_end_matches('\r'))?;
+    if !pending.is_empty() {
+        let line = decode_sse_line(std::mem::take(&mut pending))?;
+        if !line.trim().is_empty() {
+            terminal |= handle_palette_sse_line(&window, &request.request_id, &line)?;
+        }
+    }
+    if !terminal {
+        let message = "stream ended before done".to_string();
+        let _ = window.emit(
+            "palette://stream",
+            PaletteStreamEvent::Error {
+                request_id: request.request_id,
+                message: message.clone(),
+            },
+        );
+        return Err(message);
     }
     Ok(())
+}
+
+fn drain_sse_lines(pending: &mut Vec<u8>, chunk: &[u8]) -> Result<Vec<String>, String> {
+    pending.extend_from_slice(chunk);
+    let mut lines = Vec::new();
+    while let Some(pos) = pending.iter().position(|byte| *byte == b'\n') {
+        let raw: Vec<u8> = pending.drain(..=pos).collect();
+        lines.push(decode_sse_line(raw)?);
+    }
+    Ok(lines)
+}
+
+fn decode_sse_line(mut raw: Vec<u8>) -> Result<String, String> {
+    if raw.last() == Some(&b'\n') {
+        raw.pop();
+    }
+    if raw.last() == Some(&b'\r') {
+        raw.pop();
+    }
+    String::from_utf8(raw).map_err(|err| format!("invalid UTF-8 in SSE stream: {err}"))
 }
 
 fn parse_sse_data_line(line: &str) -> Option<String> {
@@ -87,9 +137,13 @@ fn parse_sse_data_line(line: &str) -> Option<String> {
         .map(|value| value.trim().to_string())
 }
 
-fn handle_palette_sse_line(window: &tauri::Window, line: &str) -> Result<(), String> {
+fn handle_palette_sse_line(
+    window: &tauri::Window,
+    request_id: &str,
+    line: &str,
+) -> Result<bool, String> {
     let Some(data) = parse_sse_data_line(line) else {
-        return Ok(());
+        return Ok(false);
     };
     let value: serde_json::Value = serde_json::from_str(&data).map_err(|err| err.to_string())?;
     match value.get("type").and_then(|kind| kind.as_str()) {
@@ -98,19 +152,32 @@ fn handle_palette_sse_line(window: &tauri::Window, line: &str) -> Result<(), Str
                 .get("text")
                 .and_then(|text| text.as_str())
                 .unwrap_or_default();
-            window.emit(
-                "palette://stream",
-                PaletteStreamEvent::Delta {
-                    text: text.to_string(),
-                },
-            )
+            window
+                .emit(
+                    "palette://stream",
+                    PaletteStreamEvent::Delta {
+                        request_id: request_id.to_string(),
+                        text: text.to_string(),
+                    },
+                )
+                .map_err(|err| err.to_string())?;
+            Ok(false)
         }
         Some("done") => {
             let answer = value
                 .get("answer")
                 .and_then(|answer| answer.as_str())
                 .map(str::to_string);
-            window.emit("palette://stream", PaletteStreamEvent::Done { answer })
+            window
+                .emit(
+                    "palette://stream",
+                    PaletteStreamEvent::Done {
+                        request_id: request_id.to_string(),
+                        answer,
+                    },
+                )
+                .map_err(|err| err.to_string())?;
+            Ok(true)
         }
         Some("error") => {
             let message = value
@@ -118,16 +185,24 @@ fn handle_palette_sse_line(window: &tauri::Window, line: &str) -> Result<(), Str
                 .and_then(|message| message.as_str())
                 .unwrap_or("stream error")
                 .to_string();
-            window.emit("palette://stream", PaletteStreamEvent::Error { message })
+            window
+                .emit(
+                    "palette://stream",
+                    PaletteStreamEvent::Error {
+                        request_id: request_id.to_string(),
+                        message,
+                    },
+                )
+                .map_err(|err| err.to_string())?;
+            Ok(true)
         }
-        _ => Ok(()),
+        _ => Ok(false),
     }
-    .map_err(|err| err.to_string())
 }
 
 #[cfg(test)]
 mod stream_tests {
-    use super::parse_sse_data_line as parse_data_line;
+    use super::{drain_sse_lines, parse_sse_data_line as parse_data_line};
 
     #[test]
     fn parse_sse_data_line() {
@@ -140,5 +215,21 @@ mod stream_tests {
     #[test]
     fn ignores_non_data_sse_line() {
         assert_eq!(parse_data_line("event: delta"), None);
+    }
+
+    #[test]
+    fn buffers_split_utf8_until_complete_line() {
+        let mut pending = Vec::new();
+        let snowman = "data: {\"type\":\"delta\",\"text\":\"☃\"}\n".as_bytes();
+        assert!(
+            drain_sse_lines(&mut pending, &snowman[..snowman.len() - 2])
+                .unwrap()
+                .is_empty()
+        );
+
+        let lines = drain_sse_lines(&mut pending, &snowman[snowman.len() - 2..]).unwrap();
+
+        assert_eq!(lines, vec!["data: {\"type\":\"delta\",\"text\":\"☃\"}"]);
+        assert!(pending.is_empty());
     }
 }

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -1,30 +1,23 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
-  Activity,
-  CheckCircle2,
-  Copy,
-  ExternalLink,
-  RotateCw,
   Search,
   Send,
   Settings,
-  SlidersHorizontal,
   X,
-  XCircle,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/aurora/badge";
-import { Button } from "@/components/ui/aurora/button";
+import { OutputPanel } from "@/components/palette/OutputPanel";
+import { SettingsPanel } from "@/components/palette/SettingsPanel";
 import { Input } from "@/components/ui/aurora/input";
 import { ScrollArea } from "@/components/ui/aurora/scroll-area";
-import { Separator } from "@/components/ui/aurora/separator";
 import { Spinner } from "@/components/ui/aurora/spinner";
 import { StatusIndicator } from "@/components/ui/aurora/status-indicator";
 import {
   type PaletteConfig,
-  type PaletteResult,
+  buildActionRequest,
   createAxonClient,
   executeAction,
 } from "@/lib/axonClient";
@@ -35,12 +28,15 @@ import {
   actionInvokedBy,
   actionMatches,
 } from "@/lib/actions";
-import { formatPayload } from "@/lib/format";
+import { formatPayload, outputKindFor } from "@/lib/format";
+import type { RunState } from "@/lib/runState";
+import { hostLabel } from "@/lib/url";
 
-type RunState =
-  | { kind: "idle" }
-  | { kind: "running"; title: string; subtitle: string }
-  | { kind: "success" | "error"; title: string; subtitle: string; text: string; result: PaletteResult };
+type PaletteStreamEvent =
+  | { type: "started"; path: string }
+  | { type: "delta"; text: string }
+  | { type: "done"; answer?: string | null }
+  | { type: "error"; message: string };
 
 const shortcutOptions = ["Ctrl+Shift+Space", "Alt+Space", "Ctrl+Space", "Cmd+Shift+Space"] as const;
 const appWindow = getCurrentWindow();
@@ -81,6 +77,63 @@ export default function App() {
     ];
     return () => {
       void Promise.all(unlisteners).then((items) => items.forEach((unlisten) => unlisten()));
+    };
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    const unlisten = appWindow.listen<PaletteStreamEvent>("palette://stream", (event) => {
+      if (disposed) return;
+      const payload = event.payload;
+      if (payload.type === "delta") {
+        setRun((current) =>
+          current.kind === "streaming"
+            ? { ...current, text: current.text + payload.text }
+            : current,
+        );
+      } else if (payload.type === "done") {
+        setRun((current) =>
+          current.kind === "streaming"
+            ? {
+                kind: "success",
+                title: "Ask question completed",
+                subtitle: current.subtitle,
+                text: payload.answer ?? current.text,
+                outputKind: current.outputKind,
+                result: {
+                  ok: true,
+                  status: 200,
+                  path: "/v1/ask/stream",
+                  method: "POST",
+                  payload: { answer: payload.answer ?? current.text },
+                },
+              }
+            : current,
+        );
+      } else if (payload.type === "error") {
+        setRun((current) =>
+          current.kind === "streaming"
+            ? {
+                kind: "error",
+                title: "Ask question failed",
+                subtitle: "/v1/ask/stream",
+                text: payload.message,
+                outputKind: current.outputKind,
+                result: {
+                  ok: false,
+                  status: 0,
+                  path: "/v1/ask/stream",
+                  method: "POST",
+                  payload: { error: payload.message },
+                },
+              }
+            : current,
+        );
+      }
+    });
+    return () => {
+      disposed = true;
+      void unlisten.then((fn) => fn());
     };
   }, []);
 
@@ -163,16 +216,43 @@ export default function App() {
   const client = useMemo(() => (config ? createAxonClient(config) : null), [config]);
 
   async function submit(action: PaletteAction = active) {
-    if (!client || !config || !action || run.kind === "running") return;
+    if (!client || !config || !action || run.kind === "running" || run.kind === "streaming") return;
     const argument = argumentFor(action, modeAction, parsed, query);
     const validation = validationMessage(action, argument);
     if (validation) return;
     const commandLine = `${action.subcommand}${argument ? ` ${argument}` : ""}`;
-    setRun({
-      kind: "running",
-      title: `Running ${action.label}`,
-      subtitle: commandLine,
-    });
+    if (action.subcommand === "ask") {
+      const request = buildActionRequest(client, action, argument, config);
+      setRun({
+        kind: "streaming",
+        title: "Streaming Ask question",
+        subtitle: `${request.method} /v1/ask/stream`,
+        text: "",
+        outputKind: outputKindFor(action.subcommand),
+      });
+      try {
+        await invoke("axon_http_stream_request", {
+          request: {
+            ...request,
+            path: "/v1/ask/stream",
+            body: request.body,
+          },
+        });
+        return;
+      } catch {
+        setRun({
+          kind: "running",
+          title: `Running ${action.label}`,
+          subtitle: commandLine,
+        });
+      }
+    } else {
+      setRun({
+        kind: "running",
+        title: `Running ${action.label}`,
+        subtitle: commandLine,
+      });
+    }
     try {
       const result = await executeAction(client, action, argument, config);
       setRun({
@@ -180,6 +260,7 @@ export default function App() {
         title: `${action.label} ${result.ok ? "completed" : "failed"}`,
         subtitle: `${result.method} ${result.path} | HTTP ${result.status}`,
         text: formatPayload(action.subcommand, result.payload),
+        outputKind: outputKindFor(action.subcommand),
         result,
       });
     } catch (err) {
@@ -188,6 +269,7 @@ export default function App() {
         title: `${action.label} failed`,
         subtitle: commandLine,
         text: err instanceof Error ? err.message : String(err),
+        outputKind: outputKindFor(action.subcommand),
         result: { ok: false, status: 0, path: "", method: "POST", payload: null },
       });
     }
@@ -236,8 +318,7 @@ export default function App() {
     }
   }
 
-  const outputText = "text" in run ? run.text : "";
-  const outputUrl = outputText ? firstUrl(outputText) : null;
+  const outputKind = "outputKind" in run ? run.outputKind : active ? outputKindFor(active.subcommand) : "code";
 
   return (
     <div className={`aurora-page-shell palette-shell${compact ? " palette-shell-compact" : ""}`}>
@@ -288,82 +369,23 @@ export default function App() {
           className="command-submit"
           type="button"
           onClick={() => active && void submit(active)}
-          disabled={!client || !active || run.kind === "running" || Boolean(validation)}
+          disabled={!client || !active || run.kind === "running" || run.kind === "streaming" || Boolean(validation)}
           aria-label="Run selected action"
           title={validation || "Run selected action"}
         >
-          {run.kind === "running" ? <Spinner size="sm" tone="rose" /> : <Send size={15} />}
+          {run.kind === "running" || run.kind === "streaming" ? <Spinner size="sm" tone="rose" /> : <Send size={15} />}
         </button>
       </section>
 
       {settingsOpen && draftConfig && (
-        <section className="settings-panel">
-          <div className="settings-heading">
-            <SlidersHorizontal size={15} />
-            <span>Settings</span>
-          </div>
-          <label>
-            <span>Server</span>
-            <input value={draftConfig.serverUrl} onChange={(event) => setDraftConfig({ ...draftConfig, serverUrl: event.target.value })} />
-          </label>
-          <label>
-            <span>Token</span>
-            <input
-              type="password"
-              value={draftConfig.token ?? ""}
-              onChange={(event) => setDraftConfig({ ...draftConfig, token: event.target.value || null })}
-            />
-          </label>
-          <label>
-            <span>Shortcut</span>
-            <select value={draftConfig.shortcut} onChange={(event) => setDraftConfig({ ...draftConfig, shortcut: event.target.value })}>
-              {shortcutOptions.map((shortcut) => (
-                <option key={shortcut} value={shortcut}>
-                  {shortcut}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            <span>Collection</span>
-            <input value={draftConfig.collection} onChange={(event) => setDraftConfig({ ...draftConfig, collection: event.target.value })} />
-          </label>
-          <label>
-            <span>Results</span>
-            <input
-              type="number"
-              min={1}
-              max={50}
-              value={draftConfig.resultLimit}
-              onChange={(event) => setDraftConfig({ ...draftConfig, resultLimit: Number(event.target.value) })}
-            />
-          </label>
-          <label>
-            <span>Theme</span>
-            <select value={draftConfig.theme} onChange={(event) => setDraftConfig({ ...draftConfig, theme: event.target.value as PaletteConfig["theme"] })}>
-              <option value="system">System</option>
-              <option value="dark">Dark</option>
-              <option value="light">Light</option>
-            </select>
-          </label>
-          <label className="settings-check">
-            <input
-              type="checkbox"
-              checked={draftConfig.hideOnBlur}
-              onChange={(event) => setDraftConfig({ ...draftConfig, hideOnBlur: event.target.checked })}
-            />
-            <span>Hide on blur</span>
-          </label>
-          <div className="settings-actions">
-            {configError && <span>{configError}</span>}
-            <Button size="sm" variant="neutral" onClick={() => setSettingsOpen(false)}>
-              Close
-            </Button>
-            <Button size="sm" variant="rose" onClick={() => void saveSettings()}>
-              Save
-            </Button>
-          </div>
-        </section>
+        <SettingsPanel
+          configError={configError}
+          draftConfig={draftConfig}
+          shortcutOptions={shortcutOptions}
+          onChange={setDraftConfig}
+          onClose={() => setSettingsOpen(false)}
+          onSave={() => void saveSettings()}
+        />
       )}
 
       {showContent && (
@@ -382,9 +404,9 @@ export default function App() {
                   className={index === selected ? "action-row action-row-selected" : "action-row"}
                   onClick={() => {
                     setSelected(index);
-                    if (parsed.invoked && run.kind !== "running") {
+                    if (parsed.invoked && run.kind !== "running" && run.kind !== "streaming") {
                       void submit(action);
-                    } else if (acceptsDirectUrl(action) && looksLikeUrl(parsed.search) && run.kind !== "running") {
+                    } else if (acceptsDirectUrl(action) && looksLikeUrl(parsed.search) && run.kind !== "running" && run.kind !== "streaming") {
                       void submit(action);
                     } else {
                       enterActionMode(action);
@@ -409,39 +431,14 @@ export default function App() {
         )}
 
         {showResultsLayout && (
-        <section className="output-panel">
-          <div className="panel-heading">
-            <span>Output</span>
-            <span className="output-tools">
-              {"text" in run && (
-                <>
-                  <button type="button" onClick={() => void copyOutput(run.text)} title="Copy output" aria-label="Copy output">
-                    <Copy size={14} />
-                  </button>
-                  <button type="button" onClick={() => active && void submit(active)} title="Retry" aria-label="Retry">
-                    <RotateCw size={14} />
-                  </button>
-                </>
-              )}
-              {outputUrl && (
-                <button type="button" onClick={() => window.open(outputUrl, "_blank", "noopener,noreferrer")} title="Open first URL" aria-label="Open first URL">
-                  <ExternalLink size={14} />
-                </button>
-              )}
-              {run.kind === "running" ? <Spinner size="sm" /> : run.kind === "success" ? <CheckCircle2 size={15} /> : run.kind === "error" ? <XCircle size={15} /> : <Activity size={15} />}
-            </span>
-          </div>
-          <Separator />
-          <div className={`output-state output-${run.kind}`}>
-            <div className="output-title">{copied ? "Copied" : outputTitle(run)}</div>
-            <div className="output-subtitle">{outputSubtitle(run, active)}</div>
-            {"text" in run && (
-              <pre className="output-body">
-                <code>{run.text}</code>
-              </pre>
-            )}
-          </div>
-        </section>
+          <OutputPanel
+            active={active}
+            copied={copied}
+            outputKind={outputKind}
+            run={run}
+            onCopy={(text) => void copyOutput(text)}
+            onRetry={() => active && void submit(active)}
+          />
         )}
       </main>
       )}
@@ -497,26 +494,4 @@ function argumentPlaceholder(action: PaletteAction): string {
 
 function looksLikeUrl(value: string): boolean {
   return /^https?:\/\//i.test(value.trim());
-}
-
-function outputTitle(run: RunState): string {
-  if (run.kind === "idle") return "Ready";
-  return run.title;
-}
-
-function outputSubtitle(run: RunState, action: PaletteAction | undefined): string {
-  if (run.kind === "idle") return action?.description ?? "No matching action";
-  return run.subtitle;
-}
-
-function hostLabel(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    return url;
-  }
-}
-
-function firstUrl(value: string): string | null {
-  return value.match(/https?:\/\/[^\s"')\]}]+/i)?.[0] ?? null;
 }

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -33,10 +33,10 @@ import type { RunState } from "@/lib/runState";
 import { hostLabel } from "@/lib/url";
 
 type PaletteStreamEvent =
-  | { type: "started"; path: string }
-  | { type: "delta"; text: string }
-  | { type: "done"; answer?: string | null }
-  | { type: "error"; message: string };
+  | { type: "started"; requestId: string; path: string }
+  | { type: "delta"; requestId: string; text: string }
+  | { type: "done"; requestId: string; answer?: string | null }
+  | { type: "error"; requestId: string; message: string };
 
 const shortcutOptions = ["Ctrl+Shift+Space", "Alt+Space", "Ctrl+Space", "Cmd+Shift+Space"] as const;
 const appWindow = getCurrentWindow();
@@ -86,13 +86,13 @@ export default function App() {
       const payload = event.payload;
       if (payload.type === "delta") {
         setRun((current) =>
-          current.kind === "streaming"
+          current.kind === "streaming" && current.requestId === payload.requestId
             ? { ...current, text: current.text + payload.text }
             : current,
         );
       } else if (payload.type === "done") {
         setRun((current) =>
-          current.kind === "streaming"
+          current.kind === "streaming" && current.requestId === payload.requestId
             ? {
                 kind: "success",
                 title: "Ask question completed",
@@ -111,7 +111,7 @@ export default function App() {
         );
       } else if (payload.type === "error") {
         setRun((current) =>
-          current.kind === "streaming"
+          current.kind === "streaming" && current.requestId === payload.requestId
             ? {
                 kind: "error",
                 title: "Ask question failed",
@@ -221,6 +221,7 @@ export default function App() {
     if (validation) return;
     const commandLine = `${action.subcommand}${argument ? ` ${argument}` : ""}`;
     if (action.subcommand === "ask") {
+      const requestId = newRequestId();
       const request = buildActionRequest(client, action, argument, config);
       setRun({
         kind: "streaming",
@@ -228,22 +229,39 @@ export default function App() {
         subtitle: `${request.method} /v1/ask/stream`,
         text: "",
         outputKind: outputKindFor(action.subcommand),
+        requestId,
       });
       try {
         await invoke("axon_http_stream_request", {
           request: {
             ...request,
+            requestId,
             path: "/v1/ask/stream",
             body: request.body,
           },
         });
         return;
-      } catch {
-        setRun({
-          kind: "running",
-          title: `Running ${action.label}`,
-          subtitle: commandLine,
-        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setRun((current) =>
+          current.kind === "streaming" && current.requestId === requestId
+            ? {
+                kind: "error",
+                title: `${action.label} stream failed`,
+                subtitle: `${request.method} /v1/ask/stream`,
+                text: message,
+                outputKind: outputKindFor(action.subcommand),
+                result: {
+                  ok: false,
+                  status: 0,
+                  path: "/v1/ask/stream",
+                  method: "POST",
+                  payload: { error: message },
+                },
+              }
+            : current,
+        );
+        return;
       }
     } else {
       setRun({
@@ -456,6 +474,10 @@ function focusInput(select = false) {
     input?.focus();
     if (select) input?.select();
   }, 30);
+}
+
+function newRequestId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 function parseCommand(raw: string): { invoked?: PaletteAction; search: string; arg: string } {

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -6,7 +6,7 @@ import {
   Settings,
   X,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/aurora/badge";
 import { OutputPanel } from "@/components/palette/OutputPanel";
@@ -51,7 +51,6 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [run, setRun] = useState<RunState>({ kind: "idle" });
   const [copied, setCopied] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     invoke<PaletteConfig>("load_palette_config")
@@ -357,7 +356,6 @@ export default function App() {
           </button>
         )}
         <Input
-          ref={inputRef}
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           onKeyDown={onInputKeyDown}

--- a/apps/palette-tauri/src/components/palette/OutputPanel.tsx
+++ b/apps/palette-tauri/src/components/palette/OutputPanel.tsx
@@ -1,0 +1,90 @@
+import { Activity, CheckCircle2, Copy, ExternalLink, RotateCw, XCircle } from "lucide-react";
+import { Streamdown } from "streamdown";
+
+import { Spinner } from "@/components/ui/aurora/spinner";
+import { Separator } from "@/components/ui/aurora/separator";
+import type { PaletteAction } from "@/lib/actions";
+import type { RunState } from "@/lib/runState";
+
+interface OutputPanelProps {
+  active?: PaletteAction;
+  copied: boolean;
+  outputKind: "markdown" | "code";
+  run: RunState;
+  onCopy: (text: string) => void;
+  onRetry: () => void;
+}
+
+export function OutputPanel({
+  active,
+  copied,
+  outputKind,
+  run,
+  onCopy,
+  onRetry,
+}: OutputPanelProps) {
+  const outputUrl = "text" in run ? firstUrl(run.text) : null;
+
+  return (
+    <section className="output-panel">
+      <div className="panel-heading">
+        <span>Output</span>
+        <span className="output-tools">
+          {"text" in run && (
+            <>
+              <button type="button" onClick={() => onCopy(run.text)} title="Copy output" aria-label="Copy output">
+                <Copy size={14} />
+              </button>
+              <button type="button" onClick={onRetry} title="Retry" aria-label="Retry">
+                <RotateCw size={14} />
+              </button>
+            </>
+          )}
+          {outputUrl && (
+            <button type="button" onClick={() => window.open(outputUrl, "_blank", "noopener,noreferrer")} title="Open first URL" aria-label="Open first URL">
+              <ExternalLink size={14} />
+            </button>
+          )}
+          {run.kind === "running" || run.kind === "streaming" ? (
+            <Spinner size="sm" />
+          ) : run.kind === "success" ? (
+            <CheckCircle2 size={15} />
+          ) : run.kind === "error" ? (
+            <XCircle size={15} />
+          ) : (
+            <Activity size={15} />
+          )}
+        </span>
+      </div>
+      <Separator />
+      <div className={`output-state output-${run.kind}`}>
+        <div className="output-title">{copied ? "Copied" : outputTitle(run)}</div>
+        <div className="output-subtitle">{outputSubtitle(run, active)}</div>
+        {"text" in run &&
+          (outputKind === "markdown" ? (
+            <div className="output-body output-markdown">
+              <Streamdown>{run.text}</Streamdown>
+            </div>
+          ) : (
+            <pre className="output-body output-code">
+              <code>{run.text}</code>
+            </pre>
+          ))}
+      </div>
+    </section>
+  );
+}
+
+function outputTitle(run: RunState): string {
+  if (run.kind === "idle") return "Ready";
+  return run.title;
+}
+
+function outputSubtitle(run: RunState, action: PaletteAction | undefined): string {
+  if (run.kind === "idle") return action?.description ?? "No matching action";
+  return run.subtitle;
+}
+
+function firstUrl(value: string): string | null {
+  return value.match(/https?:\/\/[^\s"')\]}]+/i)?.[0] ?? null;
+}

--- a/apps/palette-tauri/src/components/palette/SettingsPanel.tsx
+++ b/apps/palette-tauri/src/components/palette/SettingsPanel.tsx
@@ -20,6 +20,10 @@ export function SettingsPanel({
   onClose,
   onSave,
 }: SettingsPanelProps) {
+  const updateConfig = <Key extends keyof PaletteConfig>(key: Key, value: PaletteConfig[Key]) => {
+    onChange({ ...draftConfig, [key]: value });
+  };
+
   return (
     <section className="settings-panel">
       <div className="settings-heading">
@@ -28,19 +32,19 @@ export function SettingsPanel({
       </div>
       <label>
         <span>Server</span>
-        <input value={draftConfig.serverUrl} onChange={(event) => onChange({ ...draftConfig, serverUrl: event.target.value })} />
+        <input value={draftConfig.serverUrl} onChange={(event) => updateConfig("serverUrl", event.target.value)} />
       </label>
       <label>
         <span>Token</span>
         <input
           type="password"
           value={draftConfig.token ?? ""}
-          onChange={(event) => onChange({ ...draftConfig, token: event.target.value || null })}
+          onChange={(event) => updateConfig("token", event.target.value || null)}
         />
       </label>
       <label>
         <span>Shortcut</span>
-        <select value={draftConfig.shortcut} onChange={(event) => onChange({ ...draftConfig, shortcut: event.target.value })}>
+        <select value={draftConfig.shortcut} onChange={(event) => updateConfig("shortcut", event.target.value)}>
           {shortcutOptions.map((shortcut) => (
             <option key={shortcut} value={shortcut}>
               {shortcut}
@@ -50,7 +54,7 @@ export function SettingsPanel({
       </label>
       <label>
         <span>Collection</span>
-        <input value={draftConfig.collection} onChange={(event) => onChange({ ...draftConfig, collection: event.target.value })} />
+        <input value={draftConfig.collection} onChange={(event) => updateConfig("collection", event.target.value)} />
       </label>
       <label>
         <span>Results</span>
@@ -59,12 +63,12 @@ export function SettingsPanel({
           min={1}
           max={50}
           value={draftConfig.resultLimit}
-          onChange={(event) => onChange({ ...draftConfig, resultLimit: Number(event.target.value) })}
+          onChange={(event) => updateConfig("resultLimit", Number(event.target.value))}
         />
       </label>
       <label>
         <span>Theme</span>
-        <select value={draftConfig.theme} onChange={(event) => onChange({ ...draftConfig, theme: event.target.value as PaletteConfig["theme"] })}>
+        <select value={draftConfig.theme} onChange={(event) => updateConfig("theme", event.target.value as PaletteConfig["theme"])}>
           <option value="system">System</option>
           <option value="dark">Dark</option>
           <option value="light">Light</option>
@@ -74,7 +78,7 @@ export function SettingsPanel({
         <input
           type="checkbox"
           checked={draftConfig.hideOnBlur}
-          onChange={(event) => onChange({ ...draftConfig, hideOnBlur: event.target.checked })}
+          onChange={(event) => updateConfig("hideOnBlur", event.target.checked)}
         />
         <span>Hide on blur</span>
       </label>

--- a/apps/palette-tauri/src/components/palette/SettingsPanel.tsx
+++ b/apps/palette-tauri/src/components/palette/SettingsPanel.tsx
@@ -1,0 +1,92 @@
+import { SlidersHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/aurora/button";
+import type { PaletteConfig } from "@/lib/axonClient";
+
+interface SettingsPanelProps {
+  configError: string | null;
+  draftConfig: PaletteConfig;
+  shortcutOptions: readonly string[];
+  onChange: (config: PaletteConfig) => void;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+export function SettingsPanel({
+  configError,
+  draftConfig,
+  shortcutOptions,
+  onChange,
+  onClose,
+  onSave,
+}: SettingsPanelProps) {
+  return (
+    <section className="settings-panel">
+      <div className="settings-heading">
+        <SlidersHorizontal size={15} />
+        <span>Settings</span>
+      </div>
+      <label>
+        <span>Server</span>
+        <input value={draftConfig.serverUrl} onChange={(event) => onChange({ ...draftConfig, serverUrl: event.target.value })} />
+      </label>
+      <label>
+        <span>Token</span>
+        <input
+          type="password"
+          value={draftConfig.token ?? ""}
+          onChange={(event) => onChange({ ...draftConfig, token: event.target.value || null })}
+        />
+      </label>
+      <label>
+        <span>Shortcut</span>
+        <select value={draftConfig.shortcut} onChange={(event) => onChange({ ...draftConfig, shortcut: event.target.value })}>
+          {shortcutOptions.map((shortcut) => (
+            <option key={shortcut} value={shortcut}>
+              {shortcut}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        <span>Collection</span>
+        <input value={draftConfig.collection} onChange={(event) => onChange({ ...draftConfig, collection: event.target.value })} />
+      </label>
+      <label>
+        <span>Results</span>
+        <input
+          type="number"
+          min={1}
+          max={50}
+          value={draftConfig.resultLimit}
+          onChange={(event) => onChange({ ...draftConfig, resultLimit: Number(event.target.value) })}
+        />
+      </label>
+      <label>
+        <span>Theme</span>
+        <select value={draftConfig.theme} onChange={(event) => onChange({ ...draftConfig, theme: event.target.value as PaletteConfig["theme"] })}>
+          <option value="system">System</option>
+          <option value="dark">Dark</option>
+          <option value="light">Light</option>
+        </select>
+      </label>
+      <label className="settings-check">
+        <input
+          type="checkbox"
+          checked={draftConfig.hideOnBlur}
+          onChange={(event) => onChange({ ...draftConfig, hideOnBlur: event.target.checked })}
+        />
+        <span>Hide on blur</span>
+      </label>
+      <div className="settings-actions">
+        {configError && <span>{configError}</span>}
+        <Button size="sm" variant="neutral" onClick={onClose}>
+          Close
+        </Button>
+        <Button size="sm" variant="rose" onClick={onSave}>
+          Save
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/palette-tauri/src/lib/axonClient.ts
+++ b/apps/palette-tauri/src/lib/axonClient.ts
@@ -21,9 +21,17 @@ export interface PaletteResult {
   payload: unknown;
 }
 
-interface Client {
+export interface Client {
   baseUrl: string;
   headers: Record<string, string>;
+}
+
+export interface PaletteHttpRequest {
+  baseUrl: string;
+  token: string | null;
+  method: "GET" | "POST";
+  path: string;
+  body: Record<string, unknown> | null;
 }
 
 export function createAxonClient(config: PaletteConfig): Client {
@@ -49,6 +57,35 @@ export async function executeAction(
   arg: string,
   config: PaletteConfig,
 ): Promise<PaletteResult> {
+  const request = buildActionRequest(client, action, arg, config);
+  try {
+    return await invoke<PaletteResult>("axon_http_request", { request });
+  } catch (error) {
+    return failedResult(request.method, request.path, error);
+  }
+}
+
+export function buildActionRequest(
+  client: Client,
+  action: PaletteAction,
+  arg: string,
+  config: PaletteConfig,
+): PaletteHttpRequest {
+  const body = bodyFor(action, arg, config);
+  return {
+    baseUrl: client.baseUrl,
+    token: tokenFromHeaders(client.headers),
+    method: body.method,
+    path: body.path,
+    body: body.body,
+  };
+}
+
+function bodyFor(
+  action: PaletteAction,
+  arg: string,
+  config: PaletteConfig,
+): { method: "GET" | "POST"; path: GetPath | PostPath; body: Record<string, unknown> | null } {
   const words = wordsFor(action, arg);
   const collection = config.collection.trim();
   const collectionBody = collection ? { collection } : {};
@@ -56,52 +93,60 @@ export async function executeAction(
 
   switch (action.subcommand) {
     case "doctor":
-      return getResult(client, "/v1/doctor");
+      return { method: "GET", path: "/v1/doctor", body: null };
     case "status":
-      return getResult(client, "/v1/status");
+      return { method: "GET", path: "/v1/status", body: null };
     case "sources":
-      return getResult(client, "/v1/sources");
+      return { method: "GET", path: "/v1/sources", body: null };
     case "domains":
-      return getResult(client, "/v1/domains");
+      return { method: "GET", path: "/v1/domains", body: null };
     case "stats":
-      return getResult(client, "/v1/stats");
+      return { method: "GET", path: "/v1/stats", body: null };
     case "scrape":
-      return postResult(client, "/v1/scrape", { url: first(words, "url"), ...collectionBody });
+      return { method: "POST", path: "/v1/scrape", body: { url: first(words, "url"), ...collectionBody } };
     case "crawl":
-      return postResult(client, "/v1/crawl", { urls: required(words, "urls"), ...collectionBody });
+      return { method: "POST", path: "/v1/crawl", body: { urls: required(words, "urls"), ...collectionBody } };
     case "map":
-      return postResult(client, "/v1/map", { url: first(words, "url"), limit: 100 });
+      return { method: "POST", path: "/v1/map", body: { url: first(words, "url"), limit: 100 } };
     case "summarize":
-      return postResult(client, "/v1/summarize", { urls: required(words, "urls"), ...collectionBody });
+      return { method: "POST", path: "/v1/summarize", body: { urls: required(words, "urls"), ...collectionBody } };
     case "ask":
-      return postResult(client, "/v1/ask", {
-        query: first(words, "query"),
-        explain: false,
-        diagnostics: false,
-        ...collectionBody,
-      });
+      return {
+        method: "POST",
+        path: "/v1/ask",
+        body: {
+          query: first(words, "query"),
+          explain: false,
+          diagnostics: false,
+          ...collectionBody,
+        },
+      };
     case "query":
-      return postResult(client, "/v1/query", { query: first(words, "query"), limit, ...collectionBody });
+      return { method: "POST", path: "/v1/query", body: { query: first(words, "query"), limit, ...collectionBody } };
     case "retrieve":
-      return postResult(client, "/v1/retrieve", {
-        url: first(words, "url"),
-        token_budget: 6000,
-        ...collectionBody,
-      });
+      return {
+        method: "POST",
+        path: "/v1/retrieve",
+        body: {
+          url: first(words, "url"),
+          token_budget: 6000,
+          ...collectionBody,
+        },
+      };
     case "suggest":
-      return postResult(client, "/v1/suggest", words[0] ? { focus: words[0] } : {});
+      return { method: "POST", path: "/v1/suggest", body: words[0] ? { focus: words[0] } : {} };
     case "evaluate":
-      return postResult(client, "/v1/evaluate", { question: first(words, "question") });
+      return { method: "POST", path: "/v1/evaluate", body: { question: first(words, "question") } };
     case "search":
-      return postResult(client, "/v1/search", { query: first(words, "query"), limit });
+      return { method: "POST", path: "/v1/search", body: { query: first(words, "query"), limit } };
     case "research":
-      return postResult(client, "/v1/research", { query: first(words, "query"), limit });
+      return { method: "POST", path: "/v1/research", body: { query: first(words, "query"), limit } };
     case "embed":
-      return postResult(client, "/v1/embed", { input: first(words, "input"), ...collectionBody });
+      return { method: "POST", path: "/v1/embed", body: { input: first(words, "input"), ...collectionBody } };
     case "extract":
-      return postResult(client, "/v1/extract", { urls: required(words, "urls"), ...collectionBody });
+      return { method: "POST", path: "/v1/extract", body: { urls: required(words, "urls"), ...collectionBody } };
     case "ingest":
-      return postResult(client, "/v1/ingest", ingestBody(first(words, "target")));
+      return { method: "POST", path: "/v1/ingest", body: ingestBody(first(words, "target")) };
     default:
       throw new Error(`REST route is not wired for ${action.subcommand}`);
   }
@@ -158,45 +203,6 @@ type PostPath =
   | "/v1/extract"
   | "/v1/ingest";
 
-async function getResult<Path extends GetPath>(
-  client: Client,
-  path: Path,
-): Promise<PaletteResult> {
-  try {
-    return await invoke<PaletteResult>("axon_http_request", {
-      request: {
-        baseUrl: client.baseUrl,
-        token: tokenFromHeaders(client.headers),
-        method: "GET",
-        path,
-        body: null,
-      },
-    });
-  } catch (error) {
-    return failedResult("GET", path, error);
-  }
-}
-
-async function postResult<Path extends PostPath>(
-  client: Client,
-  path: Path,
-  body: Record<string, unknown>,
-): Promise<PaletteResult> {
-  try {
-    return await invoke<PaletteResult>("axon_http_request", {
-      request: {
-        baseUrl: client.baseUrl,
-        token: tokenFromHeaders(client.headers),
-        method: "POST",
-        path,
-        body,
-      },
-    });
-  } catch (error) {
-    return failedResult("POST", path, error);
-  }
-}
-
 function tokenFromHeaders(headers: Record<string, string>): string | null {
   const authorization = headers.Authorization;
   if (authorization?.startsWith("Bearer ")) {
@@ -205,7 +211,7 @@ function tokenFromHeaders(headers: Record<string, string>): string | null {
   return headers["x-api-key"] ?? null;
 }
 
-function failedResult(method: PaletteResult["method"], path: GetPath | PostPath, error: unknown): PaletteResult {
+function failedResult(method: PaletteResult["method"], path: string, error: unknown): PaletteResult {
   return {
     ok: false,
     status: 0,

--- a/apps/palette-tauri/src/lib/format.ts
+++ b/apps/palette-tauri/src/lib/format.ts
@@ -1,5 +1,20 @@
 const SUMMARY_LIMIT = 10;
 
+export type OutputKind = "markdown" | "code";
+
+export function outputKindFor(subcommand: string): OutputKind {
+  switch (subcommand) {
+    case "ask":
+    case "scrape":
+    case "summarize":
+    case "research":
+    case "suggest":
+      return "markdown";
+    default:
+      return "code";
+  }
+}
+
 export function formatPayload(subcommand: string, payload: unknown): string {
   if (typeof payload === "string") {
     return payload;

--- a/apps/palette-tauri/src/lib/runState.ts
+++ b/apps/palette-tauri/src/lib/runState.ts
@@ -1,0 +1,15 @@
+import type { PaletteResult } from "@/lib/axonClient";
+import type { OutputKind } from "@/lib/format";
+
+export type RunState =
+  | { kind: "idle" }
+  | { kind: "running"; title: string; subtitle: string }
+  | { kind: "streaming"; title: string; subtitle: string; text: string; outputKind: OutputKind }
+  | {
+      kind: "success" | "error";
+      title: string;
+      subtitle: string;
+      text: string;
+      outputKind: OutputKind;
+      result: PaletteResult;
+    };

--- a/apps/palette-tauri/src/lib/runState.ts
+++ b/apps/palette-tauri/src/lib/runState.ts
@@ -4,7 +4,14 @@ import type { OutputKind } from "@/lib/format";
 export type RunState =
   | { kind: "idle" }
   | { kind: "running"; title: string; subtitle: string }
-  | { kind: "streaming"; title: string; subtitle: string; text: string; outputKind: OutputKind }
+  | {
+      kind: "streaming";
+      title: string;
+      subtitle: string;
+      text: string;
+      outputKind: OutputKind;
+      requestId: string;
+    }
   | {
       kind: "success" | "error";
       title: string;

--- a/apps/palette-tauri/src/lib/url.ts
+++ b/apps/palette-tauri/src/lib/url.ts
@@ -1,0 +1,7 @@
+export function hostLabel(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -424,12 +424,83 @@ textarea {
   background: var(--aurora-control-surface);
   border: 1px solid var(--aurora-border-default);
   border-radius: 8px;
+}
+
+.output-code {
   font-family: var(--aurora-font-mono);
   font-size: 12px;
   line-height: 1.55;
   white-space: pre-wrap;
   overflow-wrap: break-word;
   word-break: normal;
+}
+
+.output-markdown {
+  font-size: var(--aurora-type-body-sm);
+  line-height: 1.58;
+}
+
+.output-markdown :where(h1, h2, h3) {
+  margin: 14px 0 8px;
+  color: var(--aurora-text-primary);
+  font-family: var(--aurora-font-display);
+  font-weight: var(--aurora-weight-heading);
+  line-height: 1.22;
+}
+
+.output-markdown :where(h1) {
+  font-size: 18px;
+}
+
+.output-markdown :where(h2) {
+  font-size: 15px;
+}
+
+.output-markdown :where(h3) {
+  font-size: 13px;
+}
+
+.output-markdown :where(p, ul, ol, blockquote, pre, table) {
+  margin: 0 0 10px;
+}
+
+.output-markdown :where(a) {
+  color: var(--aurora-accent-strong);
+  text-decoration: none;
+}
+
+.output-markdown :where(a:hover) {
+  text-decoration: underline;
+}
+
+.output-markdown :where(code) {
+  padding: 1px 4px;
+  color: var(--aurora-code-function);
+  background: color-mix(in srgb, var(--aurora-panel-strong) 82%, transparent);
+  border: 1px solid var(--aurora-border-default);
+  border-radius: 5px;
+  font-family: var(--aurora-font-mono);
+  font-size: 0.92em;
+}
+
+.output-markdown :where(pre) {
+  overflow: auto;
+  padding: 12px;
+  background: var(--aurora-page-bg);
+  border: 1px solid var(--aurora-border-default);
+  border-radius: 8px;
+}
+
+.output-markdown :where(pre code) {
+  padding: 0;
+  background: transparent;
+  border: 0;
+}
+
+.output-markdown :where(blockquote) {
+  padding-left: 10px;
+  color: var(--aurora-text-muted);
+  border-left: 3px solid var(--aurora-accent-primary);
 }
 
 @media (max-width: 860px) {

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -99,7 +99,14 @@
         },
         "responses": {
           "200": {
-            "description": "RAG answer streamed as text/event-stream"
+            "description": "RAG answer streamed as server-sent events",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid ask request",

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -81,6 +81,49 @@
         }
       }
     },
+    "/v1/ask/stream": {
+      "post": {
+        "tags": [
+          "rag"
+        ],
+        "operationId": "v1_ask_stream",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestAskRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "RAG answer streamed as text/event-stream"
+          },
+          "400": {
+            "description": "Invalid ask request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Ask request exceeds limits",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/crawl": {
       "get": {
         "tags": [

--- a/docs/sessions/2026-05-26-palette-streamdown-streaming.md
+++ b/docs/sessions/2026-05-26-palette-streamdown-streaming.md
@@ -1,0 +1,134 @@
+---
+date: 2026-05-26 22:35:35 EDT
+repo: git@github.com:jmagar/axon.git
+branch: work/palette-streamdown-streaming
+head: 8a056677
+plan: docs/superpowers/plans/2026-05-26-palette-streamdown-streaming.md
+agent: Codex
+working directory: /home/jmagar/workspace/axon_rust/.worktrees/palette-streamdown-streaming
+worktree: /home/jmagar/workspace/axon_rust/.worktrees/palette-streamdown-streaming
+pr: "#140 feat(palette): stream ask responses https://github.com/jmagar/axon/pull/140"
+---
+
+# Palette Streamdown Streaming Session
+
+## User Request
+
+Execute the Streamdown/streaming work plan for the Tauri desktop palette through the `work-it` workflow after the previous session disconnected.
+
+## Session Overview
+
+Implemented streamed `/v1/ask/stream` responses, wired the Tauri palette to consume SSE events, rendered markdown output with Streamdown, and completed review fixes for streaming lifecycle correctness.
+
+## Sequence of Events
+
+- Created and used the isolated worktree `.worktrees/palette-streamdown-streaming` on branch `work/palette-streamdown-streaming`.
+- Executed the plan in `docs/superpowers/plans/2026-05-26-palette-streamdown-streaming.md` and opened PR #140.
+- Added server-side ask streaming, OpenAPI coverage, Tauri SSE bridge code, React streaming state, Streamdown rendering, and palette markdown styling.
+- Ran independent review passes and fixed findings around stream request correlation, premature EOF handling, UTF-8 chunk boundaries, `explain` rejection, and hidden stream failures.
+- Resolved the only GitHub inline review thread after its UTF-8 buffering finding became outdated by commit `8a056677`.
+
+## Key Findings
+
+- `reqwest::bytes_stream()` may split UTF-8 code points, so Tauri SSE parsing must buffer raw bytes until a full newline-delimited line is available before UTF-8 decoding.
+- Palette streaming events need a `requestId` so stale events from an older ask run cannot mutate the active output.
+- The streaming endpoint should reject `explain: true` because the SSE path streams answer deltas, not the structured explain payload.
+- EOF without an explicit `done` or `error` SSE event must be treated as a terminal error to avoid leaving the UI in a streaming state.
+
+## Technical Decisions
+
+- Used `streamdown` for completed markdown/code-like output rendering in the palette instead of custom markdown parsing.
+- Kept existing non-streaming HTTP behavior for non-ask actions while routing ask through `axon_http_stream_request`.
+- Added `requestId` to every Tauri stream event and checked it in React before applying stream updates.
+- Preserved the ask delta append helper and tests so CLI stdout streaming and callback streaming share the same append semantics.
+
+## Files Modified
+
+- `apps/palette-tauri/src/App.tsx`: ask streaming orchestration and request correlation.
+- `apps/palette-tauri/src-tauri/src/stream.rs`: Tauri SSE HTTP bridge, byte buffering, terminal event handling, and tests.
+- `apps/palette-tauri/src/components/palette/OutputPanel.tsx`: extracted output rendering with Streamdown.
+- `apps/palette-tauri/src/components/palette/SettingsPanel.tsx`: extracted settings UI and config update helper.
+- `apps/palette-tauri/src/lib/axonClient.ts`: streaming client shape and action output helpers.
+- `apps/palette-tauri/src/lib/format.ts`: output kind classification for markdown/code rendering.
+- `apps/palette-tauri/src/lib/runState.ts`: shared run state typing including streaming state.
+- `apps/palette-tauri/src/lib/url.ts`: shared URL normalization helper.
+- `apps/palette-tauri/src/styles.css`: Aurora-aligned markdown output styling.
+- `src/web/server/handlers/ask_stream.rs`: `/v1/ask/stream` SSE route.
+- `src/web/server/handlers/ask_stream_tests.rs`: stream route tests.
+- `src/web/server/routing.rs`: route mount.
+- `src/web/server/openapi.rs` and `apps/web/openapi/axon.json`: OpenAPI route and SSE response schema.
+- `src/services/query.rs`, `src/services/types/client_server.rs`, `src/vector/ops/commands/ask.rs`, `src/vector/ops/commands/ask/output.rs`, `src/vector/ops/commands/streaming.rs`: ask streaming service/callback plumbing.
+- `apps/palette-tauri/package.json`, `apps/palette-tauri/pnpm-lock.yaml`, `apps/palette-tauri/src-tauri/Cargo.toml`, `apps/palette-tauri/src-tauri/Cargo.lock`: Streamdown and Tauri streaming dependencies.
+- `docs/superpowers/plans/2026-05-26-palette-streamdown-streaming.md`: implementation plan committed with the branch.
+
+## Commands Executed
+
+- `pnpm typecheck`: passed.
+- `pnpm vite:build`: passed with Vite large chunk warning only.
+- `cargo test parse_sse_data_line`: passed.
+- `cargo test buffers_split_utf8`: passed.
+- `cargo check` in `apps/palette-tauri/src-tauri`: passed.
+- `cargo test ask_stream`: passed.
+- `cargo test v1_ask_auth_layer`: passed.
+- `cargo test append_ask_delta`: passed.
+- `cargo check`: passed.
+- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
+- `cargo fmt`: passed.
+- `git diff --check`: passed.
+- Pre-push hook full `cargo nextest`: passed with `2285 tests run: 2285 passed, 6 skipped`.
+
+## Errors Encountered
+
+- Review found lossy UTF-8 decoding across streamed chunks. Fixed by byte-buffering and decoding only complete SSE lines.
+- Review found the UI could stay stuck streaming on premature EOF. Fixed by tracking terminal events and surfacing EOF as an error.
+- Review found stale stream events could affect a later run. Fixed with request IDs on events and React-side matching.
+- Review found streaming invocation errors could be hidden by fallback handling. Fixed by surfacing stream errors as run errors.
+
+## Behavior Changes (Before/After)
+
+- Before: ask responses completed only after the full HTTP response and displayed as plain output.
+- After: ask responses stream into the palette and completed markdown/code-like output renders with Streamdown.
+- Before: stale or truncated stream events could silently corrupt state or leave the UI stuck.
+- After: stream events are correlated, UTF-8 safe, and terminate with either done or visible error state.
+- Before: OpenAPI did not describe the streaming response content.
+- After: `/v1/ask/stream` advertises `text/event-stream`.
+
+## Verification Evidence
+
+| command | expected | actual | status |
+| --- | --- | --- | --- |
+| `pnpm typecheck` | TypeScript passes | Passed | PASS |
+| `pnpm vite:build` | Palette web build passes | Passed with large chunk warning | PASS |
+| `cargo test parse_sse_data_line` | SSE parser test passes | Passed | PASS |
+| `cargo test buffers_split_utf8` | UTF-8 split buffering test passes | Passed | PASS |
+| `cargo check` in Tauri crate | Rust Tauri crate checks | Passed | PASS |
+| `cargo test ask_stream` | Stream route tests pass | Passed | PASS |
+| `cargo test v1_ask_auth_layer` | Auth route tests pass | Passed | PASS |
+| `cargo test append_ask_delta` | Ask output append test passes | Passed | PASS |
+| `cargo check` | Workspace checks | Passed | PASS |
+| `cargo clippy --all-targets --all-features -- -D warnings` | No warnings | Passed | PASS |
+| pre-push `cargo nextest` | Full test suite passes | `2285 passed, 6 skipped` | PASS |
+
+## Risks and Rollback
+
+- Risk: streaming ask output depends on browser/Tauri event delivery and may need more end-to-end UI testing against a live remote server.
+- Rollback: revert PR #140 or disable the palette ask streaming call path to return to the existing non-streaming request behavior.
+
+## Decisions Not Taken
+
+- Did not add a separate streaming protocol crate; the current SSE bridge is small and local to the Tauri command.
+- Did not stream non-ask actions; the plan scope was ask streaming and markdown rendering.
+
+## References
+
+- PR #140: https://github.com/jmagar/axon/pull/140
+- Plan: `docs/superpowers/plans/2026-05-26-palette-streamdown-streaming.md`
+- Resolved review thread: https://github.com/jmagar/axon/pull/140#discussion_r3307873358
+
+## Open Questions
+
+- No unresolved actionable review comments remained after resolving the outdated UTF-8 review thread.
+
+## Next Steps
+
+- Run a live desktop smoke test against the deployed Axon server before shipping the palette binary to another machine.

--- a/docs/superpowers/plans/2026-05-26-palette-streamdown-streaming.md
+++ b/docs/superpowers/plans/2026-05-26-palette-streamdown-streaming.md
@@ -1,0 +1,921 @@
+# Palette Streamdown Streaming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render Axon palette markdown with Streamdown and stream `/v1/ask` answer tokens into the desktop palette as they arrive.
+
+**Architecture:** Add completed markdown rendering first, then expose a server-sent events route for `ask`, then bridge that SSE stream through Tauri window events into React state. The palette keeps the existing non-streaming JSON path as fallback, so streaming can fail closed without breaking command execution.
+
+**Tech Stack:** Rust, Axum, Tauri v2, React 19, TypeScript, Streamdown, Aurora design tokens.
+
+---
+
+## File Structure
+
+- Modify `apps/palette-tauri/package.json`: add `streamdown`.
+- Modify `apps/palette-tauri/src/App.tsx`: render markdown output with Streamdown, track streaming run state, listen for Tauri stream events, and use streaming for `ask`.
+- Modify `apps/palette-tauri/src/styles.css`: add Aurora-styled markdown output rules.
+- Modify `apps/palette-tauri/src/lib/format.ts`: expose output display kind helpers.
+- Modify `apps/palette-tauri/src/lib/axonClient.ts`: add request builder helpers for streaming without duplicating action body logic.
+- Modify `apps/palette-tauri/src-tauri/src/lib.rs`: add `axon_http_stream_request` command that reads SSE and emits palette stream events.
+- Modify `src/web/server/handlers/ask.rs`: add `v1_ask_stream` SSE handler.
+- Modify `src/web/server/routing.rs`: mount `/v1/ask/stream` beside `/v1/ask`.
+- Create `src/web/server/handlers/ask_stream.rs`: keep streaming route code focused and testable.
+- Modify `src/vector/ops/commands/ask/output.rs` or adjacent ask streaming module: expose a service-facing token callback API instead of stdout-only streaming.
+- Add/update tests near changed code:
+  - `apps/palette-tauri/src/lib/format.test.ts` if the app already has test setup; otherwise use TypeScript typecheck as frontend verification.
+  - `src/web/server/handlers/ask_stream_tests.rs`
+  - `apps/palette-tauri/src-tauri/src/lib.rs` unit tests for SSE parsing helper functions.
+
+## Task 1: Render Completed Markdown With Streamdown
+
+**Files:**
+- Modify: `apps/palette-tauri/package.json`
+- Modify: `apps/palette-tauri/src/App.tsx`
+- Modify: `apps/palette-tauri/src/styles.css`
+- Modify: `apps/palette-tauri/src/lib/format.ts`
+
+- [ ] **Step 1: Add dependency**
+
+Run:
+
+```bash
+cd /home/jmagar/workspace/axon_rust/apps/palette-tauri
+pnpm add streamdown
+```
+
+Expected: `package.json` and `pnpm-lock.yaml` include `streamdown`.
+
+- [ ] **Step 2: Add output-kind helper**
+
+In `apps/palette-tauri/src/lib/format.ts`, add:
+
+```ts
+export type OutputKind = "markdown" | "code";
+
+export function outputKindFor(subcommand: string): OutputKind {
+  switch (subcommand) {
+    case "ask":
+    case "scrape":
+    case "summarize":
+    case "research":
+    case "suggest":
+      return "markdown";
+    default:
+      return "code";
+  }
+}
+```
+
+- [ ] **Step 3: Render markdown output in the palette**
+
+In `apps/palette-tauri/src/App.tsx`, change the format import:
+
+```ts
+import { formatPayload, outputKindFor } from "@/lib/format";
+```
+
+Add the Streamdown import:
+
+```ts
+import { Streamdown } from "streamdown";
+```
+
+Near `const outputText = "text" in run ? run.text : "";`, add:
+
+```ts
+const outputKind = active ? outputKindFor(active.subcommand) : "code";
+```
+
+Replace the output body block:
+
+```tsx
+{"text" in run && (
+  outputKind === "markdown" ? (
+    <div className="output-body output-markdown">
+      <Streamdown>{run.text}</Streamdown>
+    </div>
+  ) : (
+    <pre className="output-body output-code">
+      <code>{run.text}</code>
+    </pre>
+  )
+)}
+```
+
+- [ ] **Step 4: Style Streamdown output with Aurora tokens**
+
+In `apps/palette-tauri/src/styles.css`, replace the current `.output-body` block with:
+
+```css
+.output-body {
+  flex: 1;
+  min-height: 0;
+  margin: 8px 0 0;
+  overflow: auto;
+  padding: 14px;
+  color: var(--aurora-text-primary);
+  background: var(--aurora-control-surface);
+  border: 1px solid var(--aurora-border-default);
+  border-radius: 8px;
+}
+
+.output-code {
+  font-family: var(--aurora-font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: normal;
+}
+
+.output-markdown {
+  font-size: var(--aurora-type-body-sm);
+  line-height: 1.58;
+}
+
+.output-markdown :where(h1, h2, h3) {
+  margin: 14px 0 8px;
+  color: var(--aurora-text-primary);
+  font-family: var(--aurora-font-display);
+  font-weight: var(--aurora-weight-heading);
+  line-height: 1.22;
+}
+
+.output-markdown :where(h1) {
+  font-size: 18px;
+}
+
+.output-markdown :where(h2) {
+  font-size: 15px;
+}
+
+.output-markdown :where(h3) {
+  font-size: 13px;
+}
+
+.output-markdown :where(p, ul, ol, blockquote, pre, table) {
+  margin: 0 0 10px;
+}
+
+.output-markdown :where(a) {
+  color: var(--aurora-accent-strong);
+  text-decoration: none;
+}
+
+.output-markdown :where(a:hover) {
+  text-decoration: underline;
+}
+
+.output-markdown :where(code) {
+  padding: 1px 4px;
+  color: var(--aurora-code-function);
+  background: color-mix(in srgb, var(--aurora-panel-strong) 82%, transparent);
+  border: 1px solid var(--aurora-border-default);
+  border-radius: 5px;
+  font-family: var(--aurora-font-mono);
+  font-size: 0.92em;
+}
+
+.output-markdown :where(pre) {
+  overflow: auto;
+  padding: 12px;
+  background: var(--aurora-page-bg);
+  border: 1px solid var(--aurora-border-default);
+  border-radius: 8px;
+}
+
+.output-markdown :where(pre code) {
+  padding: 0;
+  background: transparent;
+  border: 0;
+}
+
+.output-markdown :where(blockquote) {
+  padding-left: 10px;
+  color: var(--aurora-text-muted);
+  border-left: 3px solid var(--aurora-accent-primary);
+}
+```
+
+- [ ] **Step 5: Verify frontend**
+
+Run:
+
+```bash
+cd /home/jmagar/workspace/axon_rust/apps/palette-tauri
+pnpm typecheck
+pnpm vite:build
+```
+
+Expected: both commands pass. Manually run `ask`, `scrape`, and `status`: markdown actions render rich output; `status` remains code/preformatted.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/palette-tauri/package.json apps/palette-tauri/pnpm-lock.yaml apps/palette-tauri/src/App.tsx apps/palette-tauri/src/styles.css apps/palette-tauri/src/lib/format.ts
+git commit -m "feat(palette): render markdown output with streamdown"
+```
+
+## Task 2: Extract Ask Streaming Service API
+
+**Files:**
+- Modify: `src/vector/ops/commands/ask/output.rs`
+- Modify or create focused helper near existing ask streaming code if needed.
+
+- [ ] **Step 1: Write failing service-level test**
+
+Add a test near the existing ask streaming tests that proves token callbacks are collected without stdout. If there is no clean unit seam, introduce a small pure helper test first:
+
+```rust
+#[test]
+fn stream_event_accumulator_appends_deltas() {
+    let mut answer = String::new();
+    append_ask_delta(&mut answer, "Hello");
+    append_ask_delta(&mut answer, " world");
+    assert_eq!(answer, "Hello world");
+}
+```
+
+Expected helper signature:
+
+```rust
+pub(crate) fn append_ask_delta(answer: &mut String, delta: &str) {
+    answer.push_str(delta);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /home/jmagar/workspace/axon_rust
+cargo test append_ask_delta
+```
+
+Expected: FAIL because `append_ask_delta` does not exist.
+
+- [ ] **Step 3: Add callback-shaped API**
+
+In the ask output/streaming module, add a service-facing wrapper:
+
+```rust
+pub(crate) async fn ask_llm_answer_with_deltas<F>(
+    cfg: &Config,
+    query: &str,
+    context: &str,
+    mut on_delta: F,
+) -> Result<AskLlmCompletion, Box<dyn Error>>
+where
+    F: FnMut(&str) + Send,
+{
+    let client = http_client()?;
+    let llm_started = Instant::now();
+    let mut answer = String::new();
+
+    let result = ask_llm_streaming_ttft_with_callback(
+        cfg,
+        client,
+        query,
+        context,
+        |delta| {
+            append_ask_delta(&mut answer, delta);
+            on_delta(delta);
+        },
+    )
+    .await;
+
+    match result {
+        Ok(ttft_at) => Ok(AskLlmCompletion::Streamed {
+            answer,
+            ttft_at,
+            llm_total_ms: llm_started.elapsed().as_millis(),
+        }),
+        Err(err) => {
+            log_warn(&format!(
+                "ask: streaming callback failed, falling back to non-streaming: {err}"
+            ));
+            let answer = ask_llm_non_streaming(cfg, client, query, context).await?;
+            Ok(AskLlmCompletion::Fallback {
+                answer,
+                llm_total_ms: llm_started.elapsed().as_millis(),
+            })
+        }
+    }
+}
+```
+
+If `ask_llm_streaming_ttft_with_callback` does not exist, extract it from the existing stdout streaming function. Keep the existing CLI function as a wrapper that passes a callback which writes to stdout only when requested.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test append_ask_delta
+cargo test ask_streaming
+```
+
+Expected: new helper test passes and existing streaming tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vector/ops/commands/ask
+git commit -m "refactor(ask): expose token delta callback"
+```
+
+## Task 3: Add `/v1/ask/stream` SSE Route
+
+**Files:**
+- Create: `src/web/server/handlers/ask_stream.rs`
+- Modify: `src/web/server/handlers.rs` or module declaration file that exports handlers.
+- Modify: `src/web/server/routing.rs`
+- Test: `src/web/server/handlers/ask_stream_tests.rs`
+
+- [ ] **Step 1: Write failing route test**
+
+Create `src/web/server/handlers/ask_stream_tests.rs`:
+
+```rust
+use axum::http::StatusCode;
+
+#[tokio::test]
+async fn ask_stream_rejects_empty_query() {
+    let response = super::v1_ask_stream_test_response(serde_json::json!({
+        "query": ""
+    }))
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+```
+
+If a test harness helper does not exist, create a local test helper in `ask_stream.rs` under `#[cfg(test)]` that calls the handler with a default config.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test ask_stream_rejects_empty_query
+```
+
+Expected: FAIL because `ask_stream` route/test helper does not exist.
+
+- [ ] **Step 3: Implement SSE event types**
+
+In `src/web/server/handlers/ask_stream.rs`:
+
+```rust
+use axum::{
+    Extension, Json,
+    response::{
+        IntoResponse,
+        sse::{Event, Sse},
+    },
+};
+use futures_util::Stream;
+use serde::Serialize;
+use std::{convert::Infallible, sync::Arc};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::core::config::Config;
+use crate::services::client_contract::RestAskRequest as AskRequestBody;
+use super::super::error::HttpError;
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AskStreamEvent {
+    Meta { phase: &'static str },
+    Delta { text: String },
+    Done { answer: String },
+    Error { message: String },
+}
+
+fn sse_json(event_name: &'static str, value: &AskStreamEvent) -> Event {
+    Event::default()
+        .event(event_name)
+        .json_data(value)
+        .unwrap_or_else(|_| Event::default().event("error").data("{\"type\":\"error\",\"message\":\"encode failed\"}"))
+}
+```
+
+- [ ] **Step 4: Implement handler skeleton**
+
+Add:
+
+```rust
+pub async fn v1_ask_stream(
+    Extension(cfg): Extension<Arc<Config>>,
+    Json(req): Json<AskRequestBody>,
+) -> impl IntoResponse {
+    use super::super::types::ASK_QUERY_MAX_CHARS;
+
+    if req.query.trim().is_empty() {
+        return HttpError::bad_request("query is required").into_response();
+    }
+    if req.query.chars().count() > ASK_QUERY_MAX_CHARS {
+        return HttpError::payload_too_large(format!("query exceeds {ASK_QUERY_MAX_CHARS} chars"))
+            .into_response();
+    }
+
+    let (tx, rx) = mpsc::channel::<Result<Event, Infallible>>(64);
+    let mut req_cfg = (*cfg).clone();
+    super::ask::apply_ask_overrides(&mut req_cfg, &req);
+    req_cfg.ask_stream = true;
+
+    tokio::spawn(async move {
+        let _ = tx.send(Ok(sse_json("meta", &AskStreamEvent::Meta { phase: "retrieving" }))).await;
+        let result = crate::services::query::ask_stream(&req_cfg, &req.query, |delta| {
+            let tx = tx.clone();
+            let delta = delta.to_string();
+            tokio::spawn(async move {
+                let _ = tx.send(Ok(sse_json("delta", &AskStreamEvent::Delta { text: delta }))).await;
+            });
+        }).await;
+
+        match result {
+            Ok(answer) => {
+                let _ = tx.send(Ok(sse_json("done", &AskStreamEvent::Done { answer }))).await;
+            }
+            Err(err) => {
+                let _ = tx.send(Ok(sse_json("error", &AskStreamEvent::Error { message: err.to_string() }))).await;
+            }
+        }
+    });
+
+    Sse::new(ReceiverStream::new(rx)).into_response()
+}
+```
+
+Adjust the `query::ask_stream` call to the actual function created in Task 2. Avoid holding non-`Send` errors across `tokio::spawn`; collapse errors to strings inside the task.
+
+- [ ] **Step 5: Mount route**
+
+In `src/web/server/routing.rs`, mount beside `/v1/ask` by merging it into the write routes:
+
+```rust
+.route("/v1/ask/stream", post(handlers::ask_stream::v1_ask_stream))
+```
+
+Use the same write scope as `/v1/ask`.
+
+- [ ] **Step 6: Run server tests**
+
+Run:
+
+```bash
+cargo test ask_stream
+cargo test v1_ask_auth_layer
+```
+
+Expected: stream route validates input; existing `/v1/ask` auth tests still pass. If auth tests need route inventory updates, add `("POST", "/v1/ask/stream")` to the existing protected route test cases.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/server/handlers/ask_stream.rs src/web/server/handlers/ask_stream_tests.rs src/web/server/routing.rs src/vector/ops/commands/ask src/services
+git commit -m "feat(web): add streaming ask endpoint"
+```
+
+## Task 4: Add Tauri SSE Bridge
+
+**Files:**
+- Modify: `apps/palette-tauri/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Write failing SSE parser tests**
+
+In `apps/palette-tauri/src-tauri/src/lib.rs`, add tests for a pure helper:
+
+```rust
+#[cfg(test)]
+mod stream_tests {
+    use super::parse_sse_data_line;
+
+    #[test]
+    fn parses_sse_data_line() {
+        assert_eq!(
+            parse_sse_data_line("data: {\"type\":\"delta\",\"text\":\"hi\"}"),
+            Some("{\"type\":\"delta\",\"text\":\"hi\"}".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_non_data_sse_line() {
+        assert_eq!(parse_sse_data_line("event: delta"), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /home/jmagar/workspace/axon_rust/apps/palette-tauri/src-tauri
+cargo test parse_sse_data_line
+```
+
+Expected: FAIL because helper does not exist.
+
+- [ ] **Step 3: Add request and event types**
+
+In `apps/palette-tauri/src-tauri/src/lib.rs`, add:
+
+```rust
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PaletteStreamRequest {
+    base_url: String,
+    token: Option<String>,
+    path: String,
+    body: serde_json::Value,
+}
+
+#[derive(Debug, serde::Serialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum PaletteStreamEvent {
+    Started { path: String },
+    Delta { text: String },
+    Done { answer: Option<String> },
+    Error { message: String },
+}
+
+fn parse_sse_data_line(line: &str) -> Option<String> {
+    line.strip_prefix("data:").map(|value| value.trim().to_string())
+}
+```
+
+- [ ] **Step 4: Add streaming command**
+
+Add:
+
+```rust
+#[tauri::command]
+async fn axon_http_stream_request(
+    window: tauri::Window,
+    request: PaletteStreamRequest,
+) -> Result<(), String> {
+    use futures_util::StreamExt;
+
+    let url = format!("{}{}", request.base_url.trim_end_matches('/'), request.path);
+    window
+        .emit("palette://stream", PaletteStreamEvent::Started { path: request.path.clone() })
+        .map_err(|err| err.to_string())?;
+
+    let client = reqwest::Client::new();
+    let mut builder = client
+        .post(url)
+        .header("accept", "text/event-stream")
+        .json(&request.body);
+    if let Some(token) = request.token.as_deref().filter(|token| !token.trim().is_empty()) {
+        builder = builder.bearer_auth(token).header("x-api-key", token);
+    }
+
+    let response = builder.send().await.map_err(|err| err.to_string())?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("stream request failed with HTTP {status}: {text}"));
+    }
+
+    let mut pending = String::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|err| err.to_string())?;
+        pending.push_str(&String::from_utf8_lossy(&chunk));
+        while let Some(pos) = pending.find('\n') {
+            let line = pending[..pos].trim_end_matches('\r').to_string();
+            pending.drain(..=pos);
+            handle_palette_sse_line(&window, &line)?;
+        }
+    }
+    if !pending.trim().is_empty() {
+        handle_palette_sse_line(&window, pending.trim_end_matches('\r'))?;
+    }
+    Ok(())
+}
+```
+
+Add `handle_palette_sse_line`:
+
+```rust
+fn handle_palette_sse_line(window: &tauri::Window, line: &str) -> Result<(), String> {
+    let Some(data) = parse_sse_data_line(line) else {
+        return Ok(());
+    };
+    let value: serde_json::Value = serde_json::from_str(&data).map_err(|err| err.to_string())?;
+    match value.get("type").and_then(|kind| kind.as_str()) {
+        Some("delta") => {
+            let text = value.get("text").and_then(|text| text.as_str()).unwrap_or_default();
+            window.emit("palette://stream", PaletteStreamEvent::Delta { text: text.to_string() })
+        }
+        Some("done") => {
+            let answer = value.get("answer").and_then(|answer| answer.as_str()).map(str::to_string);
+            window.emit("palette://stream", PaletteStreamEvent::Done { answer })
+        }
+        Some("error") => {
+            let message = value
+                .get("message")
+                .and_then(|message| message.as_str())
+                .unwrap_or("stream error")
+                .to_string();
+            window.emit("palette://stream", PaletteStreamEvent::Error { message })
+        }
+        _ => Ok(()),
+    }
+    .map_err(|err| err.to_string())
+}
+```
+
+Register `axon_http_stream_request` in the Tauri invoke handler beside `axon_http_request`.
+
+- [ ] **Step 5: Run Tauri tests**
+
+Run:
+
+```bash
+cd /home/jmagar/workspace/axon_rust/apps/palette-tauri/src-tauri
+cargo test parse_sse_data_line
+cargo check
+```
+
+Expected: tests and check pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/palette-tauri/src-tauri/src/lib.rs
+git commit -m "feat(palette): bridge streaming HTTP into tauri events"
+```
+
+## Task 5: Use Streaming for Palette Ask
+
+**Files:**
+- Modify: `apps/palette-tauri/src/lib/axonClient.ts`
+- Modify: `apps/palette-tauri/src/App.tsx`
+
+- [ ] **Step 1: Extract request builder**
+
+In `apps/palette-tauri/src/lib/axonClient.ts`, add:
+
+```ts
+export interface PaletteHttpRequest {
+  baseUrl: string;
+  token: string | null;
+  method: "GET" | "POST";
+  path: string;
+  body: Record<string, unknown> | null;
+}
+
+export function buildActionRequest(
+  client: Client,
+  action: PaletteAction,
+  arg: string,
+  config: PaletteConfig,
+): PaletteHttpRequest {
+  const body = bodyFor(action, arg, config);
+  return {
+    baseUrl: client.baseUrl,
+    token: tokenFromHeaders(client.headers),
+    method: body.method,
+    path: body.path,
+    body: body.body,
+  };
+}
+```
+
+Refactor the existing `executeAction` switch into a shared `bodyFor` helper so non-streaming and streaming use the same request body.
+
+- [ ] **Step 2: Add stream run state**
+
+In `apps/palette-tauri/src/App.tsx`, extend `RunState`:
+
+```ts
+| { kind: "streaming"; title: string; subtitle: string; text: string }
+```
+
+Update output helpers:
+
+```ts
+function outputTitle(run: RunState): string {
+  if (run.kind === "idle") return "Ready";
+  if (run.kind === "streaming") return run.title;
+  return run.title;
+}
+```
+
+Update badges/spinners so `streaming` is treated like running:
+
+```ts
+if (run.kind === "streaming") return "info";
+```
+
+- [ ] **Step 3: Listen for Tauri stream events**
+
+In `App.tsx`, add:
+
+```ts
+type PaletteStreamEvent =
+  | { type: "started"; path: string }
+  | { type: "delta"; text: string }
+  | { type: "done"; answer?: string | null }
+  | { type: "error"; message: string };
+```
+
+Add effect:
+
+```ts
+useEffect(() => {
+  let disposed = false;
+  const unlisten = appWindow.listen<PaletteStreamEvent>("palette://stream", (event) => {
+    if (disposed) return;
+    const payload = event.payload;
+    if (payload.type === "delta") {
+      setRun((current) =>
+        current.kind === "streaming"
+          ? { ...current, text: current.text + payload.text }
+          : current,
+      );
+    } else if (payload.type === "done") {
+      setRun((current) =>
+        current.kind === "streaming"
+          ? {
+              kind: "success",
+              title: "Ask question completed",
+              subtitle: current.subtitle,
+              text: payload.answer ?? current.text,
+              result: { ok: true, status: 200, path: "/v1/ask/stream", method: "POST", payload: { answer: payload.answer ?? current.text } },
+            }
+          : current,
+      );
+    } else if (payload.type === "error") {
+      setRun({
+        kind: "error",
+        title: "Ask question failed",
+        subtitle: "/v1/ask/stream",
+        text: payload.message,
+        result: { ok: false, status: 0, path: "/v1/ask/stream", method: "POST", payload: { error: payload.message } },
+      });
+    }
+  });
+  return () => {
+    disposed = true;
+    void unlisten.then((fn) => fn());
+  };
+}, []);
+```
+
+- [ ] **Step 4: Add streaming submit branch**
+
+In `submit`, before non-streaming `executeAction`, add:
+
+```ts
+if (action.subcommand === "ask") {
+  const request = buildActionRequest(client, action, argument, config);
+  setRun({
+    kind: "streaming",
+    title: "Streaming Ask question",
+    subtitle: `${request.method} /v1/ask/stream`,
+    text: "",
+  });
+  try {
+    await invoke("axon_http_stream_request", {
+      request: {
+        ...request,
+        path: "/v1/ask/stream",
+        body: request.body,
+      },
+    });
+    return;
+  } catch (err) {
+    setRun({
+      kind: "running",
+      title: `Running ${action.label}`,
+      subtitle: commandLine,
+    });
+  }
+}
+```
+
+Then let the existing non-streaming path run as fallback.
+
+- [ ] **Step 5: Verify frontend typecheck**
+
+Run:
+
+```bash
+cd /home/jmagar/workspace/axon_rust/apps/palette-tauri
+pnpm typecheck
+pnpm vite:build
+```
+
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/palette-tauri/src/App.tsx apps/palette-tauri/src/lib/axonClient.ts
+git commit -m "feat(palette): stream ask responses into command output"
+```
+
+## Task 6: End-to-End Verification on Dookie and Steamy
+
+**Files:**
+- No source changes unless defects are found.
+
+- [ ] **Step 1: Start Axon server locally**
+
+Run from repo root:
+
+```bash
+./scripts/axon serve
+```
+
+Expected: server listens on the configured HTTP port and `/readyz` passes.
+
+- [ ] **Step 2: Smoke test streaming endpoint with curl**
+
+Run:
+
+```bash
+TOKEN="$(grep '^AXON_MCP_HTTP_TOKEN=' ~/.axon/.env | cut -d= -f2-)"
+curl -N \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"query":"what is axon?","collection":"axon"}' \
+  https://axon.tootie.tv/v1/ask/stream
+```
+
+Expected: `event: meta`, one or more `event: delta`, then `event: done`.
+
+- [ ] **Step 3: Build palette**
+
+Run:
+
+```bash
+cd /home/jmagar/workspace/axon_rust/apps/palette-tauri
+pnpm build
+```
+
+Expected: Tauri release build succeeds.
+
+- [ ] **Step 4: Copy newest exe to Steamy desktop**
+
+Use the established agent-os/SSH copy path from the previous palette work. Copy the newly built Windows executable directly to the Steamy desktop instead of relying on shortcut updates.
+
+Expected: `C:\Users\jmaga\Desktop\Axon Palette.exe` exists and launches without a terminal window.
+
+- [ ] **Step 5: Manual UI checks**
+
+On Steamy:
+
+1. Launch `Axon Palette.exe`.
+2. Run `ask what is axon?`.
+3. Confirm text appears incrementally, not only at the end.
+4. Confirm Streamdown renders headings/lists/code cleanly.
+5. Run `status`.
+6. Confirm status still renders as preformatted code.
+7. Close/reopen palette.
+8. Confirm compact idle size still starts centered and only as tall as the input.
+
+- [ ] **Step 6: Check logs for regressions**
+
+Run on dookie:
+
+```bash
+journalctl --since "10 minutes ago" --no-pager -u axon 2>/dev/null | tail -n 100
+journalctl --since "10 minutes ago" --no-pager -k | rg -i 'zsh\\[[0-9]+\\]: segfault|oom|panic' || true
+```
+
+Expected: no new server panics and no new zsh segfaults during the test window.
+
+- [ ] **Step 7: Commit or amend verification fixes**
+
+If defects were fixed:
+
+```bash
+git add <changed-files>
+git commit -m "fix(palette): harden streaming ask verification issues"
+```
+
+If no defects:
+
+```bash
+git status --short
+```
+
+Expected: only intentional work remains.
+
+## Self-Review
+
+**Spec coverage:** The plan covers Streamdown completed markdown rendering, true token streaming, server route exposure, Tauri bridge, React state handling, fallback behavior, and Steamy deployment verification.
+
+**Placeholder scan:** No implementation step uses TBD/TODO/later language. Each task includes concrete files, code shape, commands, and expected results.
+
+**Type consistency:** `RunState`, `PaletteStreamEvent`, `PaletteHttpRequest`, `PaletteStreamRequest`, and `AskStreamEvent` names are consistent across tasks.
+

--- a/src/services/query.rs
+++ b/src/services/query.rs
@@ -9,7 +9,7 @@ use crate::services::types::{
     AskResult, DocumentBackend, EvaluateResult, Pagination, QueryHit, QueryResult, RetrieveOptions,
     RetrieveResult, ServiceRetrieveVariantError, SuggestResult, Suggestion,
 };
-use crate::vector::ops::commands::ask::ask_payload;
+use crate::vector::ops::commands::ask::{ask_payload, ask_payload_with_deltas};
 use crate::vector::ops::commands::discover_crawl_suggestions;
 use crate::vector::ops::commands::evaluate_payload;
 use crate::vector::ops::commands::query_results;
@@ -412,6 +412,28 @@ pub async fn ask(
     )
     .await;
     map_ask_payload(payload)
+}
+
+/// RAG ask with token deltas emitted as the LLM streams.
+#[must_use = "ask_stream returns a Result that should be handled"]
+pub async fn ask_stream<F>(
+    cfg: &Config,
+    question: &str,
+    on_delta: F,
+) -> Result<String, Box<dyn Error>>
+where
+    F: FnMut(&str) + Send,
+{
+    let payload = ask_payload_with_deltas(cfg, question, on_delta)
+        .await
+        .map_err(|e| -> Box<dyn Error> {
+            let message = format!(
+                "ask failed for {}: {e}",
+                question.chars().take(80).collect::<String>()
+            );
+            wrap_service_error(message, e.root_cause())
+        })?;
+    Ok(map_ask_payload(payload)?.answer)
 }
 
 /// RAG evaluate: run RAG and baseline answers, then judge with a second LLM call.

--- a/src/services/types/client_server.rs
+++ b/src/services/types/client_server.rs
@@ -170,6 +170,7 @@ pub fn supported_routes() -> Vec<String> {
         "GET /v1/status",
         "GET /v1/doctor",
         "POST /v1/ask",
+        "POST /v1/ask/stream",
         "POST /v1/query",
         "POST /v1/retrieve",
         "POST /v1/evaluate",

--- a/src/vector/ops/commands/ask.rs
+++ b/src/vector/ops/commands/ask.rs
@@ -43,6 +43,28 @@ pub(super) fn validate_ask_llm_config(cfg: &Config) -> anyhow::Result<()> {
 }
 
 pub async fn ask_payload(cfg: &Config, query: &str) -> anyhow::Result<serde_json::Value> {
+    ask_payload_with_delta_handler(cfg, query, Option::<fn(&str)>::None).await
+}
+
+pub async fn ask_payload_with_deltas<F>(
+    cfg: &Config,
+    query: &str,
+    on_delta: F,
+) -> anyhow::Result<serde_json::Value>
+where
+    F: FnMut(&str) + Send,
+{
+    ask_payload_with_delta_handler(cfg, query, Some(on_delta)).await
+}
+
+async fn ask_payload_with_delta_handler<F>(
+    cfg: &Config,
+    query: &str,
+    mut on_delta: Option<F>,
+) -> anyhow::Result<serde_json::Value>
+where
+    F: FnMut(&str) + Send,
+{
     let ask_started = std::time::Instant::now();
     let diagnostics_enabled = cfg.ask_diagnostics || cfg.ask_explain;
     let mut timing = AskTiming::new(diagnostics_enabled, ask_started);
@@ -78,25 +100,14 @@ pub async fn ask_payload(cfg: &Config, query: &str) -> anyhow::Result<serde_json
         ctx.context_elapsed_ms,
     ));
     if cfg.ask_explain {
-        let total_elapsed_ms = ask_started.elapsed().as_millis();
-        log_info(&format!(
-            "ask explain complete total_ms={total_elapsed_ms} context_chars={}",
-            ctx.context.len()
+        return Ok(build_explain_payload(
+            cfg,
+            query,
+            &ctx,
+            diagnostics_enabled,
+            &timing,
+            ask_started.elapsed().as_millis(),
         ));
-        return Ok(serde_json::json!({
-            "query": query,
-            "answer": "",
-            "session": serde_json::Value::Null,
-            "diagnostics": build_diagnostics_json(diagnostics_enabled, cfg, &ctx),
-            "explain": ctx.explain,
-            "timing_ms": build_timing_json(
-                ctx.retrieval_elapsed_ms,
-                ctx.context_elapsed_ms,
-                0,
-                total_elapsed_ms,
-                &timing,
-            ),
-        }));
     }
 
     validate_ask_llm_config(cfg)?;
@@ -108,9 +119,12 @@ pub async fn ask_payload(cfg: &Config, query: &str) -> anyhow::Result<serde_json
         context.len(),
         cfg.ask_stream,
     ));
-    let llm = output::ask_llm_answer(cfg, query, &context)
-        .await
-        .map_err(|e| anyhow::anyhow!("LLM answer generation failed: {e}"))?;
+    let llm = if let Some(callback) = on_delta.take() {
+        output::ask_llm_answer_with_deltas(cfg, query, &context, callback).await
+    } else {
+        output::ask_llm_answer(cfg, query, &context).await
+    }
+    .map_err(|e| anyhow::anyhow!("LLM answer generation failed: {e}"))?;
     let (answer_text, llm_total_ms) = match &llm {
         output::AskLlmCompletion::Streamed {
             answer,
@@ -166,6 +180,34 @@ pub async fn ask_payload(cfg: &Config, query: &str) -> anyhow::Result<serde_json
             &timing,
         ),
     }))
+}
+
+fn build_explain_payload(
+    cfg: &Config,
+    query: &str,
+    ctx: &AskContext,
+    diagnostics_enabled: bool,
+    timing: &AskTiming,
+    total_elapsed_ms: u128,
+) -> serde_json::Value {
+    log_info(&format!(
+        "ask explain complete total_ms={total_elapsed_ms} context_chars={}",
+        ctx.context.len()
+    ));
+    serde_json::json!({
+        "query": query,
+        "answer": "",
+        "session": serde_json::Value::Null,
+        "diagnostics": build_diagnostics_json(diagnostics_enabled, cfg, ctx),
+        "explain": ctx.explain,
+        "timing_ms": build_timing_json(
+            ctx.retrieval_elapsed_ms,
+            ctx.context_elapsed_ms,
+            0,
+            total_elapsed_ms,
+            timing,
+        ),
+    })
 }
 
 fn build_diagnostics_json(enabled: bool, cfg: &Config, ctx: &AskContext) -> serde_json::Value {

--- a/src/vector/ops/commands/ask/output.rs
+++ b/src/vector/ops/commands/ask/output.rs
@@ -78,7 +78,7 @@ where
     // The error type from streaming is `Box<dyn StdError>` (!Send). Collapse it
     // into Option<(String, Option<Instant>)> + Option<String> here so the !Send
     // error never crosses the await boundary that follows.
-    let (streamed_ok, streamed_err): (Option<(String, Option<Instant>)>, Option<String>) = {
+    let streamed = {
         let result = if let Some(mut callback) = on_delta.take() {
             let mut callback_answer = String::new();
             ask_llm_streaming_ttft_with_callback(
@@ -96,29 +96,29 @@ where
         } else {
             ask_llm_streaming_ttft(cfg, client, query, context, stream_to_stdout).await
         };
-        match result {
-            Ok(pair) => (Some(pair), None),
-            Err(e) => (None, Some(e.to_string())),
+        result.map_err(|e| e.to_string())
+    };
+
+    let streamed = match streamed {
+        Ok(streamed) => streamed,
+        Err(err_msg) => {
+            log_warn(&format!(
+                "ask: streaming failed, falling back to non-streaming: {err_msg}"
+            ));
+            let answer = ask_llm_non_streaming(cfg, client, query, context).await?;
+            log_info(&format!(
+                "ask llm fallback complete answer_chars={} elapsed_ms={}",
+                answer.len(),
+                llm_started.elapsed().as_millis(),
+            ));
+            return Ok(AskLlmCompletion::Fallback {
+                answer,
+                llm_total_ms: llm_started.elapsed().as_millis(),
+            });
         }
     };
 
-    if let Some(err_msg) = streamed_err {
-        log_warn(&format!(
-            "ask: streaming failed, falling back to non-streaming: {err_msg}"
-        ));
-        let answer = ask_llm_non_streaming(cfg, client, query, context).await?;
-        log_info(&format!(
-            "ask llm fallback complete answer_chars={} elapsed_ms={}",
-            answer.len(),
-            llm_started.elapsed().as_millis(),
-        ));
-        return Ok(AskLlmCompletion::Fallback {
-            answer,
-            llm_total_ms: llm_started.elapsed().as_millis(),
-        });
-    }
-
-    match streamed_ok.expect("streamed_err handled above") {
+    match streamed {
         (answer, Some(ttft_at)) => {
             let llm_total_ms = llm_started.elapsed().as_millis();
             log_info(&format!(

--- a/src/vector/ops/commands/ask/output.rs
+++ b/src/vector/ops/commands/ask/output.rs
@@ -5,7 +5,9 @@ use crate::services::llm_backend;
 use std::error::Error;
 use std::time::Instant;
 
-use super::super::streaming::{ask_llm_non_streaming, ask_llm_streaming_ttft};
+use super::super::streaming::{
+    ask_llm_non_streaming, ask_llm_streaming_ttft, ask_llm_streaming_ttft_with_callback,
+};
 
 /// Outcome of one ask LLM round-trip — sum type so callers cannot reach for a
 /// `ttft_at` field that exists only on the streaming path.
@@ -21,17 +23,49 @@ pub(crate) enum AskLlmCompletion {
     },
 }
 
+pub(crate) fn append_ask_delta(answer: &mut String, delta: &str) {
+    answer.push_str(delta);
+}
+
 pub(crate) async fn ask_llm_answer(
     cfg: &Config,
     query: &str,
     context: &str,
 ) -> Result<AskLlmCompletion, Box<dyn Error>> {
+    ask_llm_answer_impl(
+        cfg,
+        query,
+        context,
+        cfg.ask_stream && !cfg.json_output && !cfg.ask_explain,
+        Option::<fn(&str)>::None,
+    )
+    .await
+}
+
+pub(crate) async fn ask_llm_answer_with_deltas<F>(
+    cfg: &Config,
+    query: &str,
+    context: &str,
+    on_delta: F,
+) -> Result<AskLlmCompletion, Box<dyn Error>>
+where
+    F: FnMut(&str) + Send,
+{
+    ask_llm_answer_impl(cfg, query, context, false, Some(on_delta)).await
+}
+
+async fn ask_llm_answer_impl<F>(
+    cfg: &Config,
+    query: &str,
+    context: &str,
+    stream_to_stdout: bool,
+    mut on_delta: Option<F>,
+) -> Result<AskLlmCompletion, Box<dyn Error>>
+where
+    F: FnMut(&str) + Send,
+{
     let client = http_client()?;
     let llm_started = Instant::now();
-    // Keep stdout rendering centralized in the CLI command. The streaming path
-    // still gives TTFT/fallback behavior, but token deltas printed here would be
-    // followed by the CLI's final formatted answer.
-    let stream_to_stdout = cfg.ask_stream && !cfg.json_output && !cfg.ask_explain;
     log_info(&format!(
         "ask llm request start backend={:?} model={} stream={} context_chars={} query_len={}",
         cfg.llm_backend,
@@ -45,7 +79,23 @@ pub(crate) async fn ask_llm_answer(
     // into Option<(String, Option<Instant>)> + Option<String> here so the !Send
     // error never crosses the await boundary that follows.
     let (streamed_ok, streamed_err): (Option<(String, Option<Instant>)>, Option<String>) = {
-        let result = ask_llm_streaming_ttft(cfg, client, query, context, stream_to_stdout).await;
+        let result = if let Some(mut callback) = on_delta.take() {
+            let mut callback_answer = String::new();
+            ask_llm_streaming_ttft_with_callback(
+                cfg,
+                client,
+                query,
+                context,
+                stream_to_stdout,
+                move |delta| {
+                    append_ask_delta(&mut callback_answer, delta);
+                    callback(delta);
+                },
+            )
+            .await
+        } else {
+            ask_llm_streaming_ttft(cfg, client, query, context, stream_to_stdout).await
+        };
         match result {
             Ok(pair) => (Some(pair), None),
             Err(e) => (None, Some(e.to_string())),
@@ -92,5 +142,18 @@ pub(crate) async fn ask_llm_answer(
                 llm_total_ms,
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::append_ask_delta;
+
+    #[test]
+    fn append_ask_delta_appends_deltas() {
+        let mut answer = String::new();
+        append_ask_delta(&mut answer, "Hello");
+        append_ask_delta(&mut answer, " world");
+        assert_eq!(answer, "Hello world");
     }
 }

--- a/src/vector/ops/commands/streaming.rs
+++ b/src/vector/ops/commands/streaming.rs
@@ -276,16 +276,41 @@ pub(crate) async fn run_streaming_completion_ttft(
     print_tokens: bool,
     tagged: Option<(UnboundedSender<TaggedToken>, &'static str)>,
 ) -> Result<(String, Option<std::time::Instant>), Box<dyn Error>> {
-    run_streaming_completion_inner(cfg, req, print_tokens, tagged, true).await
+    run_streaming_completion_inner(
+        cfg,
+        req,
+        print_tokens,
+        tagged,
+        true,
+        Option::<fn(&str)>::None,
+    )
+    .await
 }
 
-async fn run_streaming_completion_inner(
+pub(crate) async fn run_streaming_completion_ttft_with_callback<F>(
+    cfg: &Config,
+    req: CompletionRequest,
+    print_tokens: bool,
+    tagged: Option<(UnboundedSender<TaggedToken>, &'static str)>,
+    on_delta: F,
+) -> Result<(String, Option<std::time::Instant>), Box<dyn Error>>
+where
+    F: FnMut(&str) + Send,
+{
+    run_streaming_completion_inner(cfg, req, print_tokens, tagged, true, Some(on_delta)).await
+}
+
+async fn run_streaming_completion_inner<F>(
     cfg: &Config,
     req: CompletionRequest,
     print_tokens: bool,
     tagged: Option<(UnboundedSender<TaggedToken>, &'static str)>,
     capture_ttft: bool,
-) -> Result<(String, Option<std::time::Instant>), Box<dyn Error>> {
+    mut on_delta: Option<F>,
+) -> Result<(String, Option<std::time::Instant>), Box<dyn Error>>
+where
+    F: FnMut(&str) + Send,
+{
     let req = req.backend_from_config(cfg);
     let mut state = StreamProcessorState::default();
     let stream_result = llm_backend::complete_streaming(req, |delta| {
@@ -299,7 +324,13 @@ async fn run_streaming_completion_inner(
         .map_err(|err| {
             let err: Box<dyn Error + Send + Sync> = err.to_string().into();
             err
-        })
+        })?;
+        if !delta.is_empty()
+            && let Some(callback) = on_delta.as_mut()
+        {
+            callback(delta);
+        }
+        Ok(())
     })
     .await;
     let fallback_text = match stream_result {
@@ -325,7 +356,15 @@ async fn run_streaming_completion(
     print_tokens: bool,
     tagged: Option<(UnboundedSender<TaggedToken>, &'static str)>,
 ) -> Result<String, Box<dyn Error>> {
-    let (answer, _) = run_streaming_completion_inner(cfg, req, print_tokens, tagged, false).await?;
+    let (answer, _) = run_streaming_completion_inner(
+        cfg,
+        req,
+        print_tokens,
+        tagged,
+        false,
+        Option::<fn(&str)>::None,
+    )
+    .await?;
     Ok(answer)
 }
 
@@ -371,6 +410,27 @@ pub(crate) async fn ask_llm_streaming_ttft(
         ask_completion_request(cfg, query, context, true),
         print_tokens,
         None,
+    )
+    .await
+}
+
+pub(crate) async fn ask_llm_streaming_ttft_with_callback<F>(
+    cfg: &Config,
+    _client: &reqwest::Client,
+    query: &str,
+    context: &str,
+    print_tokens: bool,
+    on_delta: F,
+) -> Result<(String, Option<std::time::Instant>), Box<dyn Error>>
+where
+    F: FnMut(&str) + Send,
+{
+    run_streaming_completion_ttft_with_callback(
+        cfg,
+        ask_completion_request(cfg, query, context, true),
+        print_tokens,
+        None,
+        on_delta,
     )
     .await
 }

--- a/src/web/server/handlers.rs
+++ b/src/web/server/handlers.rs
@@ -2,6 +2,8 @@
 pub mod admin;
 #[path = "handlers/ask.rs"]
 pub mod ask;
+#[path = "handlers/ask_stream.rs"]
+pub mod ask_stream;
 #[path = "handlers/async_jobs.rs"]
 pub mod async_jobs;
 #[path = "handlers/auth.rs"]
@@ -22,6 +24,7 @@ pub(crate) mod rest;
 pub mod setup;
 
 pub use ask::v1_ask;
+pub use ask_stream::v1_ask_stream;
 pub use auth::{login, panel_state};
 pub use config::{
     get_config, get_env_config, ops, panel_command, panel_doctor, panel_status, save_config,

--- a/src/web/server/handlers/ask.rs
+++ b/src/web/server/handlers/ask.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 ///
 /// Keep these bounds in sync with `src/core/config/parse/tuning.rs` so
 /// in-process CLI and `/v1/ask` callers get the same retrieval behavior.
-fn apply_ask_overrides(req_cfg: &mut Config, req: &AskRequestBody) {
+pub(super) fn apply_ask_overrides(req_cfg: &mut Config, req: &AskRequestBody) {
     if let Some(c) = req.collection.as_ref() {
         req_cfg.collection = c.clone();
     }

--- a/src/web/server/handlers/ask_stream.rs
+++ b/src/web/server/handlers/ask_stream.rs
@@ -1,0 +1,112 @@
+use super::super::error::HttpError;
+use crate::core::config::Config;
+use crate::services::client_contract::RestAskRequest as AskRequestBody;
+use crate::services::query as query_svc;
+use axum::{
+    Extension, Json,
+    response::{
+        IntoResponse, Response,
+        sse::{Event, Sse},
+    },
+};
+use futures_util::stream;
+use serde::Serialize;
+use std::{convert::Infallible, sync::Arc};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AskStreamEvent {
+    Meta { phase: &'static str },
+    Delta { text: String },
+    Done { answer: String },
+    Error { message: String },
+}
+
+fn sse_json(event_name: &'static str, value: &AskStreamEvent) -> Event {
+    Event::default()
+        .event(event_name)
+        .json_data(value)
+        .unwrap_or_else(|_| {
+            Event::default()
+                .event("error")
+                .data("{\"type\":\"error\",\"message\":\"encode failed\"}")
+        })
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/ask/stream",
+    request_body = AskRequestBody,
+    responses(
+        (status = 200, description = "RAG answer streamed as text/event-stream"),
+        (status = 400, description = "Invalid ask request", body = crate::web::server::error::ErrorBody),
+        (status = 413, description = "Ask request exceeds limits", body = crate::web::server::error::ErrorBody)
+    ),
+    tag = "rag"
+)]
+pub async fn v1_ask_stream(
+    Extension(cfg): Extension<Arc<Config>>,
+    Json(req): Json<AskRequestBody>,
+) -> Response {
+    use super::super::types::ASK_QUERY_MAX_CHARS;
+
+    if req.query.trim().is_empty() {
+        return HttpError::bad_request("query is required").into_response();
+    }
+    if req.query.chars().count() > ASK_QUERY_MAX_CHARS {
+        return HttpError::payload_too_large(format!("query exceeds {ASK_QUERY_MAX_CHARS} chars"))
+            .into_response();
+    }
+
+    let (tx, rx) = mpsc::unbounded_channel::<Result<Event, Infallible>>();
+    let mut req_cfg = (*cfg).clone();
+    super::ask::apply_ask_overrides(&mut req_cfg, &req);
+    req_cfg.ask_stream = true;
+    req_cfg.json_output = false;
+
+    tokio::spawn(async move {
+        let _ = tx.send(Ok(sse_json(
+            "meta",
+            &AskStreamEvent::Meta {
+                phase: "retrieving",
+            },
+        )));
+
+        let delta_tx = tx.clone();
+        let result = query_svc::ask_stream(&req_cfg, &req.query, move |delta| {
+            let _ = delta_tx.send(Ok(sse_json(
+                "delta",
+                &AskStreamEvent::Delta {
+                    text: delta.to_string(),
+                },
+            )));
+        })
+        .await
+        .map_err(|err| err.to_string());
+
+        match result {
+            Ok(answer) => {
+                let _ = tx.send(Ok(sse_json("done", &AskStreamEvent::Done { answer })));
+            }
+            Err(message) => {
+                let _ = tx.send(Ok(sse_json("error", &AskStreamEvent::Error { message })));
+            }
+        }
+    });
+
+    let event_stream = stream::unfold(rx, |mut rx| async {
+        rx.recv().await.map(|event| (event, rx))
+    });
+    Sse::new(event_stream).into_response()
+}
+
+#[cfg(test)]
+pub(super) async fn v1_ask_stream_test_response(body: serde_json::Value) -> Response {
+    let req = serde_json::from_value::<AskRequestBody>(body).expect("valid ask request");
+    v1_ask_stream(Extension(Arc::new(Config::default())), Json(req)).await
+}
+
+#[cfg(test)]
+#[path = "ask_stream_tests.rs"]
+mod tests;

--- a/src/web/server/handlers/ask_stream.rs
+++ b/src/web/server/handlers/ask_stream.rs
@@ -11,7 +11,13 @@ use axum::{
 };
 use futures_util::stream;
 use serde::Serialize;
-use std::{convert::Infallible, sync::Arc};
+use std::{
+    convert::Infallible,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 use tokio::sync::mpsc;
 
 #[derive(Debug, Serialize)]
@@ -39,7 +45,7 @@ fn sse_json(event_name: &'static str, value: &AskStreamEvent) -> Event {
     path = "/v1/ask/stream",
     request_body = AskRequestBody,
     responses(
-        (status = 200, description = "RAG answer streamed as text/event-stream"),
+        (status = 200, description = "RAG answer streamed as server-sent events", body = String, content_type = "text/event-stream"),
         (status = 400, description = "Invalid ask request", body = crate::web::server::error::ErrorBody),
         (status = 413, description = "Ask request exceeds limits", body = crate::web::server::error::ErrorBody)
     ),
@@ -58,39 +64,72 @@ pub async fn v1_ask_stream(
         return HttpError::payload_too_large(format!("query exceeds {ASK_QUERY_MAX_CHARS} chars"))
             .into_response();
     }
+    if req.explain == Some(true) {
+        return HttpError::bad_request("explain is not supported for streaming ask")
+            .into_response();
+    }
 
     let (tx, rx) = mpsc::unbounded_channel::<Result<Event, Infallible>>();
+    let disconnected = Arc::new(AtomicBool::new(false));
     let mut req_cfg = (*cfg).clone();
     super::ask::apply_ask_overrides(&mut req_cfg, &req);
     req_cfg.ask_stream = true;
     req_cfg.json_output = false;
 
     tokio::spawn(async move {
-        let _ = tx.send(Ok(sse_json(
-            "meta",
-            &AskStreamEvent::Meta {
-                phase: "retrieving",
-            },
-        )));
+        if tx
+            .send(Ok(sse_json(
+                "meta",
+                &AskStreamEvent::Meta {
+                    phase: "retrieving",
+                },
+            )))
+            .is_err()
+        {
+            return;
+        }
 
         let delta_tx = tx.clone();
+        let delta_disconnected = Arc::clone(&disconnected);
         let result = query_svc::ask_stream(&req_cfg, &req.query, move |delta| {
-            let _ = delta_tx.send(Ok(sse_json(
-                "delta",
-                &AskStreamEvent::Delta {
-                    text: delta.to_string(),
-                },
-            )));
+            if delta_disconnected.load(Ordering::Relaxed) {
+                return;
+            }
+            if delta_tx
+                .send(Ok(sse_json(
+                    "delta",
+                    &AskStreamEvent::Delta {
+                        text: delta.to_string(),
+                    },
+                )))
+                .is_err()
+            {
+                delta_disconnected.store(true, Ordering::Relaxed);
+            }
         })
         .await
         .map_err(|err| err.to_string());
 
+        if disconnected.load(Ordering::Relaxed) {
+            return;
+        }
+
         match result {
             Ok(answer) => {
-                let _ = tx.send(Ok(sse_json("done", &AskStreamEvent::Done { answer })));
+                if tx
+                    .send(Ok(sse_json("done", &AskStreamEvent::Done { answer })))
+                    .is_err()
+                {
+                    disconnected.store(true, Ordering::Relaxed);
+                }
             }
             Err(message) => {
-                let _ = tx.send(Ok(sse_json("error", &AskStreamEvent::Error { message })));
+                if tx
+                    .send(Ok(sse_json("error", &AskStreamEvent::Error { message })))
+                    .is_err()
+                {
+                    disconnected.store(true, Ordering::Relaxed);
+                }
             }
         }
     });

--- a/src/web/server/handlers/ask_stream_tests.rs
+++ b/src/web/server/handlers/ask_stream_tests.rs
@@ -9,3 +9,14 @@ async fn ask_stream_rejects_empty_query() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
+
+#[tokio::test]
+async fn ask_stream_rejects_explain_mode() {
+    let response = super::v1_ask_stream_test_response(serde_json::json!({
+        "query": "why?",
+        "explain": true
+    }))
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/src/web/server/handlers/ask_stream_tests.rs
+++ b/src/web/server/handlers/ask_stream_tests.rs
@@ -1,0 +1,11 @@
+use axum::http::StatusCode;
+
+#[tokio::test]
+async fn ask_stream_rejects_empty_query() {
+    let response = super::v1_ask_stream_test_response(serde_json::json!({
+        "query": ""
+    }))
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/src/web/server/openapi.rs
+++ b/src/web/server/openapi.rs
@@ -18,6 +18,7 @@ use super::{handlers, openapi_jobs};
         handlers::discovery::status,
         handlers::discovery::doctor,
         handlers::ask::v1_ask,
+        handlers::ask_stream::v1_ask_stream,
         handlers::rag::query,
         handlers::rag::retrieve,
         handlers::rag::evaluate,

--- a/src/web/server/routing.rs
+++ b/src/web/server/routing.rs
@@ -161,6 +161,7 @@ where
 {
     Router::<S>::new()
         .route("/v1/ask", post(handlers::v1_ask))
+        .route("/v1/ask/stream", post(handlers::v1_ask_stream))
         .layer(DefaultBodyLimit::max(ASK_BODY_LIMIT))
         .layer(Extension(cfg))
 }

--- a/src/web/server_tests.rs
+++ b/src/web/server_tests.rs
@@ -113,6 +113,7 @@ async fn all_v1_rest_routes_reject_missing_auth_when_auth_is_configured() {
         ("GET", "/v1/status"),
         ("GET", "/v1/doctor"),
         ("POST", "/v1/ask"),
+        ("POST", "/v1/ask/stream"),
         ("POST", "/v1/query"),
         ("POST", "/v1/retrieve"),
         ("POST", "/v1/evaluate"),
@@ -235,6 +236,7 @@ async fn openapi_docs_are_public_and_list_rest_routes() {
     for path in [
         "/v1/query",
         "/v1/ask",
+        "/v1/ask/stream",
         "/v1/crawl",
         "/v1/crawl/{id}",
         "/v1/embed",


### PR DESCRIPTION
## Summary
- render palette markdown output with Streamdown
- add /v1/ask/stream SSE route and ask token callback plumbing
- bridge SSE through Tauri events and stream ask output in the palette
- regenerate OpenAPI route docs

## Verification
- pnpm typecheck && pnpm vite:build (apps/palette-tauri)
- cargo test parse_sse_data_line (apps/palette-tauri/src-tauri)
- cargo test append_ask_delta
- cargo test ask_stream
- cargo test v1_ask_auth_layer
- cargo check (root)
- cargo check (apps/palette-tauri/src-tauri)
- cargo clippy --all-targets --all-features -- -D warnings
- pre-push: nextest full suite, 2284 passed, 6 skipped

## Notes
- Streaming has been verified by unit/type/build/pre-push gates; live LLM SSE smoke is still a follow-up verification target.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream ask responses into the Palette and render them live with `streamdown`. Adds an SSE `/v1/ask/stream` endpoint and a hardened Tauri stream bridge with request correlation, start/delta/done/error events, and safe cancellation.

- **New Features**
  - Server: Added `POST /v1/ask/stream` (SSE) that emits `started/meta`, `delta`, `done`, and `error`; included in OpenAPI.
  - Tauri: New `axon_http_stream_request` parses SSE, correlates by `request_id`, and emits `palette://stream` window events; handles cancellation and errors.
  - Palette UI: Live output renders markdown with `streamdown`; supports copy/retry; streaming run state; extracted `OutputPanel` and `SettingsPanel`; non-streaming JSON path remains as fallback.
  - Client: Simplified request builder in `axonClient`; selects streaming for `ask` and detects output kind for proper rendering.
  - Docs: Added session log and implementation plan for streaming.

- **Dependencies**
  - Palette: Add `streamdown`.
  - Tauri/Rust: Enable `reqwest` "stream" and add `futures-util`, `tokio-util`, `wasm-streams`.

<sup>Written for commit 38e55cd2ea20d9dae74a7caf58c129e2cdcc7a4a. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/axon/pull/140?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

