### PR TITLE
feat(android): Phase 3 — FAB fixes + Management/Setup drawers wired

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.axon.app"
         minSdk = 24
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1"
     }
 
     buildTypes {

--- a/apps/android/app/src/main/java/com/axon/app/ui/common/DrawerSubItem.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/common/DrawerSubItem.kt
@@ -1,0 +1,66 @@
+package com.axon.app.ui.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.axon.app.ui.theme.AxonColors
+
+/**
+ * Shared drawer sub-item row used by Management and Setup drawer sections.
+ *
+ * [trailing] is an optional slot for badges, chevrons, or other decorations.
+ * When [onClick] is non-null and [trailing] is null the caller is responsible
+ * for providing trailing content (e.g. a chevron icon).
+ */
+@Composable
+fun DrawerSubItem(
+    icon: ImageVector,
+    label: String,
+    detail: String,
+    detailColor: Color = AxonColors.TextMuted,
+    onClick: (() -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .let {
+                if (onClick != null)
+                    it.clickable(remember { MutableInteractionSource() }, indication = null, onClick = onClick)
+                else it
+            }
+            // vertical = 14.dp gives ~45dp row height with 17dp icon — meets 48dp with icon padding
+            .padding(vertical = 14.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = label,
+            tint = if (onClick != null) AxonColors.AccentPrimary else AxonColors.TextMuted,
+            modifier = Modifier.size(17.dp),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label, style = MaterialTheme.typography.bodySmall, color = AxonColors.TextLabel)
+            Text(
+                detail,
+                style = MaterialTheme.typography.labelSmall,
+                color = detailColor,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        trailing?.invoke()
+    }
+}

--- a/apps/android/app/src/main/java/com/axon/app/ui/common/DrawerSubItem.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/common/DrawerSubItem.kt
@@ -2,7 +2,14 @@ package com.axon.app.ui.common
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -19,9 +26,8 @@ import com.axon.app.ui.theme.AxonColors
 /**
  * Shared drawer sub-item row used by Management and Setup drawer sections.
  *
- * [trailing] is an optional slot for badges, chevrons, or other decorations.
- * When [onClick] is non-null and [trailing] is null the caller is responsible
- * for providing trailing content (e.g. a chevron icon).
+ * When [onClick] is non-null and [trailing] is null, a chevron is rendered automatically.
+ * Pass an explicit [trailing] composable for badges or other custom decorations.
  */
 @Composable
 fun DrawerSubItem(
@@ -32,15 +38,18 @@ fun DrawerSubItem(
     onClick: (() -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null,
 ) {
+    val clickModifier = if (onClick != null) {
+        Modifier.clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null,
+            onClick = onClick,
+        )
+    } else Modifier
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .let {
-                if (onClick != null)
-                    it.clickable(remember { MutableInteractionSource() }, indication = null, onClick = onClick)
-                else it
-            }
-            // vertical = 14.dp gives ~45dp row height with 17dp icon — meets 48dp with icon padding
+            .then(clickModifier)
             .padding(vertical = 14.dp, horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -61,6 +70,14 @@ fun DrawerSubItem(
                 overflow = TextOverflow.Ellipsis,
             )
         }
-        trailing?.invoke()
+        when {
+            trailing != null -> trailing()
+            onClick != null -> Icon(
+                Icons.Rounded.ChevronRight,
+                contentDescription = null,
+                tint = AxonColors.TextMuted,
+                modifier = Modifier.size(14.dp),
+            )
+        }
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/fab/FabLauncher.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/fab/FabLauncher.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
@@ -34,14 +35,22 @@ fun FabLauncher(
     var state by remember { mutableStateOf<FabState>(FabState.Idle) }
     var fabCenter by remember { mutableStateOf(IntOffset.Zero) }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        BackHandler(enabled = state !is FabState.Idle) {
-            state = FabState.Idle
+    BackHandler(enabled = state !is FabState.Idle) {
+        state = FabState.Idle
+    }
+
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        val screenCenter = remember(maxWidth, maxHeight) {
+            IntOffset(
+                x = with(density) { (maxWidth / 2).roundToPx() },
+                y = with(density) { (maxHeight / 2).roundToPx() },
+            )
         }
 
         FabRing(
             visible = state is FabState.Ring,
-            fabCenterOffset = fabCenter,
+            fabCenterOffset = if (state is FabState.Ring) screenCenter else fabCenter,
             onOpSelected = { op -> state = FabState.Input(op) },
             onDismiss = { state = FabState.Idle },
         )

--- a/apps/android/app/src/main/java/com/axon/app/ui/fab/FabLauncher.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/fab/FabLauncher.kt
@@ -1,5 +1,6 @@
 package com.axon.app.ui.fab
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -34,6 +35,10 @@ fun FabLauncher(
     var fabCenter by remember { mutableStateOf(IntOffset.Zero) }
 
     Box(modifier = modifier.fillMaxSize()) {
+        BackHandler(enabled = state !is FabState.Idle) {
+            state = FabState.Idle
+        }
+
         FabRing(
             visible = state is FabState.Ring,
             fabCenterOffset = fabCenter,

--- a/apps/android/app/src/main/java/com/axon/app/ui/fab/FabLauncher.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/fab/FabLauncher.kt
@@ -42,10 +42,7 @@ fun FabLauncher(
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         val density = LocalDensity.current
         val screenCenter = remember(maxWidth, maxHeight) {
-            IntOffset(
-                x = with(density) { (maxWidth / 2).roundToPx() },
-                y = with(density) { (maxHeight / 2).roundToPx() },
-            )
+            with(density) { IntOffset((maxWidth / 2).roundToPx(), (maxHeight / 2).roundToPx()) }
         }
 
         FabRing(
@@ -55,13 +52,12 @@ fun FabLauncher(
             onDismiss = { state = FabState.Idle },
         )
 
-        if (state is FabState.Input) {
-            val op = (state as FabState.Input).op
+        (state as? FabState.Input)?.let { input ->
             FabOpInputCard(
-                op = op,
-                onSubmit = { input ->
+                op = input.op,
+                onSubmit = { text ->
                     state = FabState.Idle
-                    onOpSubmit(op, input)
+                    onOpSubmit(input.op, text)
                 },
                 onDismiss = { state = FabState.Idle },
             )

--- a/apps/android/app/src/main/java/com/axon/app/ui/fab/FabRing.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/fab/FabRing.kt
@@ -59,11 +59,12 @@ fun FabRing(
             )
         }
 
-        FabOp.entries.forEachIndexed { i, op ->
-            val angleDeg = -90.0 + i * 36.0
-            val angleRad = Math.toRadians(angleDeg)
-            val radiusPx = with(density) { radiusDp.toPx() }
+        val radiusPx = with(density) { radiusDp.toPx() }
+        val halfTilePx = with(density) { 23.dp.roundToPx() }
+        val halfDismissPx = with(density) { 21.dp.roundToPx() }
 
+        FabOp.entries.forEachIndexed { i, op ->
+            val angleRad = Math.toRadians(-90.0 + i * 36.0)
             val dx = (radiusPx * cos(angleRad) * openProgress).roundToInt()
             val dy = (radiusPx * sin(angleRad) * openProgress).roundToInt()
 
@@ -71,8 +72,8 @@ fun FabRing(
                 op = op,
                 modifier = Modifier.offset {
                     IntOffset(
-                        x = fabCenterOffset.x + dx - with(density) { 23.dp.roundToPx() },
-                        y = fabCenterOffset.y + dy - with(density) { 23.dp.roundToPx() },
+                        x = fabCenterOffset.x + dx - halfTilePx,
+                        y = fabCenterOffset.y + dy - halfTilePx,
                     )
                 },
                 alpha = openProgress,
@@ -83,10 +84,7 @@ fun FabRing(
         // Center dismiss button
         Box(
             modifier = Modifier
-                .offset {
-                    val offsetPx = with(density) { 21.dp.roundToPx() }
-                    IntOffset(fabCenterOffset.x - offsetPx, fabCenterOffset.y - offsetPx)
-                }
+                .offset { IntOffset(fabCenterOffset.x - halfDismissPx, fabCenterOffset.y - halfDismissPx) }
                 .size(42.dp)
                 .background(Color(0xFF29B6F6), RoundedCornerShape(13.dp))
                 .clickable(remember { MutableInteractionSource() }, indication = null, onClick = onDismiss),
@@ -99,15 +97,16 @@ fun FabRing(
 
 @Composable
 private fun OpTile(op: FabOp, modifier: Modifier, alpha: Float, onClick: () -> Unit) {
-    val bg   = if (op.isAsync) asyncOpBg   else PanelStrong
-    val tint = if (op.isAsync) asyncOpTint else syncOpTint
+    val bg     = if (op.isAsync) asyncOpBg   else PanelStrong
+    val tint   = if (op.isAsync) asyncOpTint else syncOpTint
+    val border = if (op.isAsync) asyncOpTint.copy(alpha = 0.35f) else BorderStrong
 
     Box(
         modifier = modifier
             .size(46.dp)
             .graphicsLayer { this.alpha = alpha }
             .background(bg, RoundedCornerShape(13.dp))
-            .border(1.dp, if (op.isAsync) asyncOpTint.copy(alpha = 0.35f) else BorderStrong, RoundedCornerShape(13.dp))
+            .border(1.dp, border, RoundedCornerShape(13.dp))
             .clickable(remember { MutableInteractionSource() }, indication = null, onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {

--- a/apps/android/app/src/main/java/com/axon/app/ui/fab/FabRing.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/fab/FabRing.kt
@@ -49,6 +49,16 @@ fun FabRing(
     if (!visible && openProgress == 0f) return
 
     Box(modifier = modifier.fillMaxSize()) {
+        // Dim backdrop — only drawn when ring has opened far enough to be meaningful
+        if (openProgress > 0f) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xD2040A0E).copy(alpha = openProgress * 0.82f))
+                    .clickable(remember { MutableInteractionSource() }, indication = null, onClick = onDismiss),
+            )
+        }
+
         FabOp.entries.forEachIndexed { i, op ->
             val angleDeg = -90.0 + i * 36.0
             val angleRad = Math.toRadians(angleDeg)

--- a/apps/android/app/src/main/java/com/axon/app/ui/fab/FabRing.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/fab/FabRing.kt
@@ -54,7 +54,7 @@ fun FabRing(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color(0xD2040A0E).copy(alpha = openProgress * 0.82f))
+                    .background(Color(0xFF040A0E).copy(alpha = openProgress * 0.82f))
                     .clickable(remember { MutableInteractionSource() }, indication = null, onClick = onDismiss),
             )
         }

--- a/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.*
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
@@ -101,7 +100,6 @@ fun ManagementDrawerContent(
             },
             detailColor = if (statsState is MgmtActionState.Error) AxonColors.ErrorBase else AxonColors.TextMuted,
             onClick = { vm.loadStats() },
-            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Dedupe (coming soon) ──────────────────────────────────────────────
@@ -129,7 +127,6 @@ fun ManagementDrawerContent(
             detail = "Server URL, token, collection",
             detailColor = AxonColors.TextMuted,
             onClick = onOpenSettings,
-            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt
@@ -1,20 +1,180 @@
 package com.axon.app.ui.management
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.axon.app.ui.status.ConnectionState
+import com.axon.app.ui.status.ConnectionStatusViewModel
 
-/** Management drawer section — stub pending management screen. */
+private val AccentPrimary = Color(0xFF29B6F6)
+private val TextMuted     = Color(0xFFA7BCC9)
+private val WarnBase      = Color(0xFFC6A36B)
+private val ErrorBase     = Color(0xFFEF5350)
+private val SuccessBase   = Color(0xFF66BB6A)
+private val TextLabel     = Color(0xFFE1EEF7)
+
 @Composable
-fun ManagementDrawerContent() {
+fun ManagementDrawerContent(
+    onOpenSettings: () -> Unit,
+    statusVm: ConnectionStatusViewModel = viewModel(),
+    vm: ManagementViewModel = viewModel(),
+) {
+    val connState by statusVm.state.collectAsStateWithLifecycle()
+    val statsState by vm.statsState.collectAsStateWithLifecycle()
+    val doctorState by vm.doctorState.collectAsStateWithLifecycle()
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(12.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        // Management controls will go here (settings links, connection status, etc.)
+        // ── Connection status header ──────────────────────────────────────────
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text("Server", style = MaterialTheme.typography.labelSmall, color = TextMuted)
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                val (dotColor, label) = when (connState) {
+                    ConnectionState.Checking -> AccentPrimary to "Checking"
+                    ConnectionState.Online   -> SuccessBase to "Online"
+                    ConnectionState.Offline  -> ErrorBase to "Offline"
+                }
+                Box(
+                    modifier = Modifier
+                        .size(7.dp)
+                        .let { if (connState != ConnectionState.Offline) it else it },
+                ) {
+                    androidx.compose.foundation.Canvas(modifier = Modifier.fillMaxSize()) {
+                        drawCircle(color = dotColor)
+                    }
+                }
+                Text(label, style = MaterialTheme.typography.labelSmall, color = dotColor)
+                Text("·", style = MaterialTheme.typography.labelSmall, color = TextMuted)
+                Text(
+                    "Refresh",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = AccentPrimary,
+                    modifier = Modifier.clickable(remember { MutableInteractionSource() }, indication = null) {
+                        statusVm.refresh()
+                    },
+                )
+            }
+        }
+
+        // ── Monitor ───────────────────────────────────────────────────────────
+        MgmtSubItem(
+            icon = Icons.Rounded.MonitorHeart,
+            label = "Monitor",
+            detail = when (connState) {
+                ConnectionState.Checking -> "Checking…"
+                ConnectionState.Online   -> "Server reachable"
+                ConnectionState.Offline  -> "Server unreachable"
+            },
+            detailColor = when (connState) {
+                ConnectionState.Checking -> TextMuted
+                ConnectionState.Online   -> SuccessBase
+                ConnectionState.Offline  -> ErrorBase
+            },
+        )
+
+        // ── Stack (stats) ─────────────────────────────────────────────────────
+        MgmtSubItem(
+            icon = Icons.Rounded.Storage,
+            label = "Stack",
+            detail = when (val s = statsState) {
+                is MgmtActionState.Idle    -> "Tap to load"
+                is MgmtActionState.Loading -> "Loading…"
+                is MgmtActionState.Done    -> s.summary
+                is MgmtActionState.Error   -> s.message
+            },
+            detailColor = when (statsState) {
+                is MgmtActionState.Error -> ErrorBase
+                else -> TextMuted
+            },
+            onClick = { vm.loadStats() },
+        )
+
+        // ── Dedupe ────────────────────────────────────────────────────────────
+        MgmtSubItem(
+            icon = Icons.Rounded.ContentCopy,
+            label = "Dedupe",
+            detail = "Coming soon",
+            detailColor = TextMuted,
+            badgeLabel = "soon",
+            badgeColor = WarnBase,
+        )
+
+        // ── Sync ──────────────────────────────────────────────────────────────
+        MgmtSubItem(
+            icon = Icons.Rounded.Sync,
+            label = "Sync",
+            detail = "Coming soon",
+            detailColor = TextMuted,
+            badgeLabel = "soon",
+            badgeColor = WarnBase,
+        )
+
+        // ── Config ────────────────────────────────────────────────────────────
+        MgmtSubItem(
+            icon = Icons.Rounded.Tune,
+            label = "Config",
+            detail = "Server URL, token, collection",
+            detailColor = TextMuted,
+            onClick = onOpenSettings,
+        )
+    }
+}
+
+@Composable
+private fun MgmtSubItem(
+    icon: ImageVector,
+    label: String,
+    detail: String,
+    detailColor: Color = TextMuted,
+    badgeLabel: String? = null,
+    badgeColor: Color = WarnBase,
+    onClick: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .let { if (onClick != null) it.clickable(remember { MutableInteractionSource() }, indication = null, onClick = onClick) else it }
+            .padding(vertical = 8.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Icon(imageVector = icon, contentDescription = label, tint = if (onClick != null) AccentPrimary else TextMuted, modifier = Modifier.size(17.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label, style = MaterialTheme.typography.bodySmall, color = TextLabel)
+            Text(detail, style = MaterialTheme.typography.labelSmall, color = detailColor)
+        }
+        if (badgeLabel != null) {
+            Text(
+                badgeLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = badgeColor,
+            )
+        } else if (onClick != null) {
+            Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = TextMuted, modifier = Modifier.size(14.dp))
+        }
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt
@@ -1,32 +1,28 @@
 package com.axon.app.ui.management
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.*
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.axon.app.ui.common.DrawerSubItem
 import com.axon.app.ui.status.ConnectionState
 import com.axon.app.ui.status.ConnectionStatusViewModel
+import com.axon.app.ui.theme.AxonColors
 
-private val AccentPrimary = Color(0xFF29B6F6)
-private val TextMuted     = Color(0xFFA7BCC9)
-private val WarnBase      = Color(0xFFC6A36B)
-private val ErrorBase     = Color(0xFFEF5350)
-private val SuccessBase   = Color(0xFF66BB6A)
-private val TextLabel     = Color(0xFFE1EEF7)
-
+// ViewModel is activity-scoped (default ViewModelStoreOwner), so stats results
+// survive across drawer open/close cycles — intentional, avoids redundant network calls.
 @Composable
 fun ManagementDrawerContent(
     onOpenSettings: () -> Unit,
@@ -35,7 +31,6 @@ fun ManagementDrawerContent(
 ) {
     val connState by statusVm.state.collectAsStateWithLifecycle()
     val statsState by vm.statsState.collectAsStateWithLifecycle()
-    val doctorState by vm.doctorState.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier
@@ -51,37 +46,35 @@ fun ManagementDrawerContent(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            Text("Server", style = MaterialTheme.typography.labelSmall, color = TextMuted)
+            Text("Server", style = MaterialTheme.typography.labelSmall, color = AxonColors.TextMuted)
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 val (dotColor, label) = when (connState) {
-                    ConnectionState.Checking -> AccentPrimary to "Checking"
-                    ConnectionState.Online   -> SuccessBase to "Online"
-                    ConnectionState.Offline  -> ErrorBase to "Offline"
+                    ConnectionState.Checking -> AxonColors.AccentPrimary to "Checking"
+                    ConnectionState.Online   -> AxonColors.SuccessBase to "Online"
+                    ConnectionState.Offline  -> AxonColors.ErrorBase to "Offline"
                 }
-                Box(
-                    modifier = Modifier
-                        .size(7.dp)
-                        .let { if (connState != ConnectionState.Offline) it else it },
-                ) {
-                    androidx.compose.foundation.Canvas(modifier = Modifier.fillMaxSize()) {
+                Box(modifier = Modifier.size(7.dp)) {
+                    Canvas(modifier = Modifier.fillMaxSize()) {
                         drawCircle(color = dotColor)
                     }
                 }
                 Text(label, style = MaterialTheme.typography.labelSmall, color = dotColor)
-                Text("·", style = MaterialTheme.typography.labelSmall, color = TextMuted)
+                Text("·", style = MaterialTheme.typography.labelSmall, color = AxonColors.TextMuted)
                 Text(
                     "Refresh",
                     style = MaterialTheme.typography.labelSmall,
-                    color = AccentPrimary,
-                    modifier = Modifier.clickable(remember { MutableInteractionSource() }, indication = null) {
-                        statusVm.refresh()
-                    },
+                    color = AxonColors.AccentPrimary,
+                    modifier = Modifier
+                        .minimumInteractiveComponentSize()
+                        .clickable(remember { MutableInteractionSource() }, indication = null) {
+                            statusVm.refresh()
+                        },
                 )
             }
         }
 
         // ── Monitor ───────────────────────────────────────────────────────────
-        MgmtSubItem(
+        DrawerSubItem(
             icon = Icons.Rounded.MonitorHeart,
             label = "Monitor",
             detail = when (connState) {
@@ -90,14 +83,14 @@ fun ManagementDrawerContent(
                 ConnectionState.Offline  -> "Server unreachable"
             },
             detailColor = when (connState) {
-                ConnectionState.Checking -> TextMuted
-                ConnectionState.Online   -> SuccessBase
-                ConnectionState.Offline  -> ErrorBase
+                ConnectionState.Checking -> AxonColors.TextMuted
+                ConnectionState.Online   -> AxonColors.SuccessBase
+                ConnectionState.Offline  -> AxonColors.ErrorBase
             },
         )
 
         // ── Stack (stats) ─────────────────────────────────────────────────────
-        MgmtSubItem(
+        DrawerSubItem(
             icon = Icons.Rounded.Storage,
             label = "Stack",
             detail = when (val s = statsState) {
@@ -106,75 +99,37 @@ fun ManagementDrawerContent(
                 is MgmtActionState.Done    -> s.summary
                 is MgmtActionState.Error   -> s.message
             },
-            detailColor = when (statsState) {
-                is MgmtActionState.Error -> ErrorBase
-                else -> TextMuted
-            },
+            detailColor = if (statsState is MgmtActionState.Error) AxonColors.ErrorBase else AxonColors.TextMuted,
             onClick = { vm.loadStats() },
+            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
-        // ── Dedupe ────────────────────────────────────────────────────────────
-        MgmtSubItem(
+        // ── Dedupe (coming soon) ──────────────────────────────────────────────
+        DrawerSubItem(
             icon = Icons.Rounded.ContentCopy,
             label = "Dedupe",
             detail = "Coming soon",
-            detailColor = TextMuted,
-            badgeLabel = "soon",
-            badgeColor = WarnBase,
+            detailColor = AxonColors.TextMuted,
+            trailing = { Text("soon", style = MaterialTheme.typography.labelSmall, color = AxonColors.WarnBase) },
         )
 
-        // ── Sync ──────────────────────────────────────────────────────────────
-        MgmtSubItem(
+        // ── Sync (coming soon) ────────────────────────────────────────────────
+        DrawerSubItem(
             icon = Icons.Rounded.Sync,
             label = "Sync",
             detail = "Coming soon",
-            detailColor = TextMuted,
-            badgeLabel = "soon",
-            badgeColor = WarnBase,
+            detailColor = AxonColors.TextMuted,
+            trailing = { Text("soon", style = MaterialTheme.typography.labelSmall, color = AxonColors.WarnBase) },
         )
 
         // ── Config ────────────────────────────────────────────────────────────
-        MgmtSubItem(
+        DrawerSubItem(
             icon = Icons.Rounded.Tune,
             label = "Config",
             detail = "Server URL, token, collection",
-            detailColor = TextMuted,
+            detailColor = AxonColors.TextMuted,
             onClick = onOpenSettings,
+            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
-    }
-}
-
-@Composable
-private fun MgmtSubItem(
-    icon: ImageVector,
-    label: String,
-    detail: String,
-    detailColor: Color = TextMuted,
-    badgeLabel: String? = null,
-    badgeColor: Color = WarnBase,
-    onClick: (() -> Unit)? = null,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .let { if (onClick != null) it.clickable(remember { MutableInteractionSource() }, indication = null, onClick = onClick) else it }
-            .padding(vertical = 8.dp, horizontal = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Icon(imageVector = icon, contentDescription = label, tint = if (onClick != null) AccentPrimary else TextMuted, modifier = Modifier.size(17.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(label, style = MaterialTheme.typography.bodySmall, color = TextLabel)
-            Text(detail, style = MaterialTheme.typography.labelSmall, color = detailColor)
-        }
-        if (badgeLabel != null) {
-            Text(
-                badgeLabel,
-                style = MaterialTheme.typography.labelSmall,
-                color = badgeColor,
-            )
-        } else if (onClick != null) {
-            Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = TextMuted, modifier = Modifier.size(14.dp))
-        }
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.axon.app.ui.common.DrawerSubItem
+import com.axon.app.ui.common.Resource
 import com.axon.app.ui.status.ConnectionState
 import com.axon.app.ui.status.ConnectionStatusViewModel
 import com.axon.app.ui.theme.AxonColors
@@ -93,12 +94,12 @@ fun ManagementDrawerContent(
             icon = Icons.Rounded.Storage,
             label = "Stack",
             detail = when (val s = statsState) {
-                is MgmtActionState.Idle    -> "Tap to load"
-                is MgmtActionState.Loading -> "Loading…"
-                is MgmtActionState.Done    -> s.summary
-                is MgmtActionState.Error   -> s.message
+                Resource.Idle    -> "Tap to load"
+                Resource.Loading -> "Loading…"
+                is Resource.Ready -> s.value
+                is Resource.Error -> s.message
             },
-            detailColor = if (statsState is MgmtActionState.Error) AxonColors.ErrorBase else AxonColors.TextMuted,
+            detailColor = if (statsState is Resource.Error) AxonColors.ErrorBase else AxonColors.TextMuted,
             onClick = { vm.loadStats() },
         )
 

--- a/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementViewModel.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementViewModel.kt
@@ -1,0 +1,62 @@
+package com.axon.app.ui.management
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.axon.app.AxonApp
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed interface MgmtActionState {
+    data object Idle : MgmtActionState
+    data object Loading : MgmtActionState
+    data class Done(val summary: String) : MgmtActionState
+    data class Error(val message: String) : MgmtActionState
+}
+
+class ManagementViewModel(app: Application) : AndroidViewModel(app) {
+    private val container = (app as AxonApp).container
+
+    private val _statsState = MutableStateFlow<MgmtActionState>(MgmtActionState.Idle)
+    val statsState: StateFlow<MgmtActionState> = _statsState.asStateFlow()
+
+    private val _doctorState = MutableStateFlow<MgmtActionState>(MgmtActionState.Idle)
+    val doctorState: StateFlow<MgmtActionState> = _doctorState.asStateFlow()
+
+    fun loadStats() {
+        if (_statsState.value is MgmtActionState.Loading) return
+        viewModelScope.launch {
+            _statsState.value = MgmtActionState.Loading
+            container.axonClient.stats().fold(
+                onSuccess = { resp ->
+                    // payload is opaque JsonObject — show top-level key count as a summary
+                    val preview = resp.payload.entries
+                        .take(4)
+                        .joinToString(" · ") { (k, v) -> "$k: $v" }
+                    _statsState.value = MgmtActionState.Done(preview.ifBlank { "ok" })
+                },
+                onFailure = { e ->
+                    _statsState.value = MgmtActionState.Error(e.message ?: "Stats unavailable")
+                },
+            )
+        }
+    }
+
+    fun runDoctor() {
+        if (_doctorState.value is MgmtActionState.Loading) return
+        viewModelScope.launch {
+            _doctorState.value = MgmtActionState.Loading
+            container.axonClient.doctor().fold(
+                onSuccess = { resp ->
+                    val preview = resp.payload.toString().take(200)
+                    _doctorState.value = MgmtActionState.Done(preview)
+                },
+                onFailure = { e ->
+                    _doctorState.value = MgmtActionState.Error(e.message ?: "Doctor unavailable")
+                },
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementViewModel.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/management/ManagementViewModel.kt
@@ -4,59 +4,75 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.axon.app.AxonApp
+import com.axon.app.ui.common.Resource
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-sealed interface MgmtActionState {
-    data object Idle : MgmtActionState
-    data object Loading : MgmtActionState
-    data class Done(val summary: String) : MgmtActionState
-    data class Error(val message: String) : MgmtActionState
-}
-
 class ManagementViewModel(app: Application) : AndroidViewModel(app) {
     private val container = (app as AxonApp).container
 
-    private val _statsState = MutableStateFlow<MgmtActionState>(MgmtActionState.Idle)
-    val statsState: StateFlow<MgmtActionState> = _statsState.asStateFlow()
+    private val _statsState = MutableStateFlow<Resource<String>>(Resource.Idle)
+    val statsState: StateFlow<Resource<String>> = _statsState.asStateFlow()
 
-    private val _doctorState = MutableStateFlow<MgmtActionState>(MgmtActionState.Idle)
-    val doctorState: StateFlow<MgmtActionState> = _doctorState.asStateFlow()
+    private val _doctorState = MutableStateFlow<Resource<String>>(Resource.Idle)
+    val doctorState: StateFlow<Resource<String>> = _doctorState.asStateFlow()
 
     fun loadStats() {
-        if (_statsState.value is MgmtActionState.Loading) return
+        if (_statsState.value is Resource.Loading) return
         viewModelScope.launch {
-            _statsState.value = MgmtActionState.Loading
-            container.axonClient.stats().fold(
-                onSuccess = { resp ->
-                    // payload is opaque JsonObject — show top-level key count as a summary
-                    val preview = resp.payload.entries
-                        .take(4)
-                        .joinToString(" · ") { (k, v) -> "$k: $v" }
-                    _statsState.value = MgmtActionState.Done(preview.ifBlank { "ok" })
-                },
-                onFailure = { e ->
-                    _statsState.value = MgmtActionState.Error(e.message ?: "Stats unavailable")
-                },
-            )
+            _statsState.value = Resource.Loading
+            runCatching { container.axonClient.stats() }
+                .fold(
+                    onSuccess = { result ->
+                        result.fold(
+                            onSuccess = { resp ->
+                                // payload is opaque JsonObject — show top-level key count as a summary
+                                val preview = resp.payload.entries
+                                    .take(4)
+                                    .joinToString(" · ") { (k, v) -> "$k: $v" }
+                                _statsState.value = Resource.Ready(
+                                    preview.ifBlank { "(no collection data — Qdrant may be empty)" }
+                                )
+                            },
+                            onFailure = { e ->
+                                val hint = e.message?.take(120) ?: e.javaClass.simpleName
+                                _statsState.value = Resource.Error("Stats unavailable: $hint")
+                            },
+                        )
+                    },
+                    onFailure = { e ->
+                        val hint = e.message?.take(120) ?: e.javaClass.simpleName
+                        _statsState.value = Resource.Error("Unexpected error: $hint")
+                    },
+                )
         }
     }
 
     fun runDoctor() {
-        if (_doctorState.value is MgmtActionState.Loading) return
+        if (_doctorState.value is Resource.Loading) return
         viewModelScope.launch {
-            _doctorState.value = MgmtActionState.Loading
-            container.axonClient.doctor().fold(
-                onSuccess = { resp ->
-                    val preview = resp.payload.toString().take(200)
-                    _doctorState.value = MgmtActionState.Done(preview)
-                },
-                onFailure = { e ->
-                    _doctorState.value = MgmtActionState.Error(e.message ?: "Doctor unavailable")
-                },
-            )
+            _doctorState.value = Resource.Loading
+            runCatching { container.axonClient.doctor() }
+                .fold(
+                    onSuccess = { result ->
+                        result.fold(
+                            onSuccess = { resp ->
+                                val preview = resp.payload.toString().take(200)
+                                _doctorState.value = Resource.Ready(preview)
+                            },
+                            onFailure = { e ->
+                                val hint = e.message?.take(120) ?: e.javaClass.simpleName
+                                _doctorState.value = Resource.Error("Doctor unavailable: $hint")
+                            },
+                        )
+                    },
+                    onFailure = { e ->
+                        val hint = e.message?.take(120) ?: e.javaClass.simpleName
+                        _doctorState.value = Resource.Error("Unexpected error: $hint")
+                    },
+                )
         }
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/nav/DrawerSectionContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/nav/DrawerSectionContent.kt
@@ -18,7 +18,11 @@ fun DrawerSectionContent(
         DrawerSection.Sessions   -> SessionsDrawerContent(onSelect = { _ -> onDismiss() })
         DrawerSection.Jobs       -> JobsDrawerContent()
         DrawerSection.Knowledge  -> KnowledgeDrawerContent(onOpenSuggest = { navController.navigate(SuggestRoute) })
-        DrawerSection.Management -> ManagementDrawerContent()
-        DrawerSection.Setup      -> SetupDrawerContent()
+        DrawerSection.Management -> ManagementDrawerContent(
+            onOpenSettings = { navController.navigate(SettingsRoute) },
+        )
+        DrawerSection.Setup -> SetupDrawerContent(
+            onOpenSettings = { navController.navigate(SettingsRoute) },
+        )
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/nav/DrawerSectionContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/nav/DrawerSectionContent.kt
@@ -17,12 +17,12 @@ fun DrawerSectionContent(
     when (section) {
         DrawerSection.Sessions   -> SessionsDrawerContent(onSelect = { _ -> onDismiss() })
         DrawerSection.Jobs       -> JobsDrawerContent()
-        DrawerSection.Knowledge  -> KnowledgeDrawerContent(onOpenSuggest = { navController.navigate(SuggestRoute) })
+        DrawerSection.Knowledge  -> KnowledgeDrawerContent(onOpenSuggest = { onDismiss(); navController.navigate(SuggestRoute) })
         DrawerSection.Management -> ManagementDrawerContent(
-            onOpenSettings = { navController.navigate(SettingsRoute) },
+            onOpenSettings = { onDismiss(); navController.navigate(SettingsRoute) },
         )
         DrawerSection.Setup -> SetupDrawerContent(
-            onOpenSettings = { navController.navigate(SettingsRoute) },
+            onOpenSettings = { onDismiss(); navController.navigate(SettingsRoute) },
         )
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt
@@ -1,28 +1,20 @@
 package com.axon.app.ui.setup
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.axon.app.ui.common.DrawerSubItem
+import com.axon.app.ui.theme.AxonColors
 
-private val AccentPrimary = Color(0xFF29B6F6)
-private val TextMuted     = Color(0xFFA7BCC9)
-private val SuccessBase   = Color(0xFF66BB6A)
-private val ErrorBase     = Color(0xFFEF5350)
-private val TextLabel     = Color(0xFFE1EEF7)
-
+// ViewModel is activity-scoped (default ViewModelStoreOwner), so smoke/doctor
+// results survive across drawer open/close cycles — intentional.
 @Composable
 fun SetupDrawerContent(
     onOpenSettings: () -> Unit,
@@ -38,7 +30,7 @@ fun SetupDrawerContent(
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         // ── Preflight (smoke + doctor) ────────────────────────────────────────
-        SetupSubItem(
+        DrawerSubItem(
             icon = Icons.Rounded.FlightTakeoff,
             label = "Preflight",
             detail = when {
@@ -49,27 +41,29 @@ fun SetupDrawerContent(
                 else -> "Tap to run all checks"
             },
             detailColor = when {
-                smokeState is SetupActionState.Fail || doctorState is SetupActionState.Fail -> ErrorBase
-                smokeState is SetupActionState.Pass && doctorState is SetupActionState.Pass -> SuccessBase
-                else -> TextMuted
+                smokeState is SetupActionState.Fail || doctorState is SetupActionState.Fail -> AxonColors.ErrorBase
+                smokeState is SetupActionState.Pass && doctorState is SetupActionState.Pass -> AxonColors.SuccessBase
+                else -> AxonColors.TextMuted
             },
             onClick = {
                 vm.runSmoke()
                 vm.runDoctor()
             },
+            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Setup (→ Settings) ────────────────────────────────────────────────
-        SetupSubItem(
+        DrawerSubItem(
             icon = Icons.Rounded.Construction,
             label = "Setup",
             detail = "Server URL · Token · Collection",
-            detailColor = TextMuted,
+            detailColor = AxonColors.TextMuted,
             onClick = onOpenSettings,
+            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Smoke ─────────────────────────────────────────────────────────────
-        SetupSubItem(
+        DrawerSubItem(
             icon = Icons.Rounded.Wifi,
             label = "Smoke",
             detail = when (val s = smokeState) {
@@ -79,15 +73,16 @@ fun SetupDrawerContent(
                 is SetupActionState.Fail    -> s.message
             },
             detailColor = when (smokeState) {
-                is SetupActionState.Pass -> SuccessBase
-                is SetupActionState.Fail -> ErrorBase
-                else -> TextMuted
+                is SetupActionState.Pass -> AxonColors.SuccessBase
+                is SetupActionState.Fail -> AxonColors.ErrorBase
+                else -> AxonColors.TextMuted
             },
             onClick = { vm.runSmoke() },
+            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Doctor ────────────────────────────────────────────────────────────
-        SetupSubItem(
+        DrawerSubItem(
             icon = Icons.Rounded.HealthAndSafety,
             label = "Doctor",
             detail = when (val s = doctorState) {
@@ -97,47 +92,22 @@ fun SetupDrawerContent(
                 is SetupActionState.Fail    -> s.message
             },
             detailColor = when (doctorState) {
-                is SetupActionState.Pass -> SuccessBase
-                is SetupActionState.Fail -> ErrorBase
-                else -> TextMuted
+                is SetupActionState.Pass -> AxonColors.SuccessBase
+                is SetupActionState.Fail -> AxonColors.ErrorBase
+                else -> AxonColors.TextMuted
             },
             onClick = { vm.runDoctor() },
+            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Debug ─────────────────────────────────────────────────────────────
-        SetupSubItem(
+        DrawerSubItem(
             icon = Icons.Rounded.BugReport,
             label = "Debug",
             detail = "Server config · Advanced settings",
-            detailColor = TextMuted,
+            detailColor = AxonColors.TextMuted,
             onClick = onOpenSettings,
+            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
-    }
-}
-
-@Composable
-private fun SetupSubItem(
-    icon: ImageVector,
-    label: String,
-    detail: String,
-    detailColor: Color = TextMuted,
-    onClick: (() -> Unit)? = null,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .let { if (onClick != null) it.clickable(remember { MutableInteractionSource() }, indication = null, onClick = onClick) else it }
-            .padding(vertical = 8.dp, horizontal = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Icon(imageVector = icon, contentDescription = label, tint = if (onClick != null) AccentPrimary else TextMuted, modifier = Modifier.size(17.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(label, style = MaterialTheme.typography.bodySmall, color = TextLabel)
-            Text(detail, style = MaterialTheme.typography.labelSmall, color = detailColor, maxLines = 2)
-        }
-        if (onClick != null) {
-            Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = TextMuted, modifier = Modifier.size(14.dp))
-        }
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.axon.app.ui.common.DrawerSubItem
+import com.axon.app.ui.common.Resource
 import com.axon.app.ui.theme.AxonColors
 
 // ViewModel is activity-scoped (default ViewModelStoreOwner), so smoke/doctor
@@ -28,19 +29,23 @@ fun SetupDrawerContent(
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         // ── Preflight (smoke + doctor) ────────────────────────────────────────
+        // Failure surfaces before in-progress so a fast-failing smoke check is visible
+        // even while doctor is still running.
+        val smokeFail = smokeState as? Resource.Error
+        val doctorFail = doctorState as? Resource.Error
         DrawerSubItem(
             icon = Icons.Rounded.FlightTakeoff,
             label = "Preflight",
             detail = when {
-                smokeState is SetupActionState.Running || doctorState is SetupActionState.Running -> "Running checks…"
-                smokeState is SetupActionState.Fail    -> (smokeState as SetupActionState.Fail).message
-                doctorState is SetupActionState.Fail   -> (doctorState as SetupActionState.Fail).message
-                smokeState is SetupActionState.Pass && doctorState is SetupActionState.Pass -> "All checks passed"
+                smokeFail != null  -> smokeFail.message
+                doctorFail != null -> doctorFail.message
+                smokeState is Resource.Loading || doctorState is Resource.Loading -> "Running checks…"
+                smokeState is Resource.Ready && doctorState is Resource.Ready -> "All checks passed"
                 else -> "Tap to run all checks"
             },
             detailColor = when {
-                smokeState is SetupActionState.Fail || doctorState is SetupActionState.Fail -> AxonColors.ErrorBase
-                smokeState is SetupActionState.Pass && doctorState is SetupActionState.Pass -> AxonColors.SuccessBase
+                smokeFail != null || doctorFail != null -> AxonColors.ErrorBase
+                smokeState is Resource.Ready && doctorState is Resource.Ready -> AxonColors.SuccessBase
                 else -> AxonColors.TextMuted
             },
             onClick = {
@@ -63,14 +68,14 @@ fun SetupDrawerContent(
             icon = Icons.Rounded.Wifi,
             label = "Smoke",
             detail = when (val s = smokeState) {
-                is SetupActionState.Idle    -> "Tap to run /healthz"
-                is SetupActionState.Running -> "Testing connectivity…"
-                is SetupActionState.Pass    -> s.detail
-                is SetupActionState.Fail    -> s.message
+                Resource.Idle    -> "Tap to run /healthz"
+                Resource.Loading -> "Testing connectivity…"
+                is Resource.Ready -> s.value
+                is Resource.Error -> s.message
             },
             detailColor = when (smokeState) {
-                is SetupActionState.Pass -> AxonColors.SuccessBase
-                is SetupActionState.Fail -> AxonColors.ErrorBase
+                is Resource.Ready -> AxonColors.SuccessBase
+                is Resource.Error -> AxonColors.ErrorBase
                 else -> AxonColors.TextMuted
             },
             onClick = { vm.runSmoke() },
@@ -81,14 +86,14 @@ fun SetupDrawerContent(
             icon = Icons.Rounded.HealthAndSafety,
             label = "Doctor",
             detail = when (val s = doctorState) {
-                is SetupActionState.Idle    -> "Tap to run /v1/doctor"
-                is SetupActionState.Running -> "Running diagnostics…"
-                is SetupActionState.Pass    -> s.detail
-                is SetupActionState.Fail    -> s.message
+                Resource.Idle    -> "Tap to run /v1/doctor"
+                Resource.Loading -> "Running diagnostics…"
+                is Resource.Ready -> s.value
+                is Resource.Error -> s.message
             },
             detailColor = when (doctorState) {
-                is SetupActionState.Pass -> AxonColors.SuccessBase
-                is SetupActionState.Fail -> AxonColors.ErrorBase
+                is Resource.Ready -> AxonColors.SuccessBase
+                is Resource.Error -> AxonColors.ErrorBase
                 else -> AxonColors.TextMuted
             },
             onClick = { vm.runDoctor() },

--- a/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt
@@ -3,8 +3,6 @@ package com.axon.app.ui.setup
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.*
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -49,7 +47,6 @@ fun SetupDrawerContent(
                 vm.runSmoke()
                 vm.runDoctor()
             },
-            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Setup (→ Settings) ────────────────────────────────────────────────
@@ -59,7 +56,6 @@ fun SetupDrawerContent(
             detail = "Server URL · Token · Collection",
             detailColor = AxonColors.TextMuted,
             onClick = onOpenSettings,
-            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Smoke ─────────────────────────────────────────────────────────────
@@ -78,7 +74,6 @@ fun SetupDrawerContent(
                 else -> AxonColors.TextMuted
             },
             onClick = { vm.runSmoke() },
-            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Doctor ────────────────────────────────────────────────────────────
@@ -97,7 +92,6 @@ fun SetupDrawerContent(
                 else -> AxonColors.TextMuted
             },
             onClick = { vm.runDoctor() },
-            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
 
         // ── Debug ─────────────────────────────────────────────────────────────
@@ -107,7 +101,6 @@ fun SetupDrawerContent(
             detail = "Server config · Advanced settings",
             detailColor = AxonColors.TextMuted,
             onClick = onOpenSettings,
-            trailing = { Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = AxonColors.TextMuted, modifier = Modifier.size(14.dp)) },
         )
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt
@@ -1,20 +1,143 @@
 package com.axon.app.ui.setup
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 
-/** Setup drawer section — stub pending setup screen. */
+private val AccentPrimary = Color(0xFF29B6F6)
+private val TextMuted     = Color(0xFFA7BCC9)
+private val SuccessBase   = Color(0xFF66BB6A)
+private val ErrorBase     = Color(0xFFEF5350)
+private val TextLabel     = Color(0xFFE1EEF7)
+
 @Composable
-fun SetupDrawerContent() {
+fun SetupDrawerContent(
+    onOpenSettings: () -> Unit,
+    vm: SetupViewModel = viewModel(),
+) {
+    val smokeState by vm.smokeState.collectAsStateWithLifecycle()
+    val doctorState by vm.doctorState.collectAsStateWithLifecycle()
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(12.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        // Setup/onboarding controls will go here
+        // ── Preflight (smoke + doctor) ────────────────────────────────────────
+        SetupSubItem(
+            icon = Icons.Rounded.FlightTakeoff,
+            label = "Preflight",
+            detail = when {
+                smokeState is SetupActionState.Running || doctorState is SetupActionState.Running -> "Running checks…"
+                smokeState is SetupActionState.Fail    -> (smokeState as SetupActionState.Fail).message
+                doctorState is SetupActionState.Fail   -> (doctorState as SetupActionState.Fail).message
+                smokeState is SetupActionState.Pass && doctorState is SetupActionState.Pass -> "All checks passed"
+                else -> "Tap to run all checks"
+            },
+            detailColor = when {
+                smokeState is SetupActionState.Fail || doctorState is SetupActionState.Fail -> ErrorBase
+                smokeState is SetupActionState.Pass && doctorState is SetupActionState.Pass -> SuccessBase
+                else -> TextMuted
+            },
+            onClick = {
+                vm.runSmoke()
+                vm.runDoctor()
+            },
+        )
+
+        // ── Setup (→ Settings) ────────────────────────────────────────────────
+        SetupSubItem(
+            icon = Icons.Rounded.Construction,
+            label = "Setup",
+            detail = "Server URL · Token · Collection",
+            detailColor = TextMuted,
+            onClick = onOpenSettings,
+        )
+
+        // ── Smoke ─────────────────────────────────────────────────────────────
+        SetupSubItem(
+            icon = Icons.Rounded.Wifi,
+            label = "Smoke",
+            detail = when (val s = smokeState) {
+                is SetupActionState.Idle    -> "Tap to run /healthz"
+                is SetupActionState.Running -> "Testing connectivity…"
+                is SetupActionState.Pass    -> s.detail
+                is SetupActionState.Fail    -> s.message
+            },
+            detailColor = when (smokeState) {
+                is SetupActionState.Pass -> SuccessBase
+                is SetupActionState.Fail -> ErrorBase
+                else -> TextMuted
+            },
+            onClick = { vm.runSmoke() },
+        )
+
+        // ── Doctor ────────────────────────────────────────────────────────────
+        SetupSubItem(
+            icon = Icons.Rounded.HealthAndSafety,
+            label = "Doctor",
+            detail = when (val s = doctorState) {
+                is SetupActionState.Idle    -> "Tap to run /v1/doctor"
+                is SetupActionState.Running -> "Running diagnostics…"
+                is SetupActionState.Pass    -> s.detail
+                is SetupActionState.Fail    -> s.message
+            },
+            detailColor = when (doctorState) {
+                is SetupActionState.Pass -> SuccessBase
+                is SetupActionState.Fail -> ErrorBase
+                else -> TextMuted
+            },
+            onClick = { vm.runDoctor() },
+        )
+
+        // ── Debug ─────────────────────────────────────────────────────────────
+        SetupSubItem(
+            icon = Icons.Rounded.BugReport,
+            label = "Debug",
+            detail = "Server config · Advanced settings",
+            detailColor = TextMuted,
+            onClick = onOpenSettings,
+        )
+    }
+}
+
+@Composable
+private fun SetupSubItem(
+    icon: ImageVector,
+    label: String,
+    detail: String,
+    detailColor: Color = TextMuted,
+    onClick: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .let { if (onClick != null) it.clickable(remember { MutableInteractionSource() }, indication = null, onClick = onClick) else it }
+            .padding(vertical = 8.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Icon(imageVector = icon, contentDescription = label, tint = if (onClick != null) AccentPrimary else TextMuted, modifier = Modifier.size(17.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label, style = MaterialTheme.typography.bodySmall, color = TextLabel)
+            Text(detail, style = MaterialTheme.typography.labelSmall, color = detailColor, maxLines = 2)
+        }
+        if (onClick != null) {
+            Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = TextMuted, modifier = Modifier.size(14.dp))
+        }
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupViewModel.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupViewModel.kt
@@ -1,0 +1,54 @@
+package com.axon.app.ui.setup
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.axon.app.AxonApp
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed interface SetupActionState {
+    data object Idle : SetupActionState
+    data object Running : SetupActionState
+    data class Pass(val detail: String) : SetupActionState
+    data class Fail(val message: String) : SetupActionState
+}
+
+class SetupViewModel(app: Application) : AndroidViewModel(app) {
+    private val container = (app as AxonApp).container
+
+    private val _smokeState = MutableStateFlow<SetupActionState>(SetupActionState.Idle)
+    val smokeState: StateFlow<SetupActionState> = _smokeState.asStateFlow()
+
+    private val _doctorState = MutableStateFlow<SetupActionState>(SetupActionState.Idle)
+    val doctorState: StateFlow<SetupActionState> = _doctorState.asStateFlow()
+
+    fun runSmoke() {
+        if (_smokeState.value is SetupActionState.Running) return
+        viewModelScope.launch {
+            _smokeState.value = SetupActionState.Running
+            container.axonClient.healthz().fold(
+                onSuccess = { _smokeState.value = SetupActionState.Pass("/healthz → 200 OK") },
+                onFailure = { e -> _smokeState.value = SetupActionState.Fail(e.message ?: "Unreachable") },
+            )
+        }
+    }
+
+    fun runDoctor() {
+        if (_doctorState.value is SetupActionState.Running) return
+        viewModelScope.launch {
+            _doctorState.value = SetupActionState.Running
+            container.axonClient.doctor().fold(
+                onSuccess = { resp ->
+                    val preview = resp.payload.toString().take(300).trimEnd(',')
+                    _doctorState.value = SetupActionState.Pass(preview)
+                },
+                onFailure = { e ->
+                    _doctorState.value = SetupActionState.Fail(e.message ?: "Doctor unavailable")
+                },
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupViewModel.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/setup/SetupViewModel.kt
@@ -4,51 +4,67 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.axon.app.AxonApp
+import com.axon.app.ui.common.Resource
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-sealed interface SetupActionState {
-    data object Idle : SetupActionState
-    data object Running : SetupActionState
-    data class Pass(val detail: String) : SetupActionState
-    data class Fail(val message: String) : SetupActionState
-}
-
 class SetupViewModel(app: Application) : AndroidViewModel(app) {
     private val container = (app as AxonApp).container
 
-    private val _smokeState = MutableStateFlow<SetupActionState>(SetupActionState.Idle)
-    val smokeState: StateFlow<SetupActionState> = _smokeState.asStateFlow()
+    private val _smokeState = MutableStateFlow<Resource<String>>(Resource.Idle)
+    val smokeState: StateFlow<Resource<String>> = _smokeState.asStateFlow()
 
-    private val _doctorState = MutableStateFlow<SetupActionState>(SetupActionState.Idle)
-    val doctorState: StateFlow<SetupActionState> = _doctorState.asStateFlow()
+    private val _doctorState = MutableStateFlow<Resource<String>>(Resource.Idle)
+    val doctorState: StateFlow<Resource<String>> = _doctorState.asStateFlow()
 
     fun runSmoke() {
-        if (_smokeState.value is SetupActionState.Running) return
+        if (_smokeState.value is Resource.Loading) return
         viewModelScope.launch {
-            _smokeState.value = SetupActionState.Running
-            container.axonClient.healthz().fold(
-                onSuccess = { _smokeState.value = SetupActionState.Pass("/healthz → 200 OK") },
-                onFailure = { e -> _smokeState.value = SetupActionState.Fail(e.message ?: "Unreachable") },
-            )
+            _smokeState.value = Resource.Loading
+            runCatching { container.axonClient.healthz() }
+                .fold(
+                    onSuccess = { result ->
+                        result.fold(
+                            onSuccess = { _smokeState.value = Resource.Ready("/healthz → 200 OK") },
+                            onFailure = { e ->
+                                val hint = e.message?.take(120) ?: e.javaClass.simpleName
+                                _smokeState.value = Resource.Error("Unreachable: $hint")
+                            },
+                        )
+                    },
+                    onFailure = { e ->
+                        val hint = e.message?.take(120) ?: e.javaClass.simpleName
+                        _smokeState.value = Resource.Error("Unexpected error: $hint")
+                    },
+                )
         }
     }
 
     fun runDoctor() {
-        if (_doctorState.value is SetupActionState.Running) return
+        if (_doctorState.value is Resource.Loading) return
         viewModelScope.launch {
-            _doctorState.value = SetupActionState.Running
-            container.axonClient.doctor().fold(
-                onSuccess = { resp ->
-                    val preview = resp.payload.toString().take(300).trimEnd(',')
-                    _doctorState.value = SetupActionState.Pass(preview)
-                },
-                onFailure = { e ->
-                    _doctorState.value = SetupActionState.Fail(e.message ?: "Doctor unavailable")
-                },
-            )
+            _doctorState.value = Resource.Loading
+            runCatching { container.axonClient.doctor() }
+                .fold(
+                    onSuccess = { result ->
+                        result.fold(
+                            onSuccess = { resp ->
+                                val preview = resp.payload.toString().take(300).trimEnd(',')
+                                _doctorState.value = Resource.Ready(preview)
+                            },
+                            onFailure = { e ->
+                                val hint = e.message?.take(120) ?: e.javaClass.simpleName
+                                _doctorState.value = Resource.Error("Doctor unavailable: $hint")
+                            },
+                        )
+                    },
+                    onFailure = { e ->
+                        val hint = e.message?.take(120) ?: e.javaClass.simpleName
+                        _doctorState.value = Resource.Error("Unexpected error: $hint")
+                    },
+                )
         }
     }
 }

--- a/apps/android/app/src/main/java/com/axon/app/ui/theme/AxonColors.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/theme/AxonColors.kt
@@ -1,0 +1,12 @@
+package com.axon.app.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+internal object AxonColors {
+    val AccentPrimary = Color(0xFF29B6F6)
+    val TextMuted     = Color(0xFFA7BCC9)
+    val TextLabel     = Color(0xFFE1EEF7)
+    val WarnBase      = Color(0xFFC6A36B)
+    val ErrorBase     = Color(0xFFEF5350)
+    val SuccessBase   = Color(0xFF66BB6A)
+}

--- a/apps/android/app/src/main/java/com/axon/app/ui/theme/AxonColors.kt
+++ b/apps/android/app/src/main/java/com/axon/app/ui/theme/AxonColors.kt
@@ -4,9 +4,9 @@ import androidx.compose.ui.graphics.Color
 
 internal object AxonColors {
     val AccentPrimary = Color(0xFF29B6F6)
-    val TextMuted     = Color(0xFFA7BCC9)
-    val TextLabel     = Color(0xFFE1EEF7)
-    val WarnBase      = Color(0xFFC6A36B)
-    val ErrorBase     = Color(0xFFEF5350)
-    val SuccessBase   = Color(0xFF66BB6A)
+    val TextMuted = Color(0xFFA7BCC9)
+    val TextLabel = Color(0xFFE1EEF7)
+    val WarnBase = Color(0xFFC6A36B)
+    val ErrorBase = Color(0xFFEF5350)
+    val SuccessBase = Color(0xFF66BB6A)
 }

--- a/docs/sessions/2026-05-28-android-phase3-completion.md
+++ b/docs/sessions/2026-05-28-android-phase3-completion.md
@@ -1,0 +1,119 @@
+---
+date: 2026-05-28 13:45:18 EST
+repo: git@github.com:jmagar/axon.git
+branch: feat/android-phase3-completion
+head: 609439d8
+plan: docs/superpowers/plans/2026-05-28-android-phase3-completion.md
+agent: Claude (claude-sonnet-4-6)
+session id: 5f2e4037-a334-4f89-93d4-0df0b14bc0f8
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-axon-rust/5f2e4037-a334-4f89-93d4-0df0b14bc0f8.jsonl
+working directory: /home/jmagar/workspace/axon_rust/.worktrees/android-phase3
+worktree: /home/jmagar/workspace/axon_rust/.worktrees/android-phase3  609439d8 [feat/android-phase3-completion]
+pr: 144 — feat(android): Phase 3 — FAB fixes + Management/Setup drawers wired — https://github.com/jmagar/axon/pull/144
+---
+
+## User Request
+
+Execute the Android Phase 3 plan (`2026-05-28-android-phase3-completion.md`) to full completion using the `work-it` skill: implementation in an isolated worktree, multi-wave review, PR creation, and all quality gates.
+
+## Session Overview
+
+Implemented all Android Phase 3 items: FAB ring fixes, Management/Setup drawer wiring, and a full quality pass replacing bespoke UI state types with the shared `Resource<T>` sealed interface, adding `runCatching` safety to all ViewModels, fixing Preflight priority ordering, and extracting shared composable and color tokens. PR #144 was created and pushed to `feat/android-rail-redesign` target. All review waves and commit gates passed.
+
+## Sequence of Events
+
+1. Invoked `work-it` skill targeting `docs/superpowers/plans/2026-05-28-android-phase3-completion.md`
+2. Confirmed base branch `feat/android-rail-redesign` is correct for worktree
+3. Opened existing worktree at `.worktrees/android-phase3` on branch `feat/android-phase3-completion`
+4. Dispatched `kotlin-specialist` implementation agent (fallback from nonexistent `claude-android-ninja`)
+5. Implementation agent wrote all Phase 3 files, bumped versionCode/Name
+6. Hit RustEmbed pre-push hook failure — `apps/web/out/` missing in worktree; fixed by copying from main workspace
+7. Ran `lavra-review` wave and three `code_simplifier` passes — identified `Resource<String>` migration, `runCatching`, and `minimumInteractiveComponentSize` gaps
+8. Ran `pr-review-toolkit` agents; identified Preflight priority bug and dead `doctorState` in ManagementViewModel
+9. Applied all review findings: replaced bespoke state types, added `runCatching`, fixed fail-first Preflight ordering, removed dead state, added missing import
+10. Built successfully: `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
+11. Committed final fixes and pushed; verified PR #144 has only CodeRabbit auto-skip, no actionable threads
+12. Wrote this session note
+
+## Key Findings
+
+- `ui/common/Resource.kt:1` — `Resource<T>` sealed interface already existed in the codebase; both `ManagementViewModel` and `SetupViewModel` were reinventing equivalent bespoke sealed classes (`MgmtActionState`, `SetupActionState`) that should use it
+- `ui/fab/FabRing.kt` — double-applied alpha: `Color(0xD2040A0E)` applies 0xD2 alpha AND 0x04 alpha on the full ARGB, yielding a nearly-invisible backdrop; correct value is `Color(0xFF040A0E)` (opaque near-black)
+- `ui/setup/SetupDrawerContent.kt` — Preflight `when` block checked `Loading` before `Error`, making a fast-failing smoke check invisible while doctor was still running
+- `ui/management/ManagementDrawerContent.kt` — unused `doctorState` collected and hoisted via `ManagementViewModel.doctorState` (state flow created, collected, never displayed)
+- `apps/web/out/` must exist in every worktree for RustEmbed macro to compile the Rust binary during lefthook pre-push; worktrees don't share build artifacts
+
+## Technical Decisions
+
+- **`Resource<String>` over bespoke sealed classes**: the existing `Resource<T>` type already covers Idle/Loading/Ready/Error states with the same semantics; unifying keeps `when` exhaustiveness the compiler's job rather than per-ViewModel
+- **`runCatching` wrapping `viewModelScope.launch` bodies**: without it, uncaught exceptions silently kill coroutines and permanently freeze state at `Loading`; the early-return `if (Loading) return` guard then blocks retry
+- **Preflight fail-first via `val smokeFail = smokeState as? Resource.Error` locals**: avoids forced smart casts in `when` while correctly elevating error display above in-progress display
+- **`minimumInteractiveComponentSize()` on Refresh text**: plain `Text` with a `clickable` modifier fails accessibility touch target requirements; wrapping with `minimumInteractiveComponentSize()` ensures 48dp minimum without changing layout
+- **Default chevron in `DrawerSubItem`**: rendered when `onClick != null && trailing == null`; eliminates repeated boilerplate across all sub-items while remaining overridable via `trailing` slot
+
+## Files Modified
+
+| File | Purpose |
+|------|---------|
+| `apps/android/app/src/main/java/com/axon/app/ui/management/ManagementViewModel.kt` | Replaced `MgmtActionState` with `Resource<String>`, added `runCatching`, removed unused `doctorState` flow |
+| `apps/android/app/src/main/java/com/axon/app/ui/setup/SetupViewModel.kt` | Replaced `SetupActionState` with `Resource<String>`, added `runCatching` |
+| `apps/android/app/src/main/java/com/axon/app/ui/management/ManagementDrawerContent.kt` | Updated `when` expressions for `Resource<String>`, removed dead `doctorState`, added `minimumInteractiveComponentSize`, uses `DrawerSubItem` + `AxonColors` |
+| `apps/android/app/src/main/java/com/axon/app/ui/setup/SetupDrawerContent.kt` | Updated for `Resource<String>`, fixed Preflight fail-first ordering, uses `DrawerSubItem` + `AxonColors` |
+| `apps/android/app/src/main/java/com/axon/app/ui/common/DrawerSubItem.kt` | New shared composable replacing per-section `MgmtSubItem`/`SetupSubItem`; default chevron; `maxLines=2` ellipsis on detail |
+| `apps/android/app/src/main/java/com/axon/app/ui/theme/AxonColors.kt` | New centralized Aurora palette tokens object |
+| `apps/android/app/src/main/java/com/axon/app/ui/fab/FabRing.kt` | Fixed double-alpha backdrop, hoisted `radiusPx`/`halfTilePx`/`halfDismissPx` constants out of lambdas |
+| `apps/android/app/src/main/java/com/axon/app/ui/fab/FabLauncher.kt` | Added `BackHandler`, replaced `Box` with `BoxWithConstraints`, smart-cast `FabState.Input` |
+| `apps/android/app/src/main/java/com/axon/app/ui/nav/DrawerSectionContent.kt` | Passes `onOpenSettings` lambda to Management and Setup drawer composables |
+| `apps/android/app/build.gradle.kts` | versionCode 1→2, versionName "1.0"→"1.1" |
+
+## Commands Executed
+
+```bash
+# Copy web build output required by RustEmbed (worktree lacks it)
+cp -r ~/workspace/axon_rust/apps/web/out/. .worktrees/android-phase3/apps/web/out/
+
+# Kotlin compile gate
+cd .worktrees/android-phase3/apps/android && ./gradlew :app:compileDebugKotlin
+# Result: BUILD SUCCESSFUL
+
+# Push
+git push  # → branch already pushed by background job; benign conflict
+```
+
+## Errors Encountered
+
+- **RustEmbed pre-push failure**: `apps/web/out/` absent in worktree. RustEmbed embeds Next.js build output at compile time via a proc macro; the directory must exist even when building only Kotlin code via the lefthook Rust gate. Fixed by copying the output directory from the main workspace.
+- **Missing import**: `minimumInteractiveComponentSize` caused `Unresolved reference` until `import androidx.compose.material3.minimumInteractiveComponentSize` was added to ManagementDrawerContent.kt
+- **Duplicate push error**: Background push (spawned during agent dispatch) succeeded while foreground push was still running; the foreground push then failed with "reference already exists". Benign — branch was already on remote.
+
+## Behavior Changes (Before/After)
+
+| Area | Before | After |
+|------|--------|-------|
+| Smoke/Doctor state stuck | Any exception in `viewModelScope.launch` would silently freeze state at `Loading` permanently | `runCatching` captures all exceptions; state always transitions to `Ready` or `Error` |
+| Preflight priority | `Loading` was checked before `Error`, hiding a fast-failing smoke check while doctor ran | `Error` surfaces first via `as?` local bindings — fail-first ordering |
+| FAB backdrop | Double-alpha produced ~2% opacity backdrop (nearly invisible) | Correct near-black `Color(0xFF040A0E)` backdrop |
+| FAB back gesture | Android back gesture did nothing when FAB ring was open | `BackHandler` dismisses ring on back gesture |
+| State type duplication | Each section had its own identical `Idle/Loading/Success/Error` sealed class | All sections use shared `Resource<String>` |
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---------|----------|--------|--------|
+| `./gradlew :app:compileDebugKotlin` | BUILD SUCCESSFUL | BUILD SUCCESSFUL | PASS |
+| `gh pr view 144 --comments` | No actionable threads | Only CodeRabbit auto-skip comment | PASS |
+| `git status` | Clean worktree | Clean | PASS |
+
+## Risks and Rollback
+
+- All changes are confined to `apps/android/`; Rust binary is unaffected
+- Rollback: `git revert` the commits on `feat/android-phase3-completion` or close PR #144
+
+## Next Steps
+
+**Unfinished from this session:** None — all plan items implemented and verified.
+
+**Follow-on tasks:**
+- Merge PR #144 into `feat/android-rail-redesign` once satisfied
+- Trigger `@coderabbitai review` manually if external review is desired before merge (CodeRabbit auto-skipped because target is not the default branch)
+- Android Phase 4: Crystalline palette / rail redesign work described in `docs/specs/android-redesign.md`


### PR DESCRIPTION
## Summary

- **FAB ring — Back key dismissal**: `BackHandler` intercepts Back when ring/input is open; pressing Back now dismisses the ring instead of exiting the app
- **FAB ring — screen-centered (no clipping)**: replaced `Box` root with `BoxWithConstraints`, passes screen-center offset to `FabRing` when open so all 10 op items are fully visible; adds dim backdrop overlay
- **ManagementViewModel**: new `MgmtActionState` sealed interface + async `loadStats()` / `runDoctor()` coroutine calls
- **ManagementDrawerContent**: full rewrite — live connection status header + 5 spec sub-items: Monitor, Stack, Dedupe (coming soon), Sync (coming soon), Config (→ Settings)
- **SetupViewModel**: new `SetupActionState` sealed interface + async `runSmoke()` / `runDoctor()` coroutine calls
- **SetupDrawerContent**: full rewrite — 5 spec sub-items: Preflight (smoke+doctor together), Setup (→ Settings), Smoke (/healthz), Doctor (/v1/doctor), Debug (→ Settings)
- **DrawerSectionContent**: passes `onOpenSettings` lambda (→ `SettingsRoute`) to both Management and Setup cases
- **Version bump**: versionCode 1→2, versionName 1.0→1.1

## Spec Coverage

| Spec requirement | Task |
|---|---|
| FAB ring — Back key dismisses ring | Task 1 |
| FAB ring — all 10 ops visible (no clipping) | Task 2 |
| Management drawer — 5 sub-items per spec | Tasks 3–4, 7 |
| Setup drawer — 5 sub-items per spec | Tasks 5–6, 7 |
| Dim backdrop when ring is open | Task 2b |
| Config sub-item → navigates to Settings | Tasks 4, 7 |
| Setup sub-item → navigates to Settings | Tasks 6, 7 |
| Smoke test wired to `/healthz` | Tasks 5–6 |
| Doctor test wired to `/v1/doctor` | Tasks 3–6 |

## Verification

- `./gradlew assembleDebug` — **BUILD SUCCESSFUL**, APK generated
- ADB smoke tests on emulator-5554:
  - BackHandler: app stayed in foreground after Back press ✓
  - FAB ring — all 10 ops in uiautomator dump (`Missing: []`) ✓
  - Backdrop tap dismissal ✓
  - MGMT drawer sub-items: Monitor/Stack/Dedupe/Sync/Config ✓
  - SETUP drawer sub-items: Preflight/Setup/Smoke/Doctor/Debug ✓

## Notes

- Dedupe and Sync in Management are "coming soon" badges — no server endpoint exists yet; intentional deferral per spec
- Task 7 (DrawerSectionContent) was implemented alongside Task 4 — the signature change to `ManagementDrawerContent` broke `DrawerSectionContent` at compile time, making them an atomic pair

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Android FAB interactions and wires the Management and Setup drawers with live actions and Settings navigation. Also unifies async state with `Resource`, fixes fail-first Preflight, adds a shared DrawerSubItem and AxonColors, and ensures drawers dismiss before navigating.

- **New Features**
  - Management drawer: live status header; Monitor, Stack, Dedupe (soon), Sync (soon), Config → Settings; async stats/doctor via new `ManagementViewModel`.
  - Setup drawer: Preflight (Smoke + Doctor), Setup → Settings, Smoke (/healthz), Doctor (/v1/doctor), Debug → Settings; async via new `SetupViewModel`.
  - Navigation: `DrawerSectionContent` passes `onOpenSettings` to both drawers.
  - Version: bump to 1.1 (code 2).

- **Bug Fixes**
  - Back dismisses the FAB ring instead of exiting.
  - FAB ring opens at screen center; dim backdrop with tap-to-dismiss.
  - Async handling: use `Resource` + runCatching to prevent stuck loading; Preflight surfaces failures first.
  - Dismiss drawers before navigating to Suggest/Settings so the overlay clears first.

<sup>Written for commit f2e2628f7991321ad0f4c83d6ca2188197a33ed3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/144?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

