### PR TITLE
feat(ingest): unify file-ingest engine across all git providers and embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.9.0] - 2026-06-10
+
+### Added
+
+- **Unified file-ingest engine** (`src/vector/ops/file_ingest.rs`) — a single
+  shared `collect_files` walker and `chunk_file` adapter that replaces four
+  divergent copies in GitHub, GitLab, generic Git, and `embed <dir>`. All git
+  providers now produce tree-sitter AST-aware chunks with canonical
+  `code_*`/`symbol_*` Qdrant payload fields; previously only GitHub did.
+- **Symbol metadata for GitLab file ingest** — `gitlab_file_chunk_payload` added
+  to `src/ingest/gitlab/embed.rs`; closes `axon_rust-wavn`.
+- **Symbol metadata for generic Git / Gitea file ingest** — `file_docs` in
+  `src/ingest/generic_git.rs` now emits one `PreparedDoc` per `CodeChunk` with
+  `line_start/end`, `chunking_method`, `symbol_name/kind`, and
+  `symbol_extraction_status`.
+- **Symbol metadata for local `embed <dir>` code files** — `prepare_embed_docs`
+  in `src/vector/ops/tei/prepare.rs` now routes local code files through the
+  shared `chunk_file` engine and attaches `code_*`/`symbol_*` extra payload per
+  chunk, aligning `axon embed` output with the ingest path.
+
+### Changed
+
+- `src/ingest/git_files.rs` — removed the now-redundant `collect_repo_files`
+  walker (superseded by `file_ingest::collect_files`); `embed_docs` wrapper
+  retained.
+
 ## [5.8.1] - 2026-06-10
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "5.8.1"
+version = "5.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "5.8.1"
+version = "5.9.0"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 5.8.1
+Version: 5.9.0
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "5.8.1"
+    "version": "5.9.0"
   },
   "paths": {
     "/v1/ask": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/docs/sessions/2026-06-10-18-49-unify-file-ingest-engine.md
+++ b/docs/sessions/2026-06-10-18-49-unify-file-ingest-engine.md
@@ -1,0 +1,158 @@
+---
+date: 2026-06-10 18:49:27 EST
+repo: git@github.com:jmagar/axon.git
+branch: worktree-feat+unify-file-ingest-engine
+head: 8e17bf95
+plan: docs/superpowers/plans/2026-06-10-unify-code-file-ingestion-engine.md
+working directory: /home/jmagar/workspace/axon/.claude/worktrees/feat+unify-file-ingest-engine
+worktree: /home/jmagar/workspace/axon/.claude/worktrees/feat+unify-file-ingest-engine 8e17bf95 [worktree-feat+unify-file-ingest-engine]
+pr: "#202 feat(ingest): unify file-ingest engine across all git providers and embed — https://github.com/jmagar/axon/pull/202"
+beads: axon_rust-rcbe (created + closed), axon_rust-wavn (closed)
+---
+
+# Unify code/file ingestion engine — GH #189
+
+## User Request
+
+Check whether GitHub issues #163 and #189 were implemented or had beads, close #163 (confirmed done via xkv0), then write and execute an implementation plan for #189 (Unify code/file ingestion engine), open a PR, run a full multi-agent review of that PR, and dispatch agents to fix all issues found.
+
+## Session Overview
+
+This session took GitHub issue #189 from an open, untracked state to a reviewed PR with all critical and important issues resolved. The 2026-06-08 plan was found to have four compile-breaking bugs (API changes that landed in PR #192 after the plan was written); a corrected plan was written at `2026-06-10-unify-code-file-ingestion-engine.md`. A subagent executed the plan in a fresh worktree, opening PR #202. A five-dimensional parallel review found one critical data-loss bug (point-ID collision) and 14 additional issues; three parallel agents addressed all 15+ findings in the same session.
+
+## Sequence of Events
+
+1. **Triaged GH #163 and #189.** Confirmed #163 was implemented in the xkv0 epic and closed it via `gh issue close`. Confirmed #189 had no bead and no code implementation.
+2. **Invoked `superpowers:writing-plans` for #189.** Reviewed the 2026-06-08 plan and found four compile-breaking bugs: `CodeChunk.symbol_name`/`symbol_kind` fields (replaced by `symbol: Option<Symbol>` in PR #192), `chunk.symbol_kind.is_some()` predicate, `chunk.symbol_name` field access instead of method, and `GitPayload.content_kind: "file"` string instead of `ContentKind::File`.
+3. **Wrote corrected plan** at `docs/superpowers/plans/2026-06-10-unify-code-file-ingestion-engine.md`. Verified against live code: `Symbol`/`SymbolKind` public exports, `CHUNK_OVERLAP` constant, `code_symbol_extraction_status` visibility, `GitLabProject` struct fields.
+4. **Plan review found two more bugs.** `GitLabProject { id: 1, ... }` — field doesn't exist; and a Task 4 `spawn_blocking` binding that tried to destructure a 3-tuple as a 2-tuple. Both fixed in the plan before execution.
+5. **Created worktree** via `EnterWorktree` (`feat/unify-file-ingest-engine`). Dispatched a subagent with `superpowers:executing-plans` to implement all 8 tasks. Subagent committed 6 times, opened PR #202 with 2704 tests passing.
+6. **Ran `/pr-review-toolkit:review-pr`** — five parallel agents (code-reviewer, test-analyzer, silent-failure-hunter, comment-analyzer, type-design-analyzer). Found 1 critical, 5 important, 5 suggestion-level, and 5 test gap issues.
+7. **Dispatched three parallel fix agents** partitioned by file ownership. All 15+ issues resolved in one round with zero git conflicts.
+8. **Pushed** final branch state and closed `axon_rust-wavn` bead.
+
+## Key Findings
+
+- **Point-ID collision (data loss):** GitLab, generic Git, and local-embed paths emitted one `PreparedDoc` per `CodeChunk` with `idx=0` always. For prose-fallback chunks on newline-free files, all chunks got `#L1-L1` → identical UUID v5 → only the last chunk survived upsert. Fixed by appending `#{idx}` to URLs via `enumerate()`. `src/ingest/gitlab/files.rs:152`, `src/ingest/generic_git.rs:262`, `src/vector/ops/tei/prepare.rs:339`.
+- **`break` on directory iterator error** in `collect_files` abandoned all remaining entries in a directory. Should be `continue`. `src/vector/ops/file_ingest.rs:68`.
+- **`chunking_method` false positives:** `supports_tree_sitter_chunking(ext)` returned `true` for `.rs` even when tree-sitter fell back to prose. Prose chunks were labeled `"tree_sitter"` in Qdrant. Fixed by dropping the grammar-check branch, relying only on `chunk.symbol.is_some()`. `src/vector/ops/file_ingest.rs:120-126`.
+- **Local-embed `domain` always `"unknown"`:** `Url::parse` always fails for local paths — dead code. Fixed to derive domain from parent directory name. `src/vector/ops/tei/prepare.rs:319-322`.
+- **`ingest/CLAUDE.md` canonical pattern** still showed old `chunk_code` API after the PR. Would cause any new ingest source author to bypass the shared engine.
+
+## Technical Decisions
+
+- **Option (b) for collision fix** (append `#{idx}`) over option (a) (switch to GitHub's batching model with `chunk_extra`). The batching model is safer long-term but would require restructuring all three providers; the index suffix is a minimal, targeted fix with no behavioral regression.
+- **Drop `supports_tree_sitter_chunking` from `chunking_method`** rather than introducing a `ChunkingMethod` return enum from `chunk_file`. The enum approach is cleaner architecturally but breaks the public API surface of three callers; the conservative symbol-only check removes false positives without touching call sites.
+- **Parallel agent dispatch for both plan execution and review fixes**, with file-ownership partitioning to eliminate git merge conflicts. Agents 1, 2, and 3 each owned disjoint file sets.
+- **`anyhow::Result` return from `collect_files`** instead of `Box<dyn Error + Send + Sync>`, consistent with the rest of the ingest module and avoiding error-chain flattening at all three call sites.
+
+## Files Changed
+
+| Status | Path | Purpose |
+|--------|------|---------|
+| created | `src/vector/ops/file_ingest.rs` | Shared walker (`collect_files`) + `chunk_file` adapter + `SelectionPolicy` enum |
+| created | `src/vector/ops/file_ingest_tests.rs` | Engine tests (6 total after review fixes) |
+| created | `src/ingest/gitlab/embed_tests.rs` | Payload contract test for `gitlab_file_chunk_payload` |
+| created | `src/ingest/gitlab/files_tests.rs` | Owner-derivation edge-case tests (new sidecar) |
+| modified | `src/vector/ops.rs` | Added `pub mod file_ingest;` |
+| modified | `src/ingest/github/files/prepare.rs` | Rewired onto shared engine; removed `expect()` |
+| modified | `src/ingest/github/files/prepare_tests.rs` | Minor updates |
+| modified | `src/ingest/gitlab/embed.rs` | Added `gitlab_file_chunk_payload()` |
+| modified | `src/ingest/gitlab/files.rs` | Shared engine + per-chunk symbol payload + collision fix + test sidecar declaration |
+| modified | `src/ingest/generic_git.rs` | `file_doc` → `file_docs` (per-chunk), collision fix, panic message with file path |
+| modified | `src/ingest/generic_git_tests.rs` | Added non-UTF-8 and whitespace-only file tests |
+| modified | `src/ingest/git_files.rs` | Removed dead `collect_repo_files` |
+| modified | `src/vector/ops/tei/prepare.rs` | Local code files: shared engine + per-chunk payload + collision fix + domain fix + error log level |
+| modified | `src/vector/ops/tei/prepare_tests.rs` | Updated + new `dir_embed_code_file_gets_symbol_payload` test |
+| modified | `src/ingest/CLAUDE.md` | Updated canonical pattern to `chunk_file`; corrected GitLab/generic-Git descriptions |
+| modified | `src/vector/CLAUDE.md` | Added shared engine cross-reference section |
+| modified | `CHANGELOG.md` | Version 5.9.0 entry |
+| modified | `Cargo.toml` | Version bump 5.8.1 → 5.9.0 |
+| modified | `apps/web/package.json` | Version bump |
+| modified | `apps/web/openapi/axon.json` | Version bump |
+| modified | `README.md` | Version bump |
+| modified | `docs/superpowers/plans/2026-06-10-unify-code-file-ingestion-engine.md` | Created (corrected plan); review fixes applied to Task 3 struct literal and Task 4 spawn_blocking binding |
+
+## Beads Activity
+
+| Bead ID | Title | Action | Final Status | Notes |
+|---------|-------|--------|--------------|-------|
+| `axon_rust-rcbe` | Unify code/file ingestion engine (GH #189) | Created, claimed, closed | Closed | Created at session start to track #189 work; closed after PR #202 opened and review fixes pushed |
+| `axon_rust-wavn` | GitLab per-chunk symbol metadata (deferred from xkv0) | Closed | Closed | Was P4/open; resolved as part of Phase 2 of the plan (Task 3+4 in PR #202) |
+
+## Repository Maintenance
+
+**Plans:** `docs/superpowers/plans/2026-06-10-unify-code-file-ingestion-engine.md` is now fully executed (all 8 tasks complete, PR #202 open). Not moved — superpowers plans live under `docs/superpowers/plans/`, not `docs/plans/complete/`; no move needed. The older `docs/superpowers/plans/2026-06-08-unify-code-file-ingestion-engine.md` is superseded but left in place as a historical record (the newer plan references it explicitly).
+
+**Beads:** `axon_rust-rcbe` created and closed this session. `axon_rust-wavn` (GitLab symbol gap, P4, open since 2026-06-08) closed — work was delivered by PR #202 Task 3/4.
+
+**Worktrees/branches:** Worktree `feat+unify-file-ingest-engine` at `.claude/worktrees/feat+unify-file-ingest-engine` is active — PR #202 is open and not yet merged; left in place. Main worktree at `/home/jmagar/workspace/axon` is on `main` and clean. No stale worktrees detected.
+
+**Stale docs:** `src/ingest/CLAUDE.md` canonical pattern was stale post-PR (still showed `chunk_code` API) — updated this session. `src/vector/CLAUDE.md` shared-engine section added. No other stale docs identified.
+
+## Tools and Skills Used
+
+- **`superpowers:writing-plans`** — invoked to write the implementation plan; produced `2026-06-10-unify-code-file-ingestion-engine.md`
+- **`superpowers:using-git-worktrees` + `EnterWorktree`** — created isolated worktree for plan execution
+- **`superpowers:executing-plans` (subagent)** — executed all 8 plan tasks in the worktree; opened PR #202
+- **`pr-review-toolkit:review-pr`** — dispatched 5 parallel specialized review agents (code-reviewer, pr-test-analyzer, silent-failure-hunter, comment-analyzer, type-design-analyzer)
+- **3 parallel fix agents** — partitioned by file ownership; addressed all 15+ review findings
+- **`gh` CLI** — closed GH #163, viewed PR #202
+- **`bd` (beads CLI)** — created `axon_rust-rcbe`, closed `axon_rust-rcbe` and `axon_rust-wavn`
+- **`cargo check`, `cargo test --lib`** — used after each agent round to verify compile and test health
+
+## Commands Executed
+
+| Command | Result |
+|---------|--------|
+| `gh issue close 163` | Closed |
+| `git diff main...HEAD --name-only` | 21 files changed |
+| `bd close axon_rust-wavn` | Closed successfully |
+| `git log --oneline -6` | 9 commits on branch (6 feat/refactor + 3 fix/test) |
+| `git push` | Pushed to `origin/worktree-feat+unify-file-ingest-engine` |
+
+## Behavior Changes (Before/After)
+
+| Area | Before | After |
+|------|--------|-------|
+| GitLab file ingest | `chunk_code()` → `Vec<String>`, one `PreparedDoc` per file, no `symbol_*`/`code_line_*` payload | `chunk_file()` → `Vec<CodeChunk>`, one `PreparedDoc` per chunk with full `symbol_*`/`code_line_*`/`code_chunking_method` metadata |
+| generic Git / Gitea file ingest | Same prose-only path as GitLab | Same as GitLab above; Gitea inherits via `ingest_git_repository` |
+| Local `embed <dir>` code files | `chunk_code()` → `Vec<String>`, single shared payload per file | Per-chunk `PreparedDoc` with `code_file_type`, `code_chunking_method`, `symbol_*` metadata |
+| Qdrant point IDs for prose chunks on newline-free files | Collision: all chunks got same UUID, only last survived | Unique: URL includes `#{idx}` suffix |
+| `domain` field for locally embedded files | Always `"unknown"` | Parent directory name |
+| `chunking_method` label for grammar-supported ext with prose fallback | `"tree_sitter"` (false positive) | `"prose"` (correct) |
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---------|----------|--------|--------|
+| `cargo check --bin axon` (after each agent) | `Finished` | Clean, 0 errors | pass |
+| `cargo test --lib -- file_ingest` | 6 pass | 6 passed | pass |
+| `cargo test --lib -- gitlab generic_git` | All pass | 24 passed | pass |
+| `cargo test --lib` (full) | ≥ 2704 pass | 2704 passed, 0 failed | pass |
+| `just verify` (monolith + fmt + clippy) | All clean | All clean | pass |
+
+## Risks and Rollback
+
+- **URL format change for non-GitHub chunks:** The `#{idx}` suffix is a new format. Any downstream filter that matches on exact URL strings (e.g., `retrieve` by URL, watch state URLs) will not match pre-PR chunks for GitLab/generic-Git sources until those are re-ingested. Existing Qdrant data is not broken — just the new chunks get the new format going forward.
+- **Rollback:** `git revert` the 9 commits on this branch, or close PR #202 without merging. No schema version bump, so no Qdrant migration needed for rollback.
+
+## Decisions Not Taken
+
+- **GitHub batching model for collision fix** (one `PreparedDoc` per file with `chunk_extra`): would fix the root issue more thoroughly but required restructuring all three providers and changing how `prepare_embed_docs` rebuilds `chunk_extra` for non-GitHub callers. Deferred to a future PR.
+- **`ChunkingMethod` enum return from `chunk_file`**: architecturally cleaner for `chunking_method` accuracy, but breaks 3 call sites in a public API. The conservative `symbol.is_some()` check achieves the same result (no false positives) with zero API churn.
+
+## References
+
+- GH #189: https://github.com/jmagar/axon/issues/189
+- GH #163: https://github.com/jmagar/axon/issues/163 (closed)
+- PR #202: https://github.com/jmagar/axon/pull/202
+- PR #192 (xkv0 — introduced `chunk_code_chunks`, `CodeChunk.symbol`): merged prior session
+- `docs/superpowers/plans/2026-06-10-unify-code-file-ingestion-engine.md`
+
+## Next Steps
+
+- **Merge PR #202** after CI passes. No follow-on schema migration needed.
+- **Re-ingest GitLab and generic-Git repos** to populate `symbol_*`/`code_line_*` metadata for previously indexed content; use `axon refresh --filter gitlab` and `axon refresh --filter git`.
+- **Follow-on: GitHub batching model** — align GitLab/generic-Git to use one `PreparedDoc` per file with `chunk_extra` (same as GitHub) to eliminate the stale-tail cleanup gap identified in the review (orphaned chunks when file shrinks).
+- **Follow-on: `gitlab/files.rs` direct unit tests** for non-UTF-8 and oversized file skip paths — currently only owner-derivation and payload contract are tested for GitLab; the per-file read logic requires extracting it from `embed_files` or adding integration-style tests.

--- a/src/ingest/CLAUDE.md
+++ b/src/ingest/CLAUDE.md
@@ -62,18 +62,19 @@ ingest/
 - **403/404 graceful degradation:** `is_missing_or_forbidden()` returns `Ok(0)` for any phase that 403s or 404s — private features just silently produce no chunks
 - **Pagination:** `fetch_paginated()` in `client.rs` follows `x-next-page` response header, `per_page=100`; respects `max_items` cap (reuses `cfg.github_max_issues` / `cfg.github_max_prs`)
 - **Payload schema:** `source_type = "gitlab"`. Every chunk carries `provider`, `host`, `namespace_path`, `project`, `content_kind` (`"repo_metadata"` / `"file"` / `"issue"` / `"merge_request"` / `"wiki"`), `default_branch`, `visibility`, `last_activity_at`, plus a `gitlab` nested object with type-specific fields
-- **No file-level chunking strategy selection** — all file content uses `chunk_text()` (prose chunking); tree-sitter code chunking is not yet applied to GitLab files (unlike GitHub)
+- **File chunking** — `gitlab/files.rs` now uses the shared `file_ingest` engine (`chunk_file` / `collect_files`) for tree-sitter code chunking with `code_*`/`symbol_*` payload, matching the GitHub and generic-Git paths. One `PreparedDoc` per `CodeChunk`.
 
 ### Gitea/Forgejo (`gitea.rs`)
 - Uses the Gitea-compatible REST API for repository metadata, issues, and pull requests.
 - `GITEA_TOKEN` is optional for public repositories and is sent as `Authorization: token <token>` when present.
 - Known public hosts (`gitea.com`, `codeberg.org`) auto-classify from URL; self-hosted instances should use `gitea:<host>/<owner>/<repo>` or `forgejo:<host>/<owner>/<repo>`.
-- File ingest delegates to the shared generic Git clone path but preserves `source_type = "gitea"` and `provider = "gitea"` in Qdrant payloads.
+- File ingest delegates to `ingest_git_repository` in `generic_git.rs`, which now uses the shared `file_ingest` engine for tree-sitter code chunking and `code_*`/`symbol_*` payload. Preserves `source_type = "gitea"` and `provider = "gitea"` in Qdrant payloads.
 
 ### Generic Git (`generic_git.rs`)
 - Explicit-only target form: `git:https://host/path/repo.git`.
 - HTTPS-only by design; SSH and local filesystem paths are rejected.
 - Indexes repository docs by default and source files when source inclusion is enabled. It does not call provider APIs, so it does not ingest issues, PRs, wiki pages, releases, or repository metadata beyond clone-derived file metadata.
+- File ingest uses the shared engine (`src/vector/ops/file_ingest.rs`): tree-sitter code chunking with canonical `code_*`/`symbol_*` payload per chunk. One `PreparedDoc` is emitted per `CodeChunk`.
 
 ### GitHub (`github/`)
 - Uses `git clone --depth=1` subprocess for source files and wiki clone; `octocrab` for issues/PRs pagination

--- a/src/ingest/CLAUDE.md
+++ b/src/ingest/CLAUDE.md
@@ -147,17 +147,18 @@ All ingest sources use the unified `embed_prepared_docs` pipeline via `PreparedD
 use crate::core::content::url_to_domain;
 use crate::vector::ops::PreparedDoc;
 use crate::vector::ops::tei::embed_prepared_docs;
-use crate::vector::ops::input::chunk_text;       // prose: 2000-char with 200-char overlap
-use crate::vector::ops::input::code::chunk_code;  // tree-sitter AST-aware chunking
+use crate::vector::ops::file_ingest::{SelectionPolicy, chunk_file, chunking_method, collect_files};
+use crate::vector::ops::input::classify::path_extension;
 
 let url = "https://github.com/rust-lang/rust/blob/main/src/lib.rs".to_string();
 let domain = url_to_domain(&url);  // → "github.com"
-let chunks = chunk_code(&content, "rs").unwrap_or_else(|| chunk_text(&content));
+let ext = path_extension(&rel).to_ascii_lowercase();
+let chunks = chunk_file(&content, &ext); // Vec<CodeChunk> — tree-sitter or prose fallback
 
 let doc = PreparedDoc {
     url,
     domain,
-    chunks,
+    chunks: chunks.into_iter().map(|c| c.text).collect(),
     source_type: "github".to_string(),
     content_type: "text",
     title: Some("src/lib.rs".to_string()),
@@ -182,10 +183,11 @@ let summary = embed_prepared_docs(cfg, vec![doc], None).await?;
 5. Individual doc failures are logged and skipped (reported via `EmbedSummary.docs_failed`)
 
 ### Chunking
-- **Prose** (`chunk_text`): 2000-char chunks with 200-char overlap
-- **Code** (`chunk_code`): tree-sitter AST-aware (Rust, Python, JS, TS, Go, Bash); falls back to `chunk_text` for unsupported extensions
+- All git providers and local `embed <dir>` use `chunk_file(&content, ext) → Vec<CodeChunk>` from `src/vector/ops/file_ingest.rs`. Use `chunk_code` / `chunk_text` only if you need the lower-level primitives directly.
+- **`chunk_file`**: tries tree-sitter via `chunk_code_chunks`; falls back to synthetic `CodeChunk`s wrapping `chunk_text_with_offsets` — callers always get `Vec<CodeChunk>` with line ranges regardless of extension.
+- **Prose** (`chunk_text`): 2000-char chunks with 200-char overlap (low-level; prefer `chunk_file`)
+- **Code** (`chunk_code`): tree-sitter AST-aware (Rust, Python, JS, TS, Go, Bash); falls back to `chunk_text` for unsupported extensions (low-level; prefer `chunk_file`)
 - Callers must chunk content **before** building `PreparedDoc` — the pipeline expects pre-chunked `chunks: Vec<String>`
-- Choose based on file extension: `chunk_code(&text, &ext).unwrap_or_else(|| chunk_text(&text))`
 
 ## ingest_jobs Schema
 `axon_ingest_jobs` differs from other job tables:

--- a/src/ingest/generic_git.rs
+++ b/src/ingest/generic_git.rs
@@ -208,6 +208,9 @@ pub(crate) async fn file_docs(
         }
     };
 
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
     let ext = path_extension(&rel).to_ascii_lowercase();
     // Move content + ext into spawn_blocking; return both so
     // code_symbol_extraction_status can run after on the calling thread.
@@ -220,7 +223,7 @@ pub(crate) async fn file_docs(
         }
     })
     .await
-    .map_err(|e| anyhow!("chunk_file panicked: {e}"))?;
+    .map_err(|e| anyhow!("chunk_file panicked for {rel}: {e}"))?;
     if code_chunks.is_empty() {
         return Ok(Vec::new());
     }
@@ -229,7 +232,7 @@ pub(crate) async fn file_docs(
     let ftype = classify_file_type(&rel).to_string();
     let is_test = is_test_path(&rel);
     let mut docs = Vec::with_capacity(code_chunks.len());
-    for chunk in code_chunks {
+    for (idx, chunk) in code_chunks.into_iter().enumerate() {
         let method = chunking_method(&ext, &chunk);
         let extra = build_git_payload(&GitPayload {
             provider: provider.to_string(),
@@ -253,8 +256,8 @@ pub(crate) async fn file_docs(
         });
         docs.push(PreparedDoc::ingest(
             format!(
-                "{}#{}:{}#L{}-L{}",
-                target.web_url, branch, rel, chunk.start_line, chunk.end_line
+                "{}#{}:{}#L{}-L{}#{}",
+                target.web_url, branch, rel, chunk.start_line, chunk.end_line, idx
             ),
             target.host.clone(),
             vec![chunk.text],

--- a/src/ingest/generic_git.rs
+++ b/src/ingest/generic_git.rs
@@ -6,17 +6,20 @@ use reqwest::Url;
 use crate::core::config::Config;
 use crate::core::http::validate_url;
 use crate::core::logging::{log_done, log_info, log_warn};
-use crate::ingest::git_files::collect_repo_files;
 use crate::ingest::git_payload::{ContentKind, GitPayload, build_git_payload};
 use crate::ingest::progress::PhaseReporter;
 use crate::ingest::subprocess::{
     MAX_INGEST_FILE_BYTES, SUBPROCESS_TIMEOUT, run_command_with_timeout,
 };
+use crate::vector::ops::PreparedDoc;
+use crate::vector::ops::embed_prepared_docs;
+use crate::vector::ops::file_ingest::{
+    SelectionPolicy, chunk_file, chunking_method, collect_files,
+};
 use crate::vector::ops::input::classify::{
     classify_file_type, is_test_path, language_name, path_extension,
 };
-use crate::vector::ops::input::code::chunk_code;
-use crate::vector::ops::{PreparedDoc, chunk_text, embed_prepared_docs};
+use crate::vector::ops::input::code::code_symbol_extraction_status;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenericGitTarget {
@@ -123,15 +126,15 @@ pub(crate) async fn ingest_git_repository(
     let branch = current_branch(tmp.path())
         .await
         .unwrap_or_else(|| "HEAD".to_string());
-    let files = collect_repo_files(tmp.path(), include_source).await?;
+    let files = collect_files(tmp.path(), SelectionPolicy::Allowlist { include_source })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
     let total = files.len();
     let mut docs = Vec::new();
     for (index, file) in files.into_iter().enumerate() {
-        if let Some(doc) =
-            file_doc(tmp.path(), &target, &branch, file, source_type, provider).await?
-        {
-            docs.push(doc);
-        }
+        let mut file_docs =
+            file_docs(tmp.path(), &target, &branch, file, source_type, provider).await?;
+        docs.append(&mut file_docs);
         if (index + 1) % 25 == 0 || index + 1 == total {
             reporter
                 .report(serde_json::json!({"files_done": index + 1, "files_total": total}))
@@ -156,14 +159,14 @@ pub(crate) async fn ingest_git_repository(
     Ok(summary.chunks_embedded)
 }
 
-async fn file_doc(
+pub(crate) async fn file_docs(
     root: &Path,
     target: &GenericGitTarget,
     branch: &str,
     file: PathBuf,
     source_type: &str,
     provider: &str,
-) -> Result<Option<PreparedDoc>> {
+) -> Result<Vec<PreparedDoc>> {
     let rel = file
         .strip_prefix(root)?
         .to_string_lossy()
@@ -176,13 +179,13 @@ async fn file_doc(
                 "command=ingest_git skip_large_file path={rel} size_bytes={}",
                 meta.len()
             ));
-            return Ok(None);
+            return Ok(Vec::new());
         }
         Err(e) => {
             log_warn(&format!(
                 "command=ingest_git stat_failed path={rel} err={e}"
             ));
-            return Ok(None);
+            return Ok(Vec::new());
         }
         _ => {}
     }
@@ -194,51 +197,73 @@ async fn file_doc(
             log_warn(&format!(
                 "command=ingest_git read_failed path={rel} err={e}"
             ));
-            return Ok(None);
+            return Ok(Vec::new());
         }
     };
     let content = match String::from_utf8(bytes) {
         Ok(t) => t,
         Err(_) => {
             log_warn(&format!("command=ingest_git skip_non_utf8 path={rel}"));
-            return Ok(None);
+            return Ok(Vec::new());
         }
     };
 
-    // Q-H1: tree-sitter AST-aware chunking with extension routing + text fallback
     let ext = path_extension(&rel).to_ascii_lowercase();
-    let chunks = tokio::task::spawn_blocking({
+    // Move content + ext into spawn_blocking; return both so
+    // code_symbol_extraction_status can run after on the calling thread.
+    let (code_chunks, content, ext) = tokio::task::spawn_blocking({
         let content = content.clone();
         let ext = ext.clone();
-        move || chunk_code(&content, &ext).unwrap_or_else(|| chunk_text(&content))
+        move || {
+            let chunks = chunk_file(&content, &ext);
+            (chunks, content, ext)
+        }
     })
     .await
-    .unwrap_or_else(|_| chunk_text(&content));
-    if chunks.is_empty() {
-        return Ok(None);
+    .map_err(|e| anyhow!("chunk_file panicked: {e}"))?;
+    if code_chunks.is_empty() {
+        return Ok(Vec::new());
     }
-    let extra = build_git_payload(&GitPayload {
-        provider: provider.to_string(),
-        host: target.host.clone(),
-        owner: None,
-        repo: target.name.clone(),
-        content_kind: ContentKind::File,
-        branch: Some(branch.to_string()),
-        file_path: Some(rel.clone()),
-        file_language: Some(language_name(path_extension(&rel)).to_string()),
-        file_type: Some(classify_file_type(&rel).to_string()),
-        file_is_test: Some(is_test_path(&rel)),
-        meta: Some(serde_json::json!({ "clone_url": target.clone_url })),
-        ..GitPayload::default()
-    });
-    Ok(Some(PreparedDoc::ingest(
-        format!("{}#{}:{}", target.web_url, branch, rel),
-        target.host.clone(),
-        chunks,
-        source_type,
-        Some(rel.clone()),
-        Some(extra),
-    )))
+    let symbol_status = code_symbol_extraction_status(&content, &ext, &code_chunks);
+    let lang = language_name(&ext).to_string();
+    let ftype = classify_file_type(&rel).to_string();
+    let is_test = is_test_path(&rel);
+    let mut docs = Vec::with_capacity(code_chunks.len());
+    for chunk in code_chunks {
+        let method = chunking_method(&ext, &chunk);
+        let extra = build_git_payload(&GitPayload {
+            provider: provider.to_string(),
+            host: target.host.clone(),
+            owner: None,
+            repo: target.name.clone(),
+            content_kind: ContentKind::File,
+            branch: Some(branch.to_string()),
+            file_path: Some(rel.clone()),
+            file_language: Some(lang.clone()),
+            file_type: Some(ftype.clone()),
+            file_is_test: Some(is_test),
+            line_start: Some(chunk.start_line),
+            line_end: Some(chunk.end_line),
+            chunking_method: Some(method.to_string()),
+            symbol_name: chunk.symbol_name().map(str::to_string),
+            symbol_kind: chunk.symbol_kind_str().map(str::to_string),
+            symbol_extraction_status: Some(symbol_status.to_string()),
+            meta: Some(serde_json::json!({ "clone_url": target.clone_url })),
+            ..GitPayload::default()
+        });
+        docs.push(PreparedDoc::ingest(
+            format!(
+                "{}#{}:{}#L{}-L{}",
+                target.web_url, branch, rel, chunk.start_line, chunk.end_line
+            ),
+            target.host.clone(),
+            vec![chunk.text],
+            source_type,
+            Some(rel.clone()),
+            Some(extra),
+        ));
+    }
+    Ok(docs)
 }
 
 #[cfg(test)]

--- a/src/ingest/generic_git_tests.rs
+++ b/src/ingest/generic_git_tests.rs
@@ -39,3 +39,55 @@ fn rejects_non_https_generic_git_target() {
     assert!(parse_generic_git_target("git:ssh://example.com/org/repo.git").is_err());
     assert!(parse_generic_git_target("git:http://example.com/org/repo.git").is_err());
 }
+
+#[tokio::test]
+async fn file_docs_returns_empty_for_whitespace_only_file() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    // Whitespace only — the prose chunker returns the raw whitespace text as one
+    // chunk, so `code_chunks` is non-empty and a PreparedDoc is emitted.
+    // Verify the path succeeds (no panic / error) and no chunk carries a
+    // tree-sitter symbol (whitespace has no extractable symbols).
+    std::fs::write(root.join("empty.rs"), "   \n\n   \n").unwrap();
+    let target = GenericGitTarget {
+        host: "example.com".into(),
+        name: "repo".into(),
+        clone_url: "https://example.com/r.git".into(),
+        web_url: "https://example.com/r".into(),
+    };
+    let docs = file_docs(root, &target, "main", root.join("empty.rs"), "git", "git")
+        .await
+        .unwrap();
+    // The prose chunker emits a chunk even for whitespace-only content, so the
+    // result is non-empty — but none of the docs should carry tree-sitter symbols.
+    for doc in &docs {
+        let extra = doc.extra.as_ref().unwrap();
+        assert_ne!(
+            extra.get("code_chunking_method").and_then(|v| v.as_str()),
+            Some("tree_sitter"),
+            "whitespace-only file should not produce tree-sitter symbol chunks"
+        );
+    }
+}
+
+#[tokio::test]
+async fn file_docs_skips_non_utf8_without_error() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join("binary.rs"), b"\xff\xfe invalid utf8 \x00").unwrap();
+    let target = GenericGitTarget {
+        host: "example.com".into(),
+        name: "repo".into(),
+        clone_url: "https://example.com/r.git".into(),
+        web_url: "https://example.com/r".into(),
+    };
+    let result = file_docs(root, &target, "main", root.join("binary.rs"), "git", "git").await;
+    assert!(
+        result.is_ok(),
+        "non-UTF-8 file should not propagate an error"
+    );
+    assert!(
+        result.unwrap().is_empty(),
+        "non-UTF-8 file should produce no PreparedDocs"
+    );
+}

--- a/src/ingest/generic_git_tests.rs
+++ b/src/ingest/generic_git_tests.rs
@@ -1,5 +1,30 @@
 use super::*;
 
+#[tokio::test]
+async fn generic_file_docs_chunk_rust_as_code_with_symbols() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join("lib.rs"), "fn alpha() {}\n\nfn beta() {}\n").unwrap();
+    let target = GenericGitTarget {
+        host: "example.com".into(),
+        name: "repo".into(),
+        clone_url: "https://example.com/r.git".into(),
+        web_url: "https://example.com/r".into(),
+    };
+    let docs = file_docs(root, &target, "main", root.join("lib.rs"), "git", "git")
+        .await
+        .unwrap();
+    assert!(!docs.is_empty());
+    let extra = docs[0].extra.as_ref().unwrap();
+    assert_eq!(extra["code_chunking_method"], "tree_sitter");
+    assert_eq!(extra["code_file_type"], "source");
+    assert!(
+        docs.iter()
+            .any(|d| d.extra.as_ref().unwrap()["symbol_kind"] == "function"),
+        "expected at least one function-symbol chunk"
+    );
+}
+
 #[test]
 fn parses_explicit_https_git_target() {
     let target = parse_generic_git_target("git:https://example.com/org/repo.git").unwrap();

--- a/src/ingest/git_files.rs
+++ b/src/ingest/git_files.rs
@@ -1,52 +1,14 @@
 //! Shared helpers for git-backed ingest providers.
 //!
-//! Centralises the repo-tree BFS walk and the `embed_docs` thin wrapper that
-//! were previously duplicated verbatim in `generic_git`, `gitlab/files`, and
-//! the gitea embed module (Q-H2, Q-M7).
-
-use std::path::{Path, PathBuf};
+//! Provides the `embed_docs` thin wrapper shared by `generic_git`,
+//! `gitlab/files`, and the gitea embed module.  The repo-tree BFS walk has
+//! been consolidated into `src/vector/ops/file_ingest.rs` (`collect_files`),
+//! which all git providers now call directly.
 
 use anyhow::{Result, anyhow};
 
 use crate::core::config::Config;
-use crate::ingest::github::{is_indexable_doc_path, is_indexable_source_path};
 use crate::vector::ops::{PreparedDoc, embed_prepared_docs};
-
-/// Recursively walk `root`, returning all files that pass the indexability
-/// filters.  Skips `.git` directories.  Results are sorted for deterministic
-/// ordering (important for reproducible embedding).
-///
-/// This is the single canonical BFS walk shared by `generic_git`,
-/// `gitlab/files`, and `gitea` — previously three near-identical copies.
-pub(crate) async fn collect_repo_files(root: &Path, include_source: bool) -> Result<Vec<PathBuf>> {
-    let mut dirs = vec![root.to_path_buf()];
-    let mut files = Vec::new();
-    while let Some(dir) = dirs.pop() {
-        let mut entries = tokio::fs::read_dir(&dir).await?;
-        while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            let file_type = entry.file_type().await?;
-            if file_type.is_dir() {
-                if entry.file_name() != ".git" {
-                    dirs.push(path);
-                }
-                continue;
-            }
-            if !file_type.is_file() {
-                continue;
-            }
-            let rel = path
-                .strip_prefix(root)?
-                .to_string_lossy()
-                .replace('\\', "/");
-            if is_indexable_doc_path(&rel) || (include_source && is_indexable_source_path(&rel)) {
-                files.push(path);
-            }
-        }
-    }
-    files.sort();
-    Ok(files)
-}
 
 /// Thin wrapper around `embed_prepared_docs` used by all git ingest embed
 /// helpers — avoids duplicating the `map_err` / `.chunks_embedded` extraction

--- a/src/ingest/github/files/prepare.rs
+++ b/src/ingest/github/files/prepare.rs
@@ -7,18 +7,16 @@ use crate::core::config::Config;
 use crate::core::logging::log_warn;
 use crate::ingest::subprocess::MAX_INGEST_FILE_BYTES;
 use crate::vector::ops::PreparedDoc;
+use crate::vector::ops::file_ingest::{
+    SelectionPolicy, chunk_file, chunking_method, collect_files,
+};
 use crate::vector::ops::input::classify::{
     classify_file_type, is_test_path, language_name, path_extension,
 };
-use crate::vector::ops::input::{
-    chunk_text_with_offsets,
-    code::{
-        CodeChunk, chunk_code_chunks, code_symbol_extraction_status, supports_tree_sitter_chunking,
-    },
-};
+use crate::vector::ops::input::code::code_symbol_extraction_status;
 
+use super::super::GitHubCommonFields;
 use super::super::meta::{GitHubPayloadParams, build_github_payload};
-use super::super::{GitHubCommonFields, is_indexable_doc_path, is_indexable_source_path};
 use crate::ingest::git_payload::ContentKind;
 const MAX_FILE_BYTES: u64 = MAX_INGEST_FILE_BYTES;
 
@@ -37,38 +35,25 @@ pub(super) struct FileEmbedCtx {
     pub is_private: Option<bool>,
 }
 
-/// Recursively walk a directory and collect file paths relative to `root`.
+/// Recursively walk `root` and return indexable file paths relative to `root`.
+///
+/// Thin wrapper over the shared `file_ingest::collect_files` engine so GitHub
+/// uses the same walker as all other git providers.
 pub(super) async fn collect_indexable_files(
     root: &Path,
     include_source: bool,
 ) -> Result<Vec<String>> {
-    let mut files = Vec::new();
-    let mut stack = vec![root.to_path_buf()];
-
-    while let Some(dir) = stack.pop() {
-        let mut entries = tokio::fs::read_dir(&dir).await?;
-        while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-
-            if name == ".git" || name == "node_modules" || name == "__pycache__" {
-                continue;
-            }
-
-            if entry.file_type().await?.is_dir() {
-                stack.push(path);
-            } else if let Ok(rel) = path.strip_prefix(root) {
-                let rel_str = rel.to_string_lossy().to_string();
-                let should_index = is_indexable_doc_path(&rel_str)
-                    || (include_source && is_indexable_source_path(&rel_str));
-                if should_index {
-                    files.push(rel_str);
-                }
-            }
-        }
-    }
-
-    Ok(files)
+    let abs = collect_files(root, SelectionPolicy::Allowlist { include_source })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(abs
+        .into_iter()
+        .filter_map(|p| {
+            p.strip_prefix(root)
+                .ok()
+                .map(|r| r.to_string_lossy().replace('\\', "/"))
+        })
+        .collect())
 }
 
 /// Read a single file from the cloned repo and build **one** `PreparedDoc` for the
@@ -132,11 +117,11 @@ pub(super) async fn read_file_embed_docs(
     let ext = file_extension(path);
     let ext_for_chunk = ext.clone();
     let (chunks, text) = tokio::task::spawn_blocking(move || {
-        let chunks = code_or_text_chunks(&text, &ext_for_chunk);
+        let chunks = chunk_file(&text, &ext_for_chunk);
         (chunks, text)
     })
     .await
-    .map_err(|e| format!("chunk_code panicked: {e}"))?;
+    .map_err(|e| format!("chunk_file panicked: {e}"))?;
     if chunks.is_empty() {
         return Ok(Vec::new());
     }
@@ -217,64 +202,6 @@ pub(super) async fn read_file_embed_docs(
     );
     doc.chunk_extra = chunk_extra;
     Ok(vec![doc])
-}
-
-fn code_or_text_chunks(text: &str, ext: &str) -> Vec<CodeChunk> {
-    // Fall back to prose chunking both for unsupported extensions (`None`) and
-    // for supported-language files that tree-sitter splits into zero non-empty
-    // chunks (`Some([])`) — otherwise such a file would be silently dropped.
-    match chunk_code_chunks(text, ext) {
-        Some(chunks) if !chunks.is_empty() => chunks,
-        _ => text_chunks(text),
-    }
-}
-
-fn text_chunks(text: &str) -> Vec<CodeChunk> {
-    // The chunker reports each chunk's true byte offset — never re-discover the
-    // position by substring search, which matches the first duplicate
-    // occurrence and mislabels line ranges on files with repeated content.
-    chunk_text_with_offsets(text)
-        .into_iter()
-        .map(|(byte_offset, chunk)| {
-            let chunk_len = chunk.len();
-            let line_start = line_for_byte(text, byte_offset);
-            // Inclusive end so a chunk ending on a newline maps to its own last
-            // line, not the next one.
-            let line_end = if chunk_len > 0 {
-                line_for_byte(text, byte_offset + chunk_len - 1)
-            } else {
-                line_start
-            };
-            CodeChunk {
-                text: chunk,
-                byte_start: byte_offset,
-                byte_end: byte_offset + chunk_len,
-                start_line: line_start,
-                end_line: line_end,
-                declaration_start_line: line_start,
-                declaration_end_line: line_end,
-                symbol: None,
-            }
-        })
-        .collect()
-}
-
-fn chunking_method(ext: &str, chunk: &CodeChunk) -> &'static str {
-    if chunk.symbol.is_some() || supports_tree_sitter_chunking(ext) {
-        "tree_sitter"
-    } else {
-        "prose"
-    }
-}
-
-fn line_for_byte(content: &str, byte: usize) -> u32 {
-    // Snap to a char boundary: an inclusive end may land inside a multibyte
-    // character, and slicing on a non-boundary panics.
-    let mut capped = byte.min(content.len());
-    while capped > 0 && !content.is_char_boundary(capped) {
-        capped -= 1;
-    }
-    content[..capped].bytes().filter(|b| *b == b'\n').count() as u32 + 1
 }
 
 pub(super) fn build_file_embed_ctx(

--- a/src/ingest/github/files/prepare.rs
+++ b/src/ingest/github/files/prepare.rs
@@ -145,7 +145,10 @@ pub(super) async fn read_file_embed_docs(
     // Use the overall file line range (first chunk start → last chunk end).
     let file_line_start = chunks.first().map(|c| c.start_line);
     let file_line_end = chunks.last().map(|c| c.end_line);
-    let chunk_method = chunking_method(&ext, chunks.first().expect("non-empty"));
+    let chunk_method = match chunks.first() {
+        Some(c) => chunking_method(&ext, c),
+        None => return Ok(Vec::new()),
+    };
 
     // Per-chunk payload overrides (P-H1): the file's chunks share one PreparedDoc
     // for TEI batching, but each chunk keeps its own symbol_* and code_line_*

--- a/src/ingest/github/files/prepare_tests.rs
+++ b/src/ingest/github/files/prepare_tests.rs
@@ -92,9 +92,10 @@ async fn non_utf8_file_is_skipped_not_failed() {
 fn text_chunks_line_ranges_are_monotonic_with_duplicate_lines() {
     // Repeated identical lines make chunk text ambiguous; offsets must come
     // from the chunker itself so line ranges stay non-regressing and correct.
+    // Use a non-code extension so the prose path is exercised.
     let line = "the quick brown fox jumps over the lazy dog\n";
     let text = line.repeat(200);
-    let chunks = text_chunks(&text);
+    let chunks = chunk_file(&text, "txt");
     assert!(chunks.len() >= 2, "expected multiple prose chunks");
     let mut prev_start = 0u32;
     for chunk in &chunks {
@@ -119,10 +120,11 @@ fn text_chunks_byte_ranges_point_at_true_positions_with_repeated_content() {
     // A repeated block bigger than the overlap window: substring re-discovery
     // would lock the second chunk onto the first occurrence and emit wrong
     // byte ranges + line numbers. Offsets must point at each chunk's true slice
-    // and advance strictly forward.
+    // and advance strictly forward. Use a non-code extension so the prose
+    // path is exercised (chunk_file falls back to text_chunks for unknown ext).
     let block = "fn dup() { body(); }\n".repeat(150);
     let text = format!("{block}// divider\n{block}");
-    let chunks = text_chunks(&text);
+    let chunks = chunk_file(&text, "txt");
     assert!(chunks.len() >= 2, "expected multiple prose chunks");
     let mut prev_start = 0usize;
     for (i, chunk) in chunks.iter().enumerate() {
@@ -146,7 +148,7 @@ fn text_chunks_byte_ranges_point_at_true_positions_with_repeated_content() {
 #[test]
 fn prose_file_uses_prose_chunking_method() {
     let text = format!("# Title\n\n{}", "prose body line\n".repeat(60));
-    let chunks = code_or_text_chunks(&text, "md");
+    let chunks = chunk_file(&text, "md");
     assert!(!chunks.is_empty());
     assert!(chunks.iter().all(|chunk| chunk.symbol.is_none()));
     assert_eq!(chunking_method("md", &chunks[0]), "prose");

--- a/src/ingest/gitlab/embed.rs
+++ b/src/ingest/gitlab/embed.rs
@@ -9,6 +9,7 @@ use crate::ingest::git_payload::{
 use crate::vector::ops::input::classify::{
     classify_file_type, is_test_path, language_name, path_extension,
 };
+use crate::vector::ops::input::code::CodeChunk;
 use crate::vector::ops::{PreparedDoc, chunk_text};
 
 use super::client::fetch_paginated;
@@ -372,3 +373,51 @@ fn wiki_doc(
         Some(extra),
     ))
 }
+
+/// Build a canonical per-chunk GitLab file payload with code + symbol metadata.
+///
+/// Produces the same `git_*`/`code_*`/`symbol_*` fields as GitHub file chunks
+/// so cross-provider Qdrant filters work uniformly.
+pub(crate) fn gitlab_file_chunk_payload(
+    target: &GitLabTarget,
+    project: &GitLabProject,
+    rel: &str,
+    branch: &str,
+    chunk: &CodeChunk,
+    chunking_method: &str,
+    symbol_status: &str,
+) -> serde_json::Value {
+    let owner: Option<String> = {
+        let path = &target.namespace_path;
+        path.rfind('/').map(|i| path[..i].to_string())
+    };
+    build_git_payload(&GitPayload {
+        provider: "gitlab".to_string(),
+        host: target.host.clone(),
+        owner,
+        repo: target.project.clone(),
+        content_kind: ContentKind::File,
+        branch: Some(branch.to_string()),
+        file_path: Some(rel.to_string()),
+        file_language: Some(language_name(path_extension(rel)).to_string()),
+        file_type: Some(classify_file_type(rel).to_string()),
+        file_is_test: Some(is_test_path(rel)),
+        line_start: Some(chunk.start_line),
+        line_end: Some(chunk.end_line),
+        chunking_method: Some(chunking_method.to_string()),
+        symbol_name: chunk.symbol_name().map(str::to_string),
+        symbol_kind: chunk.symbol_kind_str().map(str::to_string),
+        symbol_extraction_status: Some(symbol_status.to_string()),
+        meta: Some(serde_json::json!({
+            "namespace_path": target.namespace_path,
+            "visibility": project.visibility,
+            "last_activity_at": project.last_activity_at,
+            "default_branch": project.default_branch,
+        })),
+        ..GitPayload::default()
+    })
+}
+
+#[cfg(test)]
+#[path = "embed_tests.rs"]
+mod tests;

--- a/src/ingest/gitlab/embed_tests.rs
+++ b/src/ingest/gitlab/embed_tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+use crate::ingest::gitlab::types::{GitLabProject, GitLabTarget};
+
+fn test_target() -> GitLabTarget {
+    GitLabTarget {
+        host: "gitlab.com".to_string(),
+        namespace_path: "mygroup/myproject".to_string(),
+        project: "myproject".to_string(),
+        web_url: "https://gitlab.com/mygroup/myproject".to_string(),
+        clone_url: "https://gitlab.com/mygroup/myproject.git".to_string(),
+        api_base: "https://gitlab.com/api/v4".to_string(),
+        encoded_project_path: "mygroup%2Fmyproject".to_string(),
+    }
+}
+
+fn test_project() -> GitLabProject {
+    GitLabProject {
+        path_with_namespace: "mygroup/myproject".to_string(),
+        name: "myproject".to_string(),
+        description: None,
+        default_branch: Some("main".to_string()),
+        web_url: "https://gitlab.com/mygroup/myproject".to_string(),
+        visibility: Some("public".to_string()),
+        star_count: None,
+        forks_count: None,
+        open_issues_count: None,
+        issues_enabled: None,
+        merge_requests_enabled: None,
+        wiki_enabled: None,
+        last_activity_at: None,
+    }
+}
+
+#[test]
+fn gitlab_file_chunk_payload_sets_code_and_symbol_fields() {
+    use crate::vector::ops::input::code::{CodeChunk, Symbol, SymbolKind};
+    let target = test_target();
+    let project = test_project();
+    let chunk = CodeChunk {
+        text: "fn x() {}".into(),
+        byte_start: 0,
+        byte_end: 9,
+        start_line: 10,
+        end_line: 12,
+        declaration_start_line: 10,
+        declaration_end_line: 12,
+        symbol: Some(Symbol {
+            kind: SymbolKind::Function,
+            name: Some("x".into()),
+        }),
+    };
+    let payload = gitlab_file_chunk_payload(
+        &target,
+        &project,
+        "src/lib.rs",
+        "main",
+        &chunk,
+        "tree_sitter",
+        "ok",
+    );
+    assert_eq!(payload["git_content_kind"], "file");
+    assert_eq!(payload["code_file_path"], "src/lib.rs");
+    assert_eq!(payload["code_line_start"], 10);
+    assert_eq!(payload["code_line_end"], 12);
+    assert_eq!(payload["code_chunking_method"], "tree_sitter");
+    assert_eq!(payload["symbol_name"], "x");
+    assert_eq!(payload["symbol_kind"], "function");
+    assert_eq!(payload["symbol_extraction_status"], "ok");
+}

--- a/src/ingest/gitlab/files.rs
+++ b/src/ingest/gitlab/files.rs
@@ -5,14 +5,17 @@ use base64::Engine as _;
 
 use crate::core::config::Config;
 use crate::core::logging::log_warn;
-use crate::ingest::git_files::{collect_repo_files, embed_docs};
+use crate::ingest::git_files::embed_docs;
 use crate::ingest::progress::PhaseReporter;
 use crate::ingest::subprocess::MAX_INGEST_FILE_BYTES;
 use crate::ingest::subprocess::{SUBPROCESS_TIMEOUT, run_command_with_timeout};
-use crate::vector::ops::input::code::chunk_code;
-use crate::vector::ops::{PreparedDoc, chunk_text};
+use crate::vector::ops::PreparedDoc;
+use crate::vector::ops::file_ingest::{
+    SelectionPolicy, chunk_file, chunking_method, collect_files,
+};
+use crate::vector::ops::input::code::code_symbol_extraction_status;
 
-use super::embed::gitlab_payload;
+use super::embed::gitlab_file_chunk_payload;
 use super::types::{GitLabProject, GitLabTarget};
 
 async fn clone_repo(
@@ -78,7 +81,9 @@ pub(crate) async fn embed_files(
         .report(serde_json::json!({"phase": "cloning", "repo": target.namespace_path}))
         .await;
     let tmp = clone_repo(cfg, target, branch).await?;
-    let files = collect_repo_files(tmp.path(), include_source).await?;
+    let files = collect_files(tmp.path(), SelectionPolicy::Allowlist { include_source })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     let total = files.len();
     let mut docs = Vec::new();
     for (index, file) in files.into_iter().enumerate() {
@@ -125,32 +130,45 @@ pub(crate) async fn embed_files(
             .and_then(|e| e.to_str())
             .unwrap_or("")
             .to_ascii_lowercase();
-        // Move content into spawn_blocking — avoids cloning large files.
-        let chunks = match tokio::task::spawn_blocking(move || {
-            chunk_code(&content, &ext).unwrap_or_else(|| chunk_text(&content))
+        // Move content + ext into spawn_blocking; return content + ext so
+        // code_symbol_extraction_status can run after on the calling thread.
+        let (code_chunks, content, ext) = match tokio::task::spawn_blocking(move || {
+            let chunks = chunk_file(&content, &ext);
+            (chunks, content, ext)
         })
         .await
         {
-            Ok(chunks) => chunks,
+            Ok(triple) => triple,
             Err(e) => {
                 log_warn(&format!(
                     "command=ingest_gitlab chunk_panicked path={rel} err={e}"
                 ));
-                vec![]
+                continue;
             }
         };
-        if !chunks.is_empty() {
+        if code_chunks.is_empty() {
+            continue;
+        }
+        let symbol_status = code_symbol_extraction_status(&content, &ext, &code_chunks);
+        for chunk in code_chunks {
+            let method = chunking_method(&ext, &chunk);
             docs.push(PreparedDoc::ingest(
-                format!("{}/-/blob/{}/{}", target.web_url, branch, rel),
+                format!(
+                    "{}/-/blob/{}/{}#L{}-L{}",
+                    target.web_url, branch, rel, chunk.start_line, chunk.end_line
+                ),
                 target.host.clone(),
-                chunks,
+                vec![chunk.text.clone()],
                 "gitlab",
                 Some(rel.clone()),
-                Some(gitlab_payload(
+                Some(gitlab_file_chunk_payload(
                     target,
                     project,
-                    "file",
-                    serde_json::json!({"path": rel, "branch": branch}),
+                    &rel,
+                    branch,
+                    &chunk,
+                    method,
+                    symbol_status,
                 )),
             ));
         }

--- a/src/ingest/gitlab/files.rs
+++ b/src/ingest/gitlab/files.rs
@@ -140,9 +140,12 @@ pub(crate) async fn embed_files(
         {
             Ok(triple) => triple,
             Err(e) => {
-                log_warn(&format!(
-                    "command=ingest_gitlab chunk_panicked path={rel} err={e}"
-                ));
+                tracing::error!(
+                    namespace = %target.namespace_path,
+                    path = %rel,
+                    err = %e,
+                    "ingest_gitlab: chunk_file task panicked"
+                );
                 continue;
             }
         };
@@ -150,12 +153,12 @@ pub(crate) async fn embed_files(
             continue;
         }
         let symbol_status = code_symbol_extraction_status(&content, &ext, &code_chunks);
-        for chunk in code_chunks {
+        for (idx, chunk) in code_chunks.into_iter().enumerate() {
             let method = chunking_method(&ext, &chunk);
             docs.push(PreparedDoc::ingest(
                 format!(
-                    "{}/-/blob/{}/{}#L{}-L{}",
-                    target.web_url, branch, rel, chunk.start_line, chunk.end_line
+                    "{}/-/blob/{}/{}#L{}-L{}#{}",
+                    target.web_url, branch, rel, chunk.start_line, chunk.end_line, idx
                 ),
                 target.host.clone(),
                 vec![chunk.text.clone()],
@@ -189,3 +192,7 @@ pub(crate) async fn embed_files(
         .await;
     Ok(chunks)
 }
+
+#[cfg(test)]
+#[path = "files_tests.rs"]
+mod tests;

--- a/src/ingest/gitlab/files_tests.rs
+++ b/src/ingest/gitlab/files_tests.rs
@@ -1,0 +1,121 @@
+use super::super::embed::gitlab_file_chunk_payload;
+use crate::ingest::gitlab::types::{GitLabProject, GitLabTarget};
+use crate::vector::ops::input::code::{CodeChunk, Symbol, SymbolKind};
+
+fn make_target(namespace_path: &str) -> GitLabTarget {
+    let project = namespace_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(namespace_path)
+        .to_string();
+    GitLabTarget {
+        host: "gitlab.com".into(),
+        namespace_path: namespace_path.into(),
+        project,
+        web_url: format!("https://gitlab.com/{namespace_path}"),
+        clone_url: format!("https://gitlab.com/{namespace_path}.git"),
+        api_base: "https://gitlab.com/api/v4".into(),
+        encoded_project_path: namespace_path.replace('/', "%2F"),
+    }
+}
+
+fn make_project() -> GitLabProject {
+    GitLabProject {
+        path_with_namespace: "group/project".into(),
+        name: "project".into(),
+        description: None,
+        default_branch: Some("main".into()),
+        web_url: "https://gitlab.com/group/project".into(),
+        visibility: Some("public".into()),
+        star_count: None,
+        forks_count: None,
+        open_issues_count: None,
+        issues_enabled: Some(true),
+        merge_requests_enabled: Some(true),
+        wiki_enabled: Some(false),
+        last_activity_at: None,
+    }
+}
+
+fn make_chunk() -> CodeChunk {
+    CodeChunk {
+        text: "fn x() {}".into(),
+        byte_start: 0,
+        byte_end: 9,
+        start_line: 1,
+        end_line: 1,
+        declaration_start_line: 1,
+        declaration_end_line: 1,
+        symbol: Some(Symbol {
+            kind: SymbolKind::Function,
+            name: Some("x".into()),
+        }),
+    }
+}
+
+#[test]
+fn owner_derivation_single_segment_namespace_yields_none() {
+    // Single segment: no '/' in namespace_path → owner should be None / absent
+    let target = make_target("project");
+    let project = make_project();
+    let chunk = make_chunk();
+    let payload = gitlab_file_chunk_payload(
+        &target,
+        &project,
+        "src/lib.rs",
+        "main",
+        &chunk,
+        "tree_sitter",
+        "ok",
+    );
+    // git_owner should be absent or null when there is no namespace prefix
+    assert!(
+        payload
+            .get("git_owner")
+            .map(|v| v.is_null())
+            .unwrap_or(true),
+        "single-segment namespace should produce no git_owner"
+    );
+}
+
+#[test]
+fn owner_derivation_three_segment_namespace() {
+    // Three segments: group/subgroup/project → owner should be "group/subgroup"
+    let target = make_target("group/subgroup/project");
+    let project = make_project();
+    let chunk = make_chunk();
+    let payload = gitlab_file_chunk_payload(
+        &target,
+        &project,
+        "src/lib.rs",
+        "main",
+        &chunk,
+        "tree_sitter",
+        "ok",
+    );
+    assert_eq!(
+        payload["git_owner"], "group/subgroup",
+        "three-segment namespace should produce owner = group/subgroup"
+    );
+}
+
+#[test]
+fn owner_derivation_two_segment_namespace() {
+    // Two segments: group/project → owner should be "group"
+    let target = make_target("group/project");
+    let project = make_project();
+    let chunk = make_chunk();
+    let payload = gitlab_file_chunk_payload(
+        &target,
+        &project,
+        "src/lib.rs",
+        "main",
+        &chunk,
+        "tree_sitter",
+        "ok",
+    );
+    assert_eq!(
+        payload["git_owner"], "group",
+        "two-segment namespace should produce owner = group"
+    );
+}

--- a/src/vector/CLAUDE.md
+++ b/src/vector/CLAUDE.md
@@ -9,6 +9,7 @@ TEI embedding + Qdrant vector store ops. Supports both dense-only and hybrid (de
 vector/
 ├── ops.rs           # Crate-level module root re-exporting ops/*
 └── ops/
+    ├── file_ingest.rs / file_ingest_tests.rs   # Shared walker + chunker used by all git providers and local embed
     ├── commands.rs / commands/
     │   ├── ask.rs               # Module root for the ask path
     │   ├── ask/
@@ -86,9 +87,15 @@ It also detects (and caches) the collection's **VectorMode**:
 Any new command that needs URL counts/dedup **must** use `qdrant_url_facets`. A full scroll on a 2M+ point collection takes 60-80 seconds.
 
 ### Code Chunking (tree-sitter)
-`chunk_code()` in `input/code.rs` splits source code at AST boundaries (functions, structs, classes) using tree-sitter grammars. Returns `Option<Vec<String>>` — `None` means no grammar for the extension, caller should fall back to `chunk_text()`. Supported: Rust, Python, JavaScript, TypeScript/TSX, Go, Bash. Chunk range: 500–2000 chars. GitHub ingest builds `PreparedDoc` with code chunks and embeds via `embed_prepared_docs`.
+`chunk_code()` in `input/code.rs` splits source code at AST boundaries (functions, structs, classes) using tree-sitter grammars. Returns `Option<Vec<String>>` — `None` means no grammar for the extension, caller should fall back to `chunk_text()`. Supported: Rust, Python, JavaScript, TypeScript/TSX, Go, Bash. Chunk range: 500–2000 chars.
 
-**Local directory embed** (`axon embed <dir>`, `tei/prepare.rs`) reuses the same code/prose split: it recurses the tree, prunes junk dirs and binary files via `input/select.rs`, and routes local source files (by extension) through `chunk_code` (tagged `content_type = "text"`) while markdown/docs stay on `chunk_markdown` (tagged `"markdown"`). `code::chunk_code` runs inside `spawn_blocking` there because tree-sitter parsing is CPU-bound. Crawl-output dirs (http manifest URLs) stay on prose chunking.
+**Shared file-ingest engine** (`ops/file_ingest.rs`) — the canonical entry point for all git providers and local `embed <dir>`:
+- `collect_files(root, SelectionPolicy)` — BFS walker with pruning (`select::is_pruned_dir`) and binary-ext filtering. `SelectionPolicy::Allowlist { include_source }` matches the GitHub/GitLab/generic-git allowlist; `SelectionPolicy::Permissive` accepts all non-binary, non-pruned files (used by the embed CLI path).
+- `chunk_file(content, ext)` → `Vec<CodeChunk>` — tries tree-sitter via `chunk_code_chunks`; falls back to synthetic `CodeChunk`s wrapping `chunk_text_with_offsets` so callers always get `CodeChunk` with line ranges.
+- `chunking_method(ext, chunk)` → `&'static str` — returns `"tree_sitter"` or `"prose"` based on whether the chunk carries a symbol.
+All providers (GitHub, GitLab, generic Git, Gitea) and `embed <dir>` now call this engine and emit one `PreparedDoc` per `CodeChunk` with canonical `code_*`/`symbol_*` payload fields.
+
+**Local directory embed** (`axon embed <dir>`, `tei/prepare.rs`) routes local code files through `chunk_file` + `code_symbol_extraction_status` inside `spawn_blocking`, emitting one `PreparedDoc` per chunk with `code_*`/`symbol_*` extra payload. Crawl-output dirs (http manifest URLs) stay on prose chunking via `select_chunks`.
 
 `classify_file_type()` in `input/classify.rs` tags files as `test`/`config`/`doc`/`source` for metadata enrichment. Pure function, no I/O.
 

--- a/src/vector/ops.rs
+++ b/src/vector/ops.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod file_ingest;
 pub mod input;
 pub mod qdrant;
 pub mod ranking;

--- a/src/vector/ops/file_ingest.rs
+++ b/src/vector/ops/file_ingest.rs
@@ -1,12 +1,14 @@
 //! Shared filesystem → chunked-document engine.
 //!
-//! One recursive walker + one chunk-selection adapter, used by every git
-//! provider (after clone) and the local `embed <dir>` path. Providers supply
-//! only the per-file URL and payload; this module owns file selection and the
-//! code-vs-prose chunk decision so all callers produce identical `CodeChunk`
-//! shapes and symbol metadata.
+//! One recursive walker + one chunk-selection adapter shared by all callers;
+//! per-chunk `PreparedDoc` structure varies by provider. Every git provider
+//! (after clone) and the local `embed <dir>` path supply only the per-file URL
+//! and payload; this module owns file selection and the code-vs-prose chunk
+//! decision.
 
 use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow as anyhow_err};
 
 use crate::core::logging::log_warn;
 use crate::ingest::github::{is_indexable_doc_path, is_indexable_source_path};
@@ -14,7 +16,7 @@ use crate::vector::ops::input::classify::path_extension;
 use crate::vector::ops::input::select;
 use crate::vector::ops::input::{
     chunk_text_with_offsets,
-    code::{CodeChunk, chunk_code_chunks, supports_tree_sitter_chunking},
+    code::{CodeChunk, chunk_code_chunks},
 };
 
 /// Which files a directory walk should yield.
@@ -33,10 +35,7 @@ pub enum SelectionPolicy {
 /// skipped. Pruned directories (`select::is_pruned_dir`: `.git`, `node_modules`,
 /// `target`, …) are never descended into. Symlinks are skipped (their
 /// `file_type` is neither file nor dir). Returned paths are sorted.
-pub async fn collect_files(
-    root: &Path,
-    policy: SelectionPolicy,
-) -> Result<Vec<PathBuf>, Box<dyn std::error::Error + Send + Sync>> {
+pub async fn collect_files(root: &Path, policy: SelectionPolicy) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     let mut stack = vec![root.to_path_buf()];
     let mut at_root = true;
@@ -44,7 +43,10 @@ pub async fn collect_files(
         let mut entries = match tokio::fs::read_dir(&dir).await {
             Ok(entries) => entries,
             Err(e) if at_root => {
-                return Err(format!("invalid ingest directory {}: {e}", dir.display()).into());
+                return Err(anyhow_err!(
+                    "invalid ingest directory {}: {e}",
+                    dir.display()
+                ));
             }
             Err(e) => {
                 log_warn(&format!(
@@ -65,23 +67,26 @@ pub async fn collect_files(
                         "command=ingest dir_iter_error path={} err={e}",
                         dir.display()
                     ));
-                    break;
+                    continue;
                 }
             };
             let path = entry.path();
             let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            let Ok(file_type) = entry.file_type().await else {
-                log_warn(&format!(
-                    "command=ingest skip_unknown_type path={}",
-                    path.display()
-                ));
-                continue;
+            let ft = match entry.file_type().await {
+                Ok(ft) => ft,
+                Err(e) => {
+                    log_warn(&format!(
+                        "command=ingest skip_unknown_type path={} err={e}",
+                        path.display()
+                    ));
+                    continue;
+                }
             };
-            if file_type.is_dir() {
+            if ft.is_dir() {
                 if !select::is_pruned_dir(name) {
                     stack.push(path);
                 }
-            } else if file_type.is_file() && include_file(&path, root, policy) {
+            } else if ft.is_file() && include_file(&path, root, policy) {
                 files.push(path);
             }
         }
@@ -115,10 +120,17 @@ pub fn chunk_file(content: &str, ext: &str) -> Vec<CodeChunk> {
     }
 }
 
-/// Report the chunking method for one chunk: tree-sitter when the grammar is
-/// supported (or a symbol was found), else prose.
-pub fn chunking_method(ext: &str, chunk: &CodeChunk) -> &'static str {
-    if chunk.symbol.is_some() || supports_tree_sitter_chunking(ext) {
+/// Report the chunking method for one chunk: `"tree_sitter"` when a tree-sitter
+/// grammar exists for `ext` OR the chunk carries a symbol. Note: returns
+/// `"tree_sitter"` even for grammar-supported files where no symbols were
+/// extracted (tree-sitter ran but found nothing); returns `"prose"` only when
+/// no grammar exists and the chunk has no symbol.
+///
+/// Simplified to use only `chunk.symbol` as the signal, eliminating false
+/// positives where prose fallback chunks on grammar-supported extensions were
+/// incorrectly labeled `"tree_sitter"`.
+pub fn chunking_method(_ext: &str, chunk: &CodeChunk) -> &'static str {
+    if chunk.symbol.is_some() {
         "tree_sitter"
     } else {
         "prose"

--- a/src/vector/ops/file_ingest.rs
+++ b/src/vector/ops/file_ingest.rs
@@ -1,0 +1,167 @@
+//! Shared filesystem → chunked-document engine.
+//!
+//! One recursive walker + one chunk-selection adapter, used by every git
+//! provider (after clone) and the local `embed <dir>` path. Providers supply
+//! only the per-file URL and payload; this module owns file selection and the
+//! code-vs-prose chunk decision so all callers produce identical `CodeChunk`
+//! shapes and symbol metadata.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::logging::log_warn;
+use crate::ingest::github::{is_indexable_doc_path, is_indexable_source_path};
+use crate::vector::ops::input::classify::path_extension;
+use crate::vector::ops::input::select;
+use crate::vector::ops::input::{
+    chunk_text_with_offsets,
+    code::{CodeChunk, chunk_code_chunks, supports_tree_sitter_chunking},
+};
+
+/// Which files a directory walk should yield.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionPolicy {
+    /// Git-repo ingest: curated allowlist of doc/source extensions.
+    Allowlist { include_source: bool },
+    /// Local `embed <dir>`: permissive — everything except binary extensions.
+    Permissive,
+}
+
+/// Recursively collect files under `root` per `policy`.
+///
+/// Resilience: the top-level `root` read is a hard error (nothing to embed if
+/// the target is unreadable), but an unreadable subdirectory is logged and
+/// skipped. Pruned directories (`select::is_pruned_dir`: `.git`, `node_modules`,
+/// `target`, …) are never descended into. Symlinks are skipped (their
+/// `file_type` is neither file nor dir). Returned paths are sorted.
+pub async fn collect_files(
+    root: &Path,
+    policy: SelectionPolicy,
+) -> Result<Vec<PathBuf>, Box<dyn std::error::Error + Send + Sync>> {
+    let mut files = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    let mut at_root = true;
+    while let Some(dir) = stack.pop() {
+        let mut entries = match tokio::fs::read_dir(&dir).await {
+            Ok(entries) => entries,
+            Err(e) if at_root => {
+                return Err(format!("invalid ingest directory {}: {e}", dir.display()).into());
+            }
+            Err(e) => {
+                log_warn(&format!(
+                    "command=ingest skip_unreadable_dir path={} err={e}",
+                    dir.display()
+                ));
+                at_root = false;
+                continue;
+            }
+        };
+        at_root = false;
+        loop {
+            let entry = match entries.next_entry().await {
+                Ok(Some(entry)) => entry,
+                Ok(None) => break,
+                Err(e) => {
+                    log_warn(&format!(
+                        "command=ingest dir_iter_error path={} err={e}",
+                        dir.display()
+                    ));
+                    break;
+                }
+            };
+            let path = entry.path();
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            let Ok(file_type) = entry.file_type().await else {
+                log_warn(&format!(
+                    "command=ingest skip_unknown_type path={}",
+                    path.display()
+                ));
+                continue;
+            };
+            if file_type.is_dir() {
+                if !select::is_pruned_dir(name) {
+                    stack.push(path);
+                }
+            } else if file_type.is_file() && include_file(&path, root, policy) {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn include_file(path: &Path, root: &Path, policy: SelectionPolicy) -> bool {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let ext = path_extension(name);
+    match policy {
+        SelectionPolicy::Permissive => !select::is_binary_ext(ext),
+        SelectionPolicy::Allowlist { include_source } => {
+            let Ok(rel) = path.strip_prefix(root) else {
+                return false;
+            };
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            is_indexable_doc_path(&rel) || (include_source && is_indexable_source_path(&rel))
+        }
+    }
+}
+
+/// Chunk one file's content into `CodeChunk`s: AST-aware via tree-sitter when a
+/// grammar exists for `ext`, otherwise prose chunks adapted to `CodeChunk`.
+/// CPU-bound — callers embedding many files should wrap in `spawn_blocking`.
+pub fn chunk_file(content: &str, ext: &str) -> Vec<CodeChunk> {
+    match chunk_code_chunks(content, ext) {
+        Some(chunks) if !chunks.is_empty() => chunks,
+        _ => text_chunks(content),
+    }
+}
+
+/// Report the chunking method for one chunk: tree-sitter when the grammar is
+/// supported (or a symbol was found), else prose.
+pub fn chunking_method(ext: &str, chunk: &CodeChunk) -> &'static str {
+    if chunk.symbol.is_some() || supports_tree_sitter_chunking(ext) {
+        "tree_sitter"
+    } else {
+        "prose"
+    }
+}
+
+fn text_chunks(text: &str) -> Vec<CodeChunk> {
+    chunk_text_with_offsets(text)
+        .into_iter()
+        .map(|(byte_offset, chunk)| {
+            let chunk_len = chunk.len();
+            let line_start = line_for_byte(text, byte_offset);
+            // Inclusive end so a chunk ending on a newline maps to its own last
+            // line, not the next one.
+            let line_end = if chunk_len > 0 {
+                line_for_byte(text, byte_offset + chunk_len - 1)
+            } else {
+                line_start
+            };
+            CodeChunk {
+                text: chunk,
+                byte_start: byte_offset,
+                byte_end: byte_offset + chunk_len,
+                start_line: line_start,
+                end_line: line_end,
+                declaration_start_line: line_start,
+                declaration_end_line: line_end,
+                symbol: None,
+            }
+        })
+        .collect()
+}
+
+fn line_for_byte(content: &str, byte: usize) -> u32 {
+    // Snap to a char boundary: an inclusive end may land inside a multibyte
+    // character, and slicing on a non-boundary panics.
+    let mut capped = byte.min(content.len());
+    while capped > 0 && !content.is_char_boundary(capped) {
+        capped -= 1;
+    }
+    content[..capped].bytes().filter(|b| *b == b'\n').count() as u32 + 1
+}
+
+#[cfg(test)]
+#[path = "file_ingest_tests.rs"]
+mod tests;

--- a/src/vector/ops/file_ingest_tests.rs
+++ b/src/vector/ops/file_ingest_tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn permissive_recurses_prunes_and_skips_binary() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    tokio::fs::create_dir_all(root.join("a/b")).await.unwrap();
+    tokio::fs::write(root.join("a/b/c.rs"), "fn x() {}")
+        .await
+        .unwrap();
+    tokio::fs::write(root.join("r.md"), "# hi").await.unwrap();
+    tokio::fs::write(root.join("img.png"), "x").await.unwrap();
+    tokio::fs::create_dir_all(root.join("node_modules"))
+        .await
+        .unwrap();
+    tokio::fs::write(root.join("node_modules/x.js"), "1")
+        .await
+        .unwrap();
+
+    let files = collect_files(root, SelectionPolicy::Permissive)
+        .await
+        .unwrap();
+    let names: Vec<String> = files
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    assert_eq!(files.len(), 2, "{names:?}");
+    assert!(names.iter().any(|n| n.ends_with("a/b/c.rs")));
+    assert!(names.iter().any(|n| n.ends_with("r.md")));
+    assert!(!names.iter().any(|n| n.ends_with("img.png")));
+    assert!(!names.iter().any(|n| n.contains("node_modules")));
+}
+
+#[tokio::test]
+async fn allowlist_excludes_non_source_when_include_source_false() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    tokio::fs::write(root.join("a.rs"), "fn x() {}")
+        .await
+        .unwrap();
+    tokio::fs::write(root.join("README.md"), "# hi")
+        .await
+        .unwrap();
+
+    let docs_only = collect_files(
+        root,
+        SelectionPolicy::Allowlist {
+            include_source: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(docs_only.len(), 1);
+    assert!(docs_only[0].to_string_lossy().ends_with("README.md"));
+
+    let with_src = collect_files(
+        root,
+        SelectionPolicy::Allowlist {
+            include_source: true,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(with_src.len(), 2);
+}
+
+#[test]
+fn chunk_file_uses_ast_for_rust_and_sets_symbol() {
+    let src = "fn alpha() {\n    let _ = 1;\n}\n\nfn beta() {\n    let _ = 2;\n}\n";
+    let chunks = chunk_file(src, "rs");
+    assert!(!chunks.is_empty());
+    assert!(
+        chunks.iter().any(|c| c.symbol.is_some()),
+        "expected at least one symbol-bearing chunk"
+    );
+    assert_eq!(chunking_method("rs", &chunks[0]), "tree_sitter");
+}
+
+#[test]
+fn chunk_file_falls_back_to_prose_for_unknown_ext() {
+    let text = "plain prose ".repeat(400);
+    let chunks = chunk_file(&text, "md");
+    assert!(!chunks.is_empty());
+    assert!(chunks.iter().all(|c| c.symbol.is_none()));
+    assert_eq!(chunking_method("md", &chunks[0]), "prose");
+}

--- a/src/vector/ops/file_ingest_tests.rs
+++ b/src/vector/ops/file_ingest_tests.rs
@@ -85,3 +85,33 @@ fn chunk_file_falls_back_to_prose_for_unknown_ext() {
     assert!(chunks.iter().all(|c| c.symbol.is_none()));
     assert_eq!(chunking_method("md", &chunks[0]), "prose");
 }
+
+#[test]
+fn chunk_file_handles_multibyte_content_without_panic() {
+    // A file with multibyte characters; prose fallback path since "txt" has no grammar
+    let base = "fn x() { /* 日本語コメント */ }\n";
+    let text = base.repeat(200); // large enough to produce multiple chunks
+    let chunks = chunk_file(&text, "txt");
+    assert!(!chunks.is_empty());
+    for c in &chunks {
+        // Must not panic on byte boundary — slice into the original string
+        let _ = &text[c.byte_start..c.byte_end.min(text.len())];
+    }
+}
+
+#[test]
+fn chunking_method_returns_prose_for_chunk_without_symbol() {
+    use crate::vector::ops::input::code::CodeChunk;
+    let chunk = CodeChunk {
+        text: "hello".into(),
+        byte_start: 0,
+        byte_end: 5,
+        start_line: 1,
+        end_line: 1,
+        declaration_start_line: 1,
+        declaration_end_line: 1,
+        symbol: None,
+    };
+    // Even for a Rust file extension, a symbol-less chunk should be labeled "prose"
+    assert_eq!(chunking_method("rs", &chunk), "prose");
+}

--- a/src/vector/ops/tei/prepare.rs
+++ b/src/vector/ops/tei/prepare.rs
@@ -8,8 +8,12 @@ use crate::core::http::{fetch_html, http_client};
 use crate::core::logging::log_warn;
 use crate::core::structured::extract_all;
 use crate::core::ui::{accent, symbol_for_status};
+use crate::vector::ops::file_ingest::{chunk_file, chunking_method};
 use crate::vector::ops::input;
-use crate::vector::ops::input::classify::path_extension;
+use crate::vector::ops::input::classify::{
+    classify_file_type, is_test_path, language_name, path_extension,
+};
+use crate::vector::ops::input::code::code_symbol_extraction_status;
 use crate::vector::ops::input::select;
 use spider::url::Url;
 use std::error::Error;
@@ -237,6 +241,17 @@ pub(super) async fn prepare_embed_docs(
         if input_is_dir && url.starts_with("http") && is_excluded_url_path(&url, exclude_prefixes) {
             continue;
         }
+        // For local code files: emit one PreparedDoc per CodeChunk with
+        // canonical code_* / symbol_* extra payload (mirrors the ingest path).
+        // Crawl-manifest docs (http URL) and prose files stay on the existing
+        // select_chunks prose path below.
+        if !url.starts_with("http") && select::should_chunk_as_code(&url) {
+            match embed_code_file_docs(&url, raw, resolved_source_type).await {
+                Some(docs) => prepared.extend(docs),
+                None => skipped_empty += 1,
+            }
+            continue;
+        }
         let (chunks, content_type) = select_chunks(&url, raw).await;
         if chunks.is_empty() {
             tracing::debug!(url = %url, "embed: skipping doc that chunked to nothing");
@@ -274,6 +289,66 @@ pub(super) async fn prepare_embed_docs(
         ));
     }
     Ok(prepared)
+}
+
+/// Chunk a local code file and build one `PreparedDoc` per `CodeChunk`, each
+/// carrying canonical `code_*`/`symbol_*` extra payload.
+///
+/// Returns `Some(docs)` on success (may be empty if all chunks are empty),
+/// or `None` when the file chunked to nothing (caller should count as skipped).
+async fn embed_code_file_docs(
+    url: &str,
+    raw: String,
+    source_type: &str,
+) -> Option<Vec<PreparedDoc>> {
+    let ext = path_extension(url).to_ascii_lowercase();
+    let raw_c = raw.clone();
+    let ext_c = ext.clone();
+    let code_chunks = match tokio::task::spawn_blocking(move || chunk_file(&raw_c, &ext_c)).await {
+        Ok(v) => v,
+        Err(e) => {
+            log_warn(&format!("command=embed code_chunk_panic url={url} err={e}"));
+            Vec::new()
+        }
+    };
+    if code_chunks.is_empty() {
+        tracing::debug!(url = %url, "embed: local code file chunked to nothing");
+        return None;
+    }
+    let symbol_status = code_symbol_extraction_status(&raw, &ext, &code_chunks);
+    let domain = Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| "unknown".to_string());
+    let mut docs = Vec::with_capacity(code_chunks.len());
+    for chunk in code_chunks {
+        let method = chunking_method(&ext, &chunk);
+        let extra = serde_json::json!({
+            "code_file_path": url,
+            "code_language": language_name(&ext),
+            "code_file_type": classify_file_type(url),
+            "code_is_test": is_test_path(url),
+            "code_line_start": chunk.start_line,
+            "code_line_end": chunk.end_line,
+            "code_chunking_method": method,
+            "symbol_name": chunk.symbol_name(),
+            "symbol_kind": chunk.symbol_kind_str(),
+            "symbol_extraction_status": symbol_status,
+        });
+        docs.push(PreparedDoc {
+            url: format!("{url}#L{}-L{}", chunk.start_line, chunk.end_line),
+            domain: domain.clone(),
+            chunks: vec![chunk.text],
+            source_type: source_type.to_string(),
+            content_type: "text",
+            title: Some(url.to_string()),
+            extra: Some(extra),
+            extractor_name: None,
+            structured: None,
+            chunk_extra: Vec::new(),
+        });
+    }
+    Some(docs)
 }
 
 /// Choose a chunking strategy for one document and report its content type.

--- a/src/vector/ops/tei/prepare.rs
+++ b/src/vector/ops/tei/prepare.rs
@@ -307,8 +307,8 @@ async fn embed_code_file_docs(
     let code_chunks = match tokio::task::spawn_blocking(move || chunk_file(&raw_c, &ext_c)).await {
         Ok(v) => v,
         Err(e) => {
-            log_warn(&format!("command=embed code_chunk_panic url={url} err={e}"));
-            Vec::new()
+            tracing::error!(url = %url, err = %e, "embed: chunk_file task panicked");
+            return None;
         }
     };
     if code_chunks.is_empty() {
@@ -316,12 +316,23 @@ async fn embed_code_file_docs(
         return None;
     }
     let symbol_status = code_symbol_extraction_status(&raw, &ext, &code_chunks);
-    let domain = Url::parse(url)
-        .ok()
-        .and_then(|u| u.host_str().map(|s| s.to_string()))
-        .unwrap_or_else(|| "unknown".to_string());
+    let domain = if url.starts_with("http://") || url.starts_with("https://") {
+        Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| "local".to_string())
+    } else {
+        // Local file path — use parent directory name as domain identifier
+        Path::new(url)
+            .components()
+            .rev()
+            .nth(1) // parent dir
+            .and_then(|c| c.as_os_str().to_str())
+            .unwrap_or("local")
+            .to_string()
+    };
     let mut docs = Vec::with_capacity(code_chunks.len());
-    for chunk in code_chunks {
+    for (idx, chunk) in code_chunks.into_iter().enumerate() {
         let method = chunking_method(&ext, &chunk);
         let extra = serde_json::json!({
             "code_file_path": url,
@@ -336,7 +347,7 @@ async fn embed_code_file_docs(
             "symbol_extraction_status": symbol_status,
         });
         docs.push(PreparedDoc {
-            url: format!("{url}#L{}-L{}", chunk.start_line, chunk.end_line),
+            url: format!("{url}#L{}-L{}#{}", chunk.start_line, chunk.end_line, idx),
             domain: domain.clone(),
             chunks: vec![chunk.text],
             source_type: source_type.to_string(),

--- a/src/vector/ops/tei/prepare_tests.rs
+++ b/src/vector/ops/tei/prepare_tests.rs
@@ -44,14 +44,14 @@ async fn dir_embed_recurses_and_filters() {
     let temp_dir = TempDir::new().expect("tempdir");
     let root = temp_dir.path();
 
-    // Nested source file (should be embedded).
+    // Nested source file (should be embedded — one PreparedDoc per chunk).
     tokio::fs::create_dir_all(root.join("a/b"))
         .await
         .expect("mkdir a/b");
     tokio::fs::write(root.join("a/b/c.rs"), "fn main() { println!(\"hi\"); }")
         .await
         .expect("write c.rs");
-    // Top-level doc (should be embedded).
+    // Top-level doc (should be embedded — one PreparedDoc).
     tokio::fs::write(root.join("r.md"), "# Title\n\nbody text here")
         .await
         .expect("write r.md");
@@ -72,19 +72,24 @@ async fn dir_embed_recurses_and_filters() {
         .expect("prepare docs");
 
     let urls: Vec<&str> = prepared.iter().map(|d| d.url.as_str()).collect();
-    assert_eq!(
-        prepared.len(),
-        2,
-        "expected only c.rs and r.md, got {urls:?}"
+    // c.rs is a code file → one PreparedDoc per chunk (at least 1); r.md is prose → 1 doc.
+    assert!(
+        prepared.len() >= 2,
+        "expected at least one doc for c.rs and one for r.md, got {urls:?}"
     );
-    assert!(urls.iter().any(|u| u.ends_with("a/b/c.rs")), "{urls:?}");
+    // Code chunks carry `#L{start}-L{end}` suffix; the path prefix is still present.
+    assert!(
+        urls.iter().any(|u| u.contains("a/b/c.rs")),
+        "expected a/b/c.rs in urls: {urls:?}"
+    );
     assert!(urls.iter().any(|u| u.ends_with("r.md")), "{urls:?}");
     assert!(!urls.iter().any(|u| u.ends_with("img.png")), "{urls:?}");
     assert!(!urls.iter().any(|u| u.contains("node_modules")), "{urls:?}");
 }
 
 /// Code files route through AST chunking and are tagged `content_type = "text"`;
-/// markdown/docs stay on the prose path tagged `"markdown"`.
+/// markdown/docs stay on the prose path tagged `"markdown"`. Code files produce
+/// one PreparedDoc per chunk, with the chunk URL carrying a `#L{start}-L{end}` suffix.
 #[tokio::test]
 async fn dir_embed_tags_code_and_prose_distinctly() {
     let cfg = Config::default_minimal();
@@ -101,9 +106,10 @@ async fn dir_embed_tags_code_and_prose_distinctly() {
         .await
         .expect("prepare docs");
 
+    // lib.rs → per-chunk docs; url contains "lib.rs" with optional "#L..." suffix.
     let rs = prepared
         .iter()
-        .find(|d| d.url.ends_with("lib.rs"))
+        .find(|d| d.url.contains("lib.rs"))
         .expect("lib.rs doc");
     let md = prepared
         .iter()
@@ -114,7 +120,19 @@ async fn dir_embed_tags_code_and_prose_distinctly() {
         md.content_type, "markdown",
         "docs should be tagged markdown"
     );
-    assert!(!rs.chunks.is_empty());
+    // Each per-chunk doc carries exactly one chunk string.
+    assert_eq!(
+        rs.chunks.len(),
+        1,
+        "per-chunk doc must have exactly one chunk"
+    );
+    // Code chunks also carry code_* extra payload.
+    let extra = rs
+        .extra
+        .as_ref()
+        .expect("code chunk must have extra payload");
+    assert!(extra.get("code_chunking_method").is_some());
+    assert!(extra.get("code_file_type").is_some());
 }
 
 /// A single unreadable / non-UTF-8 file in the directory is skipped, not fatal —
@@ -360,4 +378,66 @@ async fn dir_embed_http_code_extension_stays_prose() {
     assert_eq!(prepared[0].url, "https://example.com/script.py");
     // http source → prose path despite the .py extension.
     assert_eq!(prepared[0].content_type, "markdown");
+}
+
+/// A local Rust code file embedded via `embed <dir>` must produce per-chunk
+/// `PreparedDoc`s carrying canonical `code_*` and `symbol_*` extra payload.
+/// Exercises the new code branch that mirrors the ingest path so embed and ingest
+/// produce equivalent Qdrant payloads for code files.
+#[tokio::test]
+async fn dir_embed_code_file_gets_symbol_payload() {
+    let cfg = Config::default_minimal();
+    let temp_dir = TempDir::new().expect("tempdir");
+    let root = temp_dir.path();
+    tokio::fs::write(
+        root.join("lib.rs"),
+        "fn alpha() -> u32 { 1 }\n\nfn beta() -> u32 { 2 }\n",
+    )
+    .await
+    .expect("write lib.rs");
+
+    let prepared = prepare_embed_docs(&cfg, &root.to_string_lossy(), &[], None)
+        .await
+        .expect("prepare docs");
+
+    assert!(
+        !prepared.is_empty(),
+        "expected at least one chunk from lib.rs"
+    );
+    for doc in &prepared {
+        assert!(
+            doc.url.contains("lib.rs"),
+            "url should reference lib.rs: {}",
+            doc.url
+        );
+        assert_eq!(
+            doc.content_type, "text",
+            "code chunks must be tagged 'text'"
+        );
+        assert_eq!(
+            doc.chunks.len(),
+            1,
+            "per-chunk doc must hold exactly one chunk"
+        );
+        let extra = doc
+            .extra
+            .as_ref()
+            .expect("code chunk must have extra payload");
+        assert_eq!(
+            extra["code_chunking_method"], "tree_sitter",
+            "Rust file must use tree-sitter chunking"
+        );
+        assert_eq!(
+            extra["code_file_type"], "source",
+            "lib.rs should be classified as source"
+        );
+        assert!(extra.get("symbol_extraction_status").is_some());
+    }
+    // At least one chunk should carry a function symbol.
+    assert!(
+        prepared
+            .iter()
+            .any(|d| d.extra.as_ref().and_then(|e| e["symbol_kind"].as_str()) == Some("function")),
+        "expected at least one function-symbol chunk"
+    );
 }


### PR DESCRIPTION
Closes #189

## Summary

- Introduces `src/vector/ops/file_ingest.rs` — a single shared `collect_files` walker and `chunk_file` adapter (with `SelectionPolicy` enum) that replaces four divergent copies spread across GitHub, GitLab, generic Git, and the local `embed <dir>` path.
- All git providers (GitHub, GitLab, generic Git, Gitea) and `axon embed <dir>` now route code files through tree-sitter AST-aware chunking, emitting one `PreparedDoc` per `CodeChunk` with canonical `code_*`/`symbol_*` Qdrant payload. Previously only GitHub did this; GitLab, generic Git, Gitea, and local embed used prose-only chunking.
- Fixes the GitLab missing-symbols gap (`axon_rust-wavn`) and the generic-Git/Gitea prose-chunking bug in one place.
- Removes the now-dead `collect_repo_files` walker from `src/ingest/git_files.rs`.
- Bumps version `5.8.1` → `5.9.0`.

## Changed files

| File | Change |
|------|--------|
| `src/vector/ops/file_ingest.rs` (new) | Shared walker + `chunk_file` adapter |
| `src/vector/ops/file_ingest_tests.rs` (new) | 4 engine tests |
| `src/ingest/github/files/prepare.rs` | Rewired onto shared engine |
| `src/ingest/gitlab/embed.rs` | Added `gitlab_file_chunk_payload()` |
| `src/ingest/gitlab/embed_tests.rs` (new) | Payload contract test |
| `src/ingest/gitlab/files.rs` | Uses shared engine; per-chunk symbol payload |
| `src/ingest/generic_git.rs` | `file_docs` → per-chunk with symbols |
| `src/ingest/generic_git_tests.rs` | Extended with symbol assertion test |
| `src/vector/ops/tei/prepare.rs` | Local code files get per-chunk `code_*`/`symbol_*` extra |
| `src/vector/ops/tei/prepare_tests.rs` | Updated + new `dir_embed_code_file_gets_symbol_payload` test |
| `src/ingest/git_files.rs` | Removed dead `collect_repo_files` |
| `src/ingest/CLAUDE.md`, `src/vector/CLAUDE.md` | Docs updated |
| `CHANGELOG.md`, `Cargo.toml`, `README.md`, `apps/web/package.json`, `apps/web/openapi/axon.json` | Version bump to 5.9.0 |

## Test plan

- [x] `cargo check --lib` — clean, no warnings
- [x] `cargo test --lib` — 2704 passed, 0 failed
- [x] `just fmt-check` — passes
- [x] `just clippy` — clean
- [x] Monolith policy — all changed files under 500 lines, all functions under 120 lines
- [x] Pre-commit hooks — xtask-check, monolith, rustfmt all pass
- [x] Pre-push hooks — full test compile passes