### PR TITLE
chore(release): v4.15.2 — version sync across crate + web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.15.2] - 2026-05-31
+
+### Changed
+
+- Version sync: bumped all version-bearing files to 4.15.2 and brought
+  `apps/web/package.json` (+ lockfile) up from a stale 4.14.1 so the crate,
+  README, and web app agree. Regenerated `apps/web/openapi/axon.json` so its
+  embedded `info.version` matches and `openapi:check` stays green.
+
 ## [4.15.1] - 2026-05-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "4.15.1"
+version = "4.15.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "4.15.1"
+version = "4.15.2"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 4.15.1
+Version: 4.15.2
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "4.15.1"
+    "version": "4.15.2"
   },
   "paths": {
     "/v1/ask": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axon/admin-panel",
-  "version": "4.8.1",
+  "version": "4.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axon/admin-panel",
-      "version": "4.8.1",
+      "version": "4.15.2",
       "dependencies": {
         "lucide-react": "^1.16.0",
         "next": "^16.2.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "4.14.1",
+  "version": "4.15.2",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Patch bump to **4.15.2** across all version-bearing files, fixing a pre-existing version-sync gap.

## What
- `Cargo.toml` / `Cargo.lock` / `README.md` → 4.15.2
- `apps/web/package.json` + `package-lock.json` → bumped from a stale **4.14.1** (never updated through the 4.15.0/4.15.1 bumps) to 4.15.2
- `apps/web/openapi/axon.json` regenerated so its embedded `info.version` matches the crate (keeps `rest-api-parity` / `openapi:check` green)
- `CHANGELOG.md` entry

## Why
The web app's version had drifted two patches behind the crate. This brings everything into sync per the repo's all-files-match version policy.

## Verification (local)
- `cargo check --bin axon` → clean, `axon v4.15.2`
- `npm --prefix apps/web run openapi:check` → exit 0

Follow-up housekeeping from the same session (not in this PR): bd auto-backup git-add warnings silenced locally; stale `axon_rust` worktree pruned; merged `feat/watch-scheduler` deleted.

Co-authored-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronized all version-bearing files to 4.15.2 across the Rust crate and web app, updating the web app from a stale 4.14.1. Regenerated `apps/web/openapi/axon.json` so `info.version` matches and `openapi:check` passes, and added a 4.15.2 changelog entry.

<sup>Written for commit c16ebca83adf597ff9b05fc46fa6f6feef77b52b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 4.15.2 with synchronized version metadata across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->