### PR TITLE
feat(palette): add action switcher

### DIFF
--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -1,12 +1,13 @@
 import {
   ArrowLeft,
+  ChevronDown,
   ChevronRight,
   Search,
   Send,
   Settings,
   Workflow,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { actionIcon } from "@/components/palette/ActionIcon";
 import { ActionList } from "@/components/palette/ActionList";
@@ -28,6 +29,7 @@ import { appWindow, invoke, isTauriRuntime } from "@/lib/invoke";
 import {
   argumentFor,
   argumentPlaceholder,
+  actionDisplayMeta,
   focusInput,
   hostLabel,
   looksLikeUrl,
@@ -59,6 +61,10 @@ export default function App() {
   const [run, setRun] = useState<RunState>({ kind: "idle" });
   const [copied, setCopied] = useState(false);
   const [shownTick, setShownTick] = useState(0);
+  const [actionSwitcherOpen, setActionSwitcherOpen] = useState(false);
+  const [actionSwitcherQuery, setActionSwitcherQuery] = useState("");
+  const [actionSwitcherSelected, setActionSwitcherSelected] = useState(0);
+  const actionSwitcherRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     invoke<PaletteConfig>("load_palette_config")
@@ -104,7 +110,11 @@ export default function App() {
       const modifier = event.metaKey || event.ctrlKey;
       if (event.key === "Escape") {
         event.preventDefault();
-        if (settingsOpen) {
+        if (actionSwitcherOpen) {
+          setActionSwitcherOpen(false);
+          setActionSwitcherQuery("");
+          focusInput(true);
+        } else if (settingsOpen) {
           setSettingsOpen(false);
         } else if (historyOpen) {
           setHistoryOpen(false);
@@ -135,7 +145,18 @@ export default function App() {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [browseOpen, historyOpen, modeAction, query, run, settingsOpen]);
+  }, [actionSwitcherOpen, browseOpen, historyOpen, modeAction, query, run, settingsOpen]);
+
+  useEffect(() => {
+    if (!actionSwitcherOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (actionSwitcherRef.current?.contains(event.target as Node)) return;
+      setActionSwitcherOpen(false);
+      setActionSwitcherQuery("");
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    return () => window.removeEventListener("pointerdown", onPointerDown);
+  }, [actionSwitcherOpen]);
 
   useEffect(() => {
     if (!config) return;
@@ -163,6 +184,20 @@ export default function App() {
       parsed.search,
     ).slice(0, 12);
   }, [parsed.invoked, parsed.search]);
+  const switcherActions = useMemo(
+    () => sortActionsForDisplay(ACTIONS).filter((action) => action.subcommand !== modeAction?.subcommand),
+    [modeAction?.subcommand],
+  );
+  const visibleSwitcherActions = useMemo(() => {
+    const search = actionSwitcherQuery.trim();
+    if (!search) return switcherActions;
+    return sortActionsByRelevance(
+      switcherActions.filter((action) => actionMatches(action, search)),
+      search,
+    );
+  }, [actionSwitcherQuery, switcherActions]);
+  const selectedSwitcherAction =
+    visibleSwitcherActions[Math.min(actionSwitcherSelected, Math.max(visibleSwitcherActions.length - 1, 0))];
   const suggestedAction = filtered[Math.min(selected, Math.max(filtered.length - 1, 0))];
   const active = modeAction ?? suggestedAction;
   const activeArgument = active ? argumentFor(active, modeAction, parsed, query) : "";
@@ -173,16 +208,30 @@ export default function App() {
   // Once an action mode is picked, the input collects that action's argument —
   // the palette should NOT keep listing other actions. Stay compact (just the
   // command bar + mode pill) until the run produces output.
-  const enteringArgument = Boolean(modeAction) && !showOutput && !settingsOpen && !historyOpen;
+  const enteringArgument = Boolean(modeAction) && !actionSwitcherOpen && !showOutput && !settingsOpen && !historyOpen;
   const showContent =
-    settingsOpen || historyOpen || showOutput || (!enteringArgument && (hasQuery || browseOpen));
+    settingsOpen || historyOpen || showOutput || actionSwitcherOpen || (!enteringArgument && (hasQuery || browseOpen));
   const compact = !showContent;
   const showResultsLayout = showOutput || settingsOpen || historyOpen;
-  const showActionPanel = !showResultsLayout && !settingsOpen && !historyOpen && !enteringArgument;
+  const showActionPanel = !actionSwitcherOpen && !showResultsLayout && !settingsOpen && !historyOpen && !enteringArgument;
 
   useEffect(() => {
     setSelected(0);
   }, [parsed.search, modeAction]);
+
+  useEffect(() => {
+    if (!modeAction) setActionSwitcherOpen(false);
+  }, [modeAction]);
+
+  useEffect(() => {
+    setActionSwitcherSelected(0);
+  }, [actionSwitcherQuery, modeAction]);
+
+  useEffect(() => {
+    if (!actionSwitcherOpen) return;
+    const el = document.querySelector(".command-action-option-selected");
+    if (el instanceof HTMLElement) el.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [actionSwitcherOpen, actionSwitcherSelected, visibleSwitcherActions]);
 
   useWindowChrome({
     jobExpanded,
@@ -230,6 +279,17 @@ export default function App() {
     focusInput(true);
   }
 
+  function switchActionMode(action: PaletteAction) {
+    setModeAction(action);
+    if (action.argMode === "none") setQuery("");
+    setSelected(0);
+    setRun({ kind: "idle" });
+    setBrowseOpen(false);
+    setActionSwitcherOpen(false);
+    setActionSwitcherQuery("");
+    focusInput(true);
+  }
+
   async function saveSettings() {
     if (!draftConfig) return;
     try {
@@ -246,6 +306,31 @@ export default function App() {
   }
 
   function onInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (actionSwitcherOpen) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === "ArrowDown") {
+        setActionSwitcherSelected((idx) => Math.min(idx + 1, Math.max(visibleSwitcherActions.length - 1, 0)));
+      } else if (event.key === "ArrowUp") {
+        setActionSwitcherSelected((idx) => Math.max(idx - 1, 0));
+      } else if (event.key === "Home") {
+        setActionSwitcherSelected(0);
+      } else if (event.key === "End") {
+        setActionSwitcherSelected(Math.max(visibleSwitcherActions.length - 1, 0));
+      } else if (event.key === "Enter") {
+        if (selectedSwitcherAction) switchActionMode(selectedSwitcherAction);
+      } else if (event.key === "Escape") {
+        setActionSwitcherOpen(false);
+        setActionSwitcherQuery("");
+        focusInput(true);
+      } else if (event.key === "Backspace") {
+        setActionSwitcherQuery((value) => value.slice(0, -1));
+      } else if (event.key.length === 1 && !event.altKey && !event.ctrlKey && !event.metaKey) {
+        setActionSwitcherQuery((value) => `${value}${event.key}`);
+      }
+      return;
+    }
+
     if (event.key === "ArrowDown") {
       event.preventDefault();
       // Arrow-down is the keyboard affordance to browse all actions without
@@ -322,19 +407,69 @@ export default function App() {
         <span className="axon-divider" aria-hidden="true" />
         <div className="command-input-wrap" onClick={() => focusInput()}>
           {modeAction && ModeIcon ? (
-            <button
-              className={`command-mode-icon command-mode-icon-${modeAction.tone}`}
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                setModeAction(null);
-                focusInput(true);
-              }}
-              aria-label={`Clear ${modeAction.subcommand} mode`}
-              title={`${modeAction.label} mode — click to clear`}
-            >
-              <ModeIcon size={16} strokeWidth={1.9} aria-hidden="true" />
-            </button>
+            <div className="command-action-switcher" ref={actionSwitcherRef}>
+              <button
+                className={`command-action-trigger command-mode-icon-${modeAction.tone}`}
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setActionSwitcherOpen((open) => {
+                    const next = !open;
+                    if (next) {
+                      setActionSwitcherQuery("");
+                      setActionSwitcherSelected(0);
+                    }
+                    return next;
+                  });
+                }}
+                aria-haspopup="menu"
+                aria-expanded={actionSwitcherOpen}
+                aria-label={`Switch from ${modeAction.label}`}
+                title={`Switch from ${modeAction.label}`}
+              >
+                <ModeIcon size={15} strokeWidth={1.9} aria-hidden="true" />
+                <span>{actionDisplayMeta(modeAction).label}</span>
+                <ChevronDown size={13} strokeWidth={1.8} aria-hidden="true" />
+              </button>
+              {actionSwitcherOpen && (
+                <div className="command-action-menu" role="menu" aria-label="Switch action">
+                  {actionSwitcherQuery && (
+                    <div className="command-action-search" aria-live="polite">
+                      <span>Filter</span>
+                      <kbd>{actionSwitcherQuery}</kbd>
+                    </div>
+                  )}
+                  {visibleSwitcherActions.map((action, index) => {
+                    const Icon = actionIcon(action.subcommand);
+                    const meta = actionDisplayMeta(action);
+                    const selectedOption = index === actionSwitcherSelected;
+                    return (
+                      <button
+                        key={action.subcommand}
+                        className={`command-action-option command-action-option-${action.tone}${selectedOption ? " command-action-option-selected" : ""}`}
+                        type="button"
+                        role="menuitem"
+                        onMouseEnter={() => setActionSwitcherSelected(index)}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          switchActionMode(action);
+                        }}
+                      >
+                        <Icon size={15} strokeWidth={1.85} aria-hidden="true" />
+                        <span>
+                          <strong>{meta.label}</strong>
+                          <small>{meta.input} to {meta.output}</small>
+                        </span>
+                        <kbd>{action.subcommand}</kbd>
+                      </button>
+                    );
+                  })}
+                  {!visibleSwitcherActions.length && (
+                    <div className="command-action-empty">No matching actions</div>
+                  )}
+                </div>
+              )}
+            </div>
           ) : (
             <Search size={16} strokeWidth={1.65} aria-hidden="true" />
           )}

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -1131,6 +1131,7 @@ textarea {
 }
 
 .command-input-wrap {
+  position: relative;
   display: flex;
   flex: 1 1 auto;
   min-width: 0;
@@ -1145,21 +1146,48 @@ textarea {
   color: var(--aurora-text-muted);
 }
 
-/* Active-mode indicator: the selected action's icon replaces the search glyph
-   in the input. Tinted by action tone; click to clear the mode (Esc also works). */
-.command-mode-icon {
+/* Active-mode switcher: the selected action sits inside the input and opens a
+   compact list of alternate actions without resizing the command bar. */
+.command-action-switcher {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.command-action-trigger {
   all: unset;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: 0 0 auto;
+  gap: 5px;
+  max-width: 138px;
+  height: 26px;
+  padding: 0 7px;
   color: var(--aurora-accent-strong);
+  background: color-mix(in srgb, var(--aurora-control-surface) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--aurora-accent-primary) 24%, var(--aurora-border-default));
+  border-radius: 8px;
   cursor: pointer;
-  transition: color 120ms ease-out;
+  transition:
+    background 120ms ease-out,
+    border-color 120ms ease-out,
+    color 120ms ease-out;
 }
 
-.command-mode-icon:hover {
+.command-action-trigger span {
+  min-width: 0;
+  overflow: hidden;
   color: var(--aurora-text-primary);
+  font-size: 11px;
+  font-weight: 720;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-action-trigger:hover,
+.command-action-trigger[aria-expanded="true"] {
+  color: var(--aurora-text-primary);
+  background: var(--aurora-hover-bg);
+  border-color: var(--aurora-border-strong);
 }
 
 .command-mode-icon-warn {
@@ -1171,6 +1199,139 @@ textarea {
 }
 
 .command-mode-icon-violet {
+  color: var(--aurora-accent-violet-strong);
+}
+
+.command-action-menu {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 9px);
+  left: 0;
+  display: flex;
+  width: min(388px, calc(100vw - 56px));
+  max-height: min(310px, calc(100vh - 76px));
+  padding: 7px;
+  overflow-y: auto;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--aurora-text-primary);
+  background: color-mix(in srgb, var(--aurora-panel-strong) 98%, transparent);
+  border: 1px solid color-mix(in srgb, var(--aurora-border-strong) 62%, transparent);
+  border-radius: 10px;
+  box-shadow:
+    0 18px 42px rgba(0, 0, 0, 0.42),
+    inset 0 1px 0 rgba(255, 255, 255, 0.055);
+}
+
+.command-action-search,
+.command-action-empty {
+  display: flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 3px 7px;
+  color: var(--aurora-text-muted);
+  font-size: 10px;
+}
+
+.command-action-search {
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 2px;
+  border-bottom: 1px solid color-mix(in srgb, var(--aurora-border-default) 62%, transparent);
+}
+
+.command-action-search span {
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: var(--aurora-letter-eyebrow);
+  text-transform: uppercase;
+}
+
+.command-action-search kbd {
+  min-width: 0;
+  max-width: 220px;
+  overflow: hidden;
+  color: var(--aurora-accent-strong);
+  text-overflow: ellipsis;
+}
+
+.command-action-empty {
+  justify-content: center;
+}
+
+.command-action-option {
+  all: unset;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 5px 7px;
+  color: var(--aurora-accent-strong);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.command-action-option:hover {
+  background: color-mix(in srgb, var(--aurora-accent-primary) 6%, var(--aurora-panel-strong));
+  border-color: color-mix(in srgb, var(--aurora-accent-primary) 26%, var(--aurora-border-default));
+}
+
+.command-action-option-selected {
+  background: color-mix(in srgb, var(--aurora-accent-primary) 8%, var(--aurora-panel-strong));
+  border-color: color-mix(in srgb, var(--aurora-accent-primary) 34%, var(--aurora-border-default));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--aurora-text-primary) 5%, transparent),
+    var(--aurora-active-glow);
+}
+
+.command-action-option span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.command-action-option strong,
+.command-action-option small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-action-option strong {
+  color: var(--aurora-text-primary);
+  font-size: 12px;
+  font-weight: 720;
+}
+
+.command-action-option small {
+  color: var(--aurora-text-muted);
+  font-size: 10px;
+  font-weight: 520;
+}
+
+.command-action-option kbd {
+  justify-self: end;
+  max-width: 98px;
+  overflow: hidden;
+  color: var(--aurora-text-muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+}
+
+.command-action-option-warn {
+  color: var(--axon-orange-strong);
+}
+
+.command-action-option-rose {
+  color: var(--aurora-accent-pink-strong);
+}
+
+.command-action-option-violet {
   color: var(--aurora-accent-violet-strong);
 }
 


### PR DESCRIPTION
## Summary
- add a clickable selected-action switcher in the Tauri palette input
- list the other actions in a focused dropdown and preserve typed arguments when switching
- add arrow-key navigation, Enter selection, Escape close, and type-to-filter matching the palette search behavior

## Verification
- pnpm typecheck
- pnpm test
- pnpm vite:build
- Chrome/CDP smoke: click switcher, switch actions, type `scr`, use arrows, Enter to select
- pre-push hook: clippy + nextest (2813 passed, 6 skipped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an inline action switcher to the palette command bar so you can change the active action without clearing mode. Keeps any typed arguments and improves keyboard control.

- **New Features**
  - Inline trigger shows the current action and opens a compact dropdown of other actions.
  - Keyboard support: Arrow keys/Home/End to navigate, Enter to switch, Escape or outside click to close; selected option auto-scrolls into view.
  - Type-to-filter uses the same relevance sorting as the palette; keeps input focused; clears the query only for actions with no arguments; suppresses other panels while the switcher is open.

<sup>Written for commit 74c5f21b0866c7082b5fda892c9f869cff9c1c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

