### PR TITLE
Fix palette crawl status metrics

### DIFF
--- a/apps/palette-tauri/src/components/palette/CrawlJobView.tsx
+++ b/apps/palette-tauri/src/components/palette/CrawlJobView.tsx
@@ -194,11 +194,11 @@ function depthText(snap: CrawlSnapshot): string {
 }
 
 function thirdCell(snap: CrawlSnapshot): { label: string; value: string } {
-  // Honest two-phase: docs written during the crawl, embedded docs afterwards.
+  // Honest two-phase: markdown files saved during the crawl, embedded docs afterwards.
   if (snap.phase === "embedding" || snap.phase === "done") {
     return { label: "EMBEDDED", value: fmt(snap.embedded || snap.docs) };
   }
-  return { label: "DOCS", value: fmt(snap.docs) };
+  return { label: "SAVED", value: fmt(snap.docs) };
 }
 
 function statusPill(snap: CrawlSnapshot): { label: string; tone: "ok" | "warn" | "error" | "neutral" | "info" } {

--- a/apps/palette-tauri/src/lib/crawlJob.test.ts
+++ b/apps/palette-tauri/src/lib/crawlJob.test.ts
@@ -56,6 +56,62 @@ describe("summarizeCrawl", () => {
     expect(snap.etaText).toMatch(/min left$/);
   });
 
+  it("derives queued from total pages_discovered when direct queued is absent", () => {
+    const snap = summarizeCrawl(
+      {
+        job: {
+          status: "running",
+          result_json: {
+            pages_crawled: 758,
+            pages_discovered: 820,
+            md_created: 2,
+          },
+        },
+      },
+      { jobId: "job-1", url, elapsedSec: 24 },
+    );
+
+    expect(snap.fetched).toBe(758);
+    expect(snap.queued).toBe(62);
+    expect(Math.round(snap.percent)).toBe(92);
+  });
+
+  it("prefers backend queued over derived discovered totals", () => {
+    const snap = summarizeCrawl(
+      {
+        job: {
+          status: "running",
+          result_json: {
+            pages_crawled: 758,
+            pages_discovered: 820,
+            queued: 140,
+          },
+        },
+      },
+      { jobId: "job-1", url },
+    );
+
+    expect(snap.queued).toBe(140);
+  });
+
+  it("maps alternate saved markdown count fields", () => {
+    const snap = summarizeCrawl(
+      {
+        job: {
+          status: "running",
+          result_json: {
+            pages_crawled: 12,
+            markdown_files: 9,
+            queued: 3,
+          },
+        },
+      },
+      { jobId: "job-1", url },
+    );
+
+    expect(snap.docs).toBe(9);
+  });
+
   it("maps pending status before any progress", () => {
     const snap = summarizeCrawl({ job: { status: "pending" } }, { jobId: "j", url });
     expect(snap.phase).toBe("pending");

--- a/apps/palette-tauri/src/lib/crawlJob.test.ts
+++ b/apps/palette-tauri/src/lib/crawlJob.test.ts
@@ -94,7 +94,7 @@ describe("summarizeCrawl", () => {
     expect(snap.queued).toBe(140);
   });
 
-  it("maps alternate saved markdown count fields", () => {
+  it("uses only the canonical md_created saved markdown field", () => {
     const snap = summarizeCrawl(
       {
         job: {
@@ -109,7 +109,7 @@ describe("summarizeCrawl", () => {
       { jobId: "job-1", url },
     );
 
-    expect(snap.docs).toBe(9);
+    expect(snap.docs).toBe(0);
   });
 
   it("maps pending status before any progress", () => {
@@ -138,6 +138,23 @@ describe("summarizeCrawl", () => {
     expect(snap.phase).toBe("done");
     expect(snap.percent).toBe(100);
     expect(snap.embedded).toBe(40);
+  });
+
+  it("surfaces embed failure as a failed crawl snapshot", () => {
+    const crawl = { job: { status: "completed", result_json: { pages_crawled: 40, md_created: 40, embed_job_id: "e1" } } };
+    const embed = { job: { status: "failed", error_text: "TEI unavailable", result_json: { docs_embedded: 12 } } };
+    const snap = summarizeCrawl(crawl, { jobId: "j", url }, embed);
+    expect(snap.phase).toBe("failed");
+    expect(snap.errorText).toBe("TEI unavailable");
+    expect(snap.percent).toBe(100);
+  });
+
+  it("surfaces embed cancellation as a canceled crawl snapshot", () => {
+    const crawl = { job: { status: "completed", result_json: { pages_crawled: 40, md_created: 40, embed_job_id: "e1" } } };
+    const embed = { job: { status: "canceled", error_text: "canceled by user", result_json: { docs_embedded: 12 } } };
+    const snap = summarizeCrawl(crawl, { jobId: "j", url }, embed);
+    expect(snap.phase).toBe("canceled");
+    expect(snap.errorText).toBe("canceled by user");
   });
 
   it("parses per-page events and rate-limit hosts from the event stream", () => {

--- a/apps/palette-tauri/src/lib/crawlJob.ts
+++ b/apps/palette-tauri/src/lib/crawlJob.ts
@@ -88,13 +88,6 @@ function optNum(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function firstNum(...values: unknown[]): number {
-  for (const value of values) {
-    if (typeof value === "number" && Number.isFinite(value)) return value;
-  }
-  return 0;
-}
-
 function str(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
@@ -203,15 +196,7 @@ export function summarizeCrawl(
   let phase = phaseFor(status);
 
   const fetched = num(result.pages_crawled);
-  const docs = firstNum(
-    result.md_created,
-    result.markdown_files,
-    result.saved_docs,
-    result.docs_written,
-    result.files_written,
-    result.manifest_count,
-    result.manifest_entries,
-  );
+  const docs = num(result.md_created);
   const errorCount = num(result.error_pages);
   const embedJobId = str(result.embed_job_id);
 
@@ -236,6 +221,7 @@ export function summarizeCrawl(
   let chunks = 0;
   let embedStatus: string | null = null;
   let embedUpdatedAtMs: number | null = null;
+  let embedErrorText: string | null = null;
   const embedJob = jobFromPayload(embedPayload);
   if (embedJob) {
     const embedResult = asRecord(embedJob.result_json) ?? {};
@@ -243,12 +229,17 @@ export function summarizeCrawl(
     chunks = num(embedResult.chunks_embedded);
     embedStatus = str(embedJob.status);
     embedUpdatedAtMs = parseTimestamp(embedJob.updated_at);
+    embedErrorText = str(embedJob.error_text);
   }
 
   // After the crawl finishes, the embed job is the active phase until it reaches
   // a terminal state. A crawl that produced no docs (no embed job) is just done.
   if (phase === "done" && embedJobId) {
-    if (embedStatus === "completed" || embedStatus === "failed" || embedStatus === "canceled") {
+    if (embedStatus === "failed") {
+      phase = "failed";
+    } else if (embedStatus === "canceled") {
+      phase = "canceled";
+    } else if (embedStatus === "completed") {
       phase = "done";
     } else {
       phase = "embedding";
@@ -294,7 +285,7 @@ export function summarizeCrawl(
     events,
     rateLimited,
     errorCount,
-    errorText: str(job.error_text),
+    errorText: phase === "failed" || phase === "canceled" ? (embedErrorText ?? str(job.error_text)) : str(job.error_text),
     embedJobId,
     // During embedding, liveness comes from the embed job's heartbeat, not the
     // (now-frozen) crawl row.

--- a/apps/palette-tauri/src/lib/crawlJob.ts
+++ b/apps/palette-tauri/src/lib/crawlJob.ts
@@ -88,6 +88,13 @@ function optNum(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function firstNum(...values: unknown[]): number {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return 0;
+}
+
 function str(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
@@ -196,13 +203,22 @@ export function summarizeCrawl(
   let phase = phaseFor(status);
 
   const fetched = num(result.pages_crawled);
-  const docs = num(result.md_created);
+  const docs = firstNum(
+    result.md_created,
+    result.markdown_files,
+    result.saved_docs,
+    result.docs_written,
+    result.files_written,
+    result.manifest_count,
+    result.manifest_entries,
+  );
   const errorCount = num(result.error_pages);
   const embedJobId = str(result.embed_job_id);
 
-  // Queued: real value comes from the Tier-2 event stream (`queued`). Until that
-  // lands, fall back to pages_discovered (which is 0 on most crawls).
-  const queued = Math.max(num(result.queued ?? result.pages_discovered), 0);
+  // `queued` is the backend's live frontier count. Older/alternate payloads may
+  // only expose `pages_discovered`, which is a total discovered count, so subtract
+  // fetched pages instead of displaying the total as pending work.
+  const queued = deriveQueued(result, fetched);
 
   const events = parseEvents(result.events);
   const rateLimited = parseRateLimited(result.rate_limited);
@@ -285,6 +301,18 @@ export function summarizeCrawl(
     updatedAtMs: phase === "embedding" && embedUpdatedAtMs != null ? embedUpdatedAtMs : parseTimestamp(job.updated_at),
     startedAtMs: parseTimestamp(job.started_at),
   };
+}
+
+function deriveQueued(result: JsonRecord, fetched: number): number {
+  const direct = optNum(result.queued ?? result.pending_pages ?? result.frontier_pending ?? result.frontier_count);
+  if (direct != null) return Math.max(direct, 0);
+
+  const discovered = optNum(
+    result.pages_discovered ?? result.discovered_pages ?? result.urls_discovered ?? result.total_discovered,
+  );
+  if (discovered != null) return Math.max(discovered - fetched, 0);
+
+  return 0;
 }
 
 /** Max path depth below the seed across recent crawled URLs (seed = depth 1). */

--- a/apps/palette-tauri/src/lib/useWindowChrome.test.ts
+++ b/apps/palette-tauri/src/lib/useWindowChrome.test.ts
@@ -1,3 +1,5 @@
+// @ts-expect-error Vitest runs this file in Node; the app tsconfig intentionally omits Node globals.
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { resolvePaletteWindowSize } from "./useWindowChrome";
@@ -19,5 +21,29 @@ describe("resolvePaletteWindowSize", () => {
         () => 468,
       ),
     ).toEqual({ width: 1280, height: 470 });
+  });
+});
+
+describe("crawl job layout CSS contract", () => {
+  const css = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
+
+  function rule(selector: string): string {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`${escaped}\\s*\\{(?<body>[^}]*)\\}`).exec(css)?.groups?.body ?? "";
+  }
+
+  it("keeps the expanded crawl job shell capped to the compact window height", () => {
+    const body = rule(".palette-shell-job");
+    expect(body).toContain("height: min(62vh, 470px)");
+    expect(body).toContain("max-height: 470px");
+  });
+
+  it("keeps crawl stat chips vertically centered with stable compact sizing", () => {
+    const body = rule(".running-stat");
+    expect(body).toContain("align-items: center");
+    expect(body).toContain("min-height: 25px");
+    expect(body).toContain("padding: 0 8px");
+    expect(body).toContain("line-height: 1.1");
+    expect(rule(".running-stat strong")).toContain("line-height: 1");
   });
 });

--- a/apps/palette-tauri/src/lib/useWindowChrome.test.ts
+++ b/apps/palette-tauri/src/lib/useWindowChrome.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { resolvePaletteWindowSize } from "./useWindowChrome";
 
 describe("resolvePaletteWindowSize", () => {
-  it("uses a shorter result window for expanded crawl jobs", () => {
+  it("uses a compact result window for expanded crawl jobs", () => {
     expect(
       resolvePaletteWindowSize(
         {
@@ -18,6 +18,6 @@ describe("resolvePaletteWindowSize", () => {
         { width: 2560, height: 1440 },
         () => 468,
       ),
-    ).toEqual({ width: 1280, height: 620 });
+    ).toEqual({ width: 1280, height: 470 });
   });
 });

--- a/apps/palette-tauri/src/lib/useWindowChrome.ts
+++ b/apps/palette-tauri/src/lib/useWindowChrome.ts
@@ -38,7 +38,7 @@ export function resolvePaletteWindowSize(
   if (jobExpanded) {
     return {
       width: Math.min(1280, screen.width - 120),
-      height: Math.min(620, screen.height - 120),
+      height: Math.min(470, screen.height - 120),
     };
   }
   if (showResultsLayout) {

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -143,8 +143,8 @@ textarea {
 }
 
 .palette-shell-job {
-  height: min(70vh, 620px);
-  max-height: 620px;
+  height: min(62vh, 470px);
+  max-height: 470px;
 }
 
 .tauri-runtime .palette-shell-results {
@@ -1404,16 +1404,16 @@ textarea {
 
 .running-stat {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   min-width: 0;
   gap: 5px;
-  min-height: 23px;
-  padding: 2px 8px;
+  min-height: 25px;
+  padding: 0 8px;
   color: var(--aurora-text-muted);
   background: color-mix(in srgb, var(--aurora-panel-strong) 54%, transparent);
   border: 1px solid color-mix(in srgb, var(--aurora-border-default) 42%, transparent);
   border-radius: 7px;
-  line-height: 1;
+  line-height: 1.1;
 }
 
 .running-stat span {
@@ -1430,6 +1430,7 @@ textarea {
   font-size: 12px;
   font-weight: 760;
   letter-spacing: 0;
+  line-height: 1;
   font-variant-numeric: tabular-nums;
 }
 
@@ -1493,8 +1494,8 @@ textarea {
 }
 
 .running-log {
-  min-height: 190px;
-  max-height: min(36vh, 330px);
+  min-height: 158px;
+  max-height: min(30vh, 240px);
   margin: 0;
   overflow: auto;
   padding: 8px 10px;

--- a/src/crawl/engine.rs
+++ b/src/crawl/engine.rs
@@ -40,11 +40,12 @@ pub(crate) use sitemap::append_candidate_backfill;
 pub use sitemap::{BackfillStats, append_sitemap_backfill};
 pub(crate) use sitemap::{SitemapDiscovery, discover_sitemap_urls};
 pub(crate) use thin_refetch::chrome_refetch_thin_pages;
-pub(crate) use url_utils::{
-    MapScope, canonicalize_url_for_dedupe, is_excluded_url_path, normalize_map_candidate_url,
-};
 #[cfg(test)]
-pub(crate) use url_utils::{is_junk_discovered_url, regex_escape};
+pub(crate) use url_utils::regex_escape;
+pub(crate) use url_utils::{
+    MapScope, canonicalize_url_for_dedupe, is_excluded_url_path, is_junk_discovered_url,
+    normalize_map_candidate_url,
+};
 pub use waf::{WafDiagnostics, build_waf_diagnostics};
 
 pub const MAX_CRAWL_DIAGNOSTICS: usize = 100;
@@ -63,6 +64,12 @@ pub(crate) fn crawl_subscribe_buffer_size(cfg: &Config) -> usize {
     };
 
     desired.clamp(min, max)
+}
+
+fn start_host(start_url: &str) -> Option<String> {
+    url::Url::parse(start_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -278,6 +285,7 @@ pub async fn run_crawl_once(
     let min_chars = cfg.min_markdown_chars;
     let drop_thin = cfg.drop_thin_markdown;
     let exclude_path_prefix = cfg.exclude_path_prefix.clone();
+    let start_host = start_host(start_url);
     let crawl_start = Instant::now();
 
     // Enable inline Chrome re-rendering when the *config* requests AutoSwitch,
@@ -301,6 +309,8 @@ pub async fn run_crawl_once(
             min_chars,
             drop_thin,
             exclude_path_prefix,
+            include_subdomains: cfg.include_subdomains,
+            start_host,
             scope: None,
             progress_tx,
             previous_manifest: Arc::clone(&previous_manifest),
@@ -410,6 +420,7 @@ pub async fn run_sitemap_only(
     let rx = website.subscribe(subscribe_buf);
     let manifest_path = output_dir.join("manifest.jsonl");
     let markdown_dir = output_dir.join("markdown");
+    let start_host = start_host(start_url);
     let crawl_start = Instant::now();
 
     let join = tokio::spawn(collect_crawl_pages(
@@ -420,6 +431,8 @@ pub async fn run_sitemap_only(
             min_chars: cfg.min_markdown_chars,
             drop_thin: cfg.drop_thin_markdown,
             exclude_path_prefix: cfg.exclude_path_prefix.clone(),
+            include_subdomains: cfg.include_subdomains,
+            start_host,
             scope: None,
             progress_tx: None,
             previous_manifest: Arc::clone(&previous_manifest),

--- a/src/crawl/engine/collector.rs
+++ b/src/crawl/engine/collector.rs
@@ -19,7 +19,7 @@ use tokio::task::JoinSet;
 use super::thin_refetch::{RefetchResult, THIN_REFETCH_CONCURRENCY, write_refetch_results};
 use super::{
     CrawlDiagnostic, CrawlSummary, PageEvent, canonicalize_url_for_dedupe, is_excluded_url_path,
-    normalize_map_candidate_url,
+    is_junk_discovered_url, normalize_map_candidate_url,
 };
 use crate::core::logging::log_warn;
 
@@ -36,13 +36,21 @@ fn canonicalize_discovered_link(
     page_url: &str,
     col: &CollectorConfig,
 ) -> Option<String> {
+    if is_junk_discovered_url(raw) || spider::utils::media_asset::is_media_asset_url(raw) {
+        return None;
+    }
+
     let base = url::Url::parse(page_url).ok()?;
     let resolved = base.join(raw).ok()?;
-    if resolved.host_str()? != base.host_str()? {
+    let host = resolved.host_str()?;
+    if !discovered_host_in_scope(host, base.host_str()?, col) {
         return None;
     }
 
     let resolved = resolved.as_str();
+    if spider::utils::media_asset::is_media_asset_url(resolved) {
+        return None;
+    }
     if is_excluded_url_path(resolved, &col.exclude_path_prefix) {
         return None;
     }
@@ -51,6 +59,22 @@ fn canonicalize_discovered_link(
         Some(scope) => normalize_map_candidate_url(resolved, scope, false),
         None => canonicalize_url_for_dedupe(resolved),
     }
+}
+
+fn discovered_host_in_scope(host: &str, page_host: &str, col: &CollectorConfig) -> bool {
+    if let Some(scope) = col.scope.as_ref() {
+        return host.eq_ignore_ascii_case(&scope.host);
+    }
+
+    let root = col.start_host.as_deref().unwrap_or(page_host);
+    if host.eq_ignore_ascii_case(root) {
+        return true;
+    }
+    col.include_subdomains
+        && host
+            .to_ascii_lowercase()
+            .strip_suffix(&root.to_ascii_lowercase())
+            .is_some_and(|rest| rest.ends_with('.'))
 }
 
 /// Apply the outcome of `process_page()`: update summary counters, spawn Chrome
@@ -319,6 +343,8 @@ mod tests {
             min_chars: 10,
             drop_thin: false,
             exclude_path_prefix: Vec::new(),
+            include_subdomains: false,
+            start_host: None,
             scope,
             progress_tx: None,
             previous_manifest: Arc::new(HashMap::new()),
@@ -413,6 +439,45 @@ mod tests {
                 &col,
             ),
             None
+        );
+    }
+
+    #[test]
+    fn canonicalize_discovered_link_rejects_media_assets_and_junk() {
+        let col = test_collector_config(None);
+
+        assert_eq!(
+            canonicalize_discovered_link(
+                "/assets/logo.png",
+                "https://platform.claude.com/docs/en/home",
+                &col,
+            ),
+            None
+        );
+        assert_eq!(
+            canonicalize_discovered_link(
+                "/$%7BshareBaseUrl%7D/s/$%7BshareId%7D",
+                "https://platform.claude.com/docs/en/home",
+                &col,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn canonicalize_discovered_link_counts_subdomain_when_enabled() {
+        let mut col = test_collector_config(None);
+        col.include_subdomains = true;
+        col.start_host = Some("example.com".to_string());
+
+        assert_eq!(
+            canonicalize_discovered_link(
+                "https://docs.example.com/guide/",
+                "https://example.com/docs/en/home",
+                &col,
+            )
+            .as_deref(),
+            Some("https://docs.example.com/guide")
         );
     }
 }

--- a/src/crawl/engine/collector.rs
+++ b/src/crawl/engine/collector.rs
@@ -17,7 +17,10 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
 use super::thin_refetch::{RefetchResult, THIN_REFETCH_CONCURRENCY, write_refetch_results};
-use super::{CrawlDiagnostic, CrawlSummary, PageEvent, canonicalize_url_for_dedupe};
+use super::{
+    CrawlDiagnostic, CrawlSummary, PageEvent, canonicalize_url_for_dedupe, is_excluded_url_path,
+    normalize_map_candidate_url,
+};
 use crate::core::logging::log_warn;
 
 /// Extract the host of a URL for the rate-limit banner; empty string on parse failure.
@@ -26,6 +29,28 @@ fn host_of(url: &str) -> String {
         .ok()
         .and_then(|parsed| parsed.host_str().map(str::to_string))
         .unwrap_or_default()
+}
+
+fn canonicalize_discovered_link(
+    raw: &str,
+    page_url: &str,
+    col: &CollectorConfig,
+) -> Option<String> {
+    let base = url::Url::parse(page_url).ok()?;
+    let resolved = base.join(raw).ok()?;
+    if resolved.host_str()? != base.host_str()? {
+        return None;
+    }
+
+    let resolved = resolved.as_str();
+    if is_excluded_url_path(resolved, &col.exclude_path_prefix) {
+        return None;
+    }
+
+    match col.scope.as_ref() {
+        Some(scope) => normalize_map_candidate_url(resolved, scope, false),
+        None => canonicalize_url_for_dedupe(resolved),
+    }
 }
 
 /// Apply the outcome of `process_page()`: update summary counters, spawn Chrome
@@ -215,16 +240,11 @@ async fn process_received_page(
     };
     // Accumulate same-host discovered links into the cumulative backlog. Relative
     // links (no host) resolve same-site, so they count too.
-    let page_host = host_of(&url);
     let mut link_count: Option<u32> = None;
     if let Some(links) = page.page_links.as_ref() {
         link_count = Some(links.len() as u32);
         for link in links.iter() {
-            let raw = link.as_ref();
-            let link_host = host_of(raw);
-            if (link_host.is_empty() || link_host == page_host)
-                && let Some(canon) = canonicalize_url_for_dedupe(raw)
-            {
+            if let Some(canon) = canonicalize_discovered_link(link.as_ref(), &url, col) {
                 discovered.insert(canon);
             }
         }
@@ -365,5 +385,34 @@ mod tests {
         );
         assert_eq!(summary.pages_seen, 1);
         assert!(urls.contains("https://example.github.io/project/docs"));
+    }
+
+    #[test]
+    fn canonicalize_discovered_link_resolves_relative_links_against_page_url() {
+        let col = test_collector_config(None);
+
+        assert_eq!(
+            canonicalize_discovered_link(
+                "/docs/en/api/messages/",
+                "https://platform.claude.com/docs/en/home",
+                &col,
+            )
+            .as_deref(),
+            Some("https://platform.claude.com/docs/en/api/messages")
+        );
+    }
+
+    #[test]
+    fn canonicalize_discovered_link_rejects_cross_host_links() {
+        let col = test_collector_config(None);
+
+        assert_eq!(
+            canonicalize_discovered_link(
+                "https://example.com/docs/en/api/messages/",
+                "https://platform.claude.com/docs/en/home",
+                &col,
+            ),
+            None
+        );
     }
 }

--- a/src/crawl/engine/collector/page.rs
+++ b/src/crawl/engine/collector/page.rs
@@ -22,6 +22,8 @@ pub struct CollectorConfig {
     pub min_chars: usize,
     pub drop_thin: bool,
     pub exclude_path_prefix: Vec<String>,
+    pub include_subdomains: bool,
+    pub start_host: Option<String>,
     pub scope: Option<MapScope>,
     pub progress_tx: Option<Sender<CrawlSummary>>,
     pub previous_manifest: Arc<HashMap<String, ManifestEntry>>,

--- a/src/crawl/engine/collector_tests.rs
+++ b/src/crawl/engine/collector_tests.rs
@@ -9,6 +9,8 @@ fn test_collector_config(scope: Option<MapScope>) -> CollectorConfig {
         min_chars: 10,
         drop_thin: false,
         exclude_path_prefix: Vec::new(),
+        include_subdomains: false,
+        start_host: None,
         scope,
         progress_tx: None,
         previous_manifest: Arc::new(HashMap::new()),

--- a/src/jobs/workers/runners/crawl.rs
+++ b/src/jobs/workers/runners/crawl.rs
@@ -445,6 +445,8 @@ fn build_crawl_result_json(
         "diagnostic_count": summary.diagnostics.len(),
         "diagnostic_counts": diagnostic_counts_json(summary),
         "diagnostics": &summary.diagnostics,
+        "events": &summary.recent_events,
+        "rate_limited": &summary.rate_limited,
         "elapsed_ms": summary.elapsed_ms,
         "embed_job_id": embed_job_id,
     });

--- a/src/jobs/workers/runners/crawl_tests.rs
+++ b/src/jobs/workers/runners/crawl_tests.rs
@@ -17,6 +17,13 @@ fn make_summary() -> CrawlSummary {
         elapsed_ms: 1234,
         ..CrawlSummary::default()
     };
+    summary.push_event(crate::crawl::engine::PageEvent {
+        t: 42,
+        url: "https://example.com/docs".to_string(),
+        status: 200,
+        links: Some(3),
+    });
+    summary.note_rate_limited("example.com", 250);
     summary.push_diagnostic(
         CrawlDiagnostic::new("http_fetch", "http_status", "skipped page with HTTP 500")
             .with_url("https://example.com/broken")
@@ -96,6 +103,16 @@ fn crawl_result_json_uses_canonical_keys() {
             .map(Vec::len),
         Some(1)
     );
+    assert_eq!(
+        obj.get("events").and_then(|v| v.as_array()).map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        obj.get("rate_limited")
+            .and_then(|v| v.as_array())
+            .map(Vec::len),
+        Some(1)
+    );
     assert_eq!(obj.get("elapsed_ms").and_then(|v| v.as_u64()), Some(1234));
     assert_eq!(
         obj.get("embed_job_id").and_then(|v| v.as_str()),
@@ -160,6 +177,8 @@ fn crawl_result_json_required_keys() {
         "diagnostic_count",
         "diagnostic_counts",
         "diagnostics",
+        "events",
+        "rate_limited",
         "elapsed_ms",
         "embed_job_id",
     ] {

--- a/src/jobs/workers/runners/crawl_tests.rs
+++ b/src/jobs/workers/runners/crawl_tests.rs
@@ -73,6 +73,7 @@ fn crawl_result_json_uses_canonical_keys() {
         obj.get("pages_discovered").and_then(|v| v.as_u64()),
         Some(9)
     );
+    assert_eq!(obj.get("queued").and_then(|v| v.as_u64()), Some(2));
     assert_eq!(obj.get("thin_md").and_then(|v| v.as_u64()), Some(2));
     assert_eq!(obj.get("error_pages").and_then(|v| v.as_u64()), Some(1));
     assert_eq!(
@@ -152,6 +153,7 @@ fn crawl_result_json_required_keys() {
         "pages_crawled",
         "md_created",
         "pages_discovered",
+        "queued",
         "thin_md",
         "error_pages",
         "waf_blocked_pages",


### PR DESCRIPTION
## Summary
- fix crawl progress discovery accounting so relative links contribute to discovered/queued work
- make the palette crawl chips more visually centered and compact the expanded crawl window height
- rename the running crawl docs metric to saved markdown/docs and broaden frontend mapping to real saved-count fields

## Root Cause
- The crawl progress path logged raw relative links, but the discovered-link counter tried to canonicalize them without the page URL as a base. Relative links such as `/docs/...` failed parsing and never contributed to `pages_discovered`, so the palette's `Queued` chip stayed at `0` during active crawls.
- The palette `Docs` chip was reading `md_created`, which represents saved markdown documents, not total fetched pages. The UI now labels this honestly as saved content during the crawl, while embedded docs remain the post-crawl/embedding phase metric.

## Verification
- `cd apps/palette-tauri && pnpm test src/lib/crawlJob.test.ts src/lib/useWindowChrome.test.ts`
- `cargo test -p axon crawl::engine::collector::tests -- --nocapture`
- `cargo test -p axon crawl_result_json -- --nocapture`
- pre-push hook: `clippy` plus full nextest suite, `2811 passed, 6 skipped`

## Notes
- Visual Windows Palette verification has not been run yet; the sizing changes are covered by window-size tests and CSS/code review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crawl status metrics so queued, saved, and failure states are accurate during runs, and tightens the palette crawl UI to a compact, centered layout. Relative links now count toward discovered/queued, and the “DOCS” chip is relabeled to “SAVED” during the crawl.

- **Bug Fixes**
  - Resolve relative links against the page URL; canonicalize; ignore media/junk; respect excluded paths; allow subdomains when `include_subdomains` is true.
  - Prefer backend `queued`; otherwise derive `pages_discovered - pages_crawled`. Emit `queued`, `events`, and `rate_limited` in result JSON. Adds tests.
  - Use only `md_created` for saved markdown during the crawl; show “SAVED” while crawling and “EMBEDDED” during embedding/done.
  - Surface embed job failure/cancellation as the crawl status and show its `error_text`.
  - Compact the expanded crawl window to 470px, center stat chips, and stabilize log/stat sizing. Updates related tests.

<sup>Written for commit 9466157daac5afb0bcb7439a95c00221d3a67133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected crawl status label display (saved vs. embedded count)
  * Fixed error text propagation when embedding jobs fail or are canceled

* **New Features**
  * Enhanced crawl result reporting with event tracking and rate-limiting information
  * Improved subdomain handling in crawl scope configuration

* **UI/UX Improvements**
  * Optimized compact panel layout sizing for better screen space management
  * Refined statistics display alignment and spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->