### PR TITLE
feat(web): render command artifact handles in panel + /api/panel/artifact route (5.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.0] - 2026-06-10
+
+### Added
+
+- **Web panel artifact rendering** — commands that return artifact handles now
+  render them in the panel: screenshot artifacts display inline as `<img>`, other
+  kinds show concise file-metadata rows (kind badge, filename, size, download
+  link). New `GET /api/panel/artifact/{*path}` route serves files from
+  `cfg.output_dir` with MIME detection, path-containment validation, and
+  panel-auth gating. (Ported from the closed #197 affinity branch.)
+
 ## [5.7.9] - 2026-06-10
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "5.7.9"
+version = "5.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "5.7.9"
+version = "5.8.0"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 5.7.9
+Version: 5.8.0
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -961,9 +961,53 @@ function CommandResultCard({ result }: { result: CommandResultView }) {
         <img className="palette-result-image" src={result.imageUrl} alt="Screenshot" />
       )}
       {result.body && <p className="palette-result-body">{result.body}</p>}
+      {result.artifacts && result.artifacts.length > 0 && (
+        <div className="artifact-list">
+          <p className="artifact-list-label">Artifacts</p>
+          {result.artifacts.map((a) => (
+            <ArtifactRow key={a.relative_path} artifact={a} />
+          ))}
+        </div>
+      )}
       {result.raw && <pre className="palette-result-raw">{result.raw}</pre>}
     </section>
   );
+}
+
+function ArtifactRow({ artifact }: { artifact: ArtifactHandle }) {
+  const isScreenshot = artifact.kind === 'screenshot';
+  const isImage = isScreenshot || artifact.kind.startsWith('image');
+  const src = `/api/panel/artifact/${artifact.relative_path}`;
+  const name = artifact.display_path.split('/').pop() ?? artifact.display_path;
+  const meta = formatBytes(artifact.bytes) + (artifact.line_count ? ` · ${artifact.line_count.toLocaleString()} lines` : '');
+
+  if (isImage) {
+    return (
+      <div className="artifact-row artifact-row-image">
+        <span className="artifact-kind">{artifact.kind}</span>
+        <a href={src} target="_blank" rel="noreferrer" className="artifact-preview-link">
+          <img src={src} alt={artifact.display_path} className="artifact-preview" />
+        </a>
+        <span className="artifact-name" title={artifact.display_path}>{name}</span>
+        <span className="artifact-meta">{meta}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="artifact-row">
+      <span className="artifact-kind">{artifact.kind}</span>
+      <span className="artifact-name" title={artifact.display_path}>{name}</span>
+      <span className="artifact-meta">{meta}</span>
+      <a href={src} target="_blank" rel="noreferrer" download={name} className="artifact-download">↓</a>
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function DoctorCard({ service }: { service: DoctorService & { name: string } }) {
@@ -1103,6 +1147,25 @@ function titleLabel(value: string): string {
     .join(' ');
 }
 
+function extractArtifactHandles(result: Record<string, unknown> | null): ArtifactHandle[] {
+  if (!result) return [];
+  const candidates: unknown[] = [];
+  const single = result.artifact_handle;
+  if (single && typeof single === 'object') candidates.push(single);
+  for (const key of ['predicted_artifact_handles', 'output_file_handles', 'artifact_handles']) {
+    const arr = result[key];
+    if (Array.isArray(arr)) candidates.push(...arr);
+  }
+  return candidates.filter((item): item is ArtifactHandle =>
+    item !== null &&
+    typeof item === 'object' &&
+    'kind' in (item as object) &&
+    'relative_path' in (item as object) &&
+    typeof (item as ArtifactHandle).relative_path === 'string' &&
+    (item as ArtifactHandle).relative_path.length > 0
+  );
+}
+
 function formatCommandResponse(response: PanelCommandResponse): CommandResultView {
   const action = commandVerb(response.command);
   const result = asRecord(response.result);
@@ -1114,6 +1177,7 @@ function formatCommandResponse(response: PanelCommandResponse): CommandResultVie
   const title = commandResultTitle(action, result);
   const subtitle = commandResultSubtitle(action, result);
   rows.push(...commandResultRows(action, result));
+  const artifacts = extractArtifactHandles(result);
 
   const handle = extractArtifactHandle(result);
   const imageUrl = handle ? `/v1/artifacts/${handle.relative_path}` : undefined;
@@ -1124,6 +1188,7 @@ function formatCommandResponse(response: PanelCommandResponse): CommandResultVie
     subtitle,
     rows: compactRows(rows),
     body: commandResultBody(action, result),
+    artifacts: artifacts.length > 0 ? artifacts : undefined,
     raw: shouldShowRawResult(action, result) ? JSON.stringify(response.result, null, 2) : undefined,
     imageUrl
   };

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -1258,6 +1258,85 @@ textarea {
   white-space: pre-wrap;
 }
 
+/* Artifact rendering */
+.artifact-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.artifact-list-label {
+  margin: 0 0 2px;
+  color: var(--aurora-text-muted);
+  font-size: var(--aurora-type-caption);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.artifact-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--aurora-border-default);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--aurora-shell-bg) 54%, transparent);
+  padding: 6px 10px;
+  font-size: var(--aurora-type-body-sm);
+}
+
+.artifact-row-image {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.artifact-kind {
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--aurora-accent) 12%, transparent);
+  padding: 1px 6px;
+  color: var(--aurora-accent);
+  font-family: var(--aurora-font-mono);
+  font-size: var(--aurora-type-caption);
+  white-space: nowrap;
+}
+
+.artifact-name {
+  flex: 1;
+  overflow: hidden;
+  color: var(--aurora-text-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-meta {
+  color: var(--aurora-text-muted);
+  font-size: var(--aurora-type-caption);
+  white-space: nowrap;
+}
+
+.artifact-download {
+  color: var(--aurora-accent);
+  font-size: var(--aurora-type-caption);
+  text-decoration: none;
+}
+
+.artifact-download:hover {
+  text-decoration: underline;
+}
+
+.artifact-preview-link {
+  display: block;
+  width: 100%;
+}
+
+.artifact-preview {
+  display: block;
+  max-width: 100%;
+  max-height: 320px;
+  border-radius: 4px;
+  object-fit: contain;
+}
+
 @media (max-width: 980px) {
   .runtime-grid,
   .doctor-grid,

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "5.7.9"
+    "version": "5.8.0"
   },
   "paths": {
     "/v1/ask": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "5.7.9",
+  "version": "5.8.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/web/server/handlers.rs
+++ b/src/web/server/handlers.rs
@@ -35,7 +35,7 @@ pub use auth::{login, panel_state};
 pub use chat::v1_chat;
 pub use chat_stream::v1_chat_stream;
 pub use config::{
-    get_config, get_env_config, ops, panel_command, panel_doctor, panel_status, save_config,
-    save_env_config,
+    get_config, get_env_config, ops, panel_artifact, panel_command, panel_doctor, panel_status,
+    save_config, save_env_config,
 };
 pub use setup::setup_targets;

--- a/src/web/server/handlers/config.rs
+++ b/src/web/server/handlers/config.rs
@@ -15,8 +15,9 @@ use crate::services::{
 };
 use axum::{
     Json,
-    extract::State,
-    http::{HeaderMap, StatusCode},
+    body::Body,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode, header},
     response::IntoResponse,
 };
 use std::sync::Arc;
@@ -352,4 +353,47 @@ fn sanitize_status_payload(mut value: serde_json::Value) -> serde_json::Value {
         }
     }
     value
+}
+
+/// Serve an artifact file from the configured output directory.
+///
+///  must be a relative path (no , no leading ) — enforced
+/// by . Files are served from , the
+/// same root used when constructing  values.
+pub async fn panel_artifact(
+    State((state, cfg)): State<(AppState, Arc<Config>)>,
+    headers: HeaderMap,
+    Path(rel_path): Path<String>,
+) -> impl IntoResponse {
+    if !authorized(&state, &headers) {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    }
+    if rel_path.contains("..") || rel_path.starts_with("/") || rel_path.contains(' ') {
+        return (StatusCode::BAD_REQUEST, "invalid artifact path").into_response();
+    }
+    let artifact_path = cfg.output_dir.join(&rel_path);
+    let canonical_root = match cfg.output_dir.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return (StatusCode::NOT_FOUND, "output dir not found").into_response(),
+    };
+    let canonical = match artifact_path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return (StatusCode::NOT_FOUND, "artifact not found").into_response(),
+    };
+    if !canonical.starts_with(&canonical_root) {
+        return (StatusCode::FORBIDDEN, "path outside output root").into_response();
+    }
+    let bytes = match tokio::fs::read(&canonical).await {
+        Ok(b) => b,
+        Err(_) => return (StatusCode::NOT_FOUND, "artifact not found").into_response(),
+    };
+    let content_type = mime_guess::from_path(&canonical)
+        .first_raw()
+        .unwrap_or("application/octet-stream");
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, content_type)],
+        Body::from(bytes),
+    )
+        .into_response()
 }

--- a/src/web/server/routing.rs
+++ b/src/web/server/routing.rs
@@ -167,6 +167,7 @@ fn panel_routes() -> Router<ServeState> {
             post(super::super::panel_first_run::first_run_ask),
         )
         .route("/api/panel/setup/targets", get(handlers::setup_targets))
+        .route("/api/panel/artifact/{*path}", get(handlers::panel_artifact))
 }
 
 async fn v1_capabilities() -> Json<ServerInfo> {


### PR DESCRIPTION
Ports the panel-artifact rendering feature from the closed #197 affinity branch (it was dropped from #196 because its \`panel_artifact\` handler lived on that branch).

## What
- Web panel renders artifact handles returned by commands: screenshots inline as \`<img>\`, other kinds as concise file-metadata rows (kind badge, filename, size, download link).
- New \`GET /api/panel/artifact/{*path}\` route serving files from \`cfg.output_dir\` with MIME detection, path-containment validation, and panel-auth gating.

## Conflict resolution against main
- \`page.tsx\`: kept main's \`imageUrl\` field alongside the feature's new \`artifacts\` field.
- \`routing.rs\`: re-added the \`/api/panel/artifact\` route into the post-#196 split \`panel_routes()\`.

Minor version bump → 5.8.0. \`cargo check --lib\` + \`cargo clippy --lib -- -D warnings\` clean; version parity verified across Cargo.toml/lock, README, apps/web manifests, CHANGELOG.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render artifact handles in the web panel and add a secure artifact file route. Screenshots render inline; other files show a compact row with kind, name, size, and a download link.

- New Features
  - Added `GET /api/panel/artifact/{*path}` to serve files from `cfg.output_dir` with MIME detection, path containment, and panel-auth gating.
  - Panel now reads artifact handles from common result keys and surfaces them via a new `artifacts` field (keeps `imageUrl` for compatibility); added basic styles for artifact lists and previews.

<sup>Written for commit 99ed9cbd37c965dbaacea872f6841021bb09fb15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

