### PR TITLE
fix(extract): keep default single-url extract on exact page

### DIFF
--- a/docs/reference/commands/extract.md
+++ b/docs/reference/commands/extract.md
@@ -46,7 +46,7 @@ All global flags apply. Key flags:
 |------|---------|-------------|
 | `--query <text>` | — | Extraction prompt (recommended; empty prompt skips the LLM pass). |
 | `--wait <bool>` | `false` | `false`: enqueue extract job. `true`: run extraction inline and block. |
-| `--max-pages <n>` | `0` | Passed to extract web runner as crawl/page limit. |
+| `--max-pages <n>` | `1` when omitted, `0` when explicitly uncapped | Passed to extract web runner as crawl/page limit. |
 | `--output-dir <dir>` | `.cache/axon-rust/output` | Base path for extract artifacts. |
 | `--output <path>` | — | Summary JSON output path (sync mode). |
 | `--json` | `false` | JSON output for enqueue/status and sync summary. |

--- a/src/cli/client_tests.rs
+++ b/src/cli/client_tests.rs
@@ -3,28 +3,13 @@
 use super::{
     SERVER_POLL_TIMEOUT_SECS, ServerClient, ServerClientErrorKind, check_cleartext_token_allowed,
 };
-use crate::core::http::set_allow_loopback;
+use crate::core::http::LoopbackGuard;
 use httpmock::prelude::*;
 use serde_json::json;
 use serial_test::serial;
 
 const TOKEN_ENV: &str = "AXON_MCP_HTTP_TOKEN";
 const INSECURE_ENV: &str = "AXON_SERVER_INSECURE";
-
-struct LoopbackGuard;
-
-impl LoopbackGuard {
-    fn new() -> Self {
-        set_allow_loopback(true);
-        Self
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(false);
-    }
-}
 
 struct EnvGuard {
     key: &'static str,
@@ -77,7 +62,7 @@ fn cleartext_guard_allows_generic_override() {
 #[tokio::test]
 #[serial]
 async fn post_json_attaches_bearer_token() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, Some("client-token"));
     let _i = EnvGuard::set(INSECURE_ENV, None);
     let server = MockServer::start();
@@ -108,7 +93,7 @@ async fn post_json_attaches_bearer_token() {
 #[tokio::test]
 #[serial]
 async fn get_json_preserves_query_string() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
@@ -134,7 +119,7 @@ async fn get_json_preserves_query_string() {
 #[tokio::test]
 #[serial]
 async fn post_json_classifies_auth_status() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     server.mock(|when, then| {
@@ -159,7 +144,7 @@ async fn post_json_classifies_auth_status() {
 #[tokio::test]
 #[serial]
 async fn post_json_classifies_schema_version_mismatch() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     server.mock(|when, then| {

--- a/src/cli/commands/ask/ask_via_server_tests.rs
+++ b/src/cli/commands/ask/ask_via_server_tests.rs
@@ -15,7 +15,7 @@
 use super::{ask_via_server, hint_for_ask_error};
 use crate::cli::client::check_cleartext_token_allowed;
 use crate::core::config::Config;
-use crate::core::http::set_allow_loopback;
+use crate::core::http::LoopbackGuard;
 use httpmock::prelude::*;
 use serde_json::json;
 use serial_test::serial;
@@ -23,21 +23,6 @@ use std::net::TcpListener;
 
 const TOKEN_ENV: &str = "AXON_MCP_HTTP_TOKEN";
 const INSECURE_ENV: &str = "AXON_SERVER_INSECURE";
-
-struct LoopbackGuard;
-
-impl LoopbackGuard {
-    fn new() -> Self {
-        set_allow_loopback(true);
-        Self
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(false);
-    }
-}
 
 /// Snapshots an env var on construction and restores it on drop.
 /// The value `None` means "unset on restore".
@@ -190,7 +175,7 @@ fn cleartext_gate_opt_in_via_env() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_returns_parsed_result_on_200() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
@@ -212,7 +197,7 @@ async fn ask_via_server_returns_parsed_result_on_200() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_forwards_ask_overrides() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
@@ -264,7 +249,7 @@ async fn ask_via_server_forwards_ask_overrides() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_forwards_explain_and_implies_diagnostics() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
@@ -290,7 +275,7 @@ async fn ask_via_server_forwards_explain_and_implies_diagnostics() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_401_yields_token_mismatch_hint() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     server.mock(|when, then| {
@@ -310,7 +295,7 @@ async fn ask_via_server_401_yields_token_mismatch_hint() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_500_includes_body_in_error() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     server.mock(|when, then| {
@@ -329,7 +314,7 @@ async fn ask_via_server_500_includes_body_in_error() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_malformed_json_yields_decode_error() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     server.mock(|when, then| {
@@ -350,7 +335,7 @@ async fn ask_via_server_malformed_json_yields_decode_error() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_connection_refused_uses_connect_prefix() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let addr = {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -397,7 +382,7 @@ async fn ask_via_server_refuses_token_over_http_to_non_loopback() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_attaches_bearer_on_loopback_http() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, Some("loopback-token"));
     let _i = EnvGuard::set(INSECURE_ENV, None);
 
@@ -421,7 +406,7 @@ async fn ask_via_server_attaches_bearer_on_loopback_http() {
 #[tokio::test]
 #[serial]
 async fn ask_via_server_omits_bearer_when_token_is_whitespace() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, Some("   "));
     let _i = EnvGuard::set(INSECURE_ENV, None);
 
@@ -451,7 +436,7 @@ async fn ask_via_server_omits_bearer_when_token_is_whitespace() {
 #[tokio::test]
 #[serial]
 async fn payload_omits_since_before_when_none() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
@@ -481,7 +466,7 @@ async fn payload_omits_since_before_when_none() {
 #[tokio::test]
 #[serial]
 async fn payload_includes_since_before_when_set() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
@@ -508,7 +493,7 @@ async fn payload_includes_since_before_when_set() {
 #[tokio::test]
 #[serial]
 async fn endpoint_normalizes_trailing_slash_variants() {
-    let _lo = LoopbackGuard::new();
+    let _lo = LoopbackGuard::allow();
     let _t = EnvGuard::set(TOKEN_ENV, None);
     let server = MockServer::start();
     server.mock(|when, then| {

--- a/src/cli/commands/crawl/audit/sitemap_migration_tests.rs
+++ b/src/cli/commands/crawl/audit/sitemap_migration_tests.rs
@@ -10,27 +10,12 @@
 
 use super::sitemap::discover_sitemap_urls_with_robots;
 use crate::core::config::Config;
-use crate::core::http::set_allow_loopback;
+use crate::core::http::LoopbackGuard;
 use httpmock::prelude::*;
 use serial_test::serial;
 
 /// RAII guard: sets the global loopback bypass to `true` on creation
 /// and restores `false` on drop.
-struct LoopbackGuard;
-
-impl LoopbackGuard {
-    fn new() -> Self {
-        set_allow_loopback(true);
-        Self
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(false);
-    }
-}
-
 fn test_config() -> Config {
     Config {
         fetch_retries: 0,
@@ -59,7 +44,7 @@ fn sitemap_xml(urls: &[&str]) -> String {
 #[tokio::test]
 #[serial]
 async fn discover_sitemap_urls_includes_robots_declared_entries() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url(); // http://127.0.0.1:PORT
 
@@ -126,7 +111,7 @@ async fn discover_sitemap_urls_includes_robots_declared_entries() {
 #[tokio::test]
 #[serial]
 async fn discover_sitemap_urls_applies_exclude_path_prefix() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -191,7 +176,7 @@ async fn discover_sitemap_urls_applies_exclude_path_prefix() {
 #[tokio::test]
 #[serial]
 async fn discover_sitemap_urls_respects_include_subdomains_false() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url(); // http://127.0.0.1:PORT
 

--- a/src/cli/commands/crawl/sync_backfill_migration_tests.rs
+++ b/src/cli/commands/crawl/sync_backfill_migration_tests.rs
@@ -11,7 +11,7 @@
 //! that assert loopback is blocked.
 
 use crate::core::config::Config;
-use crate::core::http::set_allow_loopback;
+use crate::core::http::LoopbackGuard;
 use crate::crawl::engine::append_sitemap_backfill;
 use crate::crawl::manifest::{ManifestEntry, read_manifest_data};
 use httpmock::prelude::*;
@@ -22,21 +22,6 @@ use tempfile::TempDir;
 
 /// RAII guard: sets the global loopback bypass to `true` on creation
 /// and restores `false` on drop.
-struct LoopbackGuard;
-
-impl LoopbackGuard {
-    fn new() -> Self {
-        set_allow_loopback(true);
-        Self
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(false);
-    }
-}
-
 fn test_config(output_dir: PathBuf) -> Config {
     Config {
         fetch_retries: 0,
@@ -71,7 +56,7 @@ fn sitemap_xml(urls: &[&str]) -> String {
 #[tokio::test]
 #[serial]
 async fn sync_crawl_uses_engine_backfill_metrics_not_cli_loop() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
     let tmp = TempDir::new().expect("tempdir");
@@ -156,7 +141,7 @@ async fn sync_crawl_uses_engine_backfill_metrics_not_cli_loop() {
 #[tokio::test]
 #[serial]
 async fn sync_crawl_does_not_append_manifest_via_cli_backfill_codepath() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
     let tmp = TempDir::new().expect("tempdir");

--- a/src/cli/commands/map/map_migration_tests.rs
+++ b/src/cli/commands/map/map_migration_tests.rs
@@ -19,27 +19,12 @@
 
 use super::map_payload;
 use crate::core::config::{Config, RenderMode};
-use crate::core::http::set_allow_loopback;
+use crate::core::http::LoopbackGuard;
 use httpmock::prelude::*;
 use serial_test::serial;
 
 /// RAII guard: sets the global loopback bypass to `true` on creation
 /// and restores `false` on drop.
-struct LoopbackGuard;
-
-impl LoopbackGuard {
-    fn new() -> Self {
-        set_allow_loopback(true);
-        Self
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(false);
-    }
-}
-
 fn test_config() -> Config {
     Config {
         json_output: true,
@@ -136,7 +121,7 @@ fn setup_server_with_duplicate_sitemap(server: &MockServer) {
 #[tokio::test]
 #[serial]
 async fn map_payload_returns_unique_urls_without_cli_side_dedup() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     setup_server_with_duplicate_sitemap(&server);
 
@@ -196,7 +181,7 @@ async fn map_payload_returns_unique_urls_without_cli_side_dedup() {
 #[tokio::test]
 #[serial]
 async fn map_payload_reports_sitemap_url_count_consistently() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     setup_server_with_duplicate_sitemap(&server);
 

--- a/src/cli/commands/map/map_sitemap_tests.rs
+++ b/src/cli/commands/map/map_sitemap_tests.rs
@@ -7,28 +7,13 @@
 
 use super::map_payload;
 use crate::core::config::{Config, MapFallback, RenderMode};
-use crate::core::http::set_allow_loopback;
+use crate::core::http::LoopbackGuard;
 use httpmock::prelude::*;
 use serial_test::serial;
 
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
-
-struct LoopbackGuard;
-
-impl LoopbackGuard {
-    fn new() -> Self {
-        set_allow_loopback(true);
-        Self
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(false);
-    }
-}
 
 fn base_config() -> Config {
     Config {
@@ -111,7 +96,7 @@ fn mock_index_seeds_404(server: &MockServer) {
 #[tokio::test]
 #[serial]
 async fn test_sitemap_first_uses_sitemap_urls() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -166,7 +151,7 @@ async fn test_sitemap_first_uses_sitemap_urls() {
 #[tokio::test]
 #[serial]
 async fn test_out_of_scope_sitemap_no_anchor_fallback() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -217,7 +202,7 @@ async fn test_out_of_scope_sitemap_no_anchor_fallback() {
 #[tokio::test]
 #[serial]
 async fn test_bounded_structure_fallback_uses_anchor_hrefs() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -265,7 +250,7 @@ async fn test_bounded_structure_fallback_uses_anchor_hrefs() {
 #[tokio::test]
 #[serial]
 async fn test_structure_mode_does_not_crawl() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -321,7 +306,7 @@ async fn test_structure_mode_does_not_crawl() {
 #[tokio::test]
 #[serial]
 async fn test_sitemap_index_recursion() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -378,7 +363,7 @@ async fn test_sitemap_index_recursion() {
 #[tokio::test]
 #[serial]
 async fn test_sitemap_out_of_host_urls_filtered() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -434,7 +419,7 @@ async fn test_sitemap_out_of_host_urls_filtered() {
 #[tokio::test]
 #[serial]
 async fn test_map_fallback_crawl_opt_in() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -485,7 +470,7 @@ async fn test_map_fallback_crawl_opt_in() {
 #[tokio::test]
 #[serial]
 async fn test_bounded_structure_cross_origin_filtered() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -532,7 +517,7 @@ async fn test_bounded_structure_cross_origin_filtered() {
 #[tokio::test]
 #[serial]
 async fn test_pages_seen_zero_in_sitemap_mode() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -574,7 +559,7 @@ async fn test_pages_seen_zero_in_sitemap_mode() {
 #[tokio::test]
 #[serial]
 async fn test_warning_when_bounded_structure_too_few_urls() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -622,7 +607,7 @@ async fn test_warning_when_bounded_structure_too_few_urls() {
 #[tokio::test]
 #[serial]
 async fn test_discover_sitemaps_false_skips_sitemap_fetch() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -740,7 +725,7 @@ fn llms_txt_body(urls: &[&str]) -> String {
 #[tokio::test]
 #[serial]
 async fn map_unions_sitemap_and_llms_txt_deduped() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -790,7 +775,7 @@ async fn map_unions_sitemap_and_llms_txt_deduped() {
 #[tokio::test]
 #[serial]
 async fn map_skips_llms_txt_when_disabled() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 
@@ -842,7 +827,7 @@ async fn map_skips_llms_txt_when_disabled() {
 #[tokio::test]
 #[serial]
 async fn map_llms_only_when_no_sitemap() {
-    let _guard = LoopbackGuard::new();
+    let _guard = LoopbackGuard::allow();
     let server = MockServer::start();
     let base = server.base_url();
 

--- a/src/core/config/cli/global_args.rs
+++ b/src/core/config/cli/global_args.rs
@@ -6,7 +6,7 @@ pub(in crate::core::config) const DEFAULT_OUTPUT_DIR: &str = ".cache/axon-rust/o
 
 #[derive(Debug, Args)]
 pub(in crate::core::config) struct GlobalArgs {
-    /// Maximum pages to crawl per job (0 = unlimited)
+    /// Maximum pages to crawl per job (0 = unlimited; extract defaults to 1 when omitted)
     #[arg(global = true, long)]
     pub(in crate::core::config) max_pages: Option<u32>,
 

--- a/src/core/config/cli/global_args.rs
+++ b/src/core/config/cli/global_args.rs
@@ -7,8 +7,8 @@ pub(in crate::core::config) const DEFAULT_OUTPUT_DIR: &str = ".cache/axon-rust/o
 #[derive(Debug, Args)]
 pub(in crate::core::config) struct GlobalArgs {
     /// Maximum pages to crawl per job (0 = unlimited)
-    #[arg(global = true, long, default_value_t = 0)]
-    pub(in crate::core::config) max_pages: u32,
+    #[arg(global = true, long)]
+    pub(in crate::core::config) max_pages: Option<u32>,
 
     /// Maximum crawl depth from the start URL
     #[arg(global = true, long, default_value_t = 10)]

--- a/src/core/config/help.rs
+++ b/src/core/config/help.rs
@@ -89,7 +89,10 @@ const EMBED_OPTIONS: &[(&str, &str)] = &[
 ];
 
 const WEB_OPTIONS: &[(&str, &str)] = &[
-    ("--max-pages <n>", "Maximum pages to crawl"),
+    (
+        "--max-pages <n>",
+        "Maximum pages to crawl (extract defaults to 1 when omitted)",
+    ),
     ("--max-depth <n>", "Maximum crawl depth"),
     (
         "--render-mode <mode>",
@@ -239,7 +242,10 @@ fn print_top_level_help() {
         "--cache-http-only",
         "keep cached crawl flow on the HTTP path",
     );
-    row("--max-pages <n>", "crawl page limit (0 = uncapped)");
+    row(
+        "--max-pages <n>",
+        "crawl page limit (0 = uncapped; extract default 1)",
+    );
     row(
         "--url-glob <pattern[,..]>",
         "expand URL seeds via brace globs (e.g. {1..10}, {a,b})",

--- a/src/core/config/parse/build_config/config_literal.rs
+++ b/src/core/config/parse/build_config/config_literal.rs
@@ -73,7 +73,10 @@ fn populate_identity_and_crawl(cfg: &mut Config, inputs: &LiteralInputs<'_>) {
     cfg.train_best_rank = inputs.dispatched.train_best_rank;
     cfg.train_notes = inputs.dispatched.train_notes.clone();
     cfg.doctor_diagnose = inputs.dispatched.doctor_diagnose;
-    cfg.max_pages = g.max_pages;
+    cfg.max_pages = match (inputs.dispatched.command, g.max_pages) {
+        (CommandKind::Extract, None) => 1,
+        (_, max_pages) => max_pages.unwrap_or(0),
+    };
     cfg.max_depth = g.max_depth;
     cfg.include_subdomains = g.include_subdomains;
     cfg.exclude_path_prefix = inputs.exclude_path_prefix.clone();

--- a/src/core/config/parse/build_config/config_literal.rs
+++ b/src/core/config/parse/build_config/config_literal.rs
@@ -73,6 +73,8 @@ fn populate_identity_and_crawl(cfg: &mut Config, inputs: &LiteralInputs<'_>) {
     cfg.train_best_rank = inputs.dispatched.train_best_rank;
     cfg.train_notes = inputs.dispatched.train_notes.clone();
     cfg.doctor_diagnose = inputs.dispatched.doctor_diagnose;
+    // `extract` defaults to the exact single-page path when omitted, while
+    // explicit `--max-pages 0` keeps the shared uncapped crawl semantics.
     cfg.max_pages = match (inputs.dispatched.command, g.max_pages) {
         (CommandKind::Extract, None) => 1,
         (_, max_pages) => max_pages.unwrap_or(0),

--- a/src/core/config/parse/build_config_tests.rs
+++ b/src/core/config/parse/build_config_tests.rs
@@ -65,6 +65,24 @@ pub(super) fn into_config_via_args(extra: &[&str]) -> Result<Config, String> {
     into_config_with_sources(cli, output_dir_was_explicit, collection_was_explicit)
 }
 
+#[test]
+fn extract_defaults_to_single_page_but_explicit_zero_stays_uncapped() {
+    let _guard = ENV_LOCK.lock().unwrap();
+
+    let default_extract = into_config_via_args(&["extract", "https://example.com/page"])
+        .expect("extract config should parse");
+    assert_eq!(default_extract.max_pages, 1);
+
+    let explicit_uncapped =
+        into_config_via_args(&["--max-pages", "0", "extract", "https://example.com/page"])
+            .expect("extract config with explicit max-pages should parse");
+    assert_eq!(explicit_uncapped.max_pages, 0);
+
+    let default_crawl =
+        into_config_via_args(&["crawl", "https://example.com"]).expect("crawl config should parse");
+    assert_eq!(default_crawl.max_pages, 0);
+}
+
 /// Save/restore an env var around a test body so panics don't leak state.
 #[allow(unsafe_code)]
 pub(super) fn with_env_saved<F: FnOnce()>(keys: &[&str], body: F) {

--- a/src/core/config/types/config.rs
+++ b/src/core/config/types/config.rs
@@ -39,7 +39,7 @@ pub struct Config {
     /// Optional free-form note stored with `train` preference events.
     pub train_notes: Option<String>,
 
-    /// Maximum pages to crawl (0 = uncapped). Flag: `--max-pages`.
+    /// Maximum pages to crawl (0 = uncapped; extract defaults to 1 when omitted). Flag: `--max-pages`.
     pub max_pages: u32,
 
     /// Maximum crawl depth from the start URL. Flag: `--max-depth`.

--- a/src/core/content/engine.rs
+++ b/src/core/content/engine.rs
@@ -224,7 +224,7 @@ fn all_fallback_attempts_failed(
 }
 
 fn uses_single_page_extract_path(limit: u32) -> bool {
-    limit <= 1
+    limit == 1
 }
 
 /// Fetch a single URL directly with reqwest and extract structured data from it.

--- a/src/core/content/engine.rs
+++ b/src/core/content/engine.rs
@@ -223,6 +223,10 @@ fn all_fallback_attempts_failed(
         && results.is_empty()
 }
 
+fn uses_single_page_extract_path(limit: u32) -> bool {
+    limit <= 1
+}
+
 /// Fetch a single URL directly with reqwest and extract structured data from it.
 ///
 /// Bypasses spider entirely — spider normalises deep URL paths to the domain
@@ -323,7 +327,7 @@ pub async fn run_extract_with_engine(
     // requests for /wiki/Rust or /recipe/12345 land on the site homepage instead.
     // For Chrome mode, we use spider with limit=1 to get stealth + fingerprint
     // patches. For HTTP mode, plain reqwest fetches the exact URL directly.
-    if wcfg.limit == 1 {
+    if uses_single_page_extract_path(wcfg.limit) {
         return match wcfg.render_mode {
             RenderMode::Chrome => {
                 run_single_url_extract_chrome(&start_url, engine, &wcfg, fallback_cfg).await

--- a/src/core/content/engine_tests.rs
+++ b/src/core/content/engine_tests.rs
@@ -1,6 +1,22 @@
 use super::*;
-use crate::core::http::set_allow_loopback;
+use crate::core::http::{get_allow_loopback, set_allow_loopback};
 use httpmock::prelude::*;
+
+struct LoopbackGuard(bool);
+
+impl LoopbackGuard {
+    fn enable() -> Self {
+        let previous = get_allow_loopback();
+        set_allow_loopback(true);
+        Self(previous)
+    }
+}
+
+impl Drop for LoopbackGuard {
+    fn drop(&mut self) {
+        set_allow_loopback(self.0);
+    }
+}
 
 /// When Chrome mode is requested but no chrome_remote_url is configured,
 /// the extract engine must fall back to the HTTP path gracefully rather
@@ -40,8 +56,8 @@ async fn extract_chrome_mode_without_remote_url_falls_back_to_http() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn extract_limit_zero_uses_exact_single_url_path() {
-    set_allow_loopback(true);
+async fn extract_limit_one_uses_exact_single_url_path() {
+    let _loopback = LoopbackGuard::enable();
     let server = MockServer::start();
     let root = server.mock(|when, then| {
         when.method(GET).path("/");
@@ -58,7 +74,7 @@ async fn extract_limit_zero_uses_exact_single_url_path() {
     let wcfg = ExtractWebConfig {
         start_url: format!("{}/docs/page", server.base_url()),
         prompt: String::new(),
-        limit: 0,
+        limit: 1,
         llm_backend: crate::services::llm_backend::LlmBackendConfig::default(),
         custom_headers: vec![],
         render_mode: RenderMode::Http,
@@ -82,7 +98,7 @@ async fn extract_limit_zero_uses_exact_single_url_path() {
 
 #[test]
 fn extract_single_page_gate_preserves_explicit_multi_page_limits() {
-    assert!(uses_single_page_extract_path(0));
+    assert!(!uses_single_page_extract_path(0));
     assert!(uses_single_page_extract_path(1));
     assert!(!uses_single_page_extract_path(2));
     assert!(!uses_single_page_extract_path(25));

--- a/src/core/content/engine_tests.rs
+++ b/src/core/content/engine_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::core::http::set_allow_loopback;
+use httpmock::prelude::*;
 
 /// When Chrome mode is requested but no chrome_remote_url is configured,
 /// the extract engine must fall back to the HTTP path gracefully rather
@@ -35,4 +37,53 @@ async fn extract_chrome_mode_without_remote_url_falls_back_to_http() {
             );
         }
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn extract_limit_zero_uses_exact_single_url_path() {
+    set_allow_loopback(true);
+    let server = MockServer::start();
+    let root = server.mock(|when, then| {
+        when.method(GET).path("/");
+        then.status(200)
+            .body(r#"<html><head><meta property="og:title" content="wrong root"></head></html>"#);
+    });
+    let target = server.mock(|when, then| {
+        when.method(GET).path("/docs/page");
+        then.status(200)
+            .body(r#"<html><head><meta property="og:title" content="right target"></head></html>"#);
+    });
+
+    let engine = Arc::new(DeterministicExtractionEngine::with_default_parsers());
+    let wcfg = ExtractWebConfig {
+        start_url: format!("{}/docs/page", server.base_url()),
+        prompt: String::new(),
+        limit: 0,
+        llm_backend: crate::services::llm_backend::LlmBackendConfig::default(),
+        custom_headers: vec![],
+        render_mode: RenderMode::Http,
+        chrome_remote_url: None,
+        bypass_csp: false,
+        accept_invalid_certs: false,
+        request_timeout_ms: Some(1000),
+        fetch_retries: 0,
+        user_agent: None,
+        chrome_network_idle_timeout_secs: 0,
+    };
+
+    let run = run_extract_with_engine(wcfg, engine).await.unwrap();
+
+    root.assert_calls(0);
+    target.assert_calls(1);
+    assert_eq!(run.pages_visited, 1);
+    assert_eq!(run.results.len(), 1);
+    assert_eq!(run.results[0]["og:title"], "right target");
+}
+
+#[test]
+fn extract_single_page_gate_preserves_explicit_multi_page_limits() {
+    assert!(uses_single_page_extract_path(0));
+    assert!(uses_single_page_extract_path(1));
+    assert!(!uses_single_page_extract_path(2));
+    assert!(!uses_single_page_extract_path(25));
 }

--- a/src/core/content/engine_tests.rs
+++ b/src/core/content/engine_tests.rs
@@ -1,22 +1,6 @@
 use super::*;
-use crate::core::http::{get_allow_loopback, set_allow_loopback};
+use crate::core::http::LoopbackGuard;
 use httpmock::prelude::*;
-
-struct LoopbackGuard(bool);
-
-impl LoopbackGuard {
-    fn enable() -> Self {
-        let previous = get_allow_loopback();
-        set_allow_loopback(true);
-        Self(previous)
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(self.0);
-    }
-}
 
 /// When Chrome mode is requested but no chrome_remote_url is configured,
 /// the extract engine must fall back to the HTTP path gracefully rather
@@ -57,7 +41,7 @@ async fn extract_chrome_mode_without_remote_url_falls_back_to_http() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn extract_limit_one_uses_exact_single_url_path() {
-    let _loopback = LoopbackGuard::enable();
+    let _loopback = LoopbackGuard::allow();
     let server = MockServer::start();
     let root = server.mock(|when, then| {
         when.method(GET).path("/");

--- a/src/core/http.rs
+++ b/src/core/http.rs
@@ -31,6 +31,8 @@ pub use error::HttpError;
 pub use headers::parse_custom_headers;
 pub use normalize::normalize_url;
 #[cfg(test)]
+pub(crate) use ssrf::LoopbackGuard;
+#[cfg(test)]
 pub(crate) use ssrf::validate_resolved_ips;
 #[cfg(test)]
 pub(crate) use ssrf::{get_allow_loopback, set_allow_loopback};

--- a/src/core/http/ssrf.rs
+++ b/src/core/http/ssrf.rs
@@ -32,6 +32,34 @@ pub(crate) fn get_allow_loopback() -> bool {
     ALLOW_LOOPBACK.with(|c| c.get())
 }
 
+/// Test-only guard that restores the previous thread-local loopback bypass.
+#[cfg(test)]
+pub(crate) struct LoopbackGuard(bool);
+
+#[cfg(test)]
+impl LoopbackGuard {
+    pub(crate) fn set(allow: bool) -> Self {
+        let previous = get_allow_loopback();
+        set_allow_loopback(allow);
+        Self(previous)
+    }
+
+    pub(crate) fn allow() -> Self {
+        Self::set(true)
+    }
+
+    pub(crate) fn block() -> Self {
+        Self::set(false)
+    }
+}
+
+#[cfg(test)]
+impl Drop for LoopbackGuard {
+    fn drop(&mut self) {
+        set_allow_loopback(self.0);
+    }
+}
+
 /// Reject URLs that would allow SSRF attacks.
 ///
 /// Blocks:

--- a/src/crawl/engine/etag_tests.rs
+++ b/src/crawl/engine/etag_tests.rs
@@ -1,26 +1,8 @@
 use super::*;
+use crate::core::http::LoopbackGuard;
 use crate::crawl::engine::canonicalize_url_for_dedupe;
 use crate::crawl::manifest::ManifestEntry;
 use std::collections::{HashMap, HashSet};
-
-/// RAII guard for the thread-local loopback bypass. Enables it for the lifetime
-/// of the guard and restores the prior value on drop — panic-safe, so a failing
-/// test cannot leak `allow_loopback = true` into other tests on the same thread.
-struct LoopbackGuard(bool);
-
-impl LoopbackGuard {
-    fn enable() -> Self {
-        let prev = crate::core::http::get_allow_loopback();
-        crate::core::http::set_allow_loopback(true);
-        LoopbackGuard(prev)
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        crate::core::http::set_allow_loopback(self.0);
-    }
-}
 
 /// Run an async test body on a current-thread runtime hosted on a 16 MB-stack
 /// thread. A live `crawl_raw()` recurses deep enough through spider's pipeline to
@@ -391,7 +373,7 @@ fn seeded_validators_drive_conditional_request_and_304_drops_page() {
     block_on_big_stack(async {
         use httpmock::prelude::*;
 
-        let _loopback = LoopbackGuard::enable();
+        let _loopback = LoopbackGuard::allow();
 
         let server = MockServer::start();
         let stable_path = "/stable";
@@ -476,7 +458,7 @@ fn run1_populates_sidecar_with_seedable_key() {
     block_on_big_stack(async {
         use httpmock::prelude::*;
 
-        let _loopback = LoopbackGuard::enable();
+        let _loopback = LoopbackGuard::allow();
 
         let server = MockServer::start();
         let leaf_path = "/leaf";

--- a/src/crawl/engine/llms_txt_tests.rs
+++ b/src/crawl/engine/llms_txt_tests.rs
@@ -1,22 +1,5 @@
 use super::*;
-
-/// RAII guard for the global SSRF loopback-bypass flag. Restores the previous value on
-/// drop so a panicking test cannot leak `allow_loopback=true` into later SSRF tests.
-struct LoopbackGuard(bool);
-
-impl LoopbackGuard {
-    fn new(allow: bool) -> Self {
-        let prev = crate::core::http::get_allow_loopback();
-        crate::core::http::set_allow_loopback(allow);
-        Self(prev)
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        crate::core::http::set_allow_loopback(self.0);
-    }
-}
+use crate::core::http::LoopbackGuard;
 
 const FIXTURE: &str = "\u{feff}# Example Docs\n\n> A short summary.\n\nSome intro prose with an inline [ignored-in-prose-too](https://example.com/intro.md) link.\n\n## Docs\n\n- [Getting Started](/docs/start.md#h): the basics\n- [Guide](guide.md)\n- [External](https://other.com/x.md)\n- [Email](mailto:hi@example.com)\n- [Anchor](#section)\n\n## Optional\n\n- [Extra](/docs/extra.md)\n";
 
@@ -124,7 +107,7 @@ async fn discover_llms_txt_urls_caps_at_max() {
         request_timeout_ms: Some(5_000),
         ..Config::default()
     };
-    let _loopback = LoopbackGuard::new(true);
+    let _loopback = LoopbackGuard::allow();
     let urls = discover_llms_txt_urls(&cfg, &base).await.expect("discover");
     m.assert();
     assert_eq!(

--- a/src/crawl/engine/sitemap_tests.rs
+++ b/src/crawl/engine/sitemap_tests.rs
@@ -1,23 +1,6 @@
 use super::*;
 use crate::core::config::Config;
-
-/// RAII guard for the global SSRF loopback-bypass flag. Restores the previous value on
-/// drop so a panicking test cannot leak `allow_loopback=true` into later SSRF tests.
-struct LoopbackGuard(bool);
-
-impl LoopbackGuard {
-    fn new(allow: bool) -> Self {
-        let prev = crate::core::http::get_allow_loopback();
-        crate::core::http::set_allow_loopback(allow);
-        Self(prev)
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        crate::core::http::set_allow_loopback(self.0);
-    }
-}
+use crate::core::http::LoopbackGuard;
 
 /// Unit test for `sitemap_loc_in_scope` using real domain names.
 /// The integration test uses a loopback mock server (IP address) where
@@ -161,7 +144,7 @@ async fn fetch_text_rejects_oversized_body() {
         when.method(httpmock::Method::GET).path("/big.txt");
         then.status(200).body(&big);
     });
-    let _loopback = LoopbackGuard::new(true);
+    let _loopback = LoopbackGuard::allow();
     let client = build_client(5, None).unwrap();
     let url = server.url("/big.txt");
     let got = fetch_text_with_retry(&client, &url, 0, 0, Some(DISCOVERY_MAX_BODY_BYTES)).await;
@@ -187,7 +170,7 @@ async fn fetch_text_rejects_oversized_body_without_content_length() {
             .header("transfer-encoding", "chunked")
             .body(&big);
     });
-    let _loopback = LoopbackGuard::new(true);
+    let _loopback = LoopbackGuard::allow();
     let client = build_client(5, None).unwrap();
     let url = server.url("/chunked.txt");
     let got = fetch_text_with_retry(&client, &url, 0, 0, Some(DISCOVERY_MAX_BODY_BYTES)).await;

--- a/src/services/brand_tests.rs
+++ b/src/services/brand_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::core::config::Config;
-use crate::core::http::set_allow_loopback;
+use crate::core::http::LoopbackGuard;
 use httpmock::prelude::*;
 
 #[test]
@@ -60,7 +60,7 @@ fn test_extracts_fonts() {
 
 #[tokio::test]
 async fn test_brand_fetches_linked_stylesheet_fonts() {
-    set_allow_loopback(true);
+    let _loopback = LoopbackGuard::allow();
     let server = MockServer::start();
     let stylesheet = server.mock(|when, then| {
         when.method(GET).path("/site.css");

--- a/src/services/endpoints/candidates_tests.rs
+++ b/src/services/endpoints/candidates_tests.rs
@@ -70,26 +70,10 @@ fn candidates_skip_subdomain_for_ip() {
     assert_eq!(c.len(), 2);
 }
 
-use crate::core::http::{get_allow_loopback, set_allow_loopback};
+use crate::core::http::LoopbackGuard;
 use crate::services::types::{EndpointReport, EndpointSourceKind, McpProbeOutcome};
 use httpmock::prelude::*;
 use serial_test::serial;
-
-struct LoopbackGuard {
-    previous: bool,
-}
-impl LoopbackGuard {
-    fn allow() -> Self {
-        let previous = get_allow_loopback();
-        set_allow_loopback(true);
-        Self { previous }
-    }
-}
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(self.previous);
-    }
-}
 
 fn empty_report(url: &str) -> EndpointReport {
     EndpointReport {
@@ -147,7 +131,7 @@ async fn synthesized_same_host_mcp_confirms() {
 #[serial]
 async fn synthesized_candidate_blocked_when_loopback_disallowed() {
     // No LoopbackGuard → SSRF guard blocks 127.0.0.1.
-    set_allow_loopback(false);
+    let _loopback = LoopbackGuard::block();
     let client = crate::core::http::build_client(3, Some(crate::core::http::axon_ua())).unwrap();
     let mut report = empty_report("http://127.0.0.1:9/x");
 

--- a/src/services/endpoints/probe_tests.rs
+++ b/src/services/endpoints/probe_tests.rs
@@ -1,25 +1,7 @@
 use super::*;
-use crate::core::http::{build_client, get_allow_loopback, set_allow_loopback};
+use crate::core::http::{LoopbackGuard, build_client};
 use httpmock::prelude::*;
 use serial_test::serial;
-
-struct LoopbackGuard {
-    previous: bool,
-}
-
-impl LoopbackGuard {
-    fn allow() -> Self {
-        let previous = get_allow_loopback();
-        set_allow_loopback(true);
-        Self { previous }
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(self.previous);
-    }
-}
 
 fn probe_client() -> reqwest::Client {
     build_client(PROBE_TIMEOUT_SECS, Some(axon_ua())).expect("probe client")

--- a/src/services/endpoints_tests.rs
+++ b/src/services/endpoints_tests.rs
@@ -1,28 +1,10 @@
 use super::*;
-use crate::core::http::{get_allow_loopback, set_allow_loopback};
+use crate::core::http::LoopbackGuard;
 use crate::services::types::{EndpointKind, EndpointSourceKind};
 use httpmock::Method::{HEAD, OPTIONS};
 use httpmock::prelude::*;
 use serial_test::serial;
 use std::sync::{Arc, Mutex};
-
-struct LoopbackGuard {
-    previous: bool,
-}
-
-impl LoopbackGuard {
-    fn allow() -> Self {
-        let previous = get_allow_loopback();
-        set_allow_loopback(true);
-        Self { previous }
-    }
-}
-
-impl Drop for LoopbackGuard {
-    fn drop(&mut self) {
-        set_allow_loopback(self.previous);
-    }
-}
 
 #[tokio::test]
 #[serial]


### PR DESCRIPTION
## Summary
- treat extract max_pages=0/default as the single-page exact-URL path
- keep explicit max_pages > 1 on the multi-page spider path
- add regression coverage for the default exact-URL behavior and the gate

Closes #156

## Tests
- cargo fmt --check
- cargo test -p axon extract_ --lib
- pre-commit/pre-push hooks: monolith, rustfmt, xtask-check, clippy workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default extract now runs exact single-URL extraction when `--max-pages` is omitted, preventing spider from normalizing to the site root. Explicit `--max-pages=0` stays uncapped; multi-page limits (`>1`) still use the spider path. Addresses Linear #156.

- **Bug Fixes**
  - Extract with no `--max-pages` sets `max_pages=1`; only `limit == 1` uses the exact-URL path.
  - CLI/config: `--max-pages` is now optional; extract omits → 1, others default to 0; help/docs updated to reflect this.
  - Tests/refactor: add single-page gate coverage and introduce a shared `LoopbackGuard` to safely override loopback in tests.

<sup>Written for commit 298feec9776650876a1cd2a0aadabd9d2047a97f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extract command now defaults to processing a single page when the maximum page limit is not explicitly specified.

* **Tests**
  * Added tests verifying default page limit behavior and explicit limit override handling for Extract and Crawl commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->