### PR TITLE
style(palette): Crystalline design — darker surfaces, cyan accent system, ghost chip mode pill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,18 +24,6 @@ AXON_MCP_AUTH_ADMIN_EMAIL=
 AXON_MCP_AUTH_ALLOWED_REDIRECT_URIS=
 AXON_MCP_ALLOWED_ORIGINS=
 
-# ── MCP Google OAuth (optional — required for HTTP OAuth login) ──────────────
-# OAuth client ID and secret from Google Cloud Console
-GOOGLE_OAUTH_CLIENT_ID=
-GOOGLE_OAUTH_CLIENT_SECRET=
-# Full redirect URI override (recommended for public deployments)
-# Example: https://axon.tootie.tv/oauth/google/callback
-GOOGLE_OAUTH_REDIRECT_URI=
-# Space-delimited scopes requested from Google (default shown)
-GOOGLE_OAUTH_SCOPES="openid email profile"
-# Issuer advertised by local OAuth broker metadata
-GOOGLE_OAUTH_BROKER_ISSUER=http://127.0.0.1:8001
-
 # ── Ingest credentials ──────────────────────────────────────────────────────
 TAVILY_API_KEY=
 GITHUB_TOKEN=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Android redesign specs** — added `docs/specs/android-redesign.md` and
   implementation plans for Android phase 3 completion and the full rail redesign.
 
+### Changed
+- style(palette): Crystalline visual design — darker near-black surfaces, cyan accent system replacing rose, ghost chip mode pill with × dismiss
 ## [4.12.2] - 2026-05-27
 
 ### Added

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -369,6 +369,7 @@ export default function App() {
         {modeAction && (
           <button className="command-mode-pill" type="button" onClick={() => setModeAction(null)} title="Clear action mode">
             {modeAction.subcommand}
+            <span className="mode-pill-dismiss" aria-hidden="true">×</span>
           </button>
         )}
         <Input

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -365,9 +365,9 @@ export default function App() {
     <div className={`aurora-page-shell palette-shell${compact ? " palette-shell-compact" : ""}`}>
 
       <section className="command-bar">
-        <Search size={16} />
+        <Search size={16} aria-hidden="true" />
         {modeAction && (
-          <button className="command-mode-pill" type="button" onClick={() => setModeAction(null)} title="Clear action mode">
+          <button className="command-mode-pill" type="button" onClick={() => setModeAction(null)} aria-label={`Clear ${modeAction.subcommand} mode`}>
             {modeAction.subcommand}
             <span className="mode-pill-dismiss" aria-hidden="true">×</span>
           </button>

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -388,7 +388,7 @@ export default function App() {
           aria-label="Run selected action"
           title={validation || "Run selected action"}
         >
-          {run.kind === "running" || run.kind === "streaming" ? <Spinner size="sm" tone="rose" /> : <Send size={15} />}
+          {run.kind === "running" || run.kind === "streaming" ? <Spinner size="sm" tone="cyan" /> : <Send size={15} />}
         </button>
       </section>
 

--- a/apps/palette-tauri/src/components/aurora.css
+++ b/apps/palette-tauri/src/components/aurora.css
@@ -99,9 +99,9 @@
   --aurora-shadow-strong: 0 20px 38px rgba(0, 0, 0, 0.26);
   --aurora-highlight-medium: inset 0 1px 0 rgba(255, 255, 255, 0.035);
   --aurora-highlight-strong: inset 0 1px 0 rgba(255, 255, 255, 0.055);
-  --aurora-active-glow: 0 0 0 1px color-mix(in srgb, #29b6f6 28%, transparent),
-                        0 2px 8px color-mix(in srgb, #29b6f6 18%, transparent);
-  --aurora-focus-ring: color-mix(in srgb, #29b6f6 30%, transparent);
+  --aurora-active-glow: 0 0 0 1px color-mix(in srgb, var(--aurora-accent-primary) 28%, transparent),
+                        0 2px 8px color-mix(in srgb, var(--aurora-accent-primary) 18%, transparent);
+  --aurora-focus-ring: color-mix(in srgb, var(--aurora-accent-primary) 30%, transparent);
 
   /* Radii */
   --aurora-radius-1: 14px;
@@ -237,6 +237,7 @@
   --aurora-subtle-bg:         color-mix(in srgb, var(--aurora-hover-bg) 66%, transparent);
   --aurora-selected-bg:       color-mix(in srgb, var(--aurora-accent-primary) 10%, var(--aurora-panel-medium));
   --aurora-pressed-bg:        color-mix(in srgb, var(--aurora-accent-primary) 16%, var(--aurora-panel-medium));
+  --aurora-focus-ring:        color-mix(in srgb, var(--aurora-accent-primary) 40%, transparent);
   --aurora-focus-ring-strong: color-mix(in srgb, var(--aurora-accent-primary) 40%, transparent);
 
   /* --aurora-status-offline is deprecated; alias to --aurora-neutral. Remove after all consumers migrate. */

--- a/apps/palette-tauri/src/components/aurora.css
+++ b/apps/palette-tauri/src/components/aurora.css
@@ -1,12 +1,12 @@
 :root,
 .dark {
   /* Surfaces — navy lift tiers */
-  --aurora-page-bg:       #07131c;
+  --aurora-page-bg:       #070f18;
   --aurora-bg:            var(--aurora-page-bg);
-  --aurora-nav-bg:        #07111a;
-  --aurora-panel-medium:  #102330;
+  --aurora-nav-bg:        #060e17;
+  --aurora-panel-medium:  #0f1d2b;
   --aurora-panel-strong:  #13293a;
-  --aurora-control-surface: #0c1a24;
+  --aurora-control-surface: #071018;
   --aurora-hover-bg:      #17364b;
   --aurora-surface-raised: linear-gradient(180deg, rgba(18, 40, 56, 0.96), rgba(12, 27, 38, 0.98));
 
@@ -131,10 +131,8 @@
   --aurora-weight-label: 650;
   --aurora-weight-heading: 760;
 
-  /* Page shell — the two-radial aurora wash */
-  --aurora-shell-bg: radial-gradient(circle at 12% 0%, rgba(41, 182, 246, 0.09), transparent 28%),
-                     radial-gradient(circle at 88% 0%, rgba(28, 127, 172, 0.10), transparent 24%),
-                     var(--aurora-page-bg);
+  /* Page shell — crystalline flat surface */
+  --aurora-shell-bg: #0b1622;
 
   /* shadcn token bridge — dark */
   --background:           var(--aurora-page-bg);

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -253,20 +253,37 @@ textarea {
 .command-mode-pill {
   display: inline-flex;
   align-items: center;
-  height: 30px;
-  padding: 0 10px;
-  color: var(--aurora-accent-foreground);
-  background: color-mix(in srgb, var(--aurora-accent-primary) 18%, var(--aurora-control-surface));
-  border: 1px solid color-mix(in srgb, var(--aurora-accent-primary) 45%, var(--aurora-border-default));
-  border-radius: 999px;
+  gap: 5px;
+  height: 27px;
+  padding: 0 7px 0 10px;
+  color: #29b6f6;
+  background: transparent;
+  border: 1px solid rgba(41, 182, 246, 0.28);
+  border-radius: 6px;
   font-family: var(--aurora-font-mono);
   font-size: var(--aurora-type-caption);
   font-weight: var(--aurora-weight-label);
   cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .command-mode-pill:hover {
-  background: color-mix(in srgb, var(--aurora-accent-primary) 26%, var(--aurora-control-surface));
+  background: rgba(41, 182, 246, 0.07);
+  border-color: rgba(41, 182, 246, 0.42);
+}
+
+.mode-pill-dismiss {
+  width: 15px;
+  height: 15px;
+  border-radius: 3px;
+  background: rgba(41, 182, 246, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+  font-style: normal;
 }
 
 .palette-grid {

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -333,9 +333,9 @@ textarea {
 .panel-heading {
   justify-content: space-between;
   margin-bottom: 8px;
-  color: var(--aurora-text-muted);
+  color: #1e3448;
   font-size: var(--aurora-type-caption);
-  font-weight: var(--aurora-weight-label);
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: var(--aurora-letter-eyebrow);
 }
@@ -481,8 +481,8 @@ textarea {
   overflow: auto;
   padding: 10px 12px;
   color: var(--aurora-text-primary);
-  background: var(--aurora-control-surface);
-  border: 1px solid var(--aurora-border-default);
+  background: #040b12;
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 8px;
 }
 
@@ -573,6 +573,7 @@ textarea {
   justify-content: space-between;
   height: 34px;
   padding: 0 18px;
-  background: var(--aurora-nav-bg);
-  border-top: 1px solid var(--aurora-border-default);
+  background: #060e17;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  color: #1e3448;
 }

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -117,7 +117,7 @@ textarea {
 }
 
 .command-submit:disabled {
-  color: #1a3550;
+  color: var(--aurora-disabled-text);
   background: #0d1e2d;
   border-color: rgba(255, 255, 255, 0.07);
   box-shadow: none;
@@ -333,7 +333,7 @@ textarea {
 .panel-heading {
   justify-content: space-between;
   margin-bottom: 8px;
-  color: #1e3448;
+  color: var(--aurora-text-muted);
   font-size: var(--aurora-type-caption);
   font-weight: 700;
   text-transform: uppercase;
@@ -575,5 +575,4 @@ textarea {
   padding: 0 18px;
   background: #060e17;
   border-top: 1px solid rgba(255, 255, 255, 0.05);
-  color: #1e3448;
 }

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -399,9 +399,9 @@ textarea {
 
 .action-row:hover,
 .action-row-selected {
-  background: color-mix(in srgb, var(--aurora-accent-primary) 9%, var(--aurora-control-surface));
-  border-color: color-mix(in srgb, var(--aurora-accent-primary) 38%, var(--aurora-border-default));
-  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.12);
+  background: #0d1f30;
+  border-color: rgba(41, 182, 246, 0.22);
+  box-shadow: inset 3px 0 0 #29b6f6, 0 1px 5px rgba(0, 0, 0, 0.28);
 }
 
 .action-main {

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -78,7 +78,7 @@ textarea {
   width: 9px;
   height: 9px;
   border-radius: 999px;
-  background: #29b6f6;
+  background: var(--aurora-accent-primary);
   box-shadow: 0 0 8px rgba(41, 182, 246, 0.55);
 }
 
@@ -104,16 +104,16 @@ textarea {
   border-color: var(--aurora-border-default);
 }
 
-.command-submit:hover:not(:disabled) {
-  background: linear-gradient(135deg, #42c8ff, #1976d2);
-  box-shadow: 0 3px 14px rgba(41, 182, 246, 0.45);
-}
-
 .command-submit {
   color: #fff;
   background: linear-gradient(135deg, #29b6f6, #1565c0);
-  border-color: rgba(41, 182, 246, 0.4);
-  box-shadow: 0 2px 10px rgba(41, 182, 246, 0.35);
+  border-color: color-mix(in srgb, var(--aurora-accent-primary) 40%, transparent);
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--aurora-accent-primary) 35%, transparent);
+}
+
+.command-submit:hover:not(:disabled) {
+  background: linear-gradient(135deg, #42c8ff, #1976d2);
+  box-shadow: 0 3px 14px color-mix(in srgb, var(--aurora-accent-primary) 45%, transparent);
 }
 
 .command-submit:disabled {
@@ -256,9 +256,9 @@ textarea {
   gap: 5px;
   height: 27px;
   padding: 0 7px 0 10px;
-  color: #29b6f6;
+  color: var(--aurora-accent-primary);
   background: transparent;
-  border: 1px solid rgba(41, 182, 246, 0.28);
+  border: 1px solid color-mix(in srgb, var(--aurora-accent-primary) 28%, transparent);
   border-radius: 6px;
   font-family: var(--aurora-font-mono);
   font-size: var(--aurora-type-caption);
@@ -269,15 +269,15 @@ textarea {
 }
 
 .command-mode-pill:hover {
-  background: rgba(41, 182, 246, 0.07);
-  border-color: rgba(41, 182, 246, 0.42);
+  background: color-mix(in srgb, var(--aurora-accent-primary) 7%, transparent);
+  border-color: color-mix(in srgb, var(--aurora-accent-primary) 42%, transparent);
 }
 
 .mode-pill-dismiss {
   width: 15px;
   height: 15px;
   border-radius: 3px;
-  background: rgba(41, 182, 246, 0.1);
+  background: color-mix(in srgb, var(--aurora-accent-primary) 10%, transparent);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -399,9 +399,9 @@ textarea {
 
 .action-row:hover,
 .action-row-selected {
-  background: #0d1f30;
-  border-color: rgba(41, 182, 246, 0.22);
-  box-shadow: inset 3px 0 0 #29b6f6, 0 1px 5px rgba(0, 0, 0, 0.28);
+  background: var(--aurora-selected-bg);
+  border-color: color-mix(in srgb, var(--aurora-accent-primary) 22%, transparent);
+  box-shadow: inset 3px 0 0 var(--aurora-accent-primary), 0 1px 5px rgba(0, 0, 0, 0.28);
 }
 
 .action-main {

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -78,8 +78,8 @@ textarea {
   width: 9px;
   height: 9px;
   border-radius: 999px;
-  background: var(--aurora-accent-pink);
-  box-shadow: 0 0 12px color-mix(in srgb, var(--aurora-accent-pink) 42%, transparent);
+  background: #29b6f6;
+  box-shadow: 0 0 8px rgba(41, 182, 246, 0.55);
 }
 
 .titlebar-button,
@@ -98,22 +98,29 @@ textarea {
 }
 
 .titlebar-button:hover,
-.command-submit:hover:not(:disabled),
 .output-tools button:hover {
   color: var(--aurora-text-primary);
   background: var(--aurora-hover-bg);
   border-color: var(--aurora-border-default);
 }
 
+.command-submit:hover:not(:disabled) {
+  background: linear-gradient(135deg, #42c8ff, #1976d2);
+  box-shadow: 0 3px 14px rgba(41, 182, 246, 0.45);
+}
+
 .command-submit {
-  color: var(--aurora-accent-foreground);
-  background: var(--aurora-rose-gradient);
-  border-color: color-mix(in srgb, var(--aurora-accent-pink) 42%, transparent);
+  color: #fff;
+  background: linear-gradient(135deg, #29b6f6, #1565c0);
+  border-color: rgba(41, 182, 246, 0.4);
+  box-shadow: 0 2px 10px rgba(41, 182, 246, 0.35);
 }
 
 .command-submit:disabled {
-  color: var(--aurora-disabled-text);
-  background: var(--aurora-disabled-surface);
+  color: #1a3550;
+  background: #0d1e2d;
+  border-color: rgba(255, 255, 255, 0.07);
+  box-shadow: none;
   cursor: default;
 }
 

--- a/docs/API-PARITY.md
+++ b/docs/API-PARITY.md
@@ -77,6 +77,7 @@ GET /v1/stats
 GET /v1/status
 GET /v1/doctor
 POST /v1/ask
+POST /v1/ask/stream
 POST /v1/query
 POST /v1/retrieve
 POST /v1/evaluate

--- a/docs/sessions/2026-05-28-palette-crystalline-design.md
+++ b/docs/sessions/2026-05-28-palette-crystalline-design.md
@@ -1,0 +1,131 @@
+---
+date: 2026-05-28 11:27:37 EST
+repo: git@github.com:jmagar/axon.git
+branch: feat/palette-crystalline
+head: c4d4dabd
+plan: docs/superpowers/plans/2026-05-28-palette-crystalline.md
+agent: Claude (claude-sonnet-4-6)
+working directory: /home/jmagar/workspace/axon_rust/.worktrees/palette-crystalline
+worktree: /home/jmagar/workspace/axon_rust/.worktrees/palette-crystalline c4d4dabd [feat/palette-crystalline]
+pr: "#143 — style(palette): Crystalline design — darker surfaces, cyan accent system, ghost chip mode pill — https://github.com/jmagar/axon/pull/143"
+---
+
+## User Request
+
+Apply the Crystalline visual design to `apps/palette-tauri` per plan `docs/superpowers/plans/2026-05-28-palette-crystalline.md`: darker near-black surfaces, cyan accent system replacing rose, ghost chip mode pill with × dismiss.
+
+## Session Overview
+
+Implemented the full Crystalline palette redesign for `apps/palette-tauri` across 3 files (CSS tokens, component styles, React JSX) in an isolated worktree. Ran two independent review waves (lavra-review + toolkit) that surfaced 2 blocking a11y/contrast issues, 2 blocking light-theme token cascade bugs, 4 CSS tokenization warnings, and 2 a11y INFOs — all addressed before the final push. Created PR #143.
+
+## Sequence of Events
+
+1. Read plan file; inspected repo state on `feat/android-rail-redesign`
+2. Created worktree `.worktrees/palette-crystalline` on branch `feat/palette-crystalline` from HEAD
+3. Dispatched implementation agent with `superpowers:executing-plans`; agent completed all 7 plan tasks (8 commits: surface tokens, brand dot, submit btn, mode pill CSS, App.tsx dismiss span, action row, panel/footer/output body, version bump + CHANGELOG)
+4. Pre-push hook failed: `apps/web/out/` missing in worktree (build artifact, not in git). Copied from main workspace. Subsequent push succeeded.
+5. PR #143 created on GitHub.
+6. **lavra-review** found 2 BLOCKING contrast issues (`panel-heading` and `palette-footer` used `#1e3448` ≈ 1.4:1 contrast) + 1 WARNING (spinner `tone="rose"` missed accent swap) + 1 WARNING (`command-submit:disabled` icon near-invisible). All fixed in one commit.
+7. **Simplifier** replaced 3 raw `#29b6f6` hex values with `var(--aurora-accent-primary)` tokens.
+8. **Toolkit review** found 2 BLOCKING aurora.css token cascade bugs (`--aurora-active-glow` and `--aurora-focus-ring` hardcoded `#29b6f6`; `.light` block missing `--aurora-focus-ring` override) + 4 WARNING CSS tokenization gaps + 2 INFO a11y issues. All 8 addressed in one commit.
+9. Final push of 2 follow-up commits to PR #143.
+10. Session log saved.
+
+## Key Findings
+
+- `apps/palette-tauri/src/styles.css:127-131`: pre-existing rule `{ color: var(--aurora-text-muted) }` on `.palette-status, .palette-footer` was overridden by the later `.palette-footer` block at line 572 setting `color: #1e3448`. Fix: remove the override from the later block to let the earlier rule win.
+- `apps/palette-tauri/src/components/aurora.css:102-104`: `--aurora-active-glow` and `--aurora-focus-ring` both hardcoded `#29b6f6` hex instead of `var(--aurora-accent-primary)` — broke light-mode theming since `.light` redefines `--aurora-accent-primary: #0288d1` but neither glow/ring token would pick it up.
+- `aurora.css:.light` block: `--aurora-focus-ring` was never defined in `.light`, so light-mode focus rings used the dark-theme dark-navy cyan — invisible against the light background.
+- `apps/palette-tauri/src/App.tsx:391`: Spinner `tone="rose"` was a missed accent swap from rose to cyan.
+- `apps/web/out/` is a build artifact required by `src/web/static_assets.rs` via `#[derive(RustEmbed)]`. It is not committed to git and must be manually copied into new worktrees before the pre-push hook (`cargo clippy --workspace`) can compile.
+
+## Technical Decisions
+
+- **Worktree isolation**: Created `.worktrees/palette-crystalline` per CLAUDE.md convention rather than working on the current `feat/android-rail-redesign` branch.
+- **Token over hex**: All `rgba(41, 182, 246, ...)` values in new components (mode pill, action row border, submit button shadows) were replaced with `color-mix(in srgb, var(--aurora-accent-primary) X%, transparent)` to enable light-mode adaptation.
+- **`panel-heading` color**: Plan specified `#1e3448` (effectively invisible, 1.4:1 contrast). Changed to `var(--aurora-text-muted)` in the first review pass. The design intent (ultra-muted eyebrow label) is better served by the semantic token than by a near-invisible raw hex.
+- **`palette-footer` color**: Plan specified `#1e3448` override. Removed the override entirely — the earlier combined selector rule already sets `var(--aurora-text-muted)` which is correct and visible.
+- **`--aurora-active-glow` fix**: Replaced `#29b6f6` → `var(--aurora-accent-primary)` so the glow adapts when `.light` is active.
+- **`aria-label` on mode pill button**: Replaced `title="Clear action mode"` with `aria-label={\`Clear ${modeAction.subcommand} mode\`}` for a more specific, screen-reader-friendly accessible name.
+
+## Files Modified
+
+| File | Purpose |
+|---|---|
+| `apps/palette-tauri/src/components/aurora.css` | Darken 4 surface tokens; flatten `--aurora-shell-bg`; fix `--aurora-active-glow` and `--aurora-focus-ring` to use `var(--aurora-accent-primary)`; add `--aurora-focus-ring` to `.light` block |
+| `apps/palette-tauri/src/styles.css` | Brand dot, submit btn, mode pill ghost chip, action row, panel heading, output body, footer — crystalline values; all rgba/hex → token via `color-mix` |
+| `apps/palette-tauri/src/App.tsx` | `<span className="mode-pill-dismiss">`, spinner `tone="rose"→"cyan"`, `<Search aria-hidden>`, `aria-label` on mode pill button |
+| `apps/palette-tauri/package.json` | v4.12.2 → v4.12.3 |
+| `Cargo.toml` | v4.12.2 → v4.12.3 |
+| `CHANGELOG.md` | v4.12.3 entry |
+| `Cargo.lock` | Updated for v4.12.3 workspace version |
+
+## Commands Executed
+
+```bash
+# Worktree creation
+git worktree add -b feat/palette-crystalline .worktrees/palette-crystalline HEAD
+
+# Verification (per task)
+cd apps/palette-tauri && pnpm typecheck  # passes after every task
+
+# Build verification
+cd apps/palette-tauri && pnpm vite:build
+# → 2078 modules transformed, CSS 50.72 kB (8.70 kB gzip), built in 4.07s
+
+# Pre-push hook (full workspace Rust compile)
+# cargo clippy --workspace --all-targets --locked  ✓
+# cargo nextest run --workspace --locked --lib       ✓  (ran in ~115s)
+
+# PR creation
+gh pr create --base main --head feat/palette-crystalline  → PR #143
+```
+
+## Errors Encountered
+
+**Pre-push hook compile failure: `apps/web/out/` missing**
+- Root cause: `src/web/static_assets.rs:12` uses `#[derive(RustEmbed)]` with `#[folder = "apps/web/out/"]`. This build artifact exists in the main workspace but is not tracked in git, so new worktrees don't have it.
+- Resolution: `cp -r /home/jmagar/workspace/axon_rust/apps/web/out/ .worktrees/palette-crystalline/apps/web/out/` — copied from main workspace.
+- Follow-up: Consider adding `apps/web/out/` to `.gitignore` documentation or a worktree setup script.
+
+## Behavior Changes (Before/After)
+
+| Surface | Before | After |
+|---|---|---|
+| App background | `#07131c` navy | `#070f18` near-black |
+| Shell gradient | Radial aurora wash (cyan glows) | Flat `#0b1622` |
+| Brand dot | Rose `#f472b6` | Cyan `#29b6f6` glow |
+| Submit button | Rose gradient | Cyan linear gradient + shadow |
+| Submit button hover | Generic hover style (overridden) | Cyan brightened gradient |
+| Mode pill | Rose-tinted pill (999px radius) | Ghost chip (transparent, 6px radius, `×` dismiss) |
+| Active action row | Subtle rose border | 3px inset cyan left bar |
+| Panel headings | `var(--aurora-text-muted)` (muted) | `var(--aurora-text-muted)` (unchanged but corrected from plan's invisible `#1e3448`) |
+| Output body | `var(--aurora-control-surface)` | `#040b12` deep black |
+| Footer background | `var(--aurora-nav-bg)` | `#060e17` |
+| Running spinner | Rose | Cyan |
+| Focus rings (all themes) | Hardcoded dark-cyan `#29b6f6` | Token-aware via `var(--aurora-accent-primary)` |
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---|---|---|---|
+| `pnpm typecheck` (per task) | 0 errors | 0 errors | ✅ |
+| `pnpm vite:build` | Build completes | 2078 modules, 50.72 kB CSS | ✅ |
+| `cargo clippy --workspace --all-targets --locked` | 0 errors | 0 errors | ✅ |
+| `cargo nextest run --workspace --locked --lib` | All pass | All pass (~115s) | ✅ |
+
+## Risks and Rollback
+
+- **Light-mode adaptation**: All new cyan surfaces now use `color-mix(in srgb, var(--aurora-accent-primary) X%, transparent)` and will correctly adapt when `.light` class is active. The two `aurora.css` token fixes (active-glow, focus-ring) ensure `.light` mode works correctly.
+- **Rollback**: `git revert` the 10 commits on `feat/palette-crystalline`, or simply close PR #143 without merging.
+- **`apps/web/out/` in worktrees**: Any new worktree will need this artifact copied before Rust compilation works. Not a blocker for this PR.
+
+## Next Steps
+
+**Unfinished (not started):**
+- Visual smoke test: launch the app (`pnpm tauri dev` or `pnpm dev`) and verify the ghost chip mode pill appears correctly when an action mode is active — the `×` dismiss is only visible when `modeAction` is non-null
+- Verify light-mode rendering: toggle `.light` class in DevTools and confirm focus rings and glows use `#0288d1` not `#29b6f6`
+
+**Follow-on:**
+- `apps/web/out/` worktree setup: add to a `scripts/setup-worktree.sh` or document in `CLAUDE.md` worktree section
+- Consider adding `--aurora-focus-ring` override to `.light` block for `--aurora-focus-ring-strong` as well (currently both aliases point to the same value in `.light`)


### PR DESCRIPTION
## Summary

- **aurora.css** — Darken 4 surface tokens (`page-bg`, `nav-bg`, `panel-medium`, `control-surface`) to near-black crystalline values; flatten `shell-bg` from radial-gradient wash to flat `#0b1622`
- **styles.css** — Brand dot → cyan `#29b6f6` glow; submit button → cyan linear gradient with isolated hover rule; mode pill → ghost chip (transparent bg, rounded rect, cyan border, `mode-pill-dismiss` slot); active action row → `3px inset cyan` left border; panel heading → ultra-muted `#1e3448`; output body bg → deep `#040b12`; footer bg + border tightened
- **App.tsx** — Add `<span className="mode-pill-dismiss" aria-hidden="true">×</span>` inside mode pill button

Version bumped: `4.12.2 → 4.12.3` in `package.json`, `Cargo.toml`, and `CHANGELOG.md`.

## Changes

| File | Change |
|---|---|
| `apps/palette-tauri/src/components/aurora.css` | 4 surface tokens darkened + shell-bg flattened |
| `apps/palette-tauri/src/styles.css` | brand dot, submit btn, mode pill, action row, panel heading, output body, footer |
| `apps/palette-tauri/src/App.tsx` | `×` dismiss span in mode pill |
| `apps/palette-tauri/package.json` | v4.12.3 |
| `Cargo.toml` | v4.12.3 |
| `CHANGELOG.md` | v4.12.3 entry |

## Test plan

- [x] `pnpm typecheck` — passes (0 errors)
- [x] `pnpm vite:build` — passes (2078 modules, CSS 50.72 kB)
- [x] `cargo clippy --workspace --all-targets --locked` — passes (pre-push hook)
- [x] `cargo test --workspace --locked --lib` — passes (pre-push hook)
- [ ] Visual: launch app, verify darker surfaces, cyan submit button, ghost chip mode pill with × appears when action mode is active

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the Crystalline design to Palette with near‑black surfaces, a cyan accent system, a flat shell background, and a ghost‑chip mode pill with ×. Syncs versions to 4.12.3, removes legacy env keys, and updates API docs for route parity.

- **New Features**
  - Crystalline palette: darker surfaces, flat shell background, cyan accents; submit button uses a cyan gradient.

- **Bug Fixes**
  - A11y/token fixes: cyan spinner; `Search` icon `aria-hidden`; mode pill `aria-label`; focus/active glow use `--aurora-accent-primary` (including light-mode focus ring).
  - Docs/cleanup: added `POST /v1/ask/stream` to API parity; removed legacy `GOOGLE_OAUTH_*` from `.env.example`; version sync across `axon`, `axon-palette-tauri`, and `@axon/admin-panel` to 4.12.3.

<sup>Written for commit 4c1001db0178d017a9f4faa65b6d517d01ffecfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/143?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions management with pinning, deletion, and drawer navigation
  * Jobs drawer with real-time polling and status indicators
  * Knowledge suggestions screen for document discovery
  * Enhanced Ask screen with chat-style message bubbles and streaming support
  * FAB launcher with operations ring menu and input cards

* **Bug Fixes**
  * Fixed Jobs drawer endpoint routing and response handling
  * Resolved drawer tap interception and layout positioning issues

* **Style**
  * Applied Crystalline design theme with darker surfaces and cyan accents
  * Refactored Ask screen UI layout and navigation structure
  * Removed legacy operation mode picker interface

* **Chores**
  * Version bumped to v4.12.3
  * Updated database schema with migration support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/axon/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->