### PR TITLE
feat(chrome-extension): Aurora side-panel launcher from design handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.1] - 2026-06-08
+
+### Changed
+
+- **Chrome extension launcher internals cleanup.** Derive the per-action input
+  mode from the action catalog instead of hardcoded id-lists, unify the result
+  status-badge construction behind one helper, cache the extension config (read
+  once, refresh on `storage.onChanged`) instead of a `chrome.storage` read per
+  request, repaint the server-status dot in place rather than rebuilding the
+  browse panel, and guard tab-change re-renders on the resolved URL. No
+  behavior change.
+
 ## [5.3.0] - 2026-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0] - 2026-06-08
+
+### Added
+
+- **Chrome extension side-panel launcher (Aurora design).** Recreated the
+  `Axon Extension.html` design handoff as the extension's side panel
+  (`apps/chrome-extension`): an Aurora-styled launcher with a brand strip +
+  server status dot, a "this page" card with Scrape / Ingest / Endpoints quick
+  actions, and the full action surface grouped by family (Fetch & Read · Crawl &
+  Ingest · Search & Discover · Reason · System) and color-coded by tone
+  (cyan/orange/rose). Tapping an action opens a result view wired to the real
+  `/v1/*` API with faithful per-action renders (query hits, web results, sources
+  library → doc viewer, stats, doctor, status, accepted-job cards, brand, diff,
+  endpoints, screenshot, ask answer) plus a readable JSON fallback. Built
+  build-free in vanilla JS on the Aurora tokens (`aurora.css`) to match the
+  existing extension and MV3's no-remote-code rule.
+- **Extension context menus.** Right-click "Scrape with Axon", "Ingest this page
+  into Axon", and "Ask Axon about *selection*" open the side panel and run the
+  pre-filled action via a forwarded intent. Added the `contextMenus` permission
+  and a **Ctrl/⌘+Shift+Space** command to open the panel.
+
 ## [5.2.0] - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "5.3.0"
+version = "5.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "5.2.0"
+version = "5.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "5.3.0"
+version = "5.3.1"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "5.2.0"
+version = "5.3.0"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 5.3.0
+Version: 5.3.1
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 5.2.0
+Version: 5.3.0
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -1,41 +1,102 @@
-# Page Scraper Clipboard
+# Axon Chrome Extension
 
-Small unpacked Chrome extension that sends the current tab URL to Axon, copies useful outputs to the clipboard, and can queue, poll, and cancel crawl jobs. It includes both a toolbar popup and a Chrome side panel surface.
+An unpacked **Manifest V3** Chrome extension that brings Axon to the page you're
+on. The **side panel** is an Aurora-styled launcher: browse the full Axon action
+surface (scrape, crawl, ingest, search, query, ask, …), run an action against the
+current tab, and read the result inline. Right-click **context menus** ("Scrape
+with Axon", "Ingest this page", "Ask Axon about *selection*") pre-fill and run an
+action straight from the page.
+
+The toolbar **popup** keeps the older command-line chat surface for quick CLI-style
+commands; both talk to the same Axon `/v1/*` HTTP API.
 
 ## Load It
 
 1. Open `chrome://extensions`.
 2. Enable **Developer mode**.
-3. Click **Load unpacked**.
-4. Select this `chrome-page-scraper-extension` directory.
-5. Open extension **Options** to set the Axon URL/token.
-6. Use the popup's **Sidebar** button or Chrome's side panel picker to pin the Axon panel.
+3. Click **Load unpacked** and select this `apps/chrome-extension` directory.
+4. Open the extension **Options** to set the Axon server URL + bearer token.
+5. Click the toolbar icon (or press **Ctrl/⌘+Shift+Space**) to open the side panel,
+   or pick *Axon* from Chrome's side-panel menu.
 
-## Use It
+No build step — the side panel is plain HTML/CSS/JS on the Aurora design tokens
+(`aurora.css`), so the unpacked directory loads as-is. (MV3 forbids remote code,
+so everything ships in the package.)
 
-1. Start Axon locally: `axon serve`.
-2. Open any normal web page.
-3. Click the extension icon.
-4. Use one of the Axon actions.
+## Side panel — the launcher
 
-The default Axon server is `http://100.88.16.79:8001`, the Tailscale address observed for the Linux host where Axon is running. Configure it from the extension options page. If Chrome and Axon are on the same machine, use `http://127.0.0.1:8001` instead.
+Recreated from the Aurora design handoff (`Axon Extension.html`):
 
-Current actions:
+- **Brand strip** — Axon mark + a server status dot (green online / red offline)
+  + the configured host + a Settings button.
+- **This page** card — the current tab URL with quick actions: **Scrape**,
+  **Ingest**, **Endpoints**.
+- **Action browse** — every action grouped by family (Fetch & Read · Crawl &
+  Ingest · Search & Discover · Reason · System), color-coded by tone
+  (cyan = read, orange = async jobs, rose = LLM). `ASYNC` badges mark lifecycle
+  jobs.
+- **Run → result** — tapping an action opens a result view with an editable
+  arg bar (URL prefilled from the active tab, or a query field) and renders the
+  real response: ranked query hits, web results, the sources library → **doc
+  viewer**, stats, doctor, status, accepted-job cards, brand palettes, endpoint
+  lists, diffs, screenshots, and a generic JSON fallback for anything else.
 
-- **Scrape + crawl**: `POST /v1/scrape`, then `POST /v1/crawl`, then polls `GET /v1/crawl/{job_id}`.
-- **Auto-scrape visited pages**: optional background mode from Options. Sends completed `http://` and `https://` navigations to `POST /v1/scrape`, at most once per URL every 24 hours.
-- **Cancel crawl**: `POST /v1/crawl/{job_id}/cancel` for the currently tracked crawl job.
-- **Summarize page**: `POST /v1/summarize`.
-- **Map URLs**: `POST /v1/map`.
-- **Ask Axon**: `POST /v1/ask`.
+Server URL + bearer token are read from `chrome.storage` (set on the Options
+page), shared with the popup.
+
+## Context menus
+
+Right-click a page (or selection) to run Axon without opening the panel first:
+
+- **Scrape with Axon** (`page`, `link`) → `scrape` the page/link URL.
+- **Ingest this page into Axon** (`page`) → `ingest` the page URL.
+- **Ask Axon about "…"** (`selection`) → `ask` with the selected text.
+
+The background worker opens the side panel and forwards the intent
+(`{ type: 'axon-intent', op, arg }`); the launcher pre-fills and runs it.
+
+## Popup actions (toolbar)
+
+The popup chat still supports inline Axon commands and auto-scrape:
+
+- **Scrape + crawl**: `POST /v1/scrape`, then `POST /v1/crawl`, polling
+  `GET /v1/crawl/{job_id}`.
+- **Auto-scrape visited pages**: optional background mode (Options). Sends
+  completed `http(s)` navigations to `POST /v1/scrape`, at most once per URL
+  every 24 hours.
+- **Cancel crawl**, **Summarize**, **Map**, **Ask**, and the full set of CLI-style
+  commands typed into the composer.
+
 ## Authentication
 
-If `axon serve` is bound to loopback for local development, Axon allows tokenless HTTP. If the server is non-loopback, uses `AXON_MCP_HTTP_TOKEN`, or runs OAuth/lab-auth mode, the request must authenticate.
-
-For static token auth, paste the `AXON_MCP_HTTP_TOKEN` value into the options page token field. The extension sends it as:
+If `axon serve` is bound to loopback, Axon allows tokenless HTTP. If the server is
+non-loopback, uses `AXON_MCP_HTTP_TOKEN`, or runs OAuth/lab-auth mode, the request
+must authenticate. Paste the `AXON_MCP_HTTP_TOKEN` value into the Options token
+field; the extension sends it as:
 
 ```http
 Authorization: Bearer <token>
 ```
 
-Chrome blocks extension scripts on restricted pages like `chrome://extensions`, the Chrome Web Store, and some browser-owned pages.
+The default Axon server is `http://100.88.16.79:8001` (a Tailscale address);
+configure it from Options. If Chrome and Axon are on the same machine, use
+`http://127.0.0.1:8001`.
+
+Chrome blocks extension scripts on restricted pages like `chrome://extensions`,
+the Chrome Web Store, and some browser-owned pages.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `manifest.json` | MV3 manifest (side panel, options, background, context menus, command) |
+| `background.js` | service worker — side-panel behavior, context menus, auto-scrape |
+| `sidepanel.html` | side-panel launcher entry |
+| `aurora.css` | Aurora design tokens (dark-first, `.light` remap) |
+| `launcher.css` | launcher layout + the `ext-*` styles from the design |
+| `launcher-icons.js` | lucide-style icon set + the Axon neuron mark |
+| `launcher-data.js` | the action catalog + tone helpers |
+| `launcher-render.js` | DOM renders for each action result + response normalizers |
+| `launcher.js` | controller — config, `/v1/*` requests, browse → run → doc flow |
+| `popup.html` + `popup-*.js` | toolbar popup (command chat) |
+| `options.html` + `options.js` | server URL + token settings |

--- a/apps/chrome-extension/aurora.css
+++ b/apps/chrome-extension/aurora.css
@@ -1,0 +1,165 @@
+/* ============================================================
+ * Aurora Design System — Colors & Type
+ * Source: jmagar/lab @ apps/gateway-admin/app/globals.css
+ * Spec:   docs/design-system-contract.md
+ * Mode:   dark-first; .light remap on the same token surface
+ *
+ * Ported verbatim from the Axon Extension design handoff
+ * (aurora-design-system/.../chrome_extension/Reference/aurora.css).
+ * Fonts are loaded via <link> in sidepanel.html, so no @import here.
+ * ============================================================ */
+
+:root {
+  /* ── Aurora raw tokens (dark canon) ─────────────────────── */
+  --aurora-page-bg:        #07131c;
+  --aurora-nav-bg:         #07111a;
+  --aurora-panel-medium:   #102330;
+  --aurora-panel-medium-top: rgba(20, 44, 60, 0.18);
+  --aurora-panel-strong:   #13293a;
+  --aurora-panel-strong-top: #173245;
+  --aurora-control-surface: #0c1a24;
+  --aurora-control-surface-top: rgba(18, 40, 56, 0.96);
+
+  --aurora-border-default: #1d3d4e;
+  --aurora-border-strong:  #24536c;
+
+  --aurora-text-primary:   #e6f4fb;
+  --aurora-text-muted:     #a7bcc9;  /* WCAG-AA lifted from #90a9b9 */
+
+  --aurora-accent-primary: #29b6f6;
+  --aurora-accent-strong:  #67cbfa;
+  --aurora-accent-deep:    #1c7fac;
+
+  /* Secondary accent — rose pink for high-glance pops (mono code, key labels,
+     send affordance, agent name in chip). Sparingly. */
+  --aurora-accent-pink:    #f9a8c4;
+  --aurora-accent-pink-strong: #fbc4d6;
+  --aurora-accent-pink-deep:   #c46b88;
+
+  --aurora-warn:    #c6a36b;
+  --aurora-error:   #c78490;
+  --aurora-success: #7dd3c7;
+
+  --aurora-focus-ring:   rgba(41, 182, 246, 0.34);
+  --aurora-active-glow:  0 0 0 1px rgba(41, 182, 246, 0.18), 0 0 16px rgba(41, 182, 246, 0.08);
+  --aurora-shadow-subtle: 0 8px 16px rgba(0, 0, 0, 0.16);
+  --aurora-shadow-medium: 0 12px 24px rgba(0, 0, 0, 0.18);
+  --aurora-shadow-strong: 0 20px 38px rgba(0, 0, 0, 0.26);
+  --aurora-highlight-medium: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+  --aurora-highlight-strong: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  --aurora-hover-bg: #17364b;
+
+  /* Live-preview palette — restricted-scope only (exposure-policy editor). */
+  --aurora-preview-allowed:    #00e676;
+  --aurora-preview-unmatched:  #ff9100;
+  --aurora-preview-highlight:  #ffea00;
+
+  /* ── Tints (named alpha scale) ─────────────────────────── */
+  --aurora-tint-subtle:  12%;
+  --aurora-tint-soft:    18%;
+  --aurora-tint-medium:  30%;
+  --aurora-tint-strong:  40%;
+
+  /* ── Radii ─────────────────────────────────────────────── */
+  --radius-1: 14px;
+  --radius-2: 18px;
+  --radius-3: 22px;
+  --radius-pill: 999px;
+  --r-tile: 9px;
+
+  /* ── Spacing ───────────────────────────────────────────── */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3: 10px;
+  --space-4: 12px;
+  --space-5: 16px;
+  --space-6: 20px;
+  --space-7: 24px;
+
+  /* ── Z-index layers ────────────────────────────────────── */
+  --z-sidebar: 30;
+  --z-popover: 40;
+  --z-modal:   50;
+  --z-toast:   60;
+
+  /* ── Motion ────────────────────────────────────────────── */
+  --motion-duration-instant: 100ms;
+  --motion-duration-fast:    160ms;
+  --motion-duration-medium:  240ms;
+  --motion-duration-slow:    360ms;
+  --motion-ease-out:    cubic-bezier(0.2, 0.8, 0.2, 1);
+  --motion-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ── Line heights ──────────────────────────────────────── */
+  --lh-display-tight: 1.04;
+  --lh-display:       1.16;
+  --lh-body:          1.55;
+  --lh-dense:         1.40;
+
+  /* ── Font families ─────────────────────────────────────── */
+  --font-display: 'Manrope', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --font-sans:    'Inter',   'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --font-mono:    'JetBrains Mono', 'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+/* Light remap — overrides only raw Aurora vars. Semantic tokens still resolve. */
+.light {
+  --aurora-page-bg:         #f0f6f8;
+  --aurora-nav-bg:          #e4eff3;
+  --aurora-panel-medium:    #ffffff;
+  --aurora-panel-medium-top: rgba(220, 237, 243, 0.5);
+  --aurora-panel-strong:    #edf4f7;
+  --aurora-panel-strong-top:#e4eff3;
+  --aurora-control-surface: #e8f2f5;
+  --aurora-control-surface-top: rgba(215, 232, 239, 0.96);
+  --aurora-border-default:  #c5dae2;
+  --aurora-border-strong:   #9fbfcc;
+  --aurora-text-primary:    #162126;
+  --aurora-text-muted:      #4a6872;
+  --aurora-accent-primary:  #0288d1;
+  --aurora-accent-strong:   #0277bd;
+  --aurora-accent-deep:     #01579b;
+  --aurora-warn:            #8a6914;
+  --aurora-error:           #9c3545;
+  --aurora-success:         #2d7d6e;
+  --aurora-focus-ring:      rgba(2, 136, 209, 0.34);
+  --aurora-active-glow:     0 0 0 1px rgba(2, 136, 209, 0.18), 0 0 16px rgba(2, 136, 209, 0.08);
+  --aurora-shadow-medium:   0 12px 24px rgba(0, 0, 0, 0.08);
+  --aurora-shadow-strong:   0 20px 38px rgba(0, 0, 0, 0.12);
+  --aurora-highlight-medium: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  --aurora-highlight-strong: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  --aurora-hover-bg:        #dcedf2;
+}
+
+/* ── Aurora scrollbar (token-backed thin) ──────────────────── */
+.aurora-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--aurora-border-strong) transparent;
+}
+.aurora-scrollbar::-webkit-scrollbar { width: 6px; height: 6px; }
+.aurora-scrollbar::-webkit-scrollbar-track { background: transparent; }
+.aurora-scrollbar::-webkit-scrollbar-thumb {
+  background-color: var(--aurora-border-strong);
+  border-radius: 999px;
+}
+.aurora-scrollbar::-webkit-scrollbar-thumb:hover { background-color: var(--aurora-accent-deep); }
+
+.aurora-muted-label {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--aurora-text-muted);
+}
+
+/* ── Reduced motion ────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-duration-instant: 0ms;
+    --motion-duration-fast:    0ms;
+    --motion-duration-medium:  0ms;
+    --motion-duration-slow:    0ms;
+  }
+}

--- a/apps/chrome-extension/background.js
+++ b/apps/chrome-extension/background.js
@@ -5,6 +5,7 @@ const AUTO_SCRAPE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 chrome.runtime.onInstalled.addListener(() => {
   chrome.action.setBadgeBackgroundColor({ color: "#24536c" });
   setupSidePanelAction();
+  setupContextMenus();
 });
 
 chrome.runtime.onStartup.addListener(setupSidePanelAction);
@@ -164,3 +165,45 @@ function setupSidePanelAction() {
     ?.setPanelBehavior?.({ openPanelOnActionClick: true })
     .catch(() => {});
 }
+
+// Right-click menus → open the side panel and forward a pre-filled action
+// intent ({ op, arg }) that the launcher runs. Mirrors the design handoff
+// ("Scrape with Axon", "Ingest this page", "Ask Axon about <selection>").
+function setupContextMenus() {
+  if (!chrome.contextMenus?.create) {
+    return;
+  }
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({ id: "axon-scrape", title: "Scrape with Axon", contexts: ["page", "link"] });
+    chrome.contextMenus.create({ id: "axon-ingest", title: "Ingest this page into Axon", contexts: ["page"] });
+    chrome.contextMenus.create({ id: "axon-ask", title: 'Ask Axon about "%s"', contexts: ["selection"] });
+  });
+}
+
+chrome.contextMenus?.onClicked?.addListener(async (info, tab) => {
+  const intent =
+    info.menuItemId === "axon-scrape" ? { op: "scrape", arg: info.linkUrl || info.pageUrl || tab?.url || "" }
+    : info.menuItemId === "axon-ingest" ? { op: "ingest", arg: info.pageUrl || tab?.url || "" }
+    : info.menuItemId === "axon-ask" ? { op: "ask", arg: info.selectionText || "" }
+    : null;
+
+  if (!intent) {
+    return;
+  }
+
+  // Stash the intent so a freshly-opened panel can pick it up on load,
+  // then nudge any already-open panel via runtime message.
+  await chrome.storage.local.set({ axonPendingIntent: { ...intent, ts: Date.now() } });
+
+  try {
+    if (tab?.id && /^https?:\/\//i.test(tab.url || "")) {
+      await chrome.sidePanel.open({ tabId: tab.id });
+    } else if (tab?.windowId != null) {
+      await chrome.sidePanel.open({ windowId: tab.windowId });
+    }
+  } catch {
+    // Side panel may already be open, or the surface may be restricted.
+  }
+
+  chrome.runtime.sendMessage({ type: "axon-intent", ...intent }).catch(() => {});
+});

--- a/apps/chrome-extension/launcher-data.js
+++ b/apps/chrome-extension/launcher-data.js
@@ -1,0 +1,89 @@
+/* ============================================================
+ * Axon launcher — action surface + tone helpers
+ * The full action surface (CLI / MCP), grouped by family.
+ * Tones: cyan (fetch/read), orange (heavy/async jobs), rose (AI/LLM).
+ * Ported from the design handoff (Reference/axon/data.jsx + parts.jsx).
+ * ============================================================ */
+
+/* action families shown as sections in browse */
+const CATEGORIES = [
+  { id: "read",     label: "Fetch & Read" },
+  { id: "jobs",     label: "Crawl & Ingest" },
+  { id: "discover", label: "Search & Discover" },
+  { id: "reason",   label: "Reason" },
+  { id: "system",   label: "System & Diagnostics" },
+];
+
+/* Each op: arg drives the launcher input mode —
+ *   "url"            → prefill the active tab URL, run immediately, editable
+ *   "query"/"focus"/"input"/"target"/"message" → text input, run on submit
+ *   null + noArg     → run immediately, no input
+ * dual: needs two URLs (diff). optionalArg/noArg: can run without an arg. */
+const OPERATIONS = [
+  /* ── Fetch & Read (cyan) ── */
+  { id: "scrape",     name: "Scrape",     tone: "cyan",   icon: "scrape",   category: "read",     arg: "url",     argLabel: "URL",            argHint: "https://docs.rs/serde",                short: "Fetch one page → markdown" },
+  { id: "map",        name: "Map",        tone: "cyan",   icon: "map",      category: "read",     arg: "url",     argLabel: "domain",         argHint: "https://spider.rs",                    short: "Discover URLs, skip bodies" },
+  { id: "retrieve",   name: "Retrieve",   tone: "cyan",   icon: "database", category: "read",     arg: "url",     argLabel: "URL",            argHint: "https://docs.rs/serde",                short: "Read a stored doc by URL" },
+  { id: "screenshot", name: "Screenshot", tone: "cyan",   icon: "camera",   category: "read",     arg: "url",     argLabel: "URL",            argHint: "https://tokio.rs",                     short: "Capture a full-page PNG" },
+  { id: "diff",       name: "Diff",       tone: "cyan",   icon: "diff",     category: "read",     arg: "url",     argLabel: "URL A · URL B",  argHint: "https://a.example  https://b.example",  short: "Compare two URLs", dual: true },
+  { id: "brand",      name: "Brand",      tone: "cyan",   icon: "palette",  category: "read",     arg: "url",     argLabel: "URL",            argHint: "https://stripe.com",                   short: "Extract brand palette + type" },
+  { id: "endpoints",  name: "Endpoints",  tone: "cyan",   icon: "plug",     category: "read",     arg: "url",     argLabel: "URL",            argHint: "https://app.example.com",              short: "Discover API endpoints" },
+
+  /* ── Crawl & Ingest (orange · async lifecycle) ── */
+  { id: "crawl",      name: "Crawl",      tone: "orange", icon: "crawl",    category: "jobs",     async: true, arg: "url",    argLabel: "start URL",   argHint: "https://docs.rs",                short: "Queue a recursive site crawl" },
+  { id: "extract",    name: "Extract",    tone: "orange", icon: "braces",   category: "jobs",     async: true, arg: "url",    argLabel: "URL(s)",      argHint: "https://news.ycombinator.com",   short: "Structured extraction (LLM)" },
+  { id: "embed",      name: "Embed",      tone: "orange", icon: "layers",   category: "jobs",     async: true, arg: "input",  argLabel: "text or path", argHint: "./notes/*.md",                  short: "Embed text / files → vectors" },
+  { id: "ingest",     name: "Ingest",     tone: "orange", icon: "box",      category: "jobs",     async: true, arg: "target", argLabel: "source",      argHint: "github.com/jmagar/axon",         short: "Ingest a repo / feed / sessions" },
+
+  /* ── Search & Discover ── */
+  { id: "search",     name: "Search",     tone: "cyan",   icon: "search",   category: "discover", arg: "query", argLabel: "query",          argHint: "rust async runtime comparison",     short: "Web search (Tavily / SearXNG)" },
+  { id: "research",   name: "Research",   tone: "rose",   icon: "compass",  category: "discover", arg: "query", argLabel: "topic",          argHint: "state of WASM component model 2026", short: "Deep research + synthesis" },
+  { id: "query",      name: "Query",      tone: "cyan",   icon: "target",   category: "discover", arg: "query", argLabel: "query",          argHint: "how does Pin work",                 short: "Vector search the collection" },
+  { id: "suggest",    name: "Suggest",    tone: "rose",   icon: "sparkles", category: "discover", arg: "focus", argLabel: "focus (optional)", argHint: "tokio internals",                short: "Suggest what to crawl next", optionalArg: true, noArg: true },
+  { id: "sources",    name: "Sources",    tone: "cyan",   icon: "folder",   category: "discover", arg: null,    argLabel: "domain (optional)", argHint: "docs.rs",                       short: "List indexed sources", optionalArg: true, noArg: true },
+  { id: "domains",    name: "Domains",    tone: "cyan",   icon: "globe",    category: "discover", arg: null,    argLabel: "filter (optional)", argHint: "rs",                            short: "List indexed domains", optionalArg: true, noArg: true },
+
+  /* ── Reason (rose) ── */
+  { id: "ask",        name: "Ask",        tone: "rose",   icon: "ask",      category: "reason",   arg: "query", argLabel: "question",       argHint: "how does serde derive work?",       short: "RAG over the collection" },
+  { id: "summarize",  name: "Summarize",  tone: "rose",   icon: "summarize", category: "reason",  arg: "url",   argLabel: "URL",            argHint: "https://docs.rs/tokio",             short: "Scrape + LLM summary" },
+  { id: "evaluate",   name: "Evaluate",   tone: "rose",   icon: "beaker",   category: "reason",   arg: "query", argLabel: "question",       argHint: "what is a Waker?",                  short: "Grade retrieval quality" },
+
+  /* ── System & Diagnostics (cyan) ── */
+  { id: "doctor",     name: "Doctor",     tone: "cyan",   icon: "activity", category: "system",   arg: null, noArg: true, short: "Health-check the stack" },
+  { id: "status",     name: "Status",     tone: "cyan",   icon: "server",   category: "system",   arg: null, noArg: true, short: "Server + job status" },
+  { id: "stats",      name: "Stats",      tone: "cyan",   icon: "barChart", category: "system",   arg: null, noArg: true, short: "Collection statistics" },
+];
+
+const OP_BY_ID = Object.fromEntries(OPERATIONS.map((o) => [o.id, o]));
+const OPS_BY_CATEGORY = CATEGORIES.map((c) => ({ ...c, ops: OPERATIONS.filter((o) => o.category === c.id) }));
+
+/* Resolve an operation tone to its color trio. colorCode off → everything cyan. */
+function toneOf(t, colorCode) {
+  const c = colorCode ? t : "cyan";
+  if (c === "orange") return { base: "var(--axon-orange)", fg: "var(--axon-orange-strong)", deep: "var(--axon-orange-deep)" };
+  if (c === "rose")   return { base: "var(--aurora-accent-pink)", fg: "var(--aurora-accent-pink-strong)", deep: "var(--aurora-accent-pink-deep)" };
+  return { base: "var(--aurora-accent-primary)", fg: "var(--aurora-accent-strong)", deep: "var(--aurora-accent-deep)" };
+}
+
+const tint = (color, pct, into = "transparent") => `color-mix(in srgb, ${color} ${pct}%, ${into})`;
+
+function hostOf(u) {
+  try { return String(u).replace(/^https?:\/\//, "").replace(/\/$/, ""); } catch { return u; }
+}
+
+/* Auto-detect an ingest source_type from a target URL or shorthand. */
+function detectIngestSource(target) {
+  const t = String(target || "").toLowerCase();
+  if (/github\.com/.test(t)) return "github";
+  if (/gitlab\.com/.test(t)) return "gitlab";
+  if (/gitea|forgejo|codeberg\.org/.test(t)) return "gitea";
+  if (/reddit\.com|^\/?r\//.test(t)) return "reddit";
+  if (/youtube\.com|youtu\.be/.test(t)) return "youtube";
+  if (/\.git($|\/)/.test(t) || /^https?:\/\//.test(t)) return "git";
+  return "github";
+}
+
+window.AxonData = {
+  CATEGORIES, OPERATIONS, OP_BY_ID, OPS_BY_CATEGORY,
+  toneOf, tint, hostOf, detectIngestSource,
+};

--- a/apps/chrome-extension/launcher-icons.js
+++ b/apps/chrome-extension/launcher-icons.js
@@ -1,0 +1,114 @@
+/* ============================================================
+ * Axon launcher — icon set
+ * Lucide-style line icons (currentColor, 1.6 stroke) + Axon neuron mark.
+ * Ported from the design handoff (Reference/axon/icons.jsx) to plain DOM.
+ * ============================================================ */
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+const ICON_PATHS = {
+  search: '<circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>',
+  send: '<path d="M14.5 4.5 3 9.5l7 2 2 7 5-11.5z"/>',
+  settings: '<line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/><circle cx="9" cy="6" r="2.2" fill="var(--axon-surface)"/><circle cx="15" cy="12" r="2.2" fill="var(--axon-surface)"/><circle cx="8" cy="18" r="2.2" fill="var(--axon-surface)"/>',
+  x: '<path d="M6 6l12 12M18 6 6 18"/>',
+  copy: '<rect x="9" y="9" width="11" height="11" rx="2.5"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/>',
+  check: '<path d="M5 12.5 10 17l9-10"/>',
+  refresh: '<path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/>',
+  external: '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M19 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h6"/>',
+  clock: '<circle cx="12" cy="12" r="8.5"/><path d="M12 7.5V12l3 2"/>',
+  history: '<path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/><path d="M12 7.5V12l3.5 2"/>',
+  chevronRight: '<path d="m9 5 7 7-7 7"/>',
+  arrowLeft: '<path d="M19 12H5"/><path d="m12 19-7-7 7-7"/>',
+  chevronDown: '<path d="m6 9 6 6 6-6"/>',
+  arrowUp: '<path d="M12 19V5"/><path d="m6 11 6-6 6 6"/>',
+  arrowDown: '<path d="M12 5v14"/><path d="m6 13 6 6 6-6"/>',
+  enter: '<path d="M9 10 5 14l4 4"/><path d="M5 14h11a4 4 0 0 0 4-4V6"/>',
+  command: '<path d="M15 6a3 3 0 1 1 3 3h-3V6Z"/><path d="M9 6a3 3 0 1 0-3 3h3V6Z"/><path d="M9 18a3 3 0 1 1-3-3h3v3Z"/><path d="M15 18a3 3 0 1 0 3-3h-3v3Z"/>',
+  // operations
+  scrape: '<path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M5 3h9l5 5v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z"/><path d="M12 11v6"/><path d="m9 14 3 3 3-3"/>',
+  crawl: '<circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="6" r="2.4"/><circle cx="12" cy="18" r="2.4"/><path d="M8 7.2 10.8 16M16 7.2 13.2 16M8.3 6h7.4"/>',
+  map: '<path d="M4 5h16"/><path d="M4 5v14"/><path d="M8 10h12"/><path d="M8 10v9"/><path d="M12 15h8"/><circle cx="4" cy="5" r="1.4" fill="currentColor"/><circle cx="8" cy="10" r="1.4" fill="currentColor"/><circle cx="12" cy="15" r="1.4" fill="currentColor"/>',
+  summarize: '<path d="M4 6h16"/><path d="M4 11h11"/><path d="M4 16h16"/><path d="M4 21h8"/>',
+  ask: '<path d="M9.5 9a2.5 2.5 0 1 1 3.6 2.2c-.8.4-1.1 1-1.1 1.8v.5"/><circle cx="12" cy="17" r="0.6" fill="currentColor"/><circle cx="12" cy="12" r="9"/>',
+  // status / misc
+  globe: '<circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18Z"/>',
+  link: '<path d="M9 15 15 9"/><path d="M11 6.5 13 4.5a4 4 0 0 1 6 6l-2 2"/><path d="M13 17.5 11 19.5a4 4 0 0 1-6-6l2-2"/>',
+  server: '<rect x="3" y="4" width="18" height="7" rx="2"/><rect x="3" y="13" width="18" height="7" rx="2"/><circle cx="7" cy="7.5" r="0.7" fill="currentColor"/><circle cx="7" cy="16.5" r="0.7" fill="currentColor"/>',
+  database: '<ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
+  plus: '<path d="M12 5v14M5 12h14"/>',
+  activity: '<path d="M3 12h4l3 8 4-16 3 8h4"/>',
+  alert: '<path d="M12 3 2 20h20L12 3Z"/><path d="M12 9v5"/><circle cx="12" cy="17.5" r="0.6" fill="currentColor"/>',
+  layers: '<path d="m12 3 9 5-9 5-9-5 9-5Z"/><path d="m3 13 9 5 9-5"/>',
+  zap: '<path d="M13 3 4 14h7l-1 7 9-11h-7l1-7Z"/>',
+  dot: '<circle cx="12" cy="12" r="4" fill="currentColor" stroke="none"/>',
+  file: '<path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M5 3h9l5 5v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z"/>',
+  hash: '<path d="M9 4 7 20M17 4l-2 16M5 9h15M4 15h15"/>',
+  pin: '<path d="M12 21s7-5.5 7-11a7 7 0 1 0-14 0c0 5.5 7 11 7 11Z"/><circle cx="12" cy="10" r="2.4"/>',
+  terminal: '<rect x="3" y="4" width="18" height="16" rx="2.5"/><path d="M7 9l3 3-3 3"/><path d="M13 15h4"/>',
+  shield: '<path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6l8-3Z"/>',
+  sparkles: '<path d="M12 4l1.5 4.2L18 10l-4.5 1.8L12 16l-1.5-4.2L6 10l4.5-1.8L12 4Z"/><path d="M19 14l.7 1.8L21 17l-1.3.6L19 19l-.7-1.4L17 17l1.3-1.2L19 14Z"/>',
+  brain: '<path d="M9 4a3 3 0 0 0-3 3 3 3 0 0 0-1 5.8V15a3 3 0 0 0 4 2.8A3 3 0 0 0 12 19V5a3 3 0 0 0-3-1Z"/><path d="M15 4a3 3 0 0 1 3 3 3 3 0 0 1 1 5.8V15a3 3 0 0 1-4 2.8A3 3 0 0 1 12 19"/>',
+  // operations — extended action surface
+  camera: '<path d="M4 8h3l1.5-2.2h7L17 8h3a1 1 0 0 1 1 1v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1Z"/><circle cx="12" cy="13" r="3.4"/>',
+  diff: '<path d="M12 3v18"/><rect x="3" y="6" width="6" height="12" rx="1.4"/><rect x="15" y="6" width="6" height="12" rx="1.4"/>',
+  braces: '<path d="M8 4c-2 0-2 2-2 4s0 3-2 4c2 1 2 2 2 4s0 4 2 4"/><path d="M16 4c2 0 2 2 2 4s0 3 2 4c-2 1-2 2-2 4s0 4-2 4"/>',
+  box: '<path d="m12 3 8 4.5v9L12 21l-8-4.5v-9L12 3Z"/><path d="m4 7.5 8 4.5 8-4.5"/><path d="M12 12v9"/>',
+  compass: '<circle cx="12" cy="12" r="9"/><path d="m15.5 8.5-2 5-5 2 2-5 5-2Z"/>',
+  target: '<circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="4.5"/><circle cx="12" cy="12" r="1" fill="currentColor"/>',
+  folder: '<path d="M3 7a2 2 0 0 1 2-2h4l2 2.5h8a2 2 0 0 1 2 2V18a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z"/>',
+  beaker: '<path d="M9 3h6"/><path d="M10 3v6.5L5.5 17a2 2 0 0 0 1.8 3h9.4a2 2 0 0 0 1.8-3L14 9.5V3"/><path d="M8 14h8"/>',
+  barChart: '<path d="M4 20V10"/><path d="M10 20V4"/><path d="M16 20v-7"/><path d="M3 20h18"/>',
+  palette: '<path d="M12 3a9 9 0 1 0 0 18c1.4 0 2-1 2-2 0-1.4-1-1.6-1-3 0-.8.7-1.5 1.5-1.5H17a4 4 0 0 0 4-4c0-4-4-7.5-9-7.5Z"/><circle cx="8" cy="11" r="1.1" fill="currentColor" stroke="none"/><circle cx="12" cy="8" r="1.1" fill="currentColor" stroke="none"/><circle cx="16" cy="10" r="1.1" fill="currentColor" stroke="none"/>',
+  plug: '<path d="M9 3v5"/><path d="M15 3v5"/><path d="M7 8h10v3a5 5 0 0 1-10 0V8Z"/><path d="M12 16v5"/>',
+};
+
+/* Build a lucide-style line-icon <svg> element. */
+function iconSvg(name, opts = {}) {
+  const path = ICON_PATHS[name];
+  const svg = document.createElementNS(SVG_NS, "svg");
+  const size = opts.size || 16;
+  svg.setAttribute("width", String(size));
+  svg.setAttribute("height", String(size));
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", String(opts.stroke || 1.6));
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("aria-hidden", "true");
+  svg.style.flex = "0 0 auto";
+  if (opts.color) svg.style.color = opts.color;
+  if (path) svg.innerHTML = path;
+  return svg;
+}
+
+/* Axon neuron mark — vertical signal spine, 4 nodes ramping crawl→retrieve. */
+function axonMark(size = 22, pulse = false) {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("width", String(size));
+  svg.setAttribute("height", String(size));
+  svg.setAttribute("viewBox", "0 0 64 64");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("aria-hidden", "true");
+  if (pulse) svg.classList.add("axon-pulse");
+  svg.innerHTML = `
+    <g stroke="var(--aurora-border-strong)" stroke-width="2" stroke-linecap="round">
+      <path d="M22 9 Q28 14 31 17"/>
+      <path d="M32 7 L32 16"/>
+      <path d="M42 9 Q36 14 33 17"/>
+    </g>
+    <line x1="32" y1="22" x2="32" y2="42" stroke="var(--aurora-border-strong)" stroke-width="2" stroke-dasharray="2.5 3.5"/>
+    <circle class="axon-node" style="animation-delay:0s" cx="32" cy="20" r="5.2" fill="var(--aurora-border-strong)" stroke="var(--aurora-accent-strong)" stroke-width="1.8"/>
+    <circle class="axon-node" style="animation-delay:0.16s" cx="32" cy="30" r="5.2" fill="var(--aurora-accent-deep)" stroke="var(--aurora-accent-strong)" stroke-width="1.8"/>
+    <circle class="axon-node" style="animation-delay:0.32s" cx="32" cy="40" r="5.2" fill="var(--aurora-accent-primary)" stroke="var(--aurora-accent-strong)" stroke-width="1.8"/>
+    <circle class="axon-node" style="animation-delay:0.48s" cx="32" cy="50" r="5.2" fill="var(--aurora-accent-strong)"/>
+    <circle cx="32" cy="50" r="8" fill="none" stroke="var(--aurora-accent-strong)" stroke-width="1.2" opacity="0.4"/>
+    <g stroke="var(--aurora-accent-strong)" stroke-width="2" stroke-linecap="round">
+      <path d="M28 53 Q23 58 19 62"/>
+      <path d="M32 54 L32 62"/>
+      <path d="M36 53 Q41 58 45 62"/>
+    </g>`;
+  return svg;
+}
+
+window.AxonIcons = { iconSvg, axonMark, ICON_PATHS };

--- a/apps/chrome-extension/launcher-render.js
+++ b/apps/chrome-extension/launcher-render.js
@@ -1,0 +1,646 @@
+/* ============================================================
+ * Axon launcher — action-result renders
+ * Plain-DOM ports of the design handoff renders (Reference/axon/
+ * renders.jsx). Each render takes a normalized `data` object plus a
+ * tone trio and returns a DOM node. Normalizers (PREP) map the real
+ * /v1/* responses onto the shapes the renders expect; anything they
+ * cannot map falls back to GenericResult (readable JSON).
+ * ============================================================ */
+
+(function () {
+  const { iconSvg } = window.AxonIcons;
+  const { tint, hostOf } = window.AxonData;
+
+  /* ── tiny DOM builder (React-inline-style → element) ── */
+  const UNITLESS = new Set([
+    "opacity", "fontWeight", "zIndex", "order", "flex", "flexGrow", "flexShrink",
+    "lineHeight", "fontVariationSettings",
+  ]);
+  function applyStyle(node, style) {
+    for (const [k, v] of Object.entries(style)) {
+      if (v == null) continue;
+      node.style[k] = typeof v === "number" && !UNITLESS.has(k) ? `${v}px` : v;
+    }
+  }
+  function append(node, children) {
+    if (children == null || children === false) return;
+    if (Array.isArray(children)) { children.forEach((c) => append(node, c)); return; }
+    if (children instanceof Node) { node.appendChild(children); return; }
+    node.appendChild(document.createTextNode(String(children)));
+  }
+  function el(tag, props, children) {
+    const node = document.createElement(tag);
+    if (props) {
+      for (const [k, v] of Object.entries(props)) {
+        if (v == null) continue;
+        if (k === "style") applyStyle(node, v);
+        else if (k === "class") node.className = v;
+        else if (k === "html") node.innerHTML = v;
+        else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2).toLowerCase(), v);
+        else node.setAttribute(k, v);
+      }
+    }
+    append(node, children);
+    return node;
+  }
+  const Icon = (name, size, color, stroke) => iconSvg(name, { size: size || 16, color, stroke });
+
+  /* ── shared primitives ── */
+  function Bar(pct, tone, h = 5) {
+    return el("div", { style: { height: h, borderRadius: 999, background: "var(--axon-control)", border: "1px solid var(--aurora-border-default)", overflow: "hidden", minWidth: 36 } }, [
+      el("div", { style: { width: `${Math.max(2, Math.min(100, pct || 0))}%`, height: "100%", borderRadius: 999, background: `linear-gradient(90deg, ${tone.deep}, ${tone.base})` } }),
+    ]);
+  }
+  function Card(children, style) {
+    return el("div", { style: { borderRadius: 12, background: "var(--axon-control)", border: "1px solid var(--aurora-border-default)", padding: "12px 13px", ...(style || {}) } }, children);
+  }
+  function Mono(children, color, size = 11.5) {
+    return el("span", { style: { fontFamily: "var(--font-mono)", fontSize: size, color: color || "var(--aurora-text-muted)" } }, children);
+  }
+  function col(items, gap) {
+    return el("div", { style: { display: "flex", flexDirection: "column", gap } }, items);
+  }
+
+  /* ── markdown blocks (scrape / summarize / retrieve / default) ── */
+  function MdBlocks(blocks, tones) {
+    return el("div", { style: { display: "flex", flexDirection: "column", gap: 11 } }, (blocks || []).map((b) => {
+      if (b.t === "h1") return el("h1", { style: { margin: 0, fontFamily: "var(--font-display)", fontWeight: 800, fontSize: 23, letterSpacing: "-0.03em", color: "var(--aurora-text-primary)", lineHeight: 1.12 } }, b.x);
+      if (b.t === "h2") return el("h2", { style: { margin: "6px 0 0", display: "flex", alignItems: "center", gap: 9, fontFamily: "var(--font-display)", fontWeight: 800, fontSize: 16, color: "var(--aurora-text-primary)" } }, [
+        el("span", { style: { width: 4, height: 15, borderRadius: 999, background: tones.base, flex: "0 0 4px" } }), b.x,
+      ]);
+      if (b.t === "p") return el("p", { style: { margin: 0, fontFamily: "var(--font-sans)", fontSize: 14, lineHeight: 1.6, color: "var(--aurora-text-primary)", overflowWrap: "anywhere" } }, b.x);
+      if (b.t === "ul") return el("ul", { style: { margin: 0, padding: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: 8 } }, b.x.map((li) => {
+        const [c, ...r] = String(li).split(" — ");
+        return el("li", { style: { display: "flex", gap: 10, alignItems: "baseline", fontFamily: "var(--font-sans)", fontSize: 14, lineHeight: 1.5, color: "var(--aurora-text-primary)" } }, [
+          el("span", { style: { width: 5, height: 5, borderRadius: 999, background: tones.base, flex: "0 0 5px", transform: "translateY(7px)" } }),
+          el("span", null, [
+            el("code", { style: { fontFamily: "var(--font-mono)", fontSize: 12.5, color: tones.fg } }, c),
+            r.length ? el("span", { style: { color: "var(--aurora-text-muted)" } }, ` — ${r.join(" — ")}`) : null,
+          ]),
+        ]);
+      }));
+      if (b.t === "code") return el("div", { style: { borderRadius: 11, overflow: "hidden", border: "1px solid var(--aurora-border-default)", background: "var(--axon-page)" } }, [
+        el("div", { style: { display: "flex", alignItems: "center", gap: 7, padding: "7px 12px", borderBottom: "1px solid var(--aurora-border-default)", color: "var(--aurora-text-muted)" } }, [Icon("hash", 11), Mono(b.lang || "code", null, 10.5)]),
+        el("pre", { style: { margin: 0, padding: "12px 14px", overflowX: "auto", fontFamily: "var(--font-mono)", fontSize: 12.5, lineHeight: 1.6, color: "var(--aurora-text-primary)" } }, b.x),
+      ]);
+      return null;
+    }));
+  }
+
+  /* ── query → ranked semantic hits ── */
+  function QueryHits(data, tones) {
+    return col([
+      Mono(`${data.results.length} hits · reranked`),
+      ...data.results.map((r) => Card([
+        el("div", { style: { display: "flex", alignItems: "center", gap: 9 } }, [
+          el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 11, fontWeight: 700, color: tones.fg, width: 20, flex: "0 0 auto" } }, `#${r.rank}`),
+          el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 12.5, color: "var(--aurora-accent-strong)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1, minWidth: 0 } }, hostOf(r.url)),
+          Mono(`c${r.chunk_index}`, null, 10.5),
+        ]),
+        el("p", { style: { margin: 0, fontFamily: "var(--font-sans)", fontSize: 13, lineHeight: 1.5, color: "var(--aurora-text-primary)", overflowWrap: "anywhere" } }, r.snippet),
+        el("div", { style: { display: "flex", alignItems: "center", gap: 10 } }, [
+          Mono(`score ${Number(r.score).toFixed(3)}`, null, 10),
+          el("div", { style: { flex: 1 } }, Bar((r.rerank_score || 0) * 100, tones, 4)),
+          Mono(`rerank ${Number(r.rerank_score).toFixed(2)}`, tones.fg, 10),
+        ]),
+      ], { display: "flex", flexDirection: "column", gap: 8 })),
+    ], 9);
+  }
+
+  /* ── search / research → web results ── */
+  function WebResults(data, tones, kind) {
+    const items = [];
+    if (kind === "research" && data.summary) {
+      items.push(Card([
+        el("div", { style: { display: "inline-flex", alignItems: "center", gap: 7, marginBottom: 7 } }, [Icon("sparkles", 13, tones.fg), Mono("SYNTHESIS", tones.fg, 10.5)]),
+        el("p", { style: { margin: 0, fontFamily: "var(--font-sans)", fontSize: 14, lineHeight: 1.6, color: "var(--aurora-text-primary)" } }, data.summary),
+      ], { background: tint(tones.base, 8, "var(--axon-control)"), border: `1px solid ${tint(tones.base, 26)}` }));
+    }
+    if (kind === "search" && data.auto_crawl_status) {
+      items.push(el("div", { style: { display: "flex", alignItems: "center", gap: 8, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--aurora-text-muted)" } }, [
+        Icon("crawl", 13, "var(--axon-orange-strong)"), "auto-crawl: ",
+        el("span", { style: { color: "var(--aurora-success)" } }, `${data.auto_crawl_status.enqueued} enqueued`),
+        ` · ${data.auto_crawl_status.skipped} skipped`,
+      ]));
+    }
+    (data.results || []).forEach((r) => {
+      items.push(Card([
+        el("div", { style: { display: "flex", alignItems: "baseline", gap: 8 } }, [
+          el("span", { style: { fontFamily: "var(--font-display)", fontWeight: 700, fontSize: 14, color: "var(--aurora-text-primary)", flex: 1, minWidth: 0 } }, r.title),
+          r.score != null ? Mono(`${(r.score * 100).toFixed(0)}`, tones.fg, 10) : null,
+        ]),
+        Mono(hostOf(r.url), "var(--aurora-accent-strong)", 11.5),
+        r.snippet ? el("p", { style: { margin: 0, fontFamily: "var(--font-sans)", fontSize: 13, lineHeight: 1.5, color: "var(--aurora-text-muted)", overflowWrap: "anywhere" } }, r.snippet) : null,
+      ], { display: "flex", flexDirection: "column", gap: 6 }));
+    });
+    return col(items, 10);
+  }
+
+  /* ── summarize → single synthesized summary ── */
+  function SummaryCard(data, tones) {
+    return col([
+      el("div", { style: { display: "flex", gap: 8, flexWrap: "wrap" } }, [
+        ...(data.urls || []).map((u) => el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--aurora-accent-strong)", padding: "3px 9px", borderRadius: 999, background: tint(tones.base, 10, "var(--axon-control)"), border: `1px solid ${tint(tones.base, 26)}` } }, hostOf(u))),
+        data.context_chars != null ? Mono(`${Number(data.context_chars).toLocaleString()} ctx chars${data.context_truncated ? " · truncated" : ""}`) : null,
+      ]),
+      Card([el("p", { style: { margin: 0, fontFamily: "var(--font-sans)", fontSize: 14, lineHeight: 1.62, color: "var(--aurora-text-primary)" } }, data.summary)], { background: tint(tones.base, 8, "var(--axon-control)"), border: `1px solid ${tint(tones.base, 26)}` }),
+    ], 10);
+  }
+
+  /* ── map → discovered URL list ── */
+  function MapUrls(data, tones) {
+    return col([
+      Mono(`${data.mapped_urls} of ${data.total} URLs · bodies skipped`),
+      Card(data.urls.map((u, i) => el("div", { style: { display: "flex", alignItems: "center", gap: 9, padding: "7px 8px", borderTop: i ? "1px solid var(--aurora-border-default)" : "none" } }, [
+        Icon("link", 12, tones.fg),
+        el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 12, color: "var(--aurora-text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } }, hostOf(u)),
+      ])), { padding: "6px 6px", display: "flex", flexDirection: "column" }),
+    ], 8);
+  }
+
+  /* ── sources → the indexed-doc library ── */
+  function SourcesList(data, tones, onOpenDoc) {
+    const totalChunks = data.urls.reduce((n, u) => n + (u[1] || 0), 0);
+    return col([
+      Mono(`${data.count} documents · ${totalChunks.toLocaleString()} chunks`),
+      ...data.urls.map(([url, chunks]) => el("button", {
+        style: { all: "unset", cursor: onOpenDoc ? "pointer" : "default", boxSizing: "border-box", width: "100%" },
+        ...(onOpenDoc ? { onclick: () => onOpenDoc(url) } : {}),
+      }, Card([
+        el("span", { style: { width: 34, height: 34, flex: "0 0 34px", borderRadius: 9, display: "grid", placeItems: "center", color: tones.fg, background: tint(tones.base, 12, "var(--axon-page)"), border: `1px solid ${tint(tones.base, 26)}` } }, Icon("file", 16)),
+        el("div", { style: { flex: 1, minWidth: 0 } }, [
+          el("div", { style: { fontFamily: "var(--font-sans)", fontWeight: 650, fontSize: 13.5, color: "var(--aurora-text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } }, hostOf(url).split("/").slice(1).join("/") || hostOf(url)),
+          el("div", { style: { marginTop: 2, display: "flex", gap: 8, alignItems: "center" } }, [Mono(hostOf(url).split("/")[0], "var(--aurora-accent-strong)", 11)]),
+        ]),
+        el("div", { style: { textAlign: "right", flex: "0 0 auto" } }, [
+          el("div", { style: { fontFamily: "var(--font-mono)", fontSize: 13, fontWeight: 700, color: tones.fg, fontVariantNumeric: "tabular-nums" } }, Number(chunks || 0).toLocaleString()),
+          Mono("chunks", null, 9.5),
+        ]),
+        onOpenDoc ? Icon("chevronRight", 16, "var(--aurora-text-muted)") : null,
+      ], { display: "flex", alignItems: "center", gap: 11 }))),
+    ], 8);
+  }
+
+  /* ── retrieve → the doc viewer body ── */
+  function RetrieveDoc(data, tones) {
+    return col([
+      Card([
+        el("div", { style: { display: "flex", alignItems: "center", gap: 8 } }, [
+          Icon("link", 13, tones.fg),
+          el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 12, color: "var(--aurora-text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } }, hostOf(data.matched_url)),
+        ]),
+        el("div", { style: { display: "flex", gap: 14, flexWrap: "wrap" } }, [
+          el("span", { style: { display: "inline-flex", alignItems: "center", gap: 6 } }, [Icon("layers", 12, tones.fg), Mono(`${Number(data.chunk_count || 0).toLocaleString()} chunks`, tones.fg)]),
+          el("span", { style: { display: "inline-flex", alignItems: "center", gap: 6 } }, [Icon("hash", 12), Mono(`~${Number(data.token_estimate || 0).toLocaleString()} tokens`)]),
+          el("span", { style: { display: "inline-flex", alignItems: "center", gap: 6 } }, [el("span", { style: { width: 6, height: 6, borderRadius: 999, background: "var(--aurora-success)", boxShadow: "0 0 6px var(--aurora-success)" } }), Mono(data.refresh_status || "fresh", "var(--aurora-success)")]),
+        ]),
+      ], { display: "flex", flexDirection: "column", gap: 9, background: "var(--axon-page)" }),
+      MdBlocks(data.blocks, tones),
+    ], 12);
+  }
+
+  /* ── stats → collection metrics ── */
+  function StatsGrid(data, tones) {
+    const p = data.payload;
+    const cells = [
+      { label: "Documents", value: num(p.documents), color: tones.fg },
+      { label: "Chunks", value: num(p.chunks) },
+      { label: "Vectors", value: num(p.vectors) },
+      { label: "Domains", value: p.domains != null ? p.domains : "—" },
+      { label: "Dim", value: p.dim != null ? p.dim : "—" },
+      { label: "Storage", value: p.storage_bytes != null ? `${(p.storage_bytes / 1e6).toFixed(0)} MB` : "—" },
+    ];
+    const rows = [
+      ["collection", p.collection], ["mode", p.mode], ["embedding model", p.embedding_model], ["last indexed", p.last_indexed],
+    ].filter(([, v]) => v != null);
+    return col([
+      el("div", { style: { display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 9 } }, cells.map((c) => Card([
+        el("div", { class: "aurora-muted-label", style: { fontSize: 9.5, letterSpacing: "0.14em" } }, c.label),
+        el("div", { style: { marginTop: 5, fontFamily: "var(--font-display)", fontWeight: 800, fontSize: 20, letterSpacing: "-0.03em", fontVariantNumeric: "tabular-nums", color: c.color || "var(--aurora-text-primary)" } }, c.value),
+      ], { padding: "11px 12px" }))),
+      rows.length ? Card(rows.map(([k, v]) => el("div", { style: { display: "flex", justifyContent: "space-between" } }, [Mono(k), Mono(String(v), k === "last indexed" ? "var(--aurora-success)" : "var(--aurora-text-primary)")])), { display: "flex", flexDirection: "column", gap: 7 }) : null,
+    ], 11);
+  }
+
+  /* ── domains → vector counts per domain ── */
+  function DomainsList(data, tones) {
+    const max = Math.max(1, ...data.domains.map((d) => d.vectors || 0));
+    return col([
+      Mono(`${data.domains.length} domains`),
+      Card(data.domains.map((d) => el("div", { style: { display: "flex", alignItems: "center", gap: 11 } }, [
+        el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 12.5, color: "var(--aurora-text-primary)", width: 150, flex: "0 0 auto", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } }, d.domain),
+        el("div", { style: { flex: 1 } }, Bar(((d.vectors || 0) / max) * 100, tones, 6)),
+        Mono(Number(d.vectors || 0).toLocaleString(), tones.fg, 11),
+      ])), { display: "flex", flexDirection: "column", gap: 11 }),
+    ], 8);
+  }
+
+  /* ── suggest → gap analysis with crawl/ingest chips ── */
+  function SuggestList(data, tones, onAct) {
+    return col([
+      Mono(`${data.urls.length} suggestions · gaps in the corpus`),
+      ...data.urls.map((s) => {
+        const ingest = /github\.com|reddit\.com|youtube\.com/.test(s.url);
+        const chipTone = ingest ? "var(--axon-orange)" : "var(--aurora-accent-primary)";
+        const chipFg = ingest ? "var(--axon-orange-strong)" : "var(--aurora-accent-strong)";
+        return Card([
+          Icon(ingest ? "box" : "scrape", 16, tones.fg),
+          el("div", { style: { flex: 1, minWidth: 0 } }, [
+            Mono(hostOf(s.url), "var(--aurora-accent-strong)", 12),
+            s.reason ? el("div", { style: { marginTop: 3, fontFamily: "var(--font-sans)", fontSize: 12, fontStyle: "italic", color: "var(--aurora-text-muted)" } }, s.reason) : null,
+          ]),
+          el("button", { style: { all: "unset", cursor: "pointer", fontFamily: "var(--font-sans)", fontSize: 12, fontWeight: 650, color: chipFg, padding: "5px 11px", borderRadius: 8, background: tint(chipTone, 12, "var(--axon-control)"), border: `1px solid ${tint(chipTone, 30)}`, flex: "0 0 auto" }, ...(onAct ? { onclick: () => onAct(ingest ? "ingest" : "crawl", s.url) } : {}) }, ingest ? "Ingest" : "Crawl"),
+        ], { display: "flex", alignItems: "center", gap: 11 });
+      }),
+    ], 9);
+  }
+
+  /* ── doctor → service health ── */
+  function DoctorReport(data, tones) {
+    const p = data.payload;
+    const dot = (s) => (s === "ok" ? "var(--aurora-success)" : s === "warn" ? "var(--aurora-warn)" : "var(--aurora-error)");
+    return col([
+      el("div", { style: { display: "inline-flex", alignItems: "center", gap: 8 } }, [
+        Icon("check", 14, p.ok ? "var(--aurora-success)" : "var(--aurora-error)"),
+        el("span", { style: { fontFamily: "var(--font-display)", fontWeight: 800, fontSize: 15, color: "var(--aurora-text-primary)" } }, p.ok ? "Stack healthy" : "Issues found"),
+      ]),
+      ...p.services.map((s) => Card([
+        el("span", { style: { width: 8, height: 8, borderRadius: 999, flex: "0 0 auto", background: dot(s.status), boxShadow: `0 0 6px ${dot(s.status)}` } }),
+        el("div", { style: { flex: 1, minWidth: 0 } }, [
+          el("div", { style: { fontFamily: "var(--font-sans)", fontWeight: 650, fontSize: 13.5, color: "var(--aurora-text-primary)" } }, s.name),
+          s.detail ? Mono(s.detail, null, 11) : null,
+        ]),
+        Mono(s.ms == null ? "skipped" : `${s.ms} ms`, s.ms == null ? "var(--aurora-warn)" : "var(--aurora-text-muted)", 11),
+      ], { display: "flex", alignItems: "center", gap: 11 })),
+    ], 9);
+  }
+
+  /* ── status → running/pending job rollup ── */
+  function StatusReport(data, tones) {
+    const p = data.payload;
+    return col([
+      el("div", { style: { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 9 } }, [
+        Card([el("div", { class: "aurora-muted-label", style: { fontSize: 9.5, letterSpacing: "0.14em" } }, "Running"), el("div", { style: { marginTop: 5, fontFamily: "var(--font-display)", fontWeight: 800, fontSize: 22, color: tones.fg } }, p.running)], { padding: "11px 12px" }),
+        Card([el("div", { class: "aurora-muted-label", style: { fontSize: 9.5, letterSpacing: "0.14em" } }, "Pending"), el("div", { style: { marginTop: 5, fontFamily: "var(--font-display)", fontWeight: 800, fontSize: 22, color: "var(--aurora-text-primary)" } }, p.pending)], { padding: "11px 12px" }),
+      ]),
+      Object.keys(p.by_type || {}).length ? Card(Object.entries(p.by_type).map(([k, v]) => el("div", { style: { display: "flex", alignItems: "center", gap: 10 } }, [
+        el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 12.5, color: "var(--aurora-text-primary)", flex: 1, textTransform: "capitalize" } }, k),
+        Mono(`${v.running} running`, v.running ? tones.fg : "var(--aurora-text-muted)"),
+        Mono(`· ${v.pending} pending`),
+      ])), { display: "flex", flexDirection: "column", gap: 8 }) : null,
+    ], 10);
+  }
+
+  /* ── ingest / embed / extract / crawl → accepted async job ── */
+  function JobAccepted(data, op, tones) {
+    const rows = [];
+    if (data.source_type) rows.push(["source", data.source_type]);
+    if (data.target) rows.push(["target", data.target]);
+    rows.push(["job id", data.job_id || "—"]);
+    return Card([
+      el("div", { style: { display: "flex", alignItems: "center", gap: 10 } }, [
+        el("span", { style: { width: 36, height: 36, flex: "0 0 36px", borderRadius: 10, display: "grid", placeItems: "center", color: "var(--axon-orange-strong)", background: tint("var(--axon-orange)", 14, "var(--axon-page)"), border: `1px solid ${tint("var(--axon-orange)", 30)}` } }, Icon(op.icon, 18)),
+        el("div", null, [
+          el("div", { style: { fontFamily: "var(--font-display)", fontWeight: 800, fontSize: 15, color: "var(--aurora-text-primary)" } }, "Job accepted"),
+          Mono(`${data.status || "pending"} · async`, "var(--axon-orange-strong)"),
+        ]),
+      ]),
+      el("div", { style: { display: "flex", flexDirection: "column", gap: 6 } }, rows.map(([k, v]) => el("div", { style: { display: "flex", justifyContent: "space-between", gap: 12 } }, [Mono(k), el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 11.5, color: "var(--aurora-text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 } }, String(v))]))),
+      data.status_url ? Mono(`Track it in Jobs · ${data.status_url}`, null, 11) : null,
+    ], { display: "flex", flexDirection: "column", gap: 12, background: tint("var(--axon-orange)", 8, "var(--axon-control)"), border: `1px solid ${tint("var(--axon-orange)", 28)}` });
+  }
+
+  /* ── diff → added / removed / changed ── */
+  function DiffView(data, tones) {
+    const Group = (label, items, color, sign) => (items && items.length ? Card([
+      Mono(`${sign} ${label} (${items.length})`, color),
+      ...items.map((t) => el("div", { style: { display: "flex", gap: 9, fontFamily: "var(--font-sans)", fontSize: 13, color: "var(--aurora-text-primary)" } }, [el("span", { style: { color, flex: "0 0 auto" } }, sign), el("span", null, t)])),
+    ], { display: "flex", flexDirection: "column", gap: 8 }) : null);
+    return col([
+      Mono(`${hostOf(data.url_a)} → ${hostOf(data.url_b)}`),
+      Group("added", data.added, "var(--aurora-success)", "+"),
+      Group("removed", data.removed, "var(--aurora-error)", "−"),
+      Group("changed", data.changed, "var(--aurora-warn)", "~"),
+    ], 10);
+  }
+
+  /* ── brand → palette + type ── */
+  function BrandPalette(data, tones) {
+    return col([
+      Mono(`${hostOf(data.url)} · ${data.colors.length} colors · ${data.fonts.length} faces`),
+      el("div", { style: { display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: 8 } }, data.colors.map((c) => el("div", { style: { display: "flex", flexDirection: "column", gap: 5 } }, [
+        el("div", { style: { height: 46, borderRadius: 10, background: c.hex, border: "1px solid var(--aurora-border-default)" } }),
+        Mono(c.hex, "var(--aurora-text-primary)", 9.5),
+        c.role ? Mono(c.role, null, 9) : null,
+      ]))),
+      data.fonts.length ? Card(data.fonts.map((f) => el("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "baseline" } }, [
+        el("span", { style: { fontFamily: "var(--font-display)", fontSize: 15, color: "var(--aurora-text-primary)" } }, f.family),
+        Mono(f.role),
+      ])), { display: "flex", flexDirection: "column", gap: 8 }) : null,
+    ], 11);
+  }
+
+  /* ── endpoints → discovered API surface ── */
+  function EndpointsList(data, tones) {
+    const kindColor = (k) => (k === "graphql" ? "#e535ab" : k === "websocket" ? "var(--axon-orange-strong)" : k === "rpc" ? "var(--aurora-accent-pink-strong)" : tones.fg);
+    return col([
+      Mono(`${hostOf(data.url)} · ${data.endpoints.length} endpoints · ${data.bundles.length} bundles${data.rpc_probed ? " · rpc probed" : ""}`),
+      ...data.endpoints.map((e) => Card([
+        el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 700, color: "var(--aurora-text-muted)", width: 38, flex: "0 0 auto" } }, e.method),
+        el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 12.5, color: "var(--aurora-text-primary)", flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } }, e.path),
+        e.kind ? el("span", { style: { fontFamily: "var(--font-mono)", fontSize: 9.5, color: kindColor(e.kind), padding: "2px 7px", borderRadius: 5, border: `1px solid ${tint(kindColor(e.kind), 30)}` } }, e.kind) : null,
+      ], { display: "flex", alignItems: "center", gap: 10, padding: "10px 12px" })),
+    ], 8);
+  }
+
+  /* ── screenshot → captured image placeholder ── */
+  function ScreenshotView(data, tones) {
+    return col([
+      Mono(`${hostOf(data.url)}${data.width ? ` · ${data.width}×${data.height}` : ""}${data.bytes ? ` · ${data.bytes}` : ""}${data.full_page ? " · full page" : ""}`),
+      el("div", { style: { borderRadius: 12, overflow: "hidden", border: "1px solid var(--aurora-border-default)", background: "var(--axon-page)", aspectRatio: "3 / 4", maxHeight: 340, display: "grid", placeItems: "center", backgroundImage: "repeating-linear-gradient(135deg, transparent, transparent 11px, rgba(41,182,246,0.05) 11px, rgba(41,182,246,0.05) 22px)" } }, [
+        el("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 9, color: "var(--aurora-text-muted)" } }, [Icon("camera", 28, tones.fg), data.path ? Mono(data.path, null, 10.5) : null]),
+      ]),
+    ], 10);
+  }
+
+  /* ── evaluate → readable score card (real /v1/evaluate shape) ── */
+  function EvaluateReport(data, tones) {
+    const metrics = ["accuracy", "relevance", "completeness", "specificity"].filter((k) => data[k] != null);
+    return col([
+      data.verdict ? Card([
+        Mono("VERDICT", tones.fg, 10.5),
+        el("div", { style: { marginTop: 4, fontFamily: "var(--font-display)", fontWeight: 800, fontSize: 18, color: "var(--aurora-text-primary)", textTransform: "capitalize" } }, data.verdict),
+      ]) : null,
+      metrics.length ? Card(metrics.map((k) => el("div", { style: { display: "flex", alignItems: "center", gap: 10 } }, [
+        el("span", { style: { fontFamily: "var(--font-sans)", fontSize: 12.5, color: "var(--aurora-text-primary)", width: 110, flex: "0 0 auto", textTransform: "capitalize" } }, k),
+        el("div", { style: { flex: 1 } }, Bar(scorePct(data[k]), tones, 6)),
+        Mono(String(data[k]), tones.fg),
+      ])), { display: "flex", flexDirection: "column", gap: 10 }) : null,
+      data.explanation || data.reasoning ? Card([el("p", { style: { margin: 0, fontFamily: "var(--font-sans)", fontSize: 13.5, lineHeight: 1.6, color: "var(--aurora-text-primary)" } }, data.explanation || data.reasoning)]) : null,
+    ].filter(Boolean), 11);
+  }
+
+  /* ── ask → answer + citations ── */
+  function AskAnswer(data, tones) {
+    return col([
+      el("div", { style: { display: "flex", gap: 11, alignItems: "flex-start" } }, [
+        el("span", { style: { width: 28, height: 28, flex: "0 0 28px", borderRadius: 8, display: "grid", placeItems: "center", background: tint(tones.base, 14, "var(--axon-control)"), border: `1px solid ${tint(tones.base, 30)}` } }, window.AxonIcons.axonMark(18)),
+        el("div", { style: { minWidth: 0, display: "flex", flexDirection: "column", gap: 10 } }, [
+          el("p", { style: { margin: 0, fontFamily: "var(--font-sans)", fontSize: 14, lineHeight: 1.62, color: "var(--aurora-text-primary)", overflowWrap: "anywhere" } }, data.answer),
+          data.citations && data.citations.length ? el("div", { style: { display: "flex", flexWrap: "wrap", gap: 7 } }, data.citations.map((c, i) => el("span", { style: { display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--font-mono)", fontSize: 10.5, color: tones.fg, padding: "3px 9px", borderRadius: 999, background: tint(tones.base, 10, "var(--axon-control)"), border: `1px solid ${tint(tones.base, 26)}` } }, [
+            el("span", { style: { fontWeight: 600 } }, String(c.n != null ? c.n : i + 1)),
+            el("span", { style: { color: "var(--aurora-text-muted)" } }, c.src || c),
+          ]))) : null,
+        ]),
+      ]),
+    ], 10);
+  }
+
+  /* ── generic fallback — readable JSON ── */
+  function GenericResult(op, raw) {
+    let text;
+    try { text = JSON.stringify(raw, null, 2); } catch { text = String(raw); }
+    if (text && text.length > 6000) text = `${text.slice(0, 6000)}\n…[truncated]`;
+    return col([
+      Mono(`${op.name} · response`),
+      el("div", { style: { borderRadius: 11, overflow: "hidden", border: "1px solid var(--aurora-border-default)", background: "var(--axon-page)" } }, [
+        el("pre", { style: { margin: 0, padding: "12px 14px", overflowX: "auto", fontFamily: "var(--font-mono)", fontSize: 12, lineHeight: 1.55, color: "var(--aurora-text-primary)", whiteSpace: "pre-wrap", overflowWrap: "anywhere" } }, text),
+      ]),
+    ], 9);
+  }
+
+  /* ── helpers for normalizers ── */
+  function payloadOf(r) { return r && typeof r === "object" && r.payload && typeof r.payload === "object" ? r.payload : r; }
+  function arr(v) { return Array.isArray(v) ? v : []; }
+  function num(v) { return v == null ? "—" : Number(v).toLocaleString(); }
+  function scorePct(v) { const n = Number(v); if (!Number.isFinite(n)) return 0; return n <= 1 ? n * 100 : n; }
+  function markdownToBlocks(md, title) {
+    const blocks = [];
+    if (title) blocks.push({ t: "h1", x: title });
+    const lines = String(md || "").split("\n");
+    let para = [];
+    let code = null;
+    const flush = () => { if (para.length) { blocks.push({ t: "p", x: para.join(" ").trim() }); para = []; } };
+    for (const line of lines) {
+      const fence = line.match(/^```(\w*)/);
+      if (fence) { if (code) { blocks.push({ t: "code", lang: code.lang, x: code.body.join("\n") }); code = null; } else { flush(); code = { lang: fence[1] || "text", body: [] }; } continue; }
+      if (code) { code.body.push(line); continue; }
+      const h = line.match(/^(#{1,6})\s+(.*)$/);
+      if (h) { flush(); blocks.push({ t: h[1].length === 1 ? "h1" : "h2", x: h[2].trim() }); continue; }
+      if (!line.trim()) { flush(); continue; }
+      para.push(line.replace(/^[-*]\s+/, "").trim());
+    }
+    if (code) blocks.push({ t: "code", lang: code.lang, x: code.body.join("\n") });
+    flush();
+    return blocks.slice(0, 80);
+  }
+
+  /* ── normalizers: real /v1/* response → render data (null = fall back) ── */
+  const PREP = {
+    query(r) {
+      const hits = arr(r.results).length ? r.results : arr(r.hits).length ? r.hits : arr(payloadOf(r).results);
+      if (!hits.length) return null;
+      return { results: hits.map((h, i) => {
+        const p = h.payload || h;
+        return {
+          rank: h.rank || i + 1,
+          score: h.score != null ? h.score : h.similarity != null ? h.similarity : p.score || 0,
+          rerank_score: h.rerank_score != null ? h.rerank_score : h.score != null ? h.score : 0,
+          url: p.url || p.source_url || h.url || "",
+          snippet: p.chunk_text || p.text || p.content || p.snippet || p.title || "",
+          chunk_index: p.chunk_index != null ? p.chunk_index : h.chunk_index != null ? h.chunk_index : 0,
+        };
+      }) };
+    },
+    search(r) {
+      const p = payloadOf(r);
+      const results = arr(p.results).length ? p.results : arr(r.results);
+      const jobs = p.auto_crawl_status || (arr(p.crawl_jobs).length ? { enqueued: p.crawl_jobs.length, skipped: 0 } : null);
+      return { results: results.map((x) => ({ title: x.title || x.url || x.href || "Result", url: x.url || x.href || "", snippet: x.snippet || x.content || x.text || "", score: x.score })), auto_crawl_status: jobs };
+    },
+    research(r) {
+      const p = payloadOf(r);
+      const results = arr(p.search_results).length ? p.search_results : arr(p.results).length ? p.results : arr(r.results);
+      return { summary: p.summary || p.answer || p.synthesis || "", results: results.map((x) => ({ title: x.title || x.url || "Result", url: x.url || x.href || "", snippet: x.snippet || x.content || "", score: x.score })) };
+    },
+    summarize(r) {
+      const p = payloadOf(r);
+      const summary = p.summary || r.summary;
+      if (!summary) return null;
+      return { summary, urls: arr(p.urls || r.urls), context_chars: p.context_chars != null ? p.context_chars : r.context_chars, context_truncated: p.context_truncated || r.context_truncated };
+    },
+    map(r) {
+      const p = payloadOf(r);
+      const urls = arr(p.urls).length ? p.urls : arr(r.urls);
+      return { urls: urls.slice(0, 200), total: p.total != null ? p.total : r.total != null ? r.total : urls.length, mapped_urls: p.mapped_urls != null ? p.mapped_urls : urls.length };
+    },
+    sources(r) {
+      const p = payloadOf(r);
+      const raw = arr(p.sources).length ? p.sources : arr(p.urls).length ? p.urls : arr(r.sources);
+      if (!raw.length) return null;
+      const urls = raw.map((s) => {
+        if (Array.isArray(s)) return [s[0], s[1] || 0];
+        if (typeof s === "string") return [s, 0];
+        return [s.url || s.source_url || s.id || "", s.chunk_count != null ? s.chunk_count : s.chunks != null ? s.chunks : s.points || 0];
+      });
+      return { count: p.count != null ? p.count : urls.length, urls };
+    },
+    domains(r) {
+      const p = payloadOf(r);
+      const raw = arr(p.domains).length ? p.domains : arr(r.domains);
+      if (!raw.length) return null;
+      return { domains: raw.map((d) => (typeof d === "string" ? { domain: d, vectors: 0 } : { domain: d.domain || d.host || d.name || "", vectors: d.vectors != null ? d.vectors : d.chunk_count != null ? d.chunk_count : d.chunks || 0 })) };
+    },
+    retrieve(r) {
+      const p = payloadOf(r);
+      const chunks = arr(p.chunks).length ? p.chunks : arr(p.points).length ? p.points : arr(r.chunks);
+      const matched = p.matched_url || r.matched_url || p.requested_url || r.requested_url || "";
+      let blocks = [];
+      chunks.slice(0, 12).forEach((c) => {
+        const cp = c.payload || c;
+        const txt = cp.text || cp.chunk_text || cp.content || cp.markdown || "";
+        blocks = blocks.concat(markdownToBlocks(txt));
+      });
+      if (!blocks.length) return null;
+      return {
+        matched_url: matched,
+        chunk_count: p.chunk_count != null ? p.chunk_count : chunks.length,
+        token_estimate: p.token_estimate != null ? p.token_estimate : 0,
+        truncated: !!(p.truncated || r.truncated),
+        refresh_status: p.refresh_status || "fresh",
+        blocks: blocks.slice(0, 80),
+      };
+    },
+    stats(r) {
+      const p = payloadOf(r);
+      if (!p || typeof p !== "object") return null;
+      return { payload: {
+        documents: p.documents != null ? p.documents : p.document_count,
+        chunks: p.chunks != null ? p.chunks : p.chunk_count,
+        vectors: p.vectors != null ? p.vectors : p.vector_count != null ? p.vector_count : p.points_count,
+        domains: p.domains != null ? p.domains : p.domain_count,
+        dim: p.dim != null ? p.dim : p.dimension,
+        storage_bytes: p.storage_bytes != null ? p.storage_bytes : p.bytes,
+        collection: p.collection || p.collection_name,
+        mode: p.mode || p.vector_mode,
+        embedding_model: p.embedding_model || p.model,
+        last_indexed: p.last_indexed,
+      } };
+    },
+    doctor(r) {
+      const p = payloadOf(r);
+      const rawServices = p.services;
+      let services = [];
+      if (Array.isArray(rawServices)) {
+        services = rawServices.map((s) => ({ name: s.name || s.id, status: s.status || (s.ok ? "ok" : "fail"), detail: s.detail, ms: s.ms != null ? s.ms : null }));
+      } else if (rawServices && typeof rawServices === "object") {
+        services = Object.entries(rawServices).map(([name, s]) => ({ name: name.replace(/_/g, " ").replace(/\b\w/g, (m) => m.toUpperCase()), status: s && s.ok ? "ok" : s && s.ok === false ? "fail" : "warn", detail: s && s.detail, ms: s && s.ms != null ? s.ms : null }));
+      } else return null;
+      return { payload: { ok: p.all_ok != null ? p.all_ok : p.ok, services } };
+    },
+    status(r) {
+      const p = payloadOf(r);
+      const byType = {};
+      let running = 0; let pending = 0;
+      const groups = Object.entries(p).filter(([k, v]) => k.endsWith("_jobs") && Array.isArray(v));
+      if (groups.length) {
+        groups.forEach(([k, jobs]) => {
+          const kind = k.replace(/^local_/, "").replace(/_jobs$/, "");
+          let run = 0; let pend = 0;
+          jobs.forEach((j) => { const st = String(j.status || (j.finished_at ? "completed" : j.started_at ? "running" : "pending")).toLowerCase(); if (st === "running") run += 1; else if (st === "pending" || st === "queued") pend += 1; });
+          byType[kind] = { running: run, pending: pend }; running += run; pending += pend;
+        });
+        return { payload: { running, pending, by_type: byType } };
+      }
+      if (p.running != null || p.pending != null) return { payload: { running: p.running || 0, pending: p.pending || 0, by_type: p.by_type || {} } };
+      return null;
+    },
+    suggest(r) {
+      const p = payloadOf(r);
+      const raw = arr(p.suggestions).length ? p.suggestions : arr(p.urls).length ? p.urls : arr(r.suggestions);
+      if (!raw.length) return null;
+      return { urls: raw.map((s) => (typeof s === "string" ? { url: s, reason: "" } : { url: s.url || s.href || "", reason: s.reason || s.title || "" })) };
+    },
+    job(r) {
+      const p = payloadOf(r);
+      return { job_id: r.job_id || r.jobId || r.id || p.job_id || p.id || "", status: r.status || p.status || "pending", status_url: r.status_url || p.status_url, target: r.target || p.target, source_type: r.source_type || p.source_type };
+    },
+    diff(r) {
+      const p = payloadOf(r);
+      if (!p.added && !p.removed && !p.changed) return null;
+      return { url_a: p.url_a || r.url_a || "", url_b: p.url_b || r.url_b || "", added: arr(p.added), removed: arr(p.removed), changed: arr(p.changed) };
+    },
+    brand(r) {
+      const p = payloadOf(r);
+      const colors = arr(p.colors).map((c) => (typeof c === "string" ? { hex: c } : { hex: c.hex || c.value || c.color, role: c.role || c.name }));
+      if (!colors.length) return null;
+      return { url: p.url || r.url || "", colors: colors.slice(0, 10), fonts: arr(p.fonts).map((f) => (typeof f === "string" ? { family: f } : { family: f.family || f.name, role: f.role || "" })) };
+    },
+    endpoints(r) {
+      const p = payloadOf(r);
+      const eps = arr(p.endpoints);
+      if (!eps.length) return null;
+      return { url: p.url || r.url || "", endpoints: eps.map((e) => ({ method: e.method || "GET", path: e.path || e.url || "", kind: e.kind || e.type || "rest" })), bundles: arr(p.bundles), rpc_probed: !!p.rpc_probed };
+    },
+    screenshot(r) {
+      const p = payloadOf(r);
+      return { url: p.url || r.url || "", width: p.width, height: p.height, bytes: p.bytes, full_page: p.full_page, path: p.path || p.screenshot_path };
+    },
+    evaluate(r) { const p = payloadOf(r); return p && typeof p === "object" ? p : null; },
+    ask(r) {
+      const p = payloadOf(r);
+      const answer = r.answer || p.answer || "";
+      if (!answer) return null;
+      let citations = arr(r.citations).length ? r.citations : arr(p.citations).length ? p.citations : arr(p.sources);
+      citations = citations.map((c, i) => (typeof c === "string" ? { n: i + 1, src: hostOf(c) } : { n: c.n != null ? c.n : i + 1, src: c.src || c.source || hostOf(c.url || "") }));
+      return { answer, citations };
+    },
+    scrape(r) {
+      const p = payloadOf(r);
+      const md = r.markdown || p.markdown || r.content || p.content || r.output || "";
+      const title = r.title || p.title;
+      const blocks = md ? markdownToBlocks(md, title) : (title ? [{ t: "h1", x: title }] : []);
+      if (!blocks.length) return null;
+      return { blocks };
+    },
+  };
+
+  /* ── dispatch ── */
+  function ActionBody(op, raw, tones, handlers) {
+    handlers = handlers || {};
+    try {
+      const id = op.id;
+      if (id === "query") { const d = PREP.query(raw); return d ? QueryHits(d, tones) : GenericResult(op, raw); }
+      if (id === "search") { return WebResults(PREP.search(raw), tones, "search"); }
+      if (id === "research") { return WebResults(PREP.research(raw), tones, "research"); }
+      if (id === "summarize") { const d = PREP.summarize(raw); return d ? SummaryCard(d, tones) : GenericResult(op, raw); }
+      if (id === "map") { return MapUrls(PREP.map(raw), tones); }
+      if (id === "sources") { const d = PREP.sources(raw); return d ? SourcesList(d, tones, handlers.onOpenDoc) : GenericResult(op, raw); }
+      if (id === "retrieve") { const d = PREP.retrieve(raw); return d ? RetrieveDoc(d, tones) : GenericResult(op, raw); }
+      if (id === "stats") { const d = PREP.stats(raw); return d ? StatsGrid(d, tones) : GenericResult(op, raw); }
+      if (id === "domains") { const d = PREP.domains(raw); return d ? DomainsList(d, tones) : GenericResult(op, raw); }
+      if (id === "suggest") { const d = PREP.suggest(raw); return d ? SuggestList(d, tones, handlers.onAct) : GenericResult(op, raw); }
+      if (id === "doctor") { const d = PREP.doctor(raw); return d ? DoctorReport(d, tones) : GenericResult(op, raw); }
+      if (id === "status") { const d = PREP.status(raw); return d ? StatusReport(d, tones) : GenericResult(op, raw); }
+      if (id === "ingest" || id === "embed" || id === "extract" || id === "crawl") { return JobAccepted(PREP.job(raw), op, tones); }
+      if (id === "diff") { const d = PREP.diff(raw); return d ? DiffView(d, tones) : GenericResult(op, raw); }
+      if (id === "brand") { const d = PREP.brand(raw); return d ? BrandPalette(d, tones) : GenericResult(op, raw); }
+      if (id === "endpoints") { const d = PREP.endpoints(raw); return d ? EndpointsList(d, tones) : GenericResult(op, raw); }
+      if (id === "screenshot") { return ScreenshotView(PREP.screenshot(raw), tones); }
+      if (id === "evaluate") { const d = PREP.evaluate(raw); return d ? EvaluateReport(d, tones) : GenericResult(op, raw); }
+      if (id === "ask") { const d = PREP.ask(raw); return d ? AskAnswer(d, tones) : GenericResult(op, raw); }
+      if (id === "scrape") { const d = PREP.scrape(raw); return d ? MdBlocks(d.blocks, tones) : GenericResult(op, raw); }
+      return GenericResult(op, raw);
+    } catch (e) {
+      return GenericResult(op, raw);
+    }
+  }
+
+  /* Build a doc-viewer body from a raw /v1/retrieve response. */
+  function RetrieveDocFromRaw(raw, tones) {
+    const d = PREP.retrieve(raw);
+    return d ? RetrieveDoc(d, tones) : GenericResult({ id: "retrieve", name: "Document" }, raw);
+  }
+
+  window.AxonRender = { el, Icon, ActionBody, RetrieveDocFromRaw, GenericResult };
+})();

--- a/apps/chrome-extension/launcher.css
+++ b/apps/chrome-extension/launcher.css
@@ -1,0 +1,109 @@
+/* ============================================================
+ * Axon Chrome Extension — side-panel launcher
+ * Aurora-aligned quick-action launcher: brand strip + current-tab
+ * quick actions + grouped action browse → run → result/doc flow.
+ *
+ * Recreated from the design handoff "Axon Extension.html" (the
+ * SidePanel mock). The faux ChromeWindow + page from the mock are
+ * presentation-only and dropped here — this IS the side panel.
+ * ============================================================ */
+
+/* ── Axon accent extension — electric orange (heavy/async ops) ── */
+:root { --axon-orange: #ff9645; --axon-orange-strong: #ffb474; --axon-orange-deep: #c96a1c; }
+.light { --axon-orange: #e0731a; --axon-orange-strong: #c25f10; --axon-orange-deep: #a8540e; }
+
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; }
+body {
+  color: var(--aurora-text-primary);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  /* axon surface aliases — the .light remap cascades into these */
+  --axon-control: var(--aurora-control-surface);
+  --axon-page: var(--aurora-page-bg);
+  --axon-hover: var(--aurora-hover-bg);
+  --axon-surface: var(--aurora-page-bg);
+  background:
+    radial-gradient(420px 280px at 20% -2%, rgba(41,182,246,0.10), transparent 60%),
+    radial-gradient(900px 600px at 50% 0%, #0b1c28, #050c12 70%);
+}
+body.light {
+  background:
+    radial-gradient(420px 280px at 20% -2%, rgba(2,136,209,0.10), transparent 60%),
+    radial-gradient(900px 600px at 50% 0%, #e7f1f5, #d7e7ee 70%);
+}
+
+/* side panel — fills the Chrome side-panel viewport */
+.ext-panel {
+  width: 100%; height: 100%; display: flex; flex-direction: column;
+  background:
+    radial-gradient(420px 280px at 20% -5%, rgba(41,182,246,0.10), transparent 60%),
+    var(--aurora-page-bg);
+}
+
+.ext-head { flex: 0 0 auto; display: flex; align-items: center; gap: 9px; height: 48px; padding: 0 8px 0 14px; border-bottom: 1px solid var(--aurora-border-default); background: var(--aurora-nav-bg); }
+.ext-brand { display: inline-flex; align-items: center; gap: 8px; }
+.ext-word { font-family: var(--font-display); font-weight: 800; font-size: 16px; letter-spacing: -0.02em; color: var(--aurora-text-primary); }
+.ext-dot { width: 6px; height: 6px; border-radius: 999px; background: var(--aurora-success); box-shadow: 0 0 6px var(--aurora-success); }
+.ext-dot.is-off { background: var(--aurora-error); box-shadow: 0 0 6px var(--aurora-error); }
+.ext-dot.is-wait { background: var(--aurora-warn); box-shadow: 0 0 6px var(--aurora-warn); }
+.ext-host { margin-left: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--aurora-text-muted); max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ext-icon { all: unset; cursor: pointer; width: 32px; height: 32px; border-radius: 9px; display: grid; place-items: center; color: var(--aurora-text-muted); flex: 0 0 auto; }
+.ext-icon:hover { background: var(--axon-hover); color: var(--aurora-text-primary); }
+.ext-icon:focus-visible { outline: 2px solid var(--aurora-focus-ring); outline-offset: 1px; }
+
+.ext-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 12px 13px 14px; }
+
+.ext-tabcard { border-radius: 13px; background: var(--axon-control); border: 1px solid var(--aurora-border-default); padding: 11px 12px; margin-bottom: 14px; }
+.ext-tabcard-top { display: flex; align-items: center; gap: 7px; }
+.ext-tablabel { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--aurora-text-muted); }
+.ext-taburl { font-family: var(--font-mono); font-size: 12.5px; color: var(--aurora-accent-strong); margin: 6px 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ext-taburl .dim { color: var(--aurora-text-muted); }
+.ext-quick { display: flex; gap: 7px; }
+.ext-quickbtn { all: unset; cursor: pointer; flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px; height: 32px; border-radius: 9px; font-family: var(--font-sans); font-size: 12px; font-weight: 600; color: var(--aurora-text-primary); background: var(--axon-page); border: 1px solid var(--aurora-border-default); }
+.ext-quickbtn:hover { background: var(--axon-hover); border-color: var(--aurora-border-strong); }
+.ext-quickbtn:focus-visible { outline: 2px solid var(--aurora-focus-ring); outline-offset: 1px; }
+
+.ext-seclabel { font-family: var(--font-sans); font-size: 10px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: var(--aurora-text-muted); margin: 14px 2px 7px; }
+.ext-row { all: unset; cursor: pointer; box-sizing: border-box; width: 100%; display: flex; align-items: center; gap: 11px; padding: 9px 10px; border-radius: 12px; margin-bottom: 5px; background: var(--aurora-panel-medium); border: 1px solid var(--aurora-border-default); }
+.ext-row:hover { background: var(--axon-hover); border-color: var(--aurora-border-strong); }
+.ext-row:focus-visible { outline: 2px solid var(--aurora-focus-ring); outline-offset: 1px; }
+.ext-tile { width: 32px; height: 32px; flex: 0 0 32px; border-radius: 9px; display: grid; place-items: center; }
+.ext-row-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; text-align: left; }
+.ext-row-name { font-family: var(--font-display); font-weight: 800; font-size: 13.5px; letter-spacing: -0.01em; color: var(--aurora-text-primary); display: flex; align-items: center; gap: 7px; }
+.ext-async { font-family: var(--font-mono); font-size: 8px; font-weight: 600; letter-spacing: 0.06em; color: var(--axon-orange-strong); padding: 1px 4px; border-radius: 4px; border: 1px solid color-mix(in srgb, var(--axon-orange) 34%, transparent); }
+.ext-row-sub { font-family: var(--font-sans); font-size: 11.5px; color: var(--aurora-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.ext-result-head { flex: 0 0 auto; display: flex; align-items: center; gap: 9px; padding: 9px 10px; border-bottom: 1px solid var(--aurora-border-default); background: var(--aurora-nav-bg); }
+.ext-result-title { font-family: var(--font-display); font-weight: 800; font-size: 15px; color: var(--aurora-text-primary); }
+.ext-statusbadge { margin-left: auto; display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 10.5px; color: var(--aurora-success); padding: 3px 9px; border-radius: 999px; background: color-mix(in srgb, var(--aurora-success) 12%, var(--axon-control)); border: 1px solid color-mix(in srgb, var(--aurora-success) 26%, transparent); }
+.ext-statusbadge.is-error { color: var(--aurora-error); background: color-mix(in srgb, var(--aurora-error) 12%, var(--axon-control)); border-color: color-mix(in srgb, var(--aurora-error) 26%, transparent); }
+.ext-statusbadge.is-accepted { color: var(--aurora-accent-primary); background: color-mix(in srgb, var(--aurora-accent-primary) 12%, var(--axon-control)); border-color: color-mix(in srgb, var(--aurora-accent-primary) 26%, transparent); }
+
+/* arg bar — editable target/query for the running action */
+.ext-argbar { flex: 0 0 auto; display: flex; align-items: center; gap: 8px; padding: 9px 12px; border-bottom: 1px solid var(--aurora-border-default); background: var(--axon-control); }
+.ext-argbar .ext-arg-icon { color: var(--aurora-accent-strong); flex: 0 0 auto; display: grid; place-items: center; }
+.ext-arginput { all: unset; flex: 1; min-width: 0; font-family: var(--font-mono); font-size: 12px; color: var(--aurora-text-primary); }
+.ext-arginput::placeholder { color: var(--aurora-text-muted); }
+.ext-argrun { all: unset; cursor: pointer; display: inline-flex; align-items: center; gap: 5px; height: 26px; padding: 0 11px; border-radius: 8px; font-family: var(--font-sans); font-size: 12px; font-weight: 650; color: #06131c; background: var(--aurora-accent-primary); border: 1px solid var(--aurora-accent-primary); flex: 0 0 auto; }
+.ext-argrun:hover { background: var(--aurora-accent-strong); border-color: var(--aurora-accent-strong); }
+.ext-argrun:focus-visible { outline: 2px solid var(--aurora-focus-ring); outline-offset: 1px; }
+
+/* loading + error states inside the result body */
+.ext-loading { display: flex; align-items: center; gap: 10px; padding: 6px 2px; font-family: var(--font-mono); font-size: 12px; color: var(--aurora-text-muted); }
+.ext-errorcard { border-radius: 12px; padding: 13px 14px; background: color-mix(in srgb, var(--aurora-error) 8%, var(--axon-control)); border: 1px solid color-mix(in srgb, var(--aurora-error) 30%, transparent); display: flex; flex-direction: column; gap: 8px; }
+.ext-errorcard .err-title { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-display); font-weight: 800; font-size: 14px; color: var(--aurora-error); }
+.ext-errorcard .err-body { font-family: var(--font-sans); font-size: 13px; line-height: 1.55; color: var(--aurora-text-primary); }
+.ext-errorcard .err-hint { font-family: var(--font-sans); font-size: 12px; color: var(--aurora-text-muted); }
+
+.ext-foot { flex: 0 0 auto; display: flex; align-items: center; gap: 7px; padding: 9px 14px; border-top: 1px solid var(--aurora-border-default); background: var(--aurora-nav-bg); font-family: var(--font-mono); font-size: 10px; color: var(--aurora-text-muted); }
+.ext-foot span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ── Axon neuron-mark node pulse ─────────────────────────────── */
+.axon-node { animation: axon-node-pulse 1.9s var(--motion-ease-in-out) infinite; }
+@keyframes axon-node-pulse { 0%, 100% { opacity: 0.78; } 50% { opacity: 1; } }
+.axon-pulse { animation: axon-mark-pulse 1.2s var(--motion-ease-in-out) infinite; }
+@keyframes axon-mark-pulse { 0%, 100% { opacity: 0.7; } 50% { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .axon-node, .axon-pulse { animation: none; }
+}

--- a/apps/chrome-extension/launcher.js
+++ b/apps/chrome-extension/launcher.js
@@ -14,19 +14,22 @@
   const COLOR_CODE = true; // color-code actions by family (design default on)
 
   const state = { view: "browse", tab: null, online: null, host: "", op: null, lastStatus: 200, bodyEl: null };
+  // config is read once from storage and refreshed on change (see storage.onChanged),
+  // so requestAxon reads it synchronously instead of an IPC round-trip per request.
+  let config = { axonUrl: DEFAULT_AXON_URL, axonToken: "" };
 
   /* ── config + request layer ── */
-  async function loadConfig() {
+  async function refreshConfig() {
     const stored = (chrome.storage && chrome.storage.local) ? await chrome.storage.local.get(["axonUrl", "axonToken"]) : {};
-    return { axonUrl: stored.axonUrl || DEFAULT_AXON_URL, axonToken: stored.axonToken || "" };
+    config = { axonUrl: stored.axonUrl || DEFAULT_AXON_URL, axonToken: stored.axonToken || "" };
+    return config;
   }
   function isLoopback(server) {
     try { const h = new URL(server).hostname; return h === "127.0.0.1" || h === "localhost" || h === "::1"; } catch { return false; }
   }
   async function requestAxon(method, path, body) {
-    const cfg = await loadConfig();
-    const server = cfg.axonUrl.trim().replace(/\/+$/, "");
-    const token = cfg.axonToken.trim();
+    const server = config.axonUrl.trim().replace(/\/+$/, "");
+    const token = config.axonToken.trim();
     if (!server) throw new Error("Axon server URL is required. Open Settings.");
     const headers = {};
     if (body !== undefined) headers["Content-Type"] = "application/json";
@@ -64,12 +67,15 @@
     } catch { return null; }
   }
 
-  /* ── arg model ── */
+  /* ── arg model (derived from the catalog: arg / noArg / optionalArg) ──
+   *   optional → run now, optional filter/focus input (sources, domains, suggest)
+   *   none     → run now, no input (doctor, status, stats)
+   *   url      → prefill the active tab + run (url/input/target args)
+   *   query    → wait for a typed query (search, query, ask, …) */
   function argMode(op) {
-    if (["doctor", "status", "stats"].includes(op.id)) return "none";
-    if (["suggest", "sources", "domains"].includes(op.id)) return "optional";
-    if (["search", "research", "query", "ask", "evaluate"].includes(op.id)) return "query";
-    return "url"; // scrape, map, retrieve, screenshot, diff, brand, endpoints, crawl, extract, embed, ingest, summarize
+    if (op.optionalArg) return "optional";
+    if (op.noArg) return "none";
+    return op.arg === "url" || op.arg === "input" || op.arg === "target" ? "url" : "query";
   }
   function splitUrls(arg) {
     return String(arg || "").split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
@@ -129,10 +135,16 @@
       gear,
     ]);
   }
+  function applyStatusBadge(badge, code) {
+    const ok = code >= 200 && code < 300;
+    badge.className = `ext-statusbadge ${code === 202 ? "is-accepted" : !ok ? "is-error" : ""}`;
+    badge.textContent = "";
+    badge.appendChild(Icon(ok ? "check" : "alert", 11));
+    badge.appendChild(document.createTextNode(code >= 100 ? String(code) : "ERR"));
+  }
   function resultHeader(title, back) {
-    const ok = state.lastStatus >= 200 && state.lastStatus < 300;
-    const badgeClass = state.view === "result" && state.op && state.lastStatus === 202 ? "is-accepted" : !ok ? "is-error" : "";
-    const badge = el("span", { class: `ext-statusbadge ${badgeClass}` }, [Icon(ok ? "check" : "alert", 11), String(state.lastStatus)]);
+    const badge = el("span", { class: "ext-statusbadge" });
+    applyStatusBadge(badge, state.lastStatus);
     return el("header", { class: "ext-result-head" }, [
       el("button", { class: "ext-icon", title: "Back", "aria-label": "Back", onclick: back }, iconSvg("arrowLeft", { size: 17 })),
       el("span", { class: "ext-result-title" }, title),
@@ -195,7 +207,7 @@
     let argInput = null;
     if (mode !== "none") {
       const placeholder = mode === "url" ? "URL…" : op.argLabel || "input…";
-      argInput = el("input", { class: "ext-arginput", type: "text", spellcheck: "false", autocomplete: "off", placeholder, value: state.pendingArg || "" });
+      argInput = el("input", { class: "ext-arginput", type: "text", spellcheck: "false", autocomplete: "off", placeholder });
       const run = () => runWithArg(op, argInput.value.trim());
       argInput.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); run(); } });
       panel.appendChild(el("div", { class: "ext-argbar" }, [
@@ -210,12 +222,17 @@
     panel.appendChild(body);
     panel.appendChild(footer());
 
-    // decide initial run
-    state.pendingArg = null;
-    if (mode === "url") { const initial = state.initialArg != null ? state.initialArg : ((state.tab && state.tab.url) || ""); if (argInput) argInput.value = initial; runWithArg(op, initial); }
-    else if (mode === "optional" || mode === "none") { if (state.initialArg) { if (argInput) argInput.value = state.initialArg; runWithArg(op, state.initialArg); } else runWithArg(op, ""); }
-    else if (mode === "query") { if (state.initialArg) { if (argInput) argInput.value = state.initialArg; runWithArg(op, state.initialArg); } else { body.appendChild(promptHint(op)); if (argInput) setTimeout(() => argInput.focus(), 40); } }
+    // decide initial run: url/optional/none auto-run; query waits for a typed
+    // query unless an override (context-menu intent) was supplied.
+    const initial = state.initialArg != null ? state.initialArg : (mode === "url" ? ((state.tab && state.tab.url) || "") : "");
     state.initialArg = null;
+    if (argInput) argInput.value = initial;
+    if (mode === "query" && !initial) {
+      body.appendChild(promptHint(op));
+      if (argInput) setTimeout(() => argInput.focus(), 40);
+    } else {
+      runWithArg(op, initial);
+    }
   }
   function promptHint(op) {
     return el("div", { class: "ext-loading" }, [Icon("arrowUp", 14, "var(--aurora-text-muted)"), `Enter a ${op.argLabel || "query"} above to run ${op.name}.`]);
@@ -243,18 +260,9 @@
     }
   }
   function refreshResultBadge() {
-    // rebuild only the header to reflect the latest HTTP status
-    const head = panel.querySelector(".ext-result-head");
-    if (!head) return;
-    const code = state.lastStatus;
-    const ok = code >= 200 && code < 300;
-    const label = code >= 100 ? String(code) : "ERR";
-    const badge = head.querySelector(".ext-statusbadge");
-    if (!badge) return;
-    badge.className = `ext-statusbadge ${code === 202 ? "is-accepted" : !ok ? "is-error" : ""}`;
-    badge.textContent = "";
-    badge.appendChild(Icon(ok ? "check" : "alert", 11));
-    badge.appendChild(document.createTextNode(label));
+    // update just the header badge in place to reflect the latest HTTP status
+    const badge = panel.querySelector(".ext-result-head .ext-statusbadge");
+    if (badge) applyStatusBadge(badge, state.lastStatus);
   }
   function errorCard(op, error) {
     const status = error && error.status ? error.status : "ERR";
@@ -296,25 +304,32 @@
   }
 
   /* ── server status dot ── */
+  function paintStatus() {
+    if (state.view !== "browse" || !panel) return; // browse rebuilds from state on its own
+    const dot = panel.querySelector(".ext-head .ext-dot");
+    if (dot) {
+      dot.className = `ext-dot ${state.online === false ? "is-off" : state.online == null ? "is-wait" : ""}`;
+      dot.title = state.online === false ? "Axon offline" : state.online == null ? "Checking…" : "Axon online";
+    }
+    const host = panel.querySelector(".ext-head .ext-host");
+    if (host) { host.textContent = state.host || "not configured"; host.title = state.host; }
+  }
   async function checkHealth() {
-    const cfg = await loadConfig();
-    try { state.host = new URL(cfg.axonUrl).host; } catch { state.host = cfg.axonUrl; }
+    try { state.host = new URL(config.axonUrl).host; } catch { state.host = config.axonUrl; }
     state.online = null;
-    if (state.view === "browse") render();
+    paintStatus();
     try {
       await requestAxon("GET", "/healthz");
       state.online = true;
     } catch { state.online = false; }
-    if (state.view === "browse") render();
+    paintStatus();
   }
 
   /* ── context-menu intents ── */
-  const INTENT_OPS = { scrape: "scrape", ingest: "ingest", ask: "ask" };
+  const INTENT_OPS = new Set(["scrape", "ingest", "ask"]); // ops the context menu may trigger
   function applyIntent(intent) {
-    if (!intent || !intent.op) return;
-    const opId = INTENT_OPS[intent.op];
-    if (!opId) return;
-    openAction(OP_BY_ID[opId], intent.arg || undefined);
+    if (!intent || !INTENT_OPS.has(intent.op)) return;
+    openAction(OP_BY_ID[intent.op], intent.arg || undefined);
   }
   async function consumePendingIntent() {
     if (!(chrome.storage && chrome.storage.local)) return;
@@ -325,8 +340,18 @@
     }
   }
 
+  // Re-resolve the active tab; only rebuild browse when the URL actually changed
+  // (onUpdated fires repeatedly during a single page load).
+  async function refreshTab() {
+    const next = await getActiveTab();
+    const changed = (next && next.url) !== (state.tab && state.tab.url);
+    state.tab = next;
+    if (changed && state.view === "browse") render();
+  }
+
   /* ── boot ── */
   async function init() {
+    await refreshConfig();
     state.tab = await getActiveTab();
     mount();
     checkHealth();
@@ -335,9 +360,9 @@
     chrome.runtime && chrome.runtime.onMessage && chrome.runtime.onMessage.addListener((msg) => {
       if (msg && msg.type === "axon-intent") applyIntent(msg);
     });
-    chrome.tabs && chrome.tabs.onActivated && chrome.tabs.onActivated.addListener(async () => { state.tab = await getActiveTab(); if (state.view === "browse") render(); });
-    chrome.tabs && chrome.tabs.onUpdated && chrome.tabs.onUpdated.addListener(async (_id, info) => { if (info.status === "complete" || info.url) { state.tab = await getActiveTab(); if (state.view === "browse") render(); } });
-    chrome.storage && chrome.storage.onChanged && chrome.storage.onChanged.addListener((changes, area) => { if (area === "local" && (changes.axonUrl || changes.axonToken)) checkHealth(); });
+    chrome.tabs && chrome.tabs.onActivated && chrome.tabs.onActivated.addListener(() => refreshTab());
+    chrome.tabs && chrome.tabs.onUpdated && chrome.tabs.onUpdated.addListener((_id, info) => { if (info.status === "complete" || info.url) refreshTab(); });
+    chrome.storage && chrome.storage.onChanged && chrome.storage.onChanged.addListener((changes, area) => { if (area === "local" && (changes.axonUrl || changes.axonToken)) refreshConfig().then(checkHealth); });
   }
 
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);

--- a/apps/chrome-extension/launcher.js
+++ b/apps/chrome-extension/launcher.js
@@ -1,0 +1,345 @@
+/* ============================================================
+ * Axon Chrome Extension — side-panel launcher controller
+ * Owns config + the /v1/* request layer, current-tab tracking, and
+ * the browse → run → result/doc flow from the design handoff
+ * (Reference/ext/sidepanel.jsx). Wired to the real Axon server.
+ * ============================================================ */
+
+(function () {
+  const { el, Icon, ActionBody, RetrieveDocFromRaw } = window.AxonRender;
+  const { iconSvg, axonMark } = window.AxonIcons;
+  const { OPS_BY_CATEGORY, OP_BY_ID, toneOf, tint, hostOf, detectIngestSource } = window.AxonData;
+
+  const DEFAULT_AXON_URL = "http://100.88.16.79:8001";
+  const COLOR_CODE = true; // color-code actions by family (design default on)
+
+  const state = { view: "browse", tab: null, online: null, host: "", op: null, lastStatus: 200, bodyEl: null };
+
+  /* ── config + request layer ── */
+  async function loadConfig() {
+    const stored = (chrome.storage && chrome.storage.local) ? await chrome.storage.local.get(["axonUrl", "axonToken"]) : {};
+    return { axonUrl: stored.axonUrl || DEFAULT_AXON_URL, axonToken: stored.axonToken || "" };
+  }
+  function isLoopback(server) {
+    try { const h = new URL(server).hostname; return h === "127.0.0.1" || h === "localhost" || h === "::1"; } catch { return false; }
+  }
+  async function requestAxon(method, path, body) {
+    const cfg = await loadConfig();
+    const server = cfg.axonUrl.trim().replace(/\/+$/, "");
+    const token = cfg.axonToken.trim();
+    if (!server) throw new Error("Axon server URL is required. Open Settings.");
+    const headers = {};
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (!token && path !== "/healthz" && !isLoopback(server)) throw new Error("Missing bearer token for this server. Open Settings.");
+    const res = await fetch(`${server}${path}`, { method, headers, body: body !== undefined ? JSON.stringify(body) : undefined });
+    state.lastStatus = res.status;
+    const text = await res.text();
+    if (!res.ok) {
+      let message = text;
+      try { const j = JSON.parse(text); message = j.message || j.error || text; } catch { /* keep text */ }
+      const err = new Error(message || `HTTP ${res.status}`); err.status = res.status; err.statusText = res.statusText; throw err;
+    }
+    if (!text) return {};
+    try { return JSON.parse(text); } catch { return text; }
+  }
+  function friendlyError(error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const lower = message.toLowerCase();
+    if (lower.includes("missing bearer token") || lower.includes("401") || lower.includes("auth_failed")) return "Auth failed — Axon needs the bearer token for this server. Open Settings.";
+    if (lower.includes("403") || lower.includes("forbidden")) return "Forbidden by the Axon server or proxy. Check the URL and token.";
+    if (lower.includes("failed to fetch") || lower.includes("networkerror")) return "Axon is unreachable from Chrome. Check the server URL and that Axon is listening.";
+    return message.replace(/<!--[\s\S]*?-->/g, "").trim() || "Request failed.";
+  }
+
+  /* ── current tab ── */
+  function isWeb(t) { return /^https?:\/\//i.test((t && t.url) || ""); }
+  async function getActiveTab() {
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (isWeb(tab)) return tab;
+      const all = await chrome.tabs.query({ currentWindow: true });
+      const web = all.filter(isWeb).sort((a, b) => (b.lastAccessed || 0) - (a.lastAccessed || 0))[0];
+      return web || tab || null;
+    } catch { return null; }
+  }
+
+  /* ── arg model ── */
+  function argMode(op) {
+    if (["doctor", "status", "stats"].includes(op.id)) return "none";
+    if (["suggest", "sources", "domains"].includes(op.id)) return "optional";
+    if (["search", "research", "query", "ask", "evaluate"].includes(op.id)) return "query";
+    return "url"; // scrape, map, retrieve, screenshot, diff, brand, endpoints, crawl, extract, embed, ingest, summarize
+  }
+  function splitUrls(arg) {
+    return String(arg || "").split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
+  }
+
+  /* ── API dispatch per action ── */
+  function callApi(op, arg) {
+    switch (op.id) {
+      case "scrape": return requestAxon("POST", "/v1/scrape", { url: arg, embed: true });
+      case "map": return requestAxon("POST", "/v1/map", { url: arg, limit: 100 });
+      case "retrieve": return requestAxon("POST", "/v1/retrieve", { url: arg, max_points: 50, token_budget: 8000 });
+      case "screenshot": return requestAxon("POST", "/v1/screenshot", { url: arg, full_page: true });
+      case "brand": return requestAxon("POST", "/v1/brand", { url: arg });
+      case "endpoints": return requestAxon("POST", "/v1/endpoints", { url: arg });
+      case "diff": { const u = splitUrls(arg); if (u.length < 2) { const e = new Error("Diff needs two URLs — “URL A  URL B”."); e.status = 400; throw e; } return requestAxon("POST", "/v1/diff", { url_a: u[0], url_b: u[1] }); }
+      case "crawl": return requestAxon("POST", "/v1/crawl", { urls: [arg] });
+      case "extract": return requestAxon("POST", "/v1/extract", { urls: [arg] });
+      case "embed": return requestAxon("POST", "/v1/embed", { input: arg });
+      case "ingest": return requestAxon("POST", "/v1/ingest", { source_type: detectIngestSource(arg), target: arg });
+      case "search": return requestAxon("POST", "/v1/search", { query: arg, limit: 10 });
+      case "research": return requestAxon("POST", "/v1/research", { query: arg, limit: 10 });
+      case "query": return requestAxon("POST", "/v1/query", { query: arg, limit: 10 });
+      case "suggest": return requestAxon("POST", "/v1/suggest", arg ? { focus: arg } : {});
+      case "sources": return requestAxon("GET", "/v1/sources");
+      case "domains": return requestAxon("GET", "/v1/domains");
+      case "ask": return requestAxon("POST", "/v1/ask", { query: arg });
+      case "summarize": return requestAxon("POST", "/v1/summarize", { urls: [arg] });
+      case "evaluate": return requestAxon("POST", "/v1/evaluate", { question: arg });
+      case "doctor": return requestAxon("GET", "/v1/doctor");
+      case "status": return requestAxon("GET", "/v1/status");
+      case "stats": return requestAxon("GET", "/v1/stats");
+      default: { const e = new Error(`Unsupported action: ${op.id}`); throw e; }
+    }
+  }
+
+  /* ── root ── */
+  let panel;
+  function mount() {
+    panel = el("div", { class: "ext-panel" });
+    document.getElementById("root").appendChild(panel);
+    render();
+  }
+  function render() {
+    panel.textContent = "";
+    if (state.view === "browse") renderBrowse();
+    else if (state.view === "result") renderResult();
+    else if (state.view === "doc") renderDoc();
+  }
+
+  /* ── header ── */
+  function brandHeader() {
+    const dot = el("span", { class: `ext-dot ${state.online === false ? "is-off" : state.online == null ? "is-wait" : ""}`, title: state.online === false ? "Axon offline" : state.online == null ? "Checking…" : "Axon online" });
+    const gear = el("button", { class: "ext-icon", title: "Settings", "aria-label": "Settings", onclick: openOptions }, iconSvg("settings", { size: 16 }));
+    return el("header", { class: "ext-head" }, [
+      el("span", { class: "ext-brand" }, [axonMark(22), el("span", { class: "ext-word" }, "Axon"), dot]),
+      el("span", { class: "ext-host", title: state.host }, state.host || "not configured"),
+      gear,
+    ]);
+  }
+  function resultHeader(title, back) {
+    const ok = state.lastStatus >= 200 && state.lastStatus < 300;
+    const badgeClass = state.view === "result" && state.op && state.lastStatus === 202 ? "is-accepted" : !ok ? "is-error" : "";
+    const badge = el("span", { class: `ext-statusbadge ${badgeClass}` }, [Icon(ok ? "check" : "alert", 11), String(state.lastStatus)]);
+    return el("header", { class: "ext-result-head" }, [
+      el("button", { class: "ext-icon", title: "Back", "aria-label": "Back", onclick: back }, iconSvg("arrowLeft", { size: 17 })),
+      el("span", { class: "ext-result-title" }, title),
+      badge,
+    ]);
+  }
+  function footer() {
+    return el("div", { class: "ext-foot" }, [Icon("command", 12), el("span", null, "⌘⇧Space to open · right-click any page to Scrape / Ingest / Ask")]);
+  }
+
+  /* ── browse view ── */
+  function renderBrowse() {
+    panel.appendChild(brandHeader());
+    const scroll = el("div", { class: "ext-scroll aurora-scrollbar" });
+
+    const url = (state.tab && state.tab.url) || "";
+    const dom = url ? hostOf(url).split("/")[0] : "";
+    const rest = url ? hostOf(url).slice(dom.length) : "";
+    const tabCard = el("div", { class: "ext-tabcard" }, [
+      el("div", { class: "ext-tabcard-top" }, [iconSvg("globe", { size: 13, color: "var(--aurora-accent-strong)" }), el("span", { class: "ext-tablabel" }, "THIS PAGE")]),
+      el("div", { class: "ext-taburl", title: url }, url ? [dom, el("span", { class: "dim" }, rest)] : [el("span", { class: "dim" }, "Open an http:// or https:// tab")]),
+      el("div", { class: "ext-quick" }, [
+        quickBtn("scrape", "Scrape", "scrape"),
+        quickBtn("ingest", "Ingest", "box"),
+        quickBtn("endpoints", "Endpoints", "plug"),
+      ]),
+    ]);
+    scroll.appendChild(tabCard);
+
+    OPS_BY_CATEGORY.forEach((cat) => {
+      if (!cat.ops.length) return;
+      scroll.appendChild(el("div", { class: "ext-seclabel" }, cat.label));
+      cat.ops.forEach((op) => scroll.appendChild(actionRow(op)));
+    });
+
+    panel.appendChild(scroll);
+    panel.appendChild(footer());
+  }
+  function quickBtn(opId, label, icon) {
+    const url = (state.tab && state.tab.url) || "";
+    return el("button", { class: "ext-quickbtn", disabled: url ? undefined : "", onclick: () => openAction(OP_BY_ID[opId], url || undefined) }, [iconSvg(icon, { size: 13 }), label]);
+  }
+  function actionRow(op) {
+    const t = toneOf(op.tone, COLOR_CODE);
+    const tile = el("span", { class: "ext-tile", style: { color: t.fg, background: tint(t.base, 14, "var(--axon-page)"), border: `1px solid ${tint(t.base, 28)}` } }, iconSvg(op.icon, { size: 15 }));
+    const name = el("span", { class: "ext-row-name" }, [op.name, op.async ? el("span", { class: "ext-async" }, "ASYNC") : null]);
+    return el("button", { class: "ext-row", onclick: () => openAction(op) }, [
+      tile,
+      el("span", { class: "ext-row-main" }, [name, el("span", { class: "ext-row-sub" }, op.short)]),
+      iconSvg("chevronRight", { size: 15, color: "var(--aurora-text-muted)" }),
+    ]);
+  }
+
+  /* ── result view ── */
+  function renderResult() {
+    const op = state.op;
+    const mode = argMode(op);
+    panel.appendChild(resultHeader(op.name, () => { state.view = "browse"; render(); }));
+
+    let argInput = null;
+    if (mode !== "none") {
+      const placeholder = mode === "url" ? "URL…" : op.argLabel || "input…";
+      argInput = el("input", { class: "ext-arginput", type: "text", spellcheck: "false", autocomplete: "off", placeholder, value: state.pendingArg || "" });
+      const run = () => runWithArg(op, argInput.value.trim());
+      argInput.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); run(); } });
+      panel.appendChild(el("div", { class: "ext-argbar" }, [
+        el("span", { class: "ext-arg-icon" }, iconSvg(mode === "url" ? "link" : "search", { size: 14 })),
+        argInput,
+        el("button", { class: "ext-argrun", title: "Run", onclick: run }, [iconSvg("enter", { size: 13 }), "Run"]),
+      ]));
+    }
+
+    const body = el("div", { class: "ext-scroll aurora-scrollbar", style: { paddingTop: "12px" } });
+    state.bodyEl = body;
+    panel.appendChild(body);
+    panel.appendChild(footer());
+
+    // decide initial run
+    state.pendingArg = null;
+    if (mode === "url") { const initial = state.initialArg != null ? state.initialArg : ((state.tab && state.tab.url) || ""); if (argInput) argInput.value = initial; runWithArg(op, initial); }
+    else if (mode === "optional" || mode === "none") { if (state.initialArg) { if (argInput) argInput.value = state.initialArg; runWithArg(op, state.initialArg); } else runWithArg(op, ""); }
+    else if (mode === "query") { if (state.initialArg) { if (argInput) argInput.value = state.initialArg; runWithArg(op, state.initialArg); } else { body.appendChild(promptHint(op)); if (argInput) setTimeout(() => argInput.focus(), 40); } }
+    state.initialArg = null;
+  }
+  function promptHint(op) {
+    return el("div", { class: "ext-loading" }, [Icon("arrowUp", 14, "var(--aurora-text-muted)"), `Enter a ${op.argLabel || "query"} above to run ${op.name}.`]);
+  }
+  async function runWithArg(op, arg) {
+    const body = state.bodyEl;
+    if (!body) return;
+    body.textContent = "";
+    body.appendChild(el("div", { class: "ext-loading" }, [axonMark(18, true), `Running ${op.name}…`]));
+    const tones = toneOf(op.tone, COLOR_CODE);
+    try {
+      const raw = await callApi(op, arg);
+      // refresh header status badge
+      refreshResultBadge();
+      body.textContent = "";
+      body.appendChild(ActionBody(op, raw, tones, {
+        onOpenDoc: (u) => openDoc(u),
+        onAct: (kind, u) => openAction(OP_BY_ID[kind], u),
+      }));
+    } catch (error) {
+      state.lastStatus = (error && error.status) || 0; // 0 = transport/network error
+      refreshResultBadge();
+      body.textContent = "";
+      body.appendChild(errorCard(op, error));
+    }
+  }
+  function refreshResultBadge() {
+    // rebuild only the header to reflect the latest HTTP status
+    const head = panel.querySelector(".ext-result-head");
+    if (!head) return;
+    const code = state.lastStatus;
+    const ok = code >= 200 && code < 300;
+    const label = code >= 100 ? String(code) : "ERR";
+    const badge = head.querySelector(".ext-statusbadge");
+    if (!badge) return;
+    badge.className = `ext-statusbadge ${code === 202 ? "is-accepted" : !ok ? "is-error" : ""}`;
+    badge.textContent = "";
+    badge.appendChild(Icon(ok ? "check" : "alert", 11));
+    badge.appendChild(document.createTextNode(label));
+  }
+  function errorCard(op, error) {
+    const status = error && error.status ? error.status : "ERR";
+    return el("div", { class: "ext-errorcard" }, [
+      el("div", { class: "err-title" }, [Icon("alert", 15), `${op.name} failed${typeof status === "number" ? ` · ${status}` : ""}`]),
+      el("div", { class: "err-body" }, friendlyError(error)),
+      el("div", { class: "err-hint" }, "Check Settings (server URL + token), or that Axon is running."),
+    ]);
+  }
+
+  /* ── doc viewer (sources → retrieve) ── */
+  async function openDoc(url) {
+    state.view = "doc";
+    state.docUrl = url;
+    render();
+  }
+  function renderDoc() {
+    panel.appendChild(resultHeader("Document", () => { state.view = "result"; render(); }));
+    const body = el("div", { class: "ext-scroll aurora-scrollbar", style: { paddingTop: "12px" } });
+    panel.appendChild(body);
+    panel.appendChild(footer());
+    body.appendChild(el("div", { class: "ext-loading" }, [axonMark(18, true), "Loading document…"]));
+    requestAxon("POST", "/v1/retrieve", { url: state.docUrl, max_points: 50, token_budget: 8000 })
+      .then((raw) => { refreshResultBadge(); body.textContent = ""; body.appendChild(RetrieveDocFromRaw(raw, toneOf("cyan", COLOR_CODE))); })
+      .catch((error) => { refreshResultBadge(); body.textContent = ""; body.appendChild(errorCard({ name: "Retrieve" }, error)); });
+  }
+
+  /* ── open an action (from row / quick action / context-menu intent) ── */
+  function openAction(op, argOverride) {
+    if (!op) return;
+    state.op = op;
+    state.initialArg = argOverride != null ? argOverride : null;
+    state.view = "result";
+    render();
+  }
+  function openOptions() {
+    if (chrome.runtime && chrome.runtime.openOptionsPage) chrome.runtime.openOptionsPage();
+    else window.open(chrome.runtime.getURL("options.html"));
+  }
+
+  /* ── server status dot ── */
+  async function checkHealth() {
+    const cfg = await loadConfig();
+    try { state.host = new URL(cfg.axonUrl).host; } catch { state.host = cfg.axonUrl; }
+    state.online = null;
+    if (state.view === "browse") render();
+    try {
+      await requestAxon("GET", "/healthz");
+      state.online = true;
+    } catch { state.online = false; }
+    if (state.view === "browse") render();
+  }
+
+  /* ── context-menu intents ── */
+  const INTENT_OPS = { scrape: "scrape", ingest: "ingest", ask: "ask" };
+  function applyIntent(intent) {
+    if (!intent || !intent.op) return;
+    const opId = INTENT_OPS[intent.op];
+    if (!opId) return;
+    openAction(OP_BY_ID[opId], intent.arg || undefined);
+  }
+  async function consumePendingIntent() {
+    if (!(chrome.storage && chrome.storage.local)) return;
+    const { axonPendingIntent } = await chrome.storage.local.get(["axonPendingIntent"]);
+    if (axonPendingIntent && Date.now() - (axonPendingIntent.ts || 0) < 60000) {
+      await chrome.storage.local.remove(["axonPendingIntent"]);
+      applyIntent(axonPendingIntent);
+    }
+  }
+
+  /* ── boot ── */
+  async function init() {
+    state.tab = await getActiveTab();
+    mount();
+    checkHealth();
+    consumePendingIntent();
+
+    chrome.runtime && chrome.runtime.onMessage && chrome.runtime.onMessage.addListener((msg) => {
+      if (msg && msg.type === "axon-intent") applyIntent(msg);
+    });
+    chrome.tabs && chrome.tabs.onActivated && chrome.tabs.onActivated.addListener(async () => { state.tab = await getActiveTab(); if (state.view === "browse") render(); });
+    chrome.tabs && chrome.tabs.onUpdated && chrome.tabs.onUpdated.addListener(async (_id, info) => { if (info.status === "complete" || info.url) { state.tab = await getActiveTab(); if (state.view === "browse") render(); } });
+    chrome.storage && chrome.storage.onChanged && chrome.storage.onChanged.addListener((changes, area) => { if (area === "local" && (changes.axonUrl || changes.axonToken)) checkHealth(); });
+  }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);
+  else init();
+})();

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Axon Page Scraper",
-  "version": "0.1.0",
-  "description": "Scrape pages, run Axon commands, and ask indexed context from the browser.",
+  "version": "0.2.0",
+  "description": "Scrape, crawl, ingest, search and ask Axon over the page you're on — from the side panel.",
   "options_page": "options.html",
   "icons": {
     "16": "assets/png/axon-icon-16.png",
@@ -25,9 +25,18 @@
   "side_panel": {
     "default_path": "sidepanel.html"
   },
-  "permissions": ["activeTab", "clipboardWrite", "sidePanel", "storage", "tabs"],
+  "permissions": ["activeTab", "clipboardWrite", "contextMenus", "sidePanel", "storage", "tabs"],
   "host_permissions": [
     "http://*/*",
     "https://*/*"
-  ]
+  ],
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Space",
+        "mac": "Command+Shift+Space"
+      },
+      "description": "Open the Axon side panel"
+    }
+  }
 }

--- a/apps/chrome-extension/sidepanel.html
+++ b/apps/chrome-extension/sidepanel.html
@@ -1,76 +1,20 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Axon Chat</title>
-    <link rel="stylesheet" href="popup.css">
+    <title>Axon — Side Panel</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="aurora.css">
+    <link rel="stylesheet" href="launcher.css">
   </head>
-  <body class="surface-sidebar">
-    <main>
-      <header class="app-header">
-        <div class="brand-heading">
-          <img class="brand-mark" src="assets/axon-glyph.svg" alt="" aria-hidden="true">
-          <div>
-            <p class="eyebrow">Axon extension</p>
-            <h1>Axon chat</h1>
-          </div>
-        </div>
-        <div class="header-actions">
-          <button id="open-options" class="icon-button" type="button" aria-label="Open settings" title="Settings">
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"></path>
-              <path d="M19.4 15a1.8 1.8 0 0 0 .36 1.98l.04.04a2.1 2.1 0 0 1-2.97 2.97l-.04-.04a1.8 1.8 0 0 0-1.98-.36 1.8 1.8 0 0 0-1.1 1.65V21.3a2.1 2.1 0 0 1-4.2 0v-.06a1.8 1.8 0 0 0-1.1-1.65 1.8 1.8 0 0 0-1.98.36l-.04.04a2.1 2.1 0 1 1-2.97-2.97l.04-.04A1.8 1.8 0 0 0 3.8 15a1.8 1.8 0 0 0-1.65-1.1H2.1a2.1 2.1 0 0 1 0-4.2h.06A1.8 1.8 0 0 0 3.8 8.6a1.8 1.8 0 0 0-.36-1.98l-.04-.04A2.1 2.1 0 1 1 6.37 3.6l.04.04a1.8 1.8 0 0 0 1.98.36 1.8 1.8 0 0 0 1.1-1.65V2.3a2.1 2.1 0 0 1 4.2 0v.06a1.8 1.8 0 0 0 1.1 1.65 1.8 1.8 0 0 0 1.98-.36l.04-.04a2.1 2.1 0 0 1 2.97 2.97l-.04.04a1.8 1.8 0 0 0-.36 1.98 1.8 1.8 0 0 0 1.65 1.1h.06a2.1 2.1 0 0 1 0 4.2h-.06A1.8 1.8 0 0 0 19.4 15Z"></path>
-            </svg>
-          </button>
-          <button id="api-status" class="header-badge tone-neutral" type="button" title="Check Axon API">Ready</button>
-          <button id="watch-status" class="header-badge tone-neutral" type="button" title="Toggle automatic page scraping">Paused</button>
-        </div>
-      </header>
-      <section class="target-panel" aria-label="Current target">
-        <span class="target-label">Target</span>
-        <div class="target-copy">
-          <strong id="target-title">No page selected</strong>
-          <span id="target-url">Open an http:// or https:// tab.</span>
-          <span id="target-state" class="target-state">Not scraped this session</span>
-        </div>
-      </section>
-      <section class="chat-panel output-panel" aria-labelledby="output-title">
-        <div class="panel-heading">
-          <div>
-            <h2 id="output-title">Conversation</h2>
-            <p class="panel-subtitle">Answers, crawl jobs, and Axon command output.</p>
-          </div>
-          <span id="chat-status" class="status-badge tone-neutral">Axon</span>
-        </div>
-        <div id="chat-log" class="chat-log" aria-live="polite"></div>
-        <div class="output-actions">
-          <button id="chat-reset" class="link-button" type="button">Clear</button>
-        </div>
-      </section>
-      <section class="command-panel command-center" aria-label="Message composer">
-        <div class="command-input-shell">
-          <span class="command-prompt">&gt;</span>
-          <input id="command-input" type="text" spellcheck="false" autocomplete="off" placeholder="Type naturally, or run Axon CLI commands inline.">
-          <button id="command-send" class="send-button" type="button">Send</button>
-        </div>
-      </section>
-      <section class="crawl-panel" aria-labelledby="crawl-title">
-        <div class="panel-heading">
-          <h2 id="crawl-title">Crawl</h2>
-          <span id="crawl-status" class="status-badge tone-neutral">Idle</span>
-        </div>
-        <div class="crawl-toolbar">
-          <code id="crawl-job"></code>
-          <button id="cancel-crawl" class="link-button danger-link" type="button" disabled>Cancel</button>
-        </div>
-      </section>
-      <p id="status" class="toast" role="status" aria-live="polite"></p>
-    </main>
-    <script src="popup-state.js"></script>
-    <script src="popup-actions.js"></script>
-    <script src="popup-api.js"></script>
-    <script src="popup-format.js"></script>
-    <script src="popup-render.js"></script>
+  <body>
+    <div id="root"></div>
+    <script src="launcher-icons.js"></script>
+    <script src="launcher-data.js"></script>
+    <script src="launcher-render.js"></script>
+    <script src="launcher.js"></script>
   </body>
 </html>

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "5.3.0"
+    "version": "5.3.1"
   },
   "paths": {
     "/v1/ask": {

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "5.2.0"
+    "version": "5.3.0"
   },
   "paths": {
     "/v1/ask": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axon/admin-panel",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axon/admin-panel",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "dependencies": {
         "lucide-react": "^1.16.0",
         "next": "^16.2.6",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axon/admin-panel",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axon/admin-panel",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "dependencies": {
         "lucide-react": "^1.16.0",
         "next": "^16.2.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/plugins/axon/.claude-plugin/plugin.json
+++ b/plugins/axon/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "axon",
+  "version": "5.3.0",
   "description": "Spider-powered self-hosted RAG engine \u2014 scrape, map, extract, crawl, embed, and query via MCP or CLI. A unified `axon` skill covering web crawling, GitHub/Reddit/YouTube ingest, semantic vector search, and grounded LLM answers over indexed content.",
   "author": {
     "name": "Jacob Magar",

--- a/plugins/axon/.claude-plugin/plugin.json
+++ b/plugins/axon/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "axon",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Spider-powered self-hosted RAG engine \u2014 scrape, map, extract, crawl, embed, and query via MCP or CLI. A unified `axon` skill covering web crawling, GitHub/Reddit/YouTube ingest, semantic vector search, and grounded LLM answers over indexed content.",
   "author": {
     "name": "Jacob Magar",


### PR DESCRIPTION
## What

Recreates the **"Axon Extension.html"** design handoff (Claude Design / Aurora design system) as the Chrome extension's **side panel** — an Aurora-styled launcher wired to the real Axon `/v1/*` API.

The repo already had a build-free vanilla-JS MV3 extension at `apps/chrome-extension/`, and the design targets the **side panel** specifically. So this rebuilds `sidepanel.html` as the launcher in vanilla JS (matching the repo's no-build convention and MV3's no-remote-code rule), and leaves the toolbar popup chat untouched.

## Side panel — the launcher
- **Brand strip** — Axon neuron mark + server status dot (green online / red offline / amber checking) + configured host + Settings button.
- **This page** card — current tab URL with quick actions: **Scrape · Ingest · Endpoints**.
- **Action browse** — the full action surface grouped by family (Fetch & Read · Crawl & Ingest · Search & Discover · Reason · System), color-coded by tone (cyan = read, orange = async jobs, rose = LLM), with `ASYNC` badges.
- **Run → result** — an editable arg bar (URL prefilled from the active tab, or a query field) + faithful per-action renders: ranked query hits, web results, the sources library → **doc viewer**, stats, doctor, status, accepted-job cards, brand palettes, endpoints, diffs, screenshots, ask answers — plus a readable JSON fallback for anything unmapped.

Response **normalizers** map the live `/v1/*` shapes onto the design's render shapes (defensive, with fallbacks), so the renders show real data, not the mock fixtures.

## Context menus
Right-click **Scrape with Axon**, **Ingest this page into Axon**, **Ask Axon about "…"** → opens the side panel and runs the pre-filled action via a forwarded `axon-intent`. Adds the `contextMenus` permission and a **Ctrl/⌘+Shift+Space** command to open the panel.

## Files
- New: `aurora.css` (tokens), `launcher.css`, `launcher-icons.js`, `launcher-data.js`, `launcher-render.js`, `launcher.js`
- Changed: `sidepanel.html`, `manifest.json`, `background.js`, extension `README.md`

## Notes
- **No build step / no remote code** — everything ships in the unpacked package; loads as-is. Google Fonts load via `<link>` (allowed for extension pages) with system fallbacks.
- Token + server URL are read from `chrome.storage` (Options page), shared with the popup. All requests go out from the privileged side-panel page (same as the existing popup).
- Version bumped **5.2.0 → 5.3.0** (Cargo.toml, Cargo.lock, README, plugin.json, CHANGELOG).

## Testing
- `node --check` on all new/changed JS.
- A `vm`-sandboxed DOM smoke test renders every `ActionBody` path against sample payloads mirroring the real `/v1/*` shapes (27 cases incl. empty-response + generic fallbacks) — all pass.
- Not yet loaded in a live Chrome against a running `axon serve`.

https://claude.ai/code/session_01B282Ys1BgA3AunHRNj2MUP

---
_Generated by [Claude Code](https://claude.ai/code/session_01B282Ys1BgA3AunHRNj2MUP)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Aurora-styled side-panel launcher for the Chrome extension, wired to real Axon `/v1/*` APIs. Also streamlines launcher internals (cached config, derived input modes, faster status repaint) with no behavior change, and bumps version to 5.3.1 across `@axon/admin-panel` and the OpenAPI spec.

- **New Features**
  - Side panel launcher with brand strip, “this page” quick actions, and grouped action browse → run → result/doc views.
  - Live data via `/v1/*` with defensive normalizers and a readable JSON fallback.
  - Right-click menus: Scrape, Ingest, Ask selection. Opens the panel with a prefilled intent.
  - Keyboard shortcut: Ctrl/⌘+Shift+Space to open the side panel.
  - Vanilla JS, no build or remote code; adds `aurora.css` and launcher assets. Popup chat remains unchanged.
  - `manifest.json`: adds `contextMenus` permission and command config.

- **Migration**
  - Reload the unpacked extension and accept the new `contextMenus` permission.
  - Set Axon URL and token in Options (shared with the popup).
  - Use Ctrl/⌘+Shift+Space or the action button to open the side panel.

<sup>Written for commit 892ec74f6d3e96d6a5199069923b1c1da6246cbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

