### PR TITLE
fix(mcp): publish axon action schema in tool input

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -23,6 +23,11 @@ mod server_authz;
 mod services_migration_tests;
 #[path = "server/stdio.rs"]
 mod stdio_runner;
+#[path = "server/tool_schema.rs"]
+mod tool_schema;
+#[cfg(test)]
+#[path = "server/tool_schema_tests.rs"]
+mod tool_schema_tests;
 
 use super::auth::AuthPolicy;
 use super::schema::{AxonRequest, parse_axon_request};
@@ -44,6 +49,7 @@ use rmcp::{
     service::RequestContext,
     tool, tool_handler, tool_router,
 };
+use serde_json::Value;
 pub use server_authz::required_scope_for;
 use server_authz::required_scope_for_tool;
 use std::sync::{Arc, LazyLock};
@@ -54,14 +60,7 @@ const STATUS_DASHBOARD_URI: &str = "ui://axon/status-dashboard";
 const MCP_APP_MIME_TYPE: &str = "text/html;profile=mcp-app";
 static STATUS_DASHBOARD_HTML: &str = include_str!("assets/status_dashboard.html");
 
-static MCP_TOOL_SCHEMA_MD: LazyLock<String> = LazyLock::new(|| {
-    let schema = rmcp::schemars::schema_for!(AxonRequest);
-    let schema_json = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| "{}".to_string());
-    format!(
-        "# Axon MCP Tool Schema\n\nURI: `{}`\n\nSingle tool name: `axon`\n\nRouting contract:\n- `action` is required\n- `subaction` is required for subaction families\n- `response_mode` supports `path|inline|both|auto_inline`; most actions default to `path`, while `scrape` and `retrieve` default to inline paged document reads\n\n## JSON Schema\n\n```json\n{}\n```\n",
-        MCP_TOOL_SCHEMA_URI, schema_json
-    )
-});
+static MCP_TOOL_SCHEMA_MD: LazyLock<String> = LazyLock::new(tool_schema::mcp_tool_schema_markdown);
 
 #[derive(Clone)]
 pub struct AxonMcpServer {
@@ -132,12 +131,13 @@ impl AxonMcpServer {
 impl AxonMcpServer {
     #[tool(
         name = "axon",
-        description = "Unified Axon MCP tool. Use action/subaction routing. Use action:help to list actions/subactions/defaults. Exposes schema resource axon://schema/mcp-tool. Actions: status, help, crawl, extract, embed, ingest, query, retrieve, search, map, endpoints, evaluate, suggest, doctor, domains, sources, stats, artifacts, scrape, research, ask, summarize, screenshot, elicit_demo, brand, diff."
+        description = "Unified Axon MCP tool. Use action/subaction routing. Valid actions and subactions are published in this tool inputSchema; the full typed AxonRequest schema is also exposed at axon://schema/mcp-tool. Actions: status, help, crawl, extract, embed, ingest, query, retrieve, search, map, endpoints, evaluate, suggest, doctor, domains, sources, stats, artifacts, scrape, research, ask, summarize, screenshot, elicit_demo, brand, diff.",
+        input_schema = tool_schema::axon_tool_input_schema()
     )]
     async fn axon<'a>(
         &'a self,
         peer: rmcp::Peer<RoleServer>,
-        Parameters(raw): Parameters<serde_json::Map<String, serde_json::Value>>,
+        Parameters(raw): Parameters<serde_json::Map<String, Value>>,
     ) -> Result<String, ErrorData> {
         let action = raw
             .get("action")
@@ -296,14 +296,14 @@ impl ServerHandler for AxonMcpServer {
             .arguments
             .as_ref()
             .and_then(|m| m.get("action"))
-            .and_then(serde_json::Value::as_str)
+            .and_then(Value::as_str)
             .unwrap_or("")
             .to_owned();
         let subaction: String = request
             .arguments
             .as_ref()
             .and_then(|m| m.get("subaction"))
-            .and_then(serde_json::Value::as_str)
+            .and_then(Value::as_str)
             .unwrap_or("")
             .to_owned();
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -131,7 +131,7 @@ impl AxonMcpServer {
 impl AxonMcpServer {
     #[tool(
         name = "axon",
-        description = "Unified Axon MCP tool. Use action/subaction routing. Valid actions and subactions are published in this tool inputSchema; the full typed AxonRequest schema is also exposed at axon://schema/mcp-tool. Actions: status, help, crawl, extract, embed, ingest, query, retrieve, search, map, endpoints, evaluate, suggest, doctor, domains, sources, stats, artifacts, scrape, research, ask, summarize, screenshot, elicit_demo, brand, diff.",
+        description = "Unified Axon MCP tool. Use action/subaction routing. Valid actions and subactions are published in this tool inputSchema and mirrored in the enriched schema resource at axon://schema/mcp-tool. Actions: status, help, crawl, extract, embed, ingest, query, retrieve, search, map, endpoints, evaluate, suggest, doctor, domains, sources, stats, artifacts, scrape, research, ask, summarize, screenshot, elicit_demo, brand, diff.",
         input_schema = tool_schema::axon_tool_input_schema()
     )]
     async fn axon<'a>(

--- a/src/mcp/server/authz.rs
+++ b/src/mcp/server/authz.rs
@@ -3,6 +3,214 @@ use crate::mcp::auth::AuthPolicy;
 use lab_auth::AuthContext;
 use rmcp::{ErrorData, RoleServer, service::RequestContext};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ActionScope {
+    Read,
+    Write,
+    InfoOnly,
+    ArtifactsBySubaction,
+}
+
+impl ActionScope {
+    pub(super) fn as_scope(self, subaction: &str) -> Option<&'static str> {
+        match self {
+            Self::Read => Some("axon:read"),
+            Self::Write => Some("axon:write"),
+            Self::InfoOnly => None,
+            Self::ArtifactsBySubaction => match subaction {
+                "delete" | "clean" => Some("axon:write"),
+                _ => Some("axon:read"),
+            },
+        }
+    }
+
+    pub(super) fn as_label(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::InfoOnly => "info",
+            Self::ArtifactsBySubaction => "read/write",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct McpActionSpec {
+    pub name: &'static str,
+    pub scope: ActionScope,
+    pub description: &'static str,
+    pub cost: &'static str,
+}
+
+pub(super) const MCP_ACTION_SPECS: &[McpActionSpec] = &[
+    McpActionSpec {
+        name: "help",
+        scope: ActionScope::InfoOnly,
+        description: "List actions, subactions, defaults, and schema resource links",
+        cost: "cheap",
+    },
+    McpActionSpec {
+        name: "status",
+        scope: ActionScope::Read,
+        description: "Show job queue, worker, and service status",
+        cost: "cheap",
+    },
+    McpActionSpec {
+        name: "doctor",
+        scope: ActionScope::Read,
+        description: "Diagnose Axon service connectivity",
+        cost: "cheap",
+    },
+    McpActionSpec {
+        name: "sources",
+        scope: ActionScope::Read,
+        description: "List indexed URLs and chunk counts",
+        cost: "cheap",
+    },
+    McpActionSpec {
+        name: "domains",
+        scope: ActionScope::Read,
+        description: "List indexed domains and aggregate stats",
+        cost: "cheap",
+    },
+    McpActionSpec {
+        name: "stats",
+        scope: ActionScope::Read,
+        description: "Show Qdrant collection statistics",
+        cost: "cheap",
+    },
+    McpActionSpec {
+        name: "query",
+        scope: ActionScope::Read,
+        description: "Run semantic vector search over indexed content",
+        cost: "cheap",
+    },
+    McpActionSpec {
+        name: "retrieve",
+        scope: ActionScope::Read,
+        description: "Fetch stored document chunks by URL",
+        cost: "cheap",
+    },
+    McpActionSpec {
+        name: "search",
+        scope: ActionScope::Read,
+        description: "Run Tavily web search and optionally queue crawls for results",
+        cost: "moderate",
+    },
+    McpActionSpec {
+        name: "map",
+        scope: ActionScope::Read,
+        description: "Discover URLs for a site without scraping page content",
+        cost: "moderate",
+    },
+    McpActionSpec {
+        name: "ask",
+        scope: ActionScope::Read,
+        description: "Answer a question with RAG over indexed content",
+        cost: "moderate",
+    },
+    McpActionSpec {
+        name: "evaluate",
+        scope: ActionScope::Read,
+        description: "Evaluate RAG quality against a baseline and judge diagnostics",
+        cost: "expensive",
+    },
+    McpActionSpec {
+        name: "suggest",
+        scope: ActionScope::Read,
+        description: "Suggest new documentation URLs to crawl",
+        cost: "moderate",
+    },
+    McpActionSpec {
+        name: "research",
+        scope: ActionScope::Read,
+        description: "Run Tavily AI research with synthesis",
+        cost: "expensive",
+    },
+    McpActionSpec {
+        name: "screenshot",
+        scope: ActionScope::Read,
+        description: "Capture a full-page screenshot through headless Chrome",
+        cost: "moderate",
+    },
+    McpActionSpec {
+        name: "brand",
+        scope: ActionScope::Read,
+        description: "Extract brand identity metadata from a URL",
+        cost: "moderate",
+    },
+    McpActionSpec {
+        name: "diff",
+        scope: ActionScope::Read,
+        description: "Compare two URLs for content, metadata, and link changes",
+        cost: "moderate",
+    },
+    McpActionSpec {
+        name: "artifacts",
+        scope: ActionScope::ArtifactsBySubaction,
+        description: "Read, search, inspect, or clean MCP artifact files",
+        cost: "moderate",
+    },
+    McpActionSpec {
+        name: "crawl",
+        scope: ActionScope::Write,
+        description: "Run or manage async site crawl jobs",
+        cost: "write",
+    },
+    McpActionSpec {
+        name: "extract",
+        scope: ActionScope::Write,
+        description: "Run or manage async structured extraction jobs",
+        cost: "write",
+    },
+    McpActionSpec {
+        name: "embed",
+        scope: ActionScope::Write,
+        description: "Run or manage async embedding jobs",
+        cost: "write",
+    },
+    McpActionSpec {
+        name: "ingest",
+        scope: ActionScope::Write,
+        description: "Run or manage async external-source ingestion jobs",
+        cost: "write",
+    },
+    McpActionSpec {
+        name: "scrape",
+        scope: ActionScope::Write,
+        description: "Scrape one page to markdown, HTML, raw HTML, JSON, or LLM text",
+        cost: "write",
+    },
+    McpActionSpec {
+        name: "summarize",
+        scope: ActionScope::Write,
+        description: "Scrape URL context and summarize it with the configured LLM",
+        cost: "write",
+    },
+    McpActionSpec {
+        name: "endpoints",
+        scope: ActionScope::Write,
+        description: "Discover and optionally verify static site endpoints",
+        cost: "write",
+    },
+    McpActionSpec {
+        name: "vertical_scrape",
+        scope: ActionScope::Write,
+        description: "Discover vertical extractor capabilities; scraping routes through action=scrape",
+        cost: "write",
+    },
+    McpActionSpec {
+        name: "elicit_demo",
+        scope: ActionScope::Write,
+        description: "Exercise MCP elicitation support with a demo form",
+        cost: "write",
+    },
+];
+
+pub(super) fn mcp_action_names() -> Vec<&'static str> {
+    MCP_ACTION_SPECS.iter().map(|spec| spec.name).collect()
+}
+
 /// Extract and enforce the authentication context from the rmcp request.
 ///
 /// `LoopbackDev` trusts process isolation. Mounted HTTP mode requires the auth
@@ -62,20 +270,10 @@ pub(super) fn check_scope(
 
 /// Map an axon tool action and subaction to the minimum required scope.
 pub fn required_scope_for(action: &str, subaction: &str) -> Option<&'static str> {
-    match action {
-        "help" => None,
-        "crawl" | "extract" | "embed" | "ingest" | "scrape" | "summarize" | "endpoints" => {
-            Some("axon:write")
-        }
-        "artifacts" => match subaction {
-            "delete" | "clean" => Some("axon:write"),
-            _ => Some("axon:read"),
-        },
-        "status" | "query" | "retrieve" | "search" | "map" | "evaluate" | "suggest" | "doctor"
-        | "domains" | "sources" | "stats" | "research" | "ask" | "screenshot" | "diff"
-        | "brand" => Some("axon:read"),
-        _ => Some("__deny__"),
-    }
+    MCP_ACTION_SPECS
+        .iter()
+        .find(|spec| spec.name == action)
+        .map_or(Some("__deny__"), |spec| spec.scope.as_scope(subaction))
 }
 
 pub(super) fn required_scope_for_tool(

--- a/src/mcp/server/authz.rs
+++ b/src/mcp/server/authz.rs
@@ -195,9 +195,9 @@ pub(super) const MCP_ACTION_SPECS: &[McpActionSpec] = &[
     },
     McpActionSpec {
         name: "vertical_scrape",
-        scope: ActionScope::Write,
+        scope: ActionScope::Read,
         description: "Discover vertical extractor capabilities; scraping routes through action=scrape",
-        cost: "write",
+        cost: "cheap",
     },
     McpActionSpec {
         name: "elicit_demo",

--- a/src/mcp/server/tool_schema.rs
+++ b/src/mcp/server/tool_schema.rs
@@ -1,0 +1,239 @@
+use super::{MCP_TOOL_SCHEMA_URI, server_authz};
+use crate::mcp::schema::{
+    ArtifactsSubaction, AxonRequest, CrawlSubaction, EmbedSubaction, ExtractSubaction,
+    IngestSubaction, VerticalScrapeSubaction,
+};
+use rmcp::schemars::JsonSchema;
+use serde_json::{Value, json};
+use std::collections::HashSet;
+use std::sync::{Arc, LazyLock};
+
+pub(super) fn axon_tool_input_schema() -> Arc<rmcp::model::JsonObject> {
+    static SCHEMA: LazyLock<Arc<rmcp::model::JsonObject>> =
+        LazyLock::new(|| Arc::new(build_axon_tool_input_schema()));
+    Arc::clone(&SCHEMA)
+}
+
+pub(super) fn mcp_tool_schema_markdown() -> String {
+    let schema_json =
+        serde_json::to_string_pretty(&Value::Object(axon_tool_input_schema().as_ref().clone()))
+            .unwrap_or_else(|_| "{}".to_string());
+    format!(
+        "# Axon MCP Tool Schema\n\nURI: `{}`\n\nSingle tool name: `axon`\n\nRouting contract:\n- `action` is required\n- `subaction` is required for subaction families\n- `response_mode` supports `path|inline|both|auto_inline`; most actions default to `path`, while `scrape` and `retrieve` default to inline paged document reads\n\n## JSON Schema\n\n```json\n{}\n```\n",
+        MCP_TOOL_SCHEMA_URI, schema_json
+    )
+}
+
+fn build_axon_tool_input_schema() -> rmcp::model::JsonObject {
+    let mut schema =
+        serde_json::to_value(rmcp::schemars::schema_for!(AxonRequest)).unwrap_or_else(|_| {
+            json!({
+                "type": "object",
+                "properties": {},
+            })
+        });
+
+    let supported_actions = server_authz::mcp_action_names();
+    let supported_set: HashSet<&str> = supported_actions.iter().copied().collect();
+    let typed_actions = action_names_from_schema(&schema);
+    for action in &supported_actions {
+        assert!(
+            typed_actions.contains(*action),
+            "MCP action spec `{action}` has no matching AxonRequest schema variant"
+        );
+    }
+    filter_schema_to_supported_actions(&mut schema, &supported_set);
+    enrich_tool_input_schema(&mut schema, &supported_actions);
+
+    match schema {
+        Value::Object(object) => object,
+        _ => serde_json::Map::new(),
+    }
+}
+
+fn enrich_tool_input_schema(schema: &mut Value, supported_actions: &[&'static str]) {
+    let Some(object) = schema.as_object_mut() else {
+        return;
+    };
+    object.insert("type".to_string(), json!("object"));
+    object.insert("required".to_string(), json!(["action"]));
+    let properties = object
+        .entry("properties".to_string())
+        .or_insert_with(|| json!({}));
+    let properties = properties
+        .as_object_mut()
+        .expect("schema properties should be an object");
+    properties.insert(
+        "action".to_string(),
+        json!({
+            "type": "string",
+            "enum": supported_actions,
+            "description": "Action to run. The enum is derived from Axon's MCP action specs, which also drive scope checks."
+        }),
+    );
+    properties.insert(
+        "subaction".to_string(),
+        json!({
+            "type": "string",
+            "description": "Operation within a subaction family. See x-axon-subactions for valid values by action."
+        }),
+    );
+    object.insert("x-axon-action-metadata".to_string(), axon_action_metadata());
+    object.insert("x-axon-subactions".to_string(), axon_subaction_metadata());
+    object.insert(
+        "x-axon-agent-guidance".to_string(),
+        json!({
+            "cost_order": ["cheap", "moderate", "expensive", "write"],
+            "first_pass": ["status", "doctor", "sources", "domains", "stats", "query", "retrieve", "help"],
+            "async_jobs": ["crawl", "extract", "embed", "ingest"],
+            "poll_async_jobs_with": {
+                "subaction": "status",
+                "required_field": "job_id"
+            },
+            "artifact_first": {
+                "default_response_mode": "path",
+                "inline_defaults": ["scrape", "retrieve"]
+            },
+            "schema_resource": MCP_TOOL_SCHEMA_URI
+        }),
+    );
+}
+
+fn axon_action_metadata() -> Value {
+    Value::Array(
+        server_authz::MCP_ACTION_SPECS
+            .iter()
+            .map(|spec| {
+                json!({
+                    "name": spec.name,
+                    "scope": spec.scope.as_label(),
+                    "cost": spec.cost,
+                    "description": spec.description,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn axon_subaction_metadata() -> Value {
+    json!({
+        "crawl": enum_values_for::<CrawlSubaction>(),
+        "extract": enum_values_for::<ExtractSubaction>(),
+        "embed": enum_values_for::<EmbedSubaction>(),
+        "ingest": enum_values_for::<IngestSubaction>(),
+        "artifacts": enum_values_for::<ArtifactsSubaction>(),
+        "vertical_scrape": enum_values_for::<VerticalScrapeSubaction>(),
+    })
+}
+
+fn enum_values_for<T>() -> Vec<String>
+where
+    T: JsonSchema,
+{
+    let schema = serde_json::to_value(rmcp::schemars::schema_for!(T)).unwrap_or(Value::Null);
+    let mut values = Vec::new();
+    collect_string_enums(&schema, &mut values);
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn action_names_from_schema(schema: &Value) -> HashSet<String> {
+    let mut actions = Vec::new();
+    collect_action_names(schema, &mut actions);
+    actions.into_iter().collect()
+}
+
+fn collect_action_names(value: &Value, out: &mut Vec<String>) {
+    if let Some(action) = value.pointer("/properties/action") {
+        collect_string_enums(action, out);
+    }
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_action_names(item, out);
+            }
+        }
+        Value::Object(object) => {
+            for key in ["oneOf", "anyOf", "allOf"] {
+                if let Some(values) = object.get(key).and_then(Value::as_array) {
+                    for item in values {
+                        collect_action_names(item, out);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_string_enums(value: &Value, out: &mut Vec<String>) {
+    if let Some(value) = value.get("const").and_then(Value::as_str) {
+        out.push(value.to_string());
+    }
+    if let Some(values) = value.get("enum").and_then(Value::as_array) {
+        out.extend(
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string),
+        );
+    }
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_string_enums(item, out);
+            }
+        }
+        Value::Object(object) => {
+            for key in ["oneOf", "anyOf", "allOf"] {
+                if let Some(values) = object.get(key).and_then(Value::as_array) {
+                    for item in values {
+                        collect_string_enums(item, out);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn filter_schema_to_supported_actions(schema: &mut Value, supported_actions: &HashSet<&str>) {
+    match schema {
+        Value::Array(items) => {
+            for item in items {
+                filter_schema_to_supported_actions(item, supported_actions);
+            }
+        }
+        Value::Object(object) => {
+            for key in ["oneOf", "anyOf"] {
+                if let Some(values) = object.get_mut(key).and_then(Value::as_array_mut) {
+                    values.retain(|item| {
+                        schema_branch_action(item)
+                            .is_none_or(|action| supported_actions.contains(action))
+                    });
+                    for item in values {
+                        filter_schema_to_supported_actions(item, supported_actions);
+                    }
+                }
+            }
+            if let Some(values) = object.get_mut("allOf").and_then(Value::as_array_mut) {
+                for item in values {
+                    filter_schema_to_supported_actions(item, supported_actions);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn schema_branch_action(value: &Value) -> Option<&str> {
+    let action = value.pointer("/properties/action")?;
+    action.get("const").and_then(Value::as_str).or_else(|| {
+        action
+            .get("enum")
+            .and_then(Value::as_array)
+            .and_then(|values| values.first())
+            .and_then(Value::as_str)
+    })
+}

--- a/src/mcp/server/tool_schema.rs
+++ b/src/mcp/server/tool_schema.rs
@@ -19,7 +19,7 @@ pub(super) fn mcp_tool_schema_markdown() -> String {
         serde_json::to_string_pretty(&Value::Object(axon_tool_input_schema().as_ref().clone()))
             .unwrap_or_else(|_| "{}".to_string());
     format!(
-        "# Axon MCP Tool Schema\n\nURI: `{}`\n\nSingle tool name: `axon`\n\nRouting contract:\n- `action` is required\n- `subaction` is required for subaction families\n- `response_mode` supports `path|inline|both|auto_inline`; most actions default to `path`, while `scrape` and `retrieve` default to inline paged document reads\n\n## JSON Schema\n\n```json\n{}\n```\n",
+        "# Axon MCP Tool Schema\n\nURI: `{}`\n\nSingle tool name: `axon`\n\nRouting contract:\n- `action` is required\n- `subaction` selects an operation within subaction families; many families default it when omitted\n- `response_mode` supports `path|inline|both|auto_inline`; most actions default to `path`, while `scrape` and `retrieve` default to inline paged document reads\n\n## JSON Schema\n\n```json\n{}\n```\n",
         MCP_TOOL_SCHEMA_URI, schema_json
     )
 }
@@ -37,7 +37,7 @@ fn build_axon_tool_input_schema() -> rmcp::model::JsonObject {
     let supported_set: HashSet<&str> = supported_actions.iter().copied().collect();
     let typed_actions = action_names_from_schema(&schema);
     for action in &supported_actions {
-        assert!(
+        debug_assert!(
             typed_actions.contains(*action),
             "MCP action spec `{action}` has no matching AxonRequest schema variant"
         );
@@ -60,9 +60,9 @@ fn enrich_tool_input_schema(schema: &mut Value, supported_actions: &[&'static st
     let properties = object
         .entry("properties".to_string())
         .or_insert_with(|| json!({}));
-    let properties = properties
-        .as_object_mut()
-        .expect("schema properties should be an object");
+    let Some(properties) = properties.as_object_mut() else {
+        return;
+    };
     properties.insert(
         "action".to_string(),
         json!({

--- a/src/mcp/server/tool_schema_tests.rs
+++ b/src/mcp/server/tool_schema_tests.rs
@@ -1,0 +1,67 @@
+use super::AxonMcpServer;
+use super::server_authz;
+
+fn axon_input_schema() -> serde_json::Value {
+    let tools = AxonMcpServer::tool_router().list_all();
+    let axon = tools
+        .into_iter()
+        .find(|tool| tool.name.as_ref() == "axon")
+        .expect("axon tool is registered");
+    axon.schema_as_json_value()
+}
+
+#[test]
+fn axon_tool_input_schema_publishes_action_enum_from_tools_list() {
+    let schema = axon_input_schema();
+    let action_enum = schema
+        .pointer("/properties/action/enum")
+        .and_then(serde_json::Value::as_array)
+        .expect("tools/list inputSchema publishes properties.action.enum");
+
+    for action in [
+        "crawl", "scrape", "retrieve", "ask", "query", "embed", "ingest", "status",
+    ] {
+        assert!(
+            action_enum
+                .iter()
+                .any(|value| value.as_str() == Some(action)),
+            "action enum should include {action}"
+        );
+    }
+
+    let expected = server_authz::mcp_action_names();
+    let actual = action_enum
+        .iter()
+        .map(|value| value.as_str().expect("action enum entries are strings"))
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+    assert!(!actual.contains(&"debug"));
+    assert!(!actual.contains(&"watch"));
+}
+
+#[test]
+fn axon_tool_input_schema_documents_subaction_families() {
+    let schema = axon_input_schema();
+    let subactions = schema
+        .pointer("/x-axon-subactions")
+        .and_then(serde_json::Value::as_object)
+        .expect("tools/list inputSchema documents subaction families");
+
+    for (family, expected) in [
+        ("crawl", "start"),
+        ("extract", "status"),
+        ("embed", "cancel"),
+        ("ingest", "recover"),
+        ("artifacts", "grep"),
+        ("vertical_scrape", "capabilities"),
+    ] {
+        let values = subactions
+            .get(family)
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| panic!("{family} subactions should be listed"));
+        assert!(
+            values.iter().any(|value| value.as_str() == Some(expected)),
+            "{family} subactions should include {expected}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- publish an action enum and subaction metadata in the axon tool inputSchema
- move MCP action metadata into a shared spec table used by auth scope mapping and schema metadata
- keep the schema resource aligned with the published tool schema
- split schema construction into src/mcp/server/tool_schema.rs to stay under the monolith limit

Closes #155

## Tests
- cargo fmt --check
- cargo test -p axon mcp::server::tool_schema_tests --lib
- pre-commit/pre-push hooks: monolith, rustfmt, xtask-check, clippy workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the `axon` MCP tool input schema with a typed `action` enum and documented subactions, driven from one shared action spec. Clarifies schema docs, makes `vertical_scrape` read-only, and keeps the schema resource in sync; closes #155.

- New Features
  - `axon` tool now exposes an `inputSchema` with `properties.action` enum and `x-axon-subactions` per action; schema markdown is served at `axon://schema/mcp-tool`.
  - Added `x-axon-action-metadata` (name, scope label, cost, description) and `x-axon-agent-guidance` to help agents choose actions and defaults.

- Refactors
  - Centralized MCP action definitions in `MCP_ACTION_SPECS`; `required_scope_for` now derives scopes from this table; `vertical_scrape` is read-only.
  - Moved schema construction to `src/mcp/server/tool_schema.rs`, clarified guidance text, and made schema enrichment panic-safe; added tests to verify published action enums and subaction families.

<sup>Written for commit d44acdc4fc2b6c9bba37c5c7820d296558694bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

