### PR TITLE
chore(toolchain): pin Rust 1.96.0 (5.7.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.7.9] - 2026-06-10
+
+### Changed
+
+- **Toolchain: pin Rust 1.96.0** (`rust-toolchain.toml` 1.94.0 → 1.96.0,
+  current stable). Recent branches were already building and passing the full
+  test suite under 1.96; the pin now matches. The sccache wrapper's toolchain
+  canonicalization keys `stable` and `1.96.0` to the same compiler path, so
+  dist cache archives stay consistent.
+
 ## [5.7.8] - 2026-06-10
 
 Collapse PR #197 (`feat/qdrant-affinity-tei-burst`) into this branch by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "5.7.8"
+version = "5.7.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "5.7.8"
+version = "5.7.9"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 5.7.8
+Version: 5.7.9
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "5.7.8"
+    "version": "5.7.9"
   },
   "paths": {
     "/v1/ask": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "5.7.8",
+  "version": "5.7.9",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.96.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,6 @@
 [toolchain]
 channel = "1.96.0"
+# Self-describe components so that when this file overrides CI's default toolchain
+# to 1.96.0, rustup auto-installs clippy + rustfmt for it (the dtolnay action only
+# installs components for the toolchain it pins, not the rust-toolchain.toml override).
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Bumps `rust-toolchain.toml` from 1.94.0 to current stable **1.96.0**.

- Recent branches (5.7.6/5.7.7 work) were already built and fully tested under 1.96 via the stable channel — this makes the pin match reality.
- The sccache wrapper canonicalizes `stable`/`1.96.0` to one compiler path, so dist cache archives stay consistent across both spellings.
- Full version-bump contract applied (Cargo.toml/lock, README, CHANGELOG, apps/web manifests) at 5.7.9.

Verified locally: `cargo check`, sitemap + tool_schema test suites green under 1.96.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Rust toolchain to 1.96.0 and bump project version to 5.7.9. Aligns builds with tested env, keeps sccache caches consistent between `stable` and `1.96.0`, and ensures CI installs `clippy`/`rustfmt` for the override.

- **Dependencies**
  - Set `rust-toolchain.toml` channel to `1.96.0` and declare `components = ["clippy", "rustfmt"]` to fix CI `cargo clippy`/`cargo fmt`.
  - Update versions to `5.7.9` across `Cargo.toml`/`Cargo.lock`, README, OpenAPI, and `@axon/admin-panel`.

<sup>Written for commit 5836a22f5f65041ee0837d832c9cfbd55db4cc11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 5.7.9
  * Updated build toolchain to stable version 1.96.0 for consistent build environment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->