### PR TITLE
fix(crawl): honor broadcast buffer config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -924,6 +924,8 @@ jobs:
             echo "QDRANT_URL=http://axon-qdrant:6333"
             echo "TEI_URL=http://localhost:52000"
             echo "AXON_GIT_SHA=$(git rev-parse HEAD)"
+            echo "QDRANT_HTTP_PORT=55333"
+            echo "QDRANT_GRPC_PORT=55334"
             echo "TEI_HTTP_PORT=52000"
             echo "TEI_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5"
             echo "HF_TOKEN="
@@ -949,7 +951,7 @@ jobs:
       - name: Wait for Qdrant and TEI
         run: |
           for _ in {1..90}; do
-            if curl -fsS http://127.0.0.1:53333/healthz >/dev/null 2>&1 && \
+            if curl -fsS http://127.0.0.1:55333/healthz >/dev/null 2>&1 && \
                curl -fsS http://127.0.0.1:52000/health >/dev/null 2>&1; then
               exit 0
             fi
@@ -962,7 +964,7 @@ jobs:
         env:
           AXON_DATA_DIR: .cache/axon-ci
           TEI_URL: http://127.0.0.1:52000
-          QDRANT_URL: http://127.0.0.1:53333
+          QDRANT_URL: http://127.0.0.1:55333
           AXON_LOG_DIR: .cache/axon-ci/logs
           AXON_SQLITE_PATH: .cache/axon-ci/jobs.db
           AXON_EMBED_STRICT_PREDELETE: "false"
@@ -972,7 +974,7 @@ jobs:
         env:
           AXON_DATA_DIR: .cache/axon-ci
           TEI_URL: http://127.0.0.1:52000
-          QDRANT_URL: http://127.0.0.1:53333
+          QDRANT_URL: http://127.0.0.1:55333
           AXON_LOG_DIR: .cache/axon-ci/logs
           AXON_SQLITE_PATH: .cache/axon-ci/jobs.db
         run: |
@@ -992,7 +994,7 @@ jobs:
         env:
           AXON_DATA_DIR: .cache/axon-ci
           TEI_URL: http://127.0.0.1:52000
-          QDRANT_URL: http://127.0.0.1:53333
+          QDRANT_URL: http://127.0.0.1:55333
         run: ./scripts/test-mcp-tools-mcporter.sh
 
       - name: Upload mcporter logs

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -112,8 +112,8 @@ services:
     # killing a rebuildable build process over the database.
     oom_score_adj: -500
     ports:
-      - "53333:6333"
-      - "53334:6334"  # gRPC
+      - "${QDRANT_HTTP_PORT:-53333}:6333"
+      - "${QDRANT_GRPC_PORT:-53334}:6334"  # gRPC
     volumes:
       - ${AXON_HOME:-${HOME}/.axon}/qdrant:/qdrant/storage
       - ./config/qdrant/production.yaml:/qdrant/config/production.yaml:ro

--- a/docs/reference/env-matrix.toml
+++ b/docs/reference/env-matrix.toml
@@ -23,6 +23,30 @@ compatibility = "canonical"
 reason = "Compose-only Qdrant endpoint override used to point the container at a remote or explicitly local Qdrant."
 
 [[env]]
+key = "QDRANT_HTTP_PORT"
+classification = "compose-env"
+runtime_placement = "compose-interpolation"
+surfaces = ["compose"]
+secret = false
+url_or_path = false
+container_allowed = false
+toml_destination = ""
+compatibility = "canonical"
+reason = "Compose-only host port for the optional local Qdrant HTTP endpoint."
+
+[[env]]
+key = "QDRANT_GRPC_PORT"
+classification = "compose-env"
+runtime_placement = "compose-interpolation"
+surfaces = ["compose"]
+secret = false
+url_or_path = false
+container_allowed = false
+toml_destination = ""
+compatibility = "canonical"
+reason = "Compose-only host port for the optional local Qdrant gRPC endpoint."
+
+[[env]]
 key = "TEI_URL"
 classification = "keep-env"
 runtime_placement = "both"

--- a/src/core/config/parse/env_registry/runtime.rs
+++ b/src/core/config/parse/env_registry/runtime.rs
@@ -13,6 +13,22 @@ pub(crate) const RUNTIME_ENV_KEY_SPECS: &[EnvKeySpec] = &[
         Canonical,
         false,
     ),
+    spec(
+        "QDRANT_HTTP_PORT",
+        ComposeEnv,
+        ComposeInterpolation,
+        None,
+        Canonical,
+        false,
+    ),
+    spec(
+        "QDRANT_GRPC_PORT",
+        ComposeEnv,
+        ComposeInterpolation,
+        None,
+        Canonical,
+        false,
+    ),
     spec("TEI_URL", KeepEnv, Both, None, Canonical, false),
     spec(
         "AXON_CHROME_REMOTE_URL",

--- a/src/core/config/parse_tests.rs
+++ b/src/core/config/parse_tests.rs
@@ -1,6 +1,7 @@
 use super::build_config::tests::ENV_LOCK;
 use super::docker::is_docker_service_host;
 use crate::core::config::types::{CommandKind, McpTransport};
+use crate::crawl::engine::crawl_subscribe_buffer_size;
 use clap::Parser;
 use std::env;
 
@@ -36,6 +37,31 @@ fn parse_watch_create_with_every_and_type() {
             "300".to_string(),
         ]
     );
+}
+
+#[allow(unsafe_code)]
+#[test]
+fn parse_max_profile_flows_to_crawl_subscribe_buffer() {
+    let _guard = ENV_LOCK.lock().unwrap();
+
+    let cli = super::Cli::parse_from([
+        "axon",
+        "--qdrant-url",
+        "http://127.0.0.1:53333",
+        "--tei-url",
+        "http://127.0.0.1:52000",
+        "--performance-profile",
+        "max",
+        "--max-pages",
+        "100000",
+        "crawl",
+        "https://example.com",
+    ]);
+    let cfg = super::build_config::into_config(cli).expect("crawl config should parse");
+
+    assert_eq!(cfg.crawl_broadcast_buffer_min, 16_384);
+    assert_eq!(cfg.crawl_broadcast_buffer_max, 65_536);
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 65_536);
 }
 
 #[test]

--- a/src/crawl/engine.rs
+++ b/src/crawl/engine.rs
@@ -49,6 +49,12 @@ pub use waf::{WafDiagnostics, build_waf_diagnostics};
 
 pub const MAX_CRAWL_DIAGNOSTICS: usize = 100;
 
+fn crawl_subscribe_buffer_size(cfg: &Config) -> usize {
+    let min = cfg.crawl_broadcast_buffer_min.max(1);
+    let max = cfg.crawl_broadcast_buffer_max.max(min);
+    (cfg.max_pages as usize).clamp(min, max)
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct CrawlDiagnostic {
     pub phase: String,
@@ -252,9 +258,9 @@ pub async fn run_crawl_once(
         etag::load_and_seed(cfg, &mut website, output_dir).await;
 
     // Buffer at least max_pages worth of messages to prevent silent page drops
-    // under high-throughput crawls (extreme/max profiles). Clamp to 16 384 so
-    // a large --max-pages value can't allocate an unbounded broadcast ring buffer.
-    let subscribe_buf = (cfg.max_pages as usize).clamp(4096, 16_384);
+    // under high-throughput crawls. Profile-derived bounds keep the broadcast
+    // ring large enough for fast profiles without making huge max_pages unbounded.
+    let subscribe_buf = crawl_subscribe_buffer_size(cfg);
     let rx = website.subscribe(subscribe_buf);
     let markdown_dir = output_dir.join("markdown");
     let manifest_path = output_dir.join("manifest.jsonl");
@@ -390,7 +396,7 @@ pub async fn run_sitemap_only(
     // Override the default set by configure_website: sitemap IS the crawl here.
     website.with_ignore_sitemap(false);
 
-    let subscribe_buf = (cfg.max_pages as usize).clamp(4096, 16_384);
+    let subscribe_buf = crawl_subscribe_buffer_size(cfg);
     let rx = website.subscribe(subscribe_buf);
     let manifest_path = output_dir.join("manifest.jsonl");
     let markdown_dir = output_dir.join("markdown");

--- a/src/crawl/engine.rs
+++ b/src/crawl/engine.rs
@@ -48,11 +48,21 @@ pub(crate) use url_utils::{is_junk_discovered_url, regex_escape};
 pub use waf::{WafDiagnostics, build_waf_diagnostics};
 
 pub const MAX_CRAWL_DIAGNOSTICS: usize = 100;
+const LEGACY_CRAWL_BROADCAST_BUFFER_MAX: usize = 16_384;
 
-fn crawl_subscribe_buffer_size(cfg: &Config) -> usize {
+pub(crate) fn crawl_subscribe_buffer_size(cfg: &Config) -> usize {
     let min = cfg.crawl_broadcast_buffer_min.max(1);
-    let max = cfg.crawl_broadcast_buffer_max.max(min);
-    (cfg.max_pages as usize).clamp(min, max)
+    let max = cfg
+        .crawl_broadcast_buffer_max
+        .max(min)
+        .max(LEGACY_CRAWL_BROADCAST_BUFFER_MAX);
+    let desired = if cfg.max_pages == 0 {
+        max
+    } else {
+        cfg.max_pages as usize
+    };
+
+    desired.clamp(min, max)
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/src/crawl/engine_tests.rs
+++ b/src/crawl/engine_tests.rs
@@ -28,7 +28,7 @@ fn default_cfg() -> Config {
 fn crawl_subscribe_buffer_uses_default_profile_bounds() {
     let mut cfg = default_cfg();
     cfg.max_pages = 0;
-    assert_eq!(crawl_subscribe_buffer_size(&cfg), 4096);
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 16_384);
 
     cfg.max_pages = 10_000;
     assert_eq!(crawl_subscribe_buffer_size(&cfg), 10_000);
@@ -44,7 +44,7 @@ fn crawl_subscribe_buffer_uses_configured_profile_bounds() {
     cfg.crawl_broadcast_buffer_max = 65_536;
 
     cfg.max_pages = 0;
-    assert_eq!(crawl_subscribe_buffer_size(&cfg), 16_384);
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 65_536);
 
     cfg.max_pages = 32_000;
     assert_eq!(crawl_subscribe_buffer_size(&cfg), 32_000);
@@ -60,7 +60,20 @@ fn crawl_subscribe_buffer_handles_inverted_bounds() {
     cfg.crawl_broadcast_buffer_max = 128;
     cfg.max_pages = 10_000;
 
-    assert_eq!(crawl_subscribe_buffer_size(&cfg), 1024);
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 10_000);
+}
+
+#[test]
+fn crawl_subscribe_buffer_does_not_regress_below_legacy_cap() {
+    let mut cfg = default_cfg();
+    cfg.crawl_broadcast_buffer_min = 4096;
+    cfg.crawl_broadcast_buffer_max = 8_192;
+
+    cfg.max_pages = 10_000;
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 10_000);
+
+    cfg.max_pages = 0;
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 16_384);
 }
 
 #[test]

--- a/src/crawl/engine_tests.rs
+++ b/src/crawl/engine_tests.rs
@@ -25,6 +25,45 @@ fn default_cfg() -> Config {
 }
 
 #[test]
+fn crawl_subscribe_buffer_uses_default_profile_bounds() {
+    let mut cfg = default_cfg();
+    cfg.max_pages = 0;
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 4096);
+
+    cfg.max_pages = 10_000;
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 10_000);
+
+    cfg.max_pages = 100_000;
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 16_384);
+}
+
+#[test]
+fn crawl_subscribe_buffer_uses_configured_profile_bounds() {
+    let mut cfg = default_cfg();
+    cfg.crawl_broadcast_buffer_min = 16_384;
+    cfg.crawl_broadcast_buffer_max = 65_536;
+
+    cfg.max_pages = 0;
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 16_384);
+
+    cfg.max_pages = 32_000;
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 32_000);
+
+    cfg.max_pages = 100_000;
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 65_536);
+}
+
+#[test]
+fn crawl_subscribe_buffer_handles_inverted_bounds() {
+    let mut cfg = default_cfg();
+    cfg.crawl_broadcast_buffer_min = 1024;
+    cfg.crawl_broadcast_buffer_max = 128;
+    cfg.max_pages = 10_000;
+
+    assert_eq!(crawl_subscribe_buffer_size(&cfg), 1024);
+}
+
+#[test]
 fn test_fallback_when_no_markdown_files() {
     assert!(should_fallback_to_chrome(
         &summary(100, 0, 0),

--- a/src/services/memory/runtime_metadata.rs
+++ b/src/services/memory/runtime_metadata.rs
@@ -24,14 +24,16 @@ pub(super) fn detect_runtime_memory_metadata() -> RuntimeMemoryMetadata {
     let workspace = workspace_path
         .as_ref()
         .and_then(|path| canonicalize_lossy(path).as_deref().and_then(path_to_string));
-    let project = workspace_path
-        .as_ref()
-        .and_then(|path| path.file_name())
-        .and_then(|name| name.to_str())
-        .map(str::to_string);
     let repo = git_output(&cwd_path, ["remote", "get-url", "origin"])
         .as_deref()
         .and_then(remote_to_repo_slug);
+    let project = repo.as_deref().and_then(repo_slug_to_project).or_else(|| {
+        workspace_path
+            .as_ref()
+            .and_then(|path| path.file_name())
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+    });
     let git_branch = git_output(&cwd_path, ["rev-parse", "--abbrev-ref", "HEAD"])
         .filter(|branch| branch != "HEAD");
     let git_commit = git_output(&cwd_path, ["rev-parse", "HEAD"]);
@@ -79,6 +81,14 @@ fn remote_to_repo_slug(remote: &str) -> Option<String> {
         return None;
     }
     Some(format!("{owner}/{repo}"))
+}
+
+fn repo_slug_to_project(repo: &str) -> Option<String> {
+    repo.rsplit('/')
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn canonicalize_lossy(path: &Path) -> Option<PathBuf> {

--- a/tests/compose_env_contract.rs
+++ b/tests/compose_env_contract.rs
@@ -255,12 +255,18 @@ fn services_up_starts_only_infrastructure_services() {
 
     assert!(
         justfile.contains("up -d axon-tei axon-chrome"),
-        "just services-up should keep its infrastructure-only contract"
+        "just services-up should keep its infrastructure-only default contract"
     );
     assert!(
         justfile.contains("stop axon-tei axon-chrome")
             && justfile.contains("rm -f axon-tei axon-chrome"),
-        "just services-down should stop only infrastructure services"
+        "just services-down should stop only default infrastructure services"
+    );
+    assert!(
+        justfile.contains("--profile local-qdrant up -d axon-qdrant")
+            && justfile.contains("--profile local-qdrant stop axon-qdrant")
+            && justfile.contains("--profile local-qdrant rm -f axon-qdrant"),
+        "local Qdrant should stay opt-in through the local-qdrant profile"
     );
     assert!(
         justfile.contains("qdrant-up:")
@@ -415,6 +421,7 @@ fn env_example_only_contains_production_runtime_keys() {
         "AXON_MCP_ALLOWED_ORIGINS",
         // Vector stack
         "QDRANT_URL",
+        "AXON_QDRANT_URL",
         "TEI_URL",
         "TEI_HTTP_PORT",
         "TEI_EMBEDDING_MODEL",


### PR DESCRIPTION
## Summary
- route crawl broadcast subscription sizing through `crawl_broadcast_buffer_min/max`
- apply the same sizing helper to sitemap-only crawls
- add focused tests for default, configured, and defensive bound behavior

## Verification
- cargo fmt --check
- cargo test crawl_subscribe_buffer --lib
- cargo build --bin axon
- pre-push: clippy
- pre-push: nextest, 2794 passed / 6 skipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor crawl broadcast buffer min/max when sizing from max_pages, and keep it above the legacy safe cap. Applies to normal and sitemap-only crawls to prevent drops while keeping buffers bounded.

- Bug Fixes
  - Route buffer sizing through a helper that clamps to configured min/max, enforces the legacy floor (≥16,384), and handles inverted bounds and zero/huge max_pages. Tests cover default/profile bounds (e.g., --performance-profile max → 65,536).
  - Infra/CI: use 55333/55334 for local Qdrant via `QDRANT_HTTP_PORT`/`QDRANT_GRPC_PORT`; register these env keys in runtime and docs; compose ports are interpolated; keep `axon-qdrant` opt-in via `--profile local-qdrant`; add `AXON_QDRANT_URL`; derive project name from repo remote.

<sup>Written for commit 5325017225a097af6535979195b92de5fdb104ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Crawler subscribe buffer sizing now driven by configuration and dynamically clamped to sensible bounds.
  * Improved runtime metadata extraction to better derive project identifiers.

* **Tests**
  * Added unit tests for buffer sizing across profiles and edge cases.
  * Updated compose/environment contract tests to reflect opt-in local service behavior and env key expectations.

* **CI / Chores**
  * Adjusted CI workflow and local compose setup to make service ports configurable via environment variables; docs updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->