### PR TITLE
feat(cli): add release binary updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Discovery and ingest:
 Operations:
 
 - `setup`
+- `update` — install the latest GitHub Release binary and sync the local container
 - `doctor`
 - `debug`
 - `serve`

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -252,6 +252,31 @@ Restart `axon serve` locally as in the standard deploy procedure.
 
 ## Upgrade Procedure
 
+### Updating the local Axon binary from GitHub Releases
+
+Use `axon update` to install the latest published Linux release binary into
+`~/.local/bin/axon` and restart the local Axon container against the same
+binary:
+
+```bash
+axon update
+```
+
+Useful variants:
+
+```bash
+axon update --version v5.9.2      # install a specific release tag
+axon update --no-container        # update PATH only
+axon update --force               # reinstall even if the version already matches
+```
+
+The updater currently supports the `axon-linux-x86_64.tar.gz` GitHub Release
+asset and requires the matching `.sha256` sidecar. It downloads into a temporary
+directory, verifies the checksum, installs atomically over the destination, and
+only then syncs the Compose service. For local smoke tests or CI, set
+`AXON_UPDATE_FILE_RELEASE_DIR` to a directory containing those two release files
+and `AXON_UPDATE_INSTALL_PATH` to a temporary destination.
+
 For code/config upgrades:
 
 1. Review release diff (especially schema, env vars, and worker tuning). Note any new `AXON_HEADLESS_GEMINI_*`, `AXON_LLM_*`, or test infrastructure variables.

--- a/docs/reference/env-matrix.toml
+++ b/docs/reference/env-matrix.toml
@@ -263,6 +263,30 @@ compatibility = "advanced"
 reason = "Development Compose bind-mount source for the locally built Axon binary directory."
 
 [[env]]
+key = "AXON_UPDATE_FILE_RELEASE_DIR"
+classification = "external/test-only"
+runtime_placement = "not-runtime"
+surfaces = ["src", "docs"]
+secret = false
+url_or_path = true
+container_allowed = false
+toml_destination = ""
+compatibility = "advanced"
+reason = "Host-side update smoke-test override pointing at a directory with local release assets."
+
+[[env]]
+key = "AXON_UPDATE_INSTALL_PATH"
+classification = "trusted-operator-bootstrap"
+runtime_placement = "host-only"
+surfaces = ["src", "docs"]
+secret = false
+url_or_path = true
+container_allowed = false
+toml_destination = ""
+compatibility = "advanced"
+reason = "Host-side axon update install destination override; useful for controlled local installs and smoke tests."
+
+[[env]]
 key = "AXON_BASE_ENV_FILE"
 classification = "external/test-only"
 runtime_placement = "not-runtime"

--- a/docs/sessions/2026-06-13-axon-update-release-sync.md
+++ b/docs/sessions/2026-06-13-axon-update-release-sync.md
@@ -1,0 +1,159 @@
+---
+date: 2026-06-13 21:01:18 EDT
+repo: git@github.com:jmagar/axon.git
+branch: codex/axon-update-release-sync
+head: de4b90f1
+plan: docs/superpowers/plans/2026-06-13-axon-update-release-sync.md
+working directory: /home/jmagar/workspace/axon/.worktrees/axon-update-release-sync
+worktree: /home/jmagar/workspace/axon/.worktrees/axon-update-release-sync
+pr: "#211 feat(cli): add release binary updater https://github.com/jmagar/axon/pull/211"
+---
+
+# Axon update release sync
+
+## User Request
+
+Create and enter a new worktree, then use `writing-plans` to create `axon update` so Axon can download the latest built GitHub Release binary, put it on PATH, and sync it into the container. The follow-up `vibin:work-it` request required PR creation, review follow-through, comment handling, verification, and session documentation.
+
+## Session Overview
+
+Implemented `axon update`, published PR #211, addressed CodeRabbit feedback, repaired the env/config boundary matrix drift found by CI, and verified the branch locally and remotely. The feature now downloads a release archive and `.sha256`, verifies the checksum, atomically installs `axon`, and optionally restarts the local compose service using the installed binary directory.
+
+## Sequence of Events
+
+1. Created worktree `/home/jmagar/workspace/axon/.worktrees/axon-update-release-sync` on branch `codex/axon-update-release-sync`.
+2. Wrote the superpowers plan at `docs/superpowers/plans/2026-06-13-axon-update-release-sync.md`.
+3. Dispatched worker agent `019ec354-6040-7373-b5cf-a1c913f99627` to execute the plan; reviewed and verified its implementation.
+4. Committed and pushed the feature branch, then opened PR #211.
+5. CodeRabbit posted three actionable comments; all were fixed in `de4b90f1`.
+6. CI initially failed `env_config_boundary_matrix_is_current`; added `AXON_UPDATE_FILE_RELEASE_DIR` and `AXON_UPDATE_INSTALL_PATH` to the matrix and registered the host install-path override.
+7. Watched the refreshed PR checks until all required jobs passed.
+
+## Key Findings
+
+- `src/cli/commands/update.rs` needed to use Axon's shared `http_client()` rather than constructing a per-command `reqwest::Client`.
+- `tests/env_config_boundary.rs` treats new env-like tokens as contract drift unless they are classified in `docs/reference/env-matrix.toml`.
+- `AXON_UPDATE_FILE_RELEASE_DIR` is a local/test release-asset override, while `AXON_UPDATE_INSTALL_PATH` is a trusted host-side install destination override.
+- Subagent review fanout was degraded because spawned review agents hit the Codex usage limit; CodeRabbit and local manual review filled the actionable review path.
+
+## Technical Decisions
+
+- `axon update` defaults to `jmagar/axon` and Linux x86_64 release assets because the current deployment target is the dookie Linux host.
+- The install path defaults to `~/.local/bin/axon`, matching the user PATH goal, with `AXON_UPDATE_INSTALL_PATH` retained for controlled smoke tests.
+- The container sync path updates `AXON_DEV_TARGET_DIR` for `docker compose up -d axon --no-deps --no-build`, then restarts `axon` so the bind-mounted binary is active.
+- JSON output now uses `serde_json::to_string_pretty`; human output uses Aurora CLI UI helpers.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `README.md` | - | Add `update` to the command map | `git diff --name-status main...HEAD` |
+| modified | `docs/operations/deployment.md` | - | Document update usage and smoke-test env overrides | `git diff --name-status main...HEAD` |
+| modified | `docs/reference/env-matrix.toml` | - | Classify new update env keys | CI env boundary test |
+| created | `docs/superpowers/plans/2026-06-13-axon-update-release-sync.md` | - | Implementation plan from `writing-plans` | plan file committed |
+| modified | `src/cli/commands.rs` | - | Register update command module/tests | branch diff |
+| created | `src/cli/commands/update.rs` | - | Implement release download, checksum, install, container sync | branch diff |
+| created | `src/cli/commands/update_tests.rs` | - | Focused update behavior coverage | `cargo test --locked update_` |
+| modified | `src/core/config/cli.rs` | - | Add CLI args for update | parse tests |
+| modified | `src/core/config/help.rs` | - | Include update in curated help | help contract test |
+| modified | `src/core/config/parse/build_config.rs` | - | Wire update build config | parse tests |
+| modified | `src/core/config/parse/build_config/command_dispatch.rs` | - | Exempt update from service URL validation | parse tests |
+| modified | `src/core/config/parse/env_registry/advanced.rs` | - | Register `AXON_UPDATE_INSTALL_PATH` | env boundary test |
+| modified | `src/core/config/parse_tests.rs` | - | Cover update parse behavior | `cargo test --locked update_` |
+| modified | `src/core/config/types/enums.rs` | - | Add `CommandKind::Update` | type tests |
+| modified | `src/core/config/types_tests.rs` | - | Cover update command kind string | `cargo test --locked update_` |
+| modified | `src/lib.rs` | - | Dispatch `run_update` from CLI runtime | branch diff |
+
+## Beads Activity
+
+No bead activity observed for this session. `bd list --all --sort updated --reverse --limit 20 --json` returned older closed review beads unrelated to PR #211.
+
+## Repository Maintenance
+
+Plans: inspected `docs/plans` and `docs/superpowers/plans`; the new plan remains active with the PR and was not moved to a complete folder.
+
+Beads: checked recent beads and found no session-specific bead to create, claim, or close.
+
+Worktrees and branches: inspected `git worktree list --porcelain`, local branches, and remote branches. Left `/home/jmagar/workspace/axon` on `main`, this PR worktree on `codex/axon-update-release-sync`, and sibling worktree `.worktrees/fix-source-doc-char-boundary` untouched because it is an active branch.
+
+Stale docs: updated `docs/operations/deployment.md` during implementation and `docs/reference/env-matrix.toml` after CI exposed env-boundary drift.
+
+Transparency: no worktree or branch cleanup was performed because nothing was proven stale or merged.
+
+## Tools and Skills Used
+
+- Shell and Git: created worktree/branch, committed, pushed, inspected diffs and logs.
+- GitHub CLI: created PR #211, fetched comments/reviews/checks, watched CI.
+- Superpowers skills: `using-git-worktrees`, `writing-plans`, `verification-before-completion`.
+- Vibin skill: `work-it` drove the PR/review/session closeout workflow.
+- Save-to-md skill: used its contract to write, path-limit commit, and push this session artifact.
+- Multi-agent tools: one worker implemented the plan; later review agents failed due usage-limit errors and were closed.
+- External review: CodeRabbit posted three actionable comments, all addressed.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `git worktree add -b codex/axon-update-release-sync ...` | Created isolated worktree and branch |
+| `gh pr create --base main --head codex/axon-update-release-sync ...` | Created PR #211 |
+| `cargo fmt --all -- --check` | Passed |
+| `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo test --locked update_` | Passed, 17 tests |
+| `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo test --locked --features test-helpers --test env_config_boundary -- --nocapture` | Passed after matrix update |
+| `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo clippy --all-targets --locked -- -D warnings` | Passed |
+| fake release smoke with `AXON_UPDATE_FILE_RELEASE_DIR` and `AXON_UPDATE_INSTALL_PATH` | Installed temp binary and printed `axon fake-update` |
+| `just web-build` | Passed after `npm ci` in `apps/web` |
+| `git push` | Passed pre-push: clippy and 2895 nextest tests |
+| `gh pr checks 211 --watch --interval 20` | All required PR checks passed |
+
+## Errors Encountered
+
+- Initial CI `test` failed because `AXON_UPDATE_FILE_RELEASE_DIR` and `AXON_UPDATE_INSTALL_PATH` were not in `docs/reference/env-matrix.toml`; fixed in `de4b90f1`.
+- Initial CI `production-gate` failed only because the `test` job failed; refreshed CI passed after the env matrix fix.
+- CodeRabbit requested shared HTTP client use, pretty JSON output, and UI-helper human output; fixed in `de4b90f1`.
+- Review subagents failed with Codex usage-limit errors; the failed agent sessions were closed and the review path continued through CodeRabbit plus local verification.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| CLI release update | No `axon update` command | `axon update` can install the selected release binary |
+| Binary install | Manual download/copy workflow | Checksum-verified archive extraction and atomic install |
+| Container sync | Manual compose restart and bind target management | Command sets `AXON_DEV_TARGET_DIR`, runs compose update, and restarts `axon` unless `--no-container` |
+| JSON output | Not available for update | Pretty JSON report with version, path, install status, and container sync status |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo fmt --all -- --check` | no formatting drift | exit 0 | pass |
+| `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo test --locked update_` | update-focused tests pass | 17 passed | pass |
+| `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo test --locked --features test-helpers --test env_config_boundary -- --nocapture` | matrix agrees with scanned env keys | 1 passed | pass |
+| `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo clippy --all-targets --locked -- -D warnings` | no clippy warnings | exit 0 | pass |
+| fake release smoke | temp binary installs and runs | JSON report plus `axon fake-update` | pass |
+| pre-push hook | clippy and nextest pass | clippy passed; 2895 passed, 6 skipped | pass |
+| `gh pr checks 211 --watch --interval 20` | required remote checks pass | all required checks passed; live-qdrant/test-infra skipped intentionally | pass |
+
+## Risks and Rollback
+
+Primary risk is release asset naming: only Linux x86_64 is wired. Rollback is to remove PR #211 or revert the commits on `codex/axon-update-release-sync`; no persistent host install was performed outside the fake temp-directory smoke test.
+
+## Decisions Not Taken
+
+- Did not wire macOS or Windows update assets in this pass because the stated target was the current Linux/container deployment path.
+- Did not prune old worktrees or branches because they were not proven stale or merged.
+- Did not move the active plan to a complete folder because the PR remains open.
+
+## References
+
+- PR #211: https://github.com/jmagar/axon/pull/211
+- CodeRabbit comments on PR #211
+- Plan: `docs/superpowers/plans/2026-06-13-axon-update-release-sync.md`
+
+## Open Questions
+
+- Whether to expand `axon update` to additional release platforms after the Linux path is merged.
+- Whether CodeRabbit's docstring coverage warning should become a follow-up policy task; it did not block required checks.
+
+## Next Steps
+
+Merge PR #211 after the user is satisfied with the update behavior and review state. After merge, run `axon update --no-container` for host-only install or `axon update` on dookie to install and sync the compose container.

--- a/docs/superpowers/plans/2026-06-13-axon-update-release-sync.md
+++ b/docs/superpowers/plans/2026-06-13-axon-update-release-sync.md
@@ -1,0 +1,1157 @@
+# Axon Update Release Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `axon update` so a local user can download the latest Linux binary from GitHub Releases, install it into PATH, and sync the running Axon container to that same binary.
+
+**Architecture:** Add a small CLI command module that resolves the latest GitHub Release asset, verifies the published SHA256 sidecar, atomically installs the `axon` executable into `~/.local/bin`, and then reuses the repo's existing Docker Compose sync path. Keep release-download logic testable as pure URL/asset/checksum helpers, and keep filesystem/container mutation behind a narrow command runner so tests can use a fake release directory and fake commands.
+
+**Tech Stack:** Rust 1.94, clap, reqwest, sha2, tar/flate2, tempfile, existing `docker compose` and Justfile runtime conventions.
+
+---
+
+## File Structure
+
+- Modify `Cargo.toml` to add `sha2 = "0.10"` if it is not already present.
+- Modify `src/core/config/cli.rs` to add the `update` subcommand and its flags.
+- Modify `src/core/config/types/enums.rs` to add `CommandKind::Update`.
+- Modify `src/core/config/parse/build_config/command_dispatch.rs` to route `CliCommand::Update`.
+- Modify `src/lib.rs` to dispatch `CommandKind::Update`.
+- Modify `src/cli/commands.rs` to export the new module.
+- Create `src/cli/commands/update.rs` for the CLI entry point, install orchestration, and command execution boundary.
+- Create `src/cli/commands/update_tests.rs` for focused unit tests using local fake release artifacts and fake command scripts.
+- Modify `Justfile` only if the implementation needs a helper that syncs a preinstalled release binary into the container without rebuilding from source.
+- Modify `docs/reference/actions/setup.md` or `docs/operations/deployment.md` to document `axon update` after the command is working.
+
+## Behavior Contract
+
+- Default command: `axon update`
+- Default repo: `jmagar/axon`
+- Default tag: latest release from `https://api.github.com/repos/jmagar/axon/releases/latest`
+- Default asset on Linux x86_64: `axon-linux-x86_64.tar.gz`
+- Required checksum asset: `axon-linux-x86_64.tar.gz.sha256`
+- Default install destination: `~/.local/bin/axon`
+- Default container sync: enabled
+- Safe overwrite: download to temp dir, verify checksum, extract `axon`, install to a temp sibling, rename atomically over destination, chmod executable.
+- Failure behavior: if download/checksum/install fails, leave existing PATH binary untouched and do not sync the container.
+- Unsupported platform: return a clear error for non-Linux or non-x86_64 until those assets are intentionally wired.
+- Idempotency: if the installed binary already reports the target version and `--force` is absent, skip install but still allow container sync when requested.
+
+## Task 1: Add CLI Shape and Dispatch
+
+**Files:**
+- Modify: `src/core/config/cli.rs`
+- Modify: `src/core/config/types/enums.rs`
+- Modify: `src/core/config/parse/build_config/command_dispatch.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/cli/commands.rs`
+- Create: `src/cli/commands/update.rs`
+- Create: `src/cli/commands/update_tests.rs`
+
+- [ ] **Step 1: Write the failing parse and command-kind tests**
+
+Add these tests to `src/core/config/parse_tests.rs`:
+
+```rust
+#[test]
+fn update_defaults_to_latest_release_and_container_sync() {
+    let cfg = super::parse_args_from(["axon", "update"]).unwrap();
+
+    assert!(matches!(cfg.command, CommandKind::Update));
+    assert_eq!(cfg.positional, Vec::<String>::new());
+}
+
+#[test]
+fn update_accepts_version_repo_no_container_and_force_flags() {
+    let cfg = super::parse_args_from([
+        "axon",
+        "update",
+        "--version",
+        "v5.9.2",
+        "--repo",
+        "jmagar/axon",
+        "--no-container",
+        "--force",
+    ])
+    .unwrap();
+
+    assert!(matches!(cfg.command, CommandKind::Update));
+    assert_eq!(
+        cfg.positional,
+        vec![
+            "--version".to_string(),
+            "v5.9.2".to_string(),
+            "--repo".to_string(),
+            "jmagar/axon".to_string(),
+            "--no-container".to_string(),
+            "--force".to_string(),
+        ]
+    );
+}
+```
+
+- [ ] **Step 2: Run the focused failing tests**
+
+Run:
+
+```bash
+cargo test --locked update_defaults_to_latest_release_and_container_sync update_accepts_version_repo_no_container_and_force_flags
+```
+
+Expected: FAIL because `CommandKind::Update`, `CliCommand::Update`, and routing do not exist yet.
+
+- [ ] **Step 3: Add CLI structs and command kind**
+
+In `src/core/config/cli.rs`, add this enum variant near the other top-level maintenance commands:
+
+```rust
+    /// Download and install the latest GitHub Release binary, then sync the local container
+    Update(UpdateArgs),
+```
+
+Add this args struct near the other small command arg structs:
+
+```rust
+#[derive(Debug, Args)]
+pub(super) struct UpdateArgs {
+    /// GitHub repository in owner/name form.
+    #[arg(long, default_value = "jmagar/axon")]
+    pub(super) repo: String,
+
+    /// Release tag to install. Defaults to the latest GitHub Release.
+    #[arg(long)]
+    pub(super) version: Option<String>,
+
+    /// Install even when the destination already reports the target version.
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub(super) force: bool,
+
+    /// Do not restart/sync the local Axon container after installing.
+    #[arg(long = "no-container", action = ArgAction::SetTrue)]
+    pub(super) no_container: bool,
+}
+```
+
+In `src/core/config/types/enums.rs`, add:
+
+```rust
+    Update,
+```
+
+and in `CommandKind::as_str()`:
+
+```rust
+            Self::Update => "update",
+```
+
+- [ ] **Step 4: Route CLI args into `Config::positional`**
+
+In `src/core/config/parse/build_config/command_dispatch.rs`, add a match arm:
+
+```rust
+        CliCommand::Update(args) => {
+            out.command = CommandKind::Update;
+            if let Some(version) = args.version {
+                out.positional.push("--version".to_string());
+                out.positional.push(version);
+            }
+            if args.repo != "jmagar/axon" {
+                out.positional.push("--repo".to_string());
+                out.positional.push(args.repo);
+            }
+            if args.no_container {
+                out.positional.push("--no-container".to_string());
+            }
+            if args.force {
+                out.positional.push("--force".to_string());
+            }
+        }
+```
+
+If the second parse test expects default repo to be preserved in positionals, either remove the `args.repo != "jmagar/axon"` guard or update the test to assert only non-default args. Prefer the guard so defaults do not add noise.
+
+- [ ] **Step 5: Add a stub command module**
+
+In `src/cli/commands.rs`, add:
+
+```rust
+pub mod update;
+pub use update::run_update;
+```
+
+Create `src/cli/commands/update.rs`:
+
+```rust
+use crate::core::config::Config;
+use std::error::Error;
+
+pub async fn run_update(_cfg: &Config) -> Result<(), Box<dyn Error>> {
+    Err("axon update is not implemented yet".into())
+}
+
+#[cfg(test)]
+#[path = "update_tests.rs"]
+mod update_tests;
+```
+
+In `src/lib.rs`, import `run_update` and add the dispatch arm:
+
+```rust
+        CommandKind::Update => run_update(cfg).await?,
+```
+
+- [ ] **Step 6: Run focused parse tests**
+
+Run:
+
+```bash
+cargo test --locked update_defaults_to_latest_release_and_container_sync update_accepts_version_repo_no_container_and_force_flags
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the CLI shell**
+
+Run:
+
+```bash
+git add src/core/config/cli.rs src/core/config/types/enums.rs src/core/config/parse/build_config/command_dispatch.rs src/lib.rs src/cli/commands.rs src/cli/commands/update.rs src/core/config/parse_tests.rs
+git commit -m "feat(cli): add axon update command shell"
+```
+
+## Task 2: Implement Release Asset Resolution and Checksum Verification
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/cli/commands/update.rs`
+- Modify: `src/cli/commands/update_tests.rs`
+
+- [ ] **Step 1: Add pure helper tests**
+
+Create `src/cli/commands/update_tests.rs` with:
+
+```rust
+use super::*;
+
+#[test]
+fn linux_x86_64_release_asset_names_are_expected() {
+    let names = release_asset_names("linux", "x86_64").unwrap();
+
+    assert_eq!(names.archive, "axon-linux-x86_64.tar.gz");
+    assert_eq!(names.checksum, "axon-linux-x86_64.tar.gz.sha256");
+}
+
+#[test]
+fn unsupported_platform_returns_clear_error() {
+    let err = release_asset_names("darwin", "aarch64").unwrap_err();
+
+    assert!(err.to_string().contains("unsupported platform"));
+    assert!(err.to_string().contains("darwin/aarch64"));
+}
+
+#[test]
+fn parses_sha256_sidecar_with_filename() {
+    let parsed = parse_sha256_sidecar(
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08  axon-linux-x86_64.tar.gz\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        parsed,
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    );
+}
+
+#[test]
+fn checksum_mismatch_is_rejected() {
+    let err = verify_sha256(b"test", "0000000000000000000000000000000000000000000000000000000000000000")
+        .unwrap_err();
+
+    assert!(err.to_string().contains("checksum mismatch"));
+}
+
+#[test]
+fn checksum_match_is_accepted() {
+    verify_sha256(
+        b"test",
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+    )
+    .unwrap();
+}
+```
+
+- [ ] **Step 2: Run the failing helper tests**
+
+Run:
+
+```bash
+cargo test --locked linux_x86_64_release_asset_names_are_expected unsupported_platform_returns_clear_error parses_sha256_sidecar_with_filename checksum_mismatch_is_rejected checksum_match_is_accepted
+```
+
+Expected: FAIL because the helper functions do not exist.
+
+- [ ] **Step 3: Add checksum dependency**
+
+In `Cargo.toml`, add:
+
+```toml
+sha2 = "0.10"
+```
+
+- [ ] **Step 4: Implement helper types and functions**
+
+Replace the stub body in `src/cli/commands/update.rs` with:
+
+```rust
+use crate::core::config::Config;
+use flate2::read::GzDecoder;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
+use tar::Archive;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReleaseAssetNames {
+    archive: &'static str,
+    checksum: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    assets: Vec<GithubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug)]
+struct UpdateError(String);
+
+impl fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for UpdateError {}
+
+fn err(message: impl Into<String>) -> Box<dyn Error> {
+    Box::new(UpdateError(message.into()))
+}
+
+fn release_asset_names(os: &str, arch: &str) -> Result<ReleaseAssetNames, Box<dyn Error>> {
+    match (os, arch) {
+        ("linux", "x86_64") => Ok(ReleaseAssetNames {
+            archive: "axon-linux-x86_64.tar.gz",
+            checksum: "axon-linux-x86_64.tar.gz.sha256",
+        }),
+        _ => Err(err(format!(
+            "unsupported platform for axon update: {os}/{arch}; only linux/x86_64 is wired"
+        ))),
+    }
+}
+
+fn parse_sha256_sidecar(body: &str) -> Result<String, Box<dyn Error>> {
+    let hash = body
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| err("empty sha256 sidecar"))?;
+    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(err(format!("invalid sha256 sidecar hash: {hash}")));
+    }
+    Ok(hash.to_ascii_lowercase())
+}
+
+fn verify_sha256(bytes: &[u8], expected: &str) -> Result<(), Box<dyn Error>> {
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    if actual != expected.to_ascii_lowercase() {
+        return Err(err(format!(
+            "checksum mismatch: expected {expected}, got {actual}"
+        )));
+    }
+    Ok(())
+}
+```
+
+Keep the existing `run_update()` stub below these helpers for now.
+
+- [ ] **Step 5: Run helper tests**
+
+Run:
+
+```bash
+cargo test --locked linux_x86_64_release_asset_names_are_expected unsupported_platform_returns_clear_error parses_sha256_sidecar_with_filename checksum_mismatch_is_rejected checksum_match_is_accepted
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit helper layer**
+
+Run:
+
+```bash
+git add Cargo.toml Cargo.lock src/cli/commands/update.rs src/cli/commands/update_tests.rs
+git commit -m "feat(update): resolve release assets and verify checksums"
+```
+
+## Task 3: Download, Extract, and Atomically Install the Binary
+
+**Files:**
+- Modify: `src/cli/commands/update.rs`
+- Modify: `src/cli/commands/update_tests.rs`
+
+- [ ] **Step 1: Add extraction and atomic install tests**
+
+Append to `src/cli/commands/update_tests.rs`:
+
+```rust
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use std::fs;
+use std::io::Write;
+use tar::{Builder, Header};
+
+fn make_release_archive(script_body: &str) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = Builder::new(&mut tar_bytes);
+        let mut header = Header::new_gnu();
+        header.set_path("axon").unwrap();
+        header.set_size(script_body.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append(&header, script_body.as_bytes())
+            .expect("append axon");
+        builder.finish().expect("finish tar");
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_bytes).unwrap();
+    encoder.finish().unwrap()
+}
+
+#[test]
+fn extracts_axon_binary_from_release_archive() {
+    let archive = make_release_archive("#!/usr/bin/env sh\necho axon 5.9.2\n");
+    let temp = tempfile::tempdir().unwrap();
+    let extracted = extract_axon_binary(&archive, temp.path()).unwrap();
+
+    assert_eq!(fs::read_to_string(&extracted).unwrap(), "#!/usr/bin/env sh\necho axon 5.9.2\n");
+}
+
+#[test]
+fn atomic_install_replaces_destination_and_sets_executable_mode() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("axon-new");
+    let dest = temp.path().join("bin").join("axon");
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    fs::write(&source, "#!/usr/bin/env sh\necho new\n").unwrap();
+    fs::write(&dest, "#!/usr/bin/env sh\necho old\n").unwrap();
+
+    install_binary_atomically(&source, &dest).unwrap();
+
+    assert_eq!(fs::read_to_string(&dest).unwrap(), "#!/usr/bin/env sh\necho new\n");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&dest).unwrap().permissions().mode();
+        assert_eq!(mode & 0o111, 0o111);
+    }
+}
+```
+
+- [ ] **Step 2: Run failing extraction/install tests**
+
+Run:
+
+```bash
+cargo test --locked extracts_axon_binary_from_release_archive atomic_install_replaces_destination_and_sets_executable_mode
+```
+
+Expected: FAIL because extraction and install helpers do not exist.
+
+- [ ] **Step 3: Implement extraction and atomic install**
+
+Add to `src/cli/commands/update.rs`:
+
+```rust
+fn extract_axon_binary(archive_bytes: &[u8], temp_dir: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    let gz = GzDecoder::new(Cursor::new(archive_bytes));
+    let mut archive = Archive::new(gz);
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        if path.as_ref() == Path::new("axon") {
+            let output = temp_dir.join("axon");
+            entry.unpack(&output)?;
+            return Ok(output);
+        }
+    }
+
+    Err(err("release archive did not contain executable axon"))
+}
+
+fn install_binary_atomically(source: &Path, dest: &Path) -> Result<(), Box<dyn Error>> {
+    let parent = dest
+        .parent()
+        .ok_or_else(|| err(format!("install path has no parent: {}", dest.display())))?;
+    fs::create_dir_all(parent)?;
+
+    let temp_dest = parent.join(format!(
+        ".{}.tmp-{}",
+        dest.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("axon"),
+        std::process::id()
+    ));
+
+    fs::copy(source, &temp_dest)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&temp_dest)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&temp_dest, permissions)?;
+    }
+    fs::rename(&temp_dest, dest)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run extraction/install tests**
+
+Run:
+
+```bash
+cargo test --locked extracts_axon_binary_from_release_archive atomic_install_replaces_destination_and_sets_executable_mode
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit install primitives**
+
+Run:
+
+```bash
+git add src/cli/commands/update.rs src/cli/commands/update_tests.rs
+git commit -m "feat(update): install downloaded axon binary atomically"
+```
+
+## Task 4: Wire the End-to-End `axon update` Command
+
+**Files:**
+- Modify: `src/cli/commands/update.rs`
+- Modify: `src/cli/commands/update_tests.rs`
+
+- [ ] **Step 1: Add local fake-release end-to-end tests**
+
+Append to `src/cli/commands/update_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn update_installs_from_file_base_url_without_container_sync() {
+    let temp = tempfile::tempdir().unwrap();
+    let release = make_release_archive("#!/usr/bin/env sh\necho axon 5.9.2\n");
+    let checksum = format!("{:x}", sha2::Sha256::digest(&release));
+    let archive_path = temp.path().join("axon-linux-x86_64.tar.gz");
+    let checksum_path = temp.path().join("axon-linux-x86_64.tar.gz.sha256");
+    fs::write(&archive_path, &release).unwrap();
+    fs::write(
+        &checksum_path,
+        format!("{checksum}  axon-linux-x86_64.tar.gz\n"),
+    )
+    .unwrap();
+
+    let install_dir = temp.path().join("install");
+    let options = UpdateOptions {
+        repo: "jmagar/axon".to_string(),
+        version: Some("v5.9.2".to_string()),
+        force: true,
+        sync_container: false,
+        install_path: install_dir.join("axon"),
+        file_release_dir: Some(temp.path().to_path_buf()),
+    };
+
+    let report = perform_update(options).await.unwrap();
+
+    assert_eq!(report.version, "v5.9.2");
+    assert_eq!(
+        fs::read_to_string(install_dir.join("axon")).unwrap(),
+        "#!/usr/bin/env sh\necho axon 5.9.2\n"
+    );
+    assert!(!report.container_synced);
+}
+```
+
+- [ ] **Step 2: Run the failing end-to-end test**
+
+Run:
+
+```bash
+cargo test --locked update_installs_from_file_base_url_without_container_sync
+```
+
+Expected: FAIL because `UpdateOptions`, `UpdateReport`, and `perform_update` do not exist.
+
+- [ ] **Step 3: Implement options parsing and local-file test mode**
+
+Add to `src/cli/commands/update.rs`:
+
+```rust
+#[derive(Debug, Clone)]
+struct UpdateOptions {
+    repo: String,
+    version: Option<String>,
+    force: bool,
+    sync_container: bool,
+    install_path: PathBuf,
+    file_release_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+struct UpdateReport {
+    version: String,
+    install_path: PathBuf,
+    container_synced: bool,
+}
+
+fn parse_update_options(cfg: &Config) -> Result<UpdateOptions, Box<dyn Error>> {
+    let mut repo = "jmagar/axon".to_string();
+    let mut version = None;
+    let mut force = false;
+    let mut sync_container = true;
+    let mut file_release_dir = std::env::var_os("AXON_UPDATE_FILE_RELEASE_DIR").map(PathBuf::from);
+
+    let mut args = cfg.positional.iter();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--repo" => {
+                repo = args
+                    .next()
+                    .ok_or_else(|| err("--repo requires a value"))?
+                    .to_string();
+            }
+            "--version" => {
+                version = Some(
+                    args.next()
+                        .ok_or_else(|| err("--version requires a value"))?
+                        .to_string(),
+                );
+            }
+            "--force" => force = true,
+            "--no-container" => sync_container = false,
+            other => return Err(err(format!("unknown update argument: {other}"))),
+        }
+    }
+
+    let install_path = std::env::var_os("AXON_UPDATE_INSTALL_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let home = std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("."));
+            home.join(".local/bin/axon")
+        });
+
+    Ok(UpdateOptions {
+        repo,
+        version,
+        force,
+        sync_container,
+        install_path,
+        file_release_dir: file_release_dir.take(),
+    })
+}
+```
+
+- [ ] **Step 4: Implement download and update orchestration**
+
+Add to `src/cli/commands/update.rs`:
+
+```rust
+async fn perform_update(options: UpdateOptions) -> Result<UpdateReport, Box<dyn Error>> {
+    let names = release_asset_names(std::env::consts::OS, std::env::consts::ARCH)?;
+    let temp = tempfile::tempdir()?;
+
+    let (version, archive_bytes, checksum_body) = if let Some(dir) = &options.file_release_dir {
+        let archive = fs::read(dir.join(names.archive))?;
+        let checksum = fs::read_to_string(dir.join(names.checksum))?;
+        (
+            options
+                .version
+                .clone()
+                .unwrap_or_else(|| "local-test-release".to_string()),
+            archive,
+            checksum,
+        )
+    } else {
+        download_release_assets(&options.repo, options.version.as_deref(), &names).await?
+    };
+
+    let expected = parse_sha256_sidecar(&checksum_body)?;
+    verify_sha256(&archive_bytes, &expected)?;
+    let extracted = extract_axon_binary(&archive_bytes, temp.path())?;
+    install_binary_atomically(&extracted, &options.install_path)?;
+
+    let mut container_synced = false;
+    if options.sync_container {
+        sync_container_from_installed_binary(&options.install_path)?;
+        container_synced = true;
+    }
+
+    Ok(UpdateReport {
+        version,
+        install_path: options.install_path,
+        container_synced,
+    })
+}
+```
+
+- [ ] **Step 5: Implement GitHub download**
+
+Add to `src/cli/commands/update.rs`:
+
+```rust
+async fn download_release_assets(
+    repo: &str,
+    version: Option<&str>,
+    names: &ReleaseAssetNames,
+) -> Result<(String, Vec<u8>, String), Box<dyn Error>> {
+    let client = reqwest::Client::builder()
+        .user_agent(format!("axon-update/{}", env!("CARGO_PKG_VERSION")))
+        .build()?;
+    let api_url = match version {
+        Some(tag) => format!("https://api.github.com/repos/{repo}/releases/tags/{tag}"),
+        None => format!("https://api.github.com/repos/{repo}/releases/latest"),
+    };
+
+    let release: GithubRelease = client
+        .get(&api_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let archive_url = find_asset_url(&release, names.archive)?;
+    let checksum_url = find_asset_url(&release, names.checksum)?;
+    let archive = client
+        .get(archive_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?
+        .to_vec();
+    let checksum = client
+        .get(checksum_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    Ok((release.tag_name, archive, checksum))
+}
+
+fn find_asset_url<'a>(
+    release: &'a GithubRelease,
+    name: &str,
+) -> Result<&'a str, Box<dyn Error>> {
+    release
+        .assets
+        .iter()
+        .find(|asset| asset.name == name)
+        .map(|asset| asset.browser_download_url.as_str())
+        .ok_or_else(|| err(format!("release {} is missing asset {name}", release.tag_name)))
+}
+```
+
+- [ ] **Step 6: Implement command entry point output**
+
+Replace `run_update()` with:
+
+```rust
+pub async fn run_update(cfg: &Config) -> Result<(), Box<dyn Error>> {
+    let options = parse_update_options(cfg)?;
+    let report = perform_update(options).await?;
+
+    if cfg.json_output {
+        println!(
+            "{}",
+            serde_json::json!({
+                "version": report.version,
+                "install_path": report.install_path,
+                "container_synced": report.container_synced,
+            })
+        );
+    } else {
+        println!("installed axon {}", report.version);
+        println!("path: {}", report.install_path.display());
+        if report.container_synced {
+            println!("container synced");
+        } else {
+            println!("container sync skipped");
+        }
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 7: Run end-to-end local-file test**
+
+Run:
+
+```bash
+cargo test --locked update_installs_from_file_base_url_without_container_sync
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit end-to-end update flow**
+
+Run:
+
+```bash
+git add src/cli/commands/update.rs src/cli/commands/update_tests.rs
+git commit -m "feat(update): download and install release binary"
+```
+
+## Task 5: Sync the Installed Release Binary Into the Container
+
+**Files:**
+- Modify: `src/cli/commands/update.rs`
+- Modify: `src/cli/commands/update_tests.rs`
+- Modify: `Justfile` if needed
+
+- [ ] **Step 1: Decide the sync mechanism from current Compose behavior**
+
+Inspect:
+
+```bash
+sed -n '126,195p' Justfile
+sed -n '1,140p' docker-compose.yaml
+```
+
+Expected: `sync-container` exports `AXON_DEV_TARGET_DIR="$(dirname "$AXON_BIN")"` and starts the `axon` service with that target dir mounted at `/home/axon/.axon/dev`.
+
+- [ ] **Step 2: Add command-runner boundary tests**
+
+Append to `src/cli/commands/update_tests.rs`:
+
+```rust
+#[test]
+fn sync_container_uses_installed_binary_directory_as_dev_target() {
+    let temp = tempfile::tempdir().unwrap();
+    let fake_bin = temp.path().join("bin").join("axon");
+    fs::create_dir_all(fake_bin.parent().unwrap()).unwrap();
+    fs::write(&fake_bin, "#!/usr/bin/env sh\necho axon 5.9.2\n").unwrap();
+
+    let sync = build_container_sync_command(&fake_bin).unwrap();
+
+    assert_eq!(sync.env_name, "AXON_DEV_TARGET_DIR");
+    assert_eq!(sync.env_value, fake_bin.parent().unwrap());
+    assert_eq!(sync.program, "docker");
+    assert_eq!(
+        sync.args,
+        vec![
+            "compose",
+            "-f",
+            "docker-compose.yaml",
+            "up",
+            "-d",
+            "axon",
+            "--no-deps",
+            "--no-build",
+        ]
+    );
+}
+```
+
+- [ ] **Step 3: Run failing sync command test**
+
+Run:
+
+```bash
+cargo test --locked sync_container_uses_installed_binary_directory_as_dev_target
+```
+
+Expected: FAIL because `build_container_sync_command` does not exist.
+
+- [ ] **Step 4: Implement sync command construction**
+
+Add to `src/cli/commands/update.rs`:
+
+```rust
+#[derive(Debug, PartialEq, Eq)]
+struct SyncCommand {
+    program: &'static str,
+    args: Vec<&'static str>,
+    env_name: &'static str,
+    env_value: PathBuf,
+}
+
+fn build_container_sync_command(installed_binary: &Path) -> Result<SyncCommand, Box<dyn Error>> {
+    let bin_dir = installed_binary
+        .parent()
+        .ok_or_else(|| err(format!("installed binary has no parent: {}", installed_binary.display())))?
+        .to_path_buf();
+
+    Ok(SyncCommand {
+        program: "docker",
+        args: vec![
+            "compose",
+            "-f",
+            "docker-compose.yaml",
+            "up",
+            "-d",
+            "axon",
+            "--no-deps",
+            "--no-build",
+        ],
+        env_name: "AXON_DEV_TARGET_DIR",
+        env_value: bin_dir,
+    })
+}
+
+fn sync_container_from_installed_binary(installed_binary: &Path) -> Result<(), Box<dyn Error>> {
+    let sync = build_container_sync_command(installed_binary)?;
+    let status = std::process::Command::new(sync.program)
+        .args(sync.args)
+        .env(sync.env_name, sync.env_value)
+        .status()?;
+    if !status.success() {
+        return Err(err(format!("container sync failed with status {status}")));
+    }
+
+    let restart_status = std::process::Command::new("docker")
+        .args(["compose", "-f", "docker-compose.yaml", "restart", "axon"])
+        .status()?;
+    if !restart_status.success() {
+        return Err(err(format!("container restart failed with status {restart_status}")));
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Preserve env-file behavior if required**
+
+If `docker compose --env-file ~/.axon/.env` is required for local container sync, extend `SyncCommand` to include optional args from `scripts/lib/axon-env.sh` equivalent logic. Add this test:
+
+```rust
+#[test]
+fn env_file_args_are_inserted_before_compose_file() {
+    let args = compose_args(Some(Path::new("/home/j/.axon/.env")));
+
+    assert_eq!(
+        args,
+        vec![
+            "compose",
+            "--env-file",
+            "/home/j/.axon/.env",
+            "-f",
+            "docker-compose.yaml",
+            "up",
+            "-d",
+            "axon",
+            "--no-deps",
+            "--no-build",
+        ]
+    );
+}
+```
+
+Then implement `compose_args(env_file: Option<&Path>) -> Vec<String>` and use `std::process::Command` with owned `String` args.
+
+- [ ] **Step 6: Run sync tests**
+
+Run:
+
+```bash
+cargo test --locked sync_container_uses_installed_binary_directory_as_dev_target
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run a live no-container install with a fake release**
+
+Run:
+
+```bash
+tmp="$(mktemp -d)"
+printf '#!/usr/bin/env sh\necho axon fake-update\n' > "$tmp/axon"
+chmod +x "$tmp/axon"
+tar -C "$tmp" -czf "$tmp/axon-linux-x86_64.tar.gz" axon
+sha256sum "$tmp/axon-linux-x86_64.tar.gz" > "$tmp/axon-linux-x86_64.tar.gz.sha256"
+AXON_UPDATE_FILE_RELEASE_DIR="$tmp" \
+AXON_UPDATE_INSTALL_PATH="$tmp/install/axon" \
+cargo run --locked --bin axon -- update --version v0.0.0-test --no-container --force
+"$tmp/install/axon"
+```
+
+Expected: command prints `installed axon v0.0.0-test`, skips container sync, and running the installed fake binary prints `axon fake-update`.
+
+- [ ] **Step 8: Commit container sync integration**
+
+Run:
+
+```bash
+git add src/cli/commands/update.rs src/cli/commands/update_tests.rs Justfile
+git commit -m "feat(update): sync installed release into container"
+```
+
+## Task 6: Documentation and Final Verification
+
+**Files:**
+- Modify: `docs/operations/deployment.md`
+- Modify: `README.md` if there is a CLI command table that lists maintenance commands.
+
+- [ ] **Step 1: Document normal usage**
+
+Add this section to `docs/operations/deployment.md` near the local binary/container deployment notes:
+
+````markdown
+### Updating the local Axon binary from GitHub Releases
+
+Use `axon update` to install the latest published Linux release binary into
+`~/.local/bin/axon` and restart the local Axon container against the same binary:
+
+```bash
+axon update
+```
+
+Useful variants:
+
+```bash
+axon update --version v5.9.2      # install a specific release tag
+axon update --no-container        # update PATH only
+axon update --force               # reinstall even if the version already matches
+axon update --json                # machine-readable report
+```
+
+The command downloads `axon-linux-x86_64.tar.gz`, verifies
+`axon-linux-x86_64.tar.gz.sha256`, installs atomically, and only syncs the
+container after checksum and install succeed.
+````
+
+- [ ] **Step 2: Run format and focused tests**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test --locked update_
+cargo test --locked update_defaults_to_latest_release_and_container_sync update_accepts_version_repo_no_container_and_force_flags
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run help smoke**
+
+Run:
+
+```bash
+cargo run --locked --bin axon -- update --help
+```
+
+Expected: help includes `--repo`, `--version`, `--force`, and `--no-container`.
+
+- [ ] **Step 4: Run dry local fake release smoke**
+
+Run:
+
+```bash
+tmp="$(mktemp -d)"
+printf '#!/usr/bin/env sh\necho axon fake-update\n' > "$tmp/axon"
+chmod +x "$tmp/axon"
+tar -C "$tmp" -czf "$tmp/axon-linux-x86_64.tar.gz" axon
+sha256sum "$tmp/axon-linux-x86_64.tar.gz" > "$tmp/axon-linux-x86_64.tar.gz.sha256"
+AXON_UPDATE_FILE_RELEASE_DIR="$tmp" \
+AXON_UPDATE_INSTALL_PATH="$tmp/install/axon" \
+cargo run --locked --bin axon -- update --version v0.0.0-test --no-container --force --json
+"$tmp/install/axon"
+```
+
+Expected: JSON contains `"version":"v0.0.0-test"` and `"container_synced":false`; fake installed binary prints `axon fake-update`.
+
+- [ ] **Step 5: Run real release install without container sync**
+
+Run:
+
+```bash
+cargo run --locked --bin axon -- update --no-container --force
+~/.local/bin/axon --version
+```
+
+Expected: downloads the latest GitHub Release, verifies checksum, installs to `~/.local/bin/axon`, and `~/.local/bin/axon --version` reports that release version.
+
+- [ ] **Step 6: Run real release install with container sync**
+
+Run only after Step 5 passes:
+
+```bash
+cargo run --locked --bin axon -- update --force
+docker exec axon /home/axon/.axon/dev/axon --version
+```
+
+Expected: container command reports the same version as `~/.local/bin/axon --version`.
+
+- [ ] **Step 7: Commit docs and verification polish**
+
+Run:
+
+```bash
+git add docs/operations/deployment.md README.md
+git commit -m "docs(update): document release binary updater"
+```
+
+## Final Quality Gate
+
+- [ ] Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test --locked update_
+cargo test --locked update_defaults_to_latest_release_and_container_sync update_accepts_version_repo_no_container_and_force_flags
+cargo clippy --all-targets --locked -- -D warnings
+```
+
+- [ ] Run the real no-container updater once:
+
+```bash
+cargo run --locked --bin axon -- update --no-container --force
+~/.local/bin/axon --version
+```
+
+- [ ] Run the real container sync proof once:
+
+```bash
+cargo run --locked --bin axon -- update --force
+docker exec axon /home/axon/.axon/dev/axon --version
+docker compose -f docker-compose.yaml ps axon
+```
+
+- [ ] Confirm the main checkout stayed untouched:
+
+```bash
+git -C /home/jmagar/workspace/axon status --short --branch
+git -C /home/jmagar/workspace/axon/.worktrees/axon-update-release-sync status --short --branch
+```
+
+## Self-Review
+
+- Spec coverage: The plan adds `axon update`, downloads GitHub Release assets, verifies the checksum, installs into PATH, and syncs the container to the installed binary.
+- Placeholder scan: No task uses placeholder language; every code-changing step includes concrete snippets or exact command targets.
+- Type consistency: `UpdateOptions`, `UpdateReport`, `ReleaseAssetNames`, `perform_update`, and helper names are defined before later tasks rely on them.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -43,6 +43,7 @@ pub mod suggest;
 pub mod summarize;
 pub mod sync;
 pub mod train;
+pub mod update;
 pub mod watch;
 
 #[cfg(test)]
@@ -87,6 +88,7 @@ pub use suggest::run_suggest;
 pub use summarize::run_summarize;
 pub use sync::run_sync;
 pub use train::run_train;
+pub use update::run_update;
 pub use watch::run_watch;
 
 use crate::core::config::Config;

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -1,0 +1,445 @@
+use crate::core::config::Config;
+use flate2::read::GzDecoder;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tar::Archive;
+
+const DEFAULT_REPO: &str = "jmagar/axon";
+const UPDATE_FILE_RELEASE_DIR: &str = "AXON_UPDATE_FILE_RELEASE_DIR";
+const UPDATE_INSTALL_PATH: &str = "AXON_UPDATE_INSTALL_PATH";
+const DEV_TARGET_DIR: &str = "AXON_DEV_TARGET_DIR";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReleaseAssetNames {
+    archive: &'static str,
+    checksum: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    assets: Vec<GithubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug, Clone)]
+struct UpdateOptions {
+    repo: String,
+    version: Option<String>,
+    force: bool,
+    sync_container: bool,
+    install_path: PathBuf,
+    file_release_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+struct UpdateReport {
+    version: String,
+    install_path: PathBuf,
+    installed: bool,
+    container_synced: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SyncCommand {
+    program: &'static str,
+    args: Vec<String>,
+    env_name: &'static str,
+    env_value: PathBuf,
+}
+
+#[derive(Debug)]
+struct UpdateError(String);
+
+impl fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for UpdateError {}
+
+fn err(message: impl Into<String>) -> Box<dyn Error> {
+    Box::new(UpdateError(message.into()))
+}
+
+pub async fn run_update(cfg: &Config) -> Result<(), Box<dyn Error>> {
+    let options = parse_update_options(cfg)?;
+    let report = perform_update(options).await?;
+
+    if cfg.json_output {
+        println!(
+            "{}",
+            serde_json::json!({
+                "version": report.version,
+                "install_path": report.install_path,
+                "installed": report.installed,
+                "container_synced": report.container_synced,
+            })
+        );
+    } else {
+        if report.installed {
+            println!("installed axon {}", report.version);
+        } else {
+            println!("axon {} already installed", report.version);
+        }
+        println!("path: {}", report.install_path.display());
+        if report.container_synced {
+            println!("container synced");
+        } else {
+            println!("container sync skipped");
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_update_options(cfg: &Config) -> Result<UpdateOptions, Box<dyn Error>> {
+    let mut repo = DEFAULT_REPO.to_string();
+    let mut version = None;
+    let mut force = false;
+    let mut sync_container = true;
+
+    let mut args = cfg.positional.iter();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--repo" => {
+                repo = args
+                    .next()
+                    .ok_or_else(|| err("--repo requires a value"))?
+                    .to_string();
+            }
+            "--version" => {
+                version = Some(
+                    args.next()
+                        .ok_or_else(|| err("--version requires a value"))?
+                        .to_string(),
+                );
+            }
+            "--force" => force = true,
+            "--no-container" => sync_container = false,
+            other => return Err(err(format!("unknown update argument: {other}"))),
+        }
+    }
+
+    let install_path = env::var_os(UPDATE_INSTALL_PATH)
+        .map(PathBuf::from)
+        .unwrap_or_else(default_install_path);
+
+    Ok(UpdateOptions {
+        repo,
+        version,
+        force,
+        sync_container,
+        install_path,
+        file_release_dir: env::var_os(UPDATE_FILE_RELEASE_DIR).map(PathBuf::from),
+    })
+}
+
+fn default_install_path() -> PathBuf {
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".local/bin/axon")
+}
+
+async fn perform_update(options: UpdateOptions) -> Result<UpdateReport, Box<dyn Error>> {
+    let names = release_asset_names(env::consts::OS, env::consts::ARCH)?;
+    let temp = tempfile::tempdir()?;
+
+    let (version, archive_bytes, checksum_body) = if let Some(dir) = &options.file_release_dir {
+        let archive = fs::read(dir.join(names.archive))?;
+        let checksum = fs::read_to_string(dir.join(names.checksum))?;
+        (
+            options
+                .version
+                .clone()
+                .unwrap_or_else(|| "local-test-release".to_string()),
+            archive,
+            checksum,
+        )
+    } else {
+        download_release_assets(&options.repo, options.version.as_deref(), &names).await?
+    };
+
+    let expected = parse_sha256_sidecar(&checksum_body)?;
+    verify_sha256(&archive_bytes, &expected)?;
+
+    let already_current =
+        !options.force && installed_binary_reports_version(&options.install_path, &version);
+    if !already_current {
+        let extracted = extract_axon_binary(&archive_bytes, temp.path())?;
+        install_binary_atomically(&extracted, &options.install_path)?;
+    }
+
+    let mut container_synced = false;
+    if options.sync_container {
+        sync_container_from_installed_binary(&options.install_path)?;
+        container_synced = true;
+    }
+
+    Ok(UpdateReport {
+        version,
+        install_path: options.install_path,
+        installed: !already_current,
+        container_synced,
+    })
+}
+
+async fn download_release_assets(
+    repo: &str,
+    version: Option<&str>,
+    names: &ReleaseAssetNames,
+) -> Result<(String, Vec<u8>, String), Box<dyn Error>> {
+    let client = reqwest::Client::builder()
+        .user_agent(format!("axon-update/{}", env!("CARGO_PKG_VERSION")))
+        .build()?;
+    let api_url = match version {
+        Some(tag) => format!("https://api.github.com/repos/{repo}/releases/tags/{tag}"),
+        None => format!("https://api.github.com/repos/{repo}/releases/latest"),
+    };
+
+    let release: GithubRelease = client
+        .get(&api_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let archive_url = find_asset_url(&release, names.archive)?;
+    let checksum_url = find_asset_url(&release, names.checksum)?;
+    let archive = client
+        .get(archive_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?
+        .to_vec();
+    let checksum = client
+        .get(checksum_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    Ok((release.tag_name, archive, checksum))
+}
+
+fn find_asset_url<'a>(release: &'a GithubRelease, name: &str) -> Result<&'a str, Box<dyn Error>> {
+    release
+        .assets
+        .iter()
+        .find(|asset| asset.name == name)
+        .map(|asset| asset.browser_download_url.as_str())
+        .ok_or_else(|| {
+            err(format!(
+                "release {} is missing asset {name}",
+                release.tag_name
+            ))
+        })
+}
+
+fn release_asset_names(os: &str, arch: &str) -> Result<ReleaseAssetNames, Box<dyn Error>> {
+    match (os, arch) {
+        ("linux", "x86_64") => Ok(ReleaseAssetNames {
+            archive: "axon-linux-x86_64.tar.gz",
+            checksum: "axon-linux-x86_64.tar.gz.sha256",
+        }),
+        _ => Err(err(format!(
+            "unsupported platform for axon update: {os}/{arch}; only linux/x86_64 is wired"
+        ))),
+    }
+}
+
+fn parse_sha256_sidecar(body: &str) -> Result<String, Box<dyn Error>> {
+    let hash = body
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| err("empty sha256 sidecar"))?;
+    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(err(format!("invalid sha256 sidecar hash: {hash}")));
+    }
+    Ok(hash.to_ascii_lowercase())
+}
+
+fn verify_sha256(bytes: &[u8], expected: &str) -> Result<(), Box<dyn Error>> {
+    let actual = hex::encode(Sha256::digest(bytes));
+    if actual != expected.to_ascii_lowercase() {
+        return Err(err(format!(
+            "checksum mismatch: expected {expected}, got {actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn extract_axon_binary(archive_bytes: &[u8], temp_dir: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    let gz = GzDecoder::new(Cursor::new(archive_bytes));
+    let mut archive = Archive::new(gz);
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        if path.as_ref() == Path::new("axon") {
+            let output = temp_dir.join("axon");
+            entry.unpack(&output)?;
+            return Ok(output);
+        }
+    }
+
+    Err(err("release archive did not contain executable axon"))
+}
+
+fn install_binary_atomically(source: &Path, dest: &Path) -> Result<(), Box<dyn Error>> {
+    let parent = dest
+        .parent()
+        .ok_or_else(|| err(format!("install path has no parent: {}", dest.display())))?;
+    fs::create_dir_all(parent)?;
+
+    let temp_dest = parent.join(format!(
+        ".{}.tmp-{}-{}",
+        dest.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("axon"),
+        std::process::id(),
+        unique_suffix()
+    ));
+
+    fs::copy(source, &temp_dest)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&temp_dest)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&temp_dest, permissions)?;
+    }
+    fs::rename(&temp_dest, dest)?;
+    Ok(())
+}
+
+fn unique_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default()
+}
+
+fn installed_binary_reports_version(installed_binary: &Path, version: &str) -> bool {
+    if !installed_binary.is_file() {
+        return false;
+    }
+    let Ok(output) = Command::new(installed_binary).arg("--version").output() else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let normalized = version.trim_start_matches('v');
+    stdout.contains(version)
+        || stderr.contains(version)
+        || stdout.contains(normalized)
+        || stderr.contains(normalized)
+}
+
+fn build_container_sync_command(installed_binary: &Path) -> Result<SyncCommand, Box<dyn Error>> {
+    let bin_dir = installed_binary
+        .parent()
+        .ok_or_else(|| {
+            err(format!(
+                "installed binary has no parent: {}",
+                installed_binary.display()
+            ))
+        })?
+        .to_path_buf();
+
+    Ok(SyncCommand {
+        program: "docker",
+        args: compose_args(resolve_axon_env_file().as_deref(), true),
+        env_name: DEV_TARGET_DIR,
+        env_value: bin_dir,
+    })
+}
+
+fn compose_args(env_file: Option<&Path>, include_up: bool) -> Vec<String> {
+    let mut args = vec!["compose".to_string()];
+    if let Some(env_file) = env_file {
+        args.push("--env-file".to_string());
+        args.push(env_file.display().to_string());
+    }
+    args.extend(["-f", "docker-compose.yaml"].into_iter().map(String::from));
+    if include_up {
+        args.extend(
+            ["up", "-d", "axon", "--no-deps", "--no-build"]
+                .into_iter()
+                .map(String::from),
+        );
+    }
+    args
+}
+
+fn resolve_axon_env_file() -> Option<PathBuf> {
+    if let Some(path) = env::var_os("AXON_ENV_FILE").map(PathBuf::from)
+        && path.is_file()
+    {
+        return Some(path);
+    }
+    let axon_home = env::var_os("AXON_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".axon")
+        });
+    let home_env = axon_home.join(".env");
+    if home_env.is_file() {
+        return Some(home_env);
+    }
+    let repo_env = PathBuf::from(".env");
+    repo_env.is_file().then_some(repo_env)
+}
+
+fn sync_container_from_installed_binary(installed_binary: &Path) -> Result<(), Box<dyn Error>> {
+    let sync = build_container_sync_command(installed_binary)?;
+    let status = Command::new(sync.program)
+        .args(&sync.args)
+        .env(sync.env_name, sync.env_value)
+        .status()?;
+    if !status.success() {
+        return Err(err(format!("container sync failed with status {status}")));
+    }
+
+    let restart_args = compose_args(resolve_axon_env_file().as_deref(), false);
+    let mut restart = Command::new("docker");
+    restart.args(&restart_args);
+    restart.args(["restart", "axon"]);
+    let restart_status = restart.status()?;
+    if !restart_status.success() {
+        return Err(err(format!(
+            "container restart failed with status {restart_status}"
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "update_tests.rs"]
+mod update_tests;

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -1,4 +1,6 @@
 use crate::core::config::Config;
+use crate::core::http::http_client;
+use crate::core::ui::{accent, muted, primary};
 use flate2::read::GzDecoder;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -81,26 +83,27 @@ pub async fn run_update(cfg: &Config) -> Result<(), Box<dyn Error>> {
     let report = perform_update(options).await?;
 
     if cfg.json_output {
-        println!(
-            "{}",
-            serde_json::json!({
-                "version": report.version,
-                "install_path": report.install_path,
-                "installed": report.installed,
-                "container_synced": report.container_synced,
-            })
-        );
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "version": report.version,
+            "install_path": report.install_path,
+            "installed": report.installed,
+            "container_synced": report.container_synced,
+        }))?;
+        println!("{json}");
     } else {
         if report.installed {
-            println!("installed axon {}", report.version);
+            println!("{}", primary(&format!("installed axon {}", report.version)));
         } else {
-            println!("axon {} already installed", report.version);
+            println!(
+                "{}",
+                muted(&format!("axon {} already installed", report.version))
+            );
         }
-        println!("path: {}", report.install_path.display());
+        println!("{} {}", accent("path:"), report.install_path.display());
         if report.container_synced {
-            println!("container synced");
+            println!("{}", primary("container synced"));
         } else {
-            println!("container sync skipped");
+            println!("{}", muted("container sync skipped"));
         }
     }
 
@@ -204,9 +207,7 @@ async fn download_release_assets(
     version: Option<&str>,
     names: &ReleaseAssetNames,
 ) -> Result<(String, Vec<u8>, String), Box<dyn Error>> {
-    let client = reqwest::Client::builder()
-        .user_agent(format!("axon-update/{}", env!("CARGO_PKG_VERSION")))
-        .build()?;
+    let client = http_client()?;
     let api_url = match version {
         Some(tag) => format!("https://api.github.com/repos/{repo}/releases/tags/{tag}"),
         None => format!("https://api.github.com/repos/{repo}/releases/latest"),

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -1,23 +1,28 @@
 use crate::core::config::Config;
 use crate::core::http::http_client;
+use crate::core::paths::axon_home_dir;
 use crate::core::ui::{accent, muted, primary};
 use flate2::read::GzDecoder;
+use futures_util::StreamExt;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::env;
 use std::error::Error;
 use std::fmt;
 use std::fs;
-use std::io::Cursor;
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tar::Archive;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time::{Duration, timeout};
 
 const DEFAULT_REPO: &str = "jmagar/axon";
 const UPDATE_FILE_RELEASE_DIR: &str = "AXON_UPDATE_FILE_RELEASE_DIR";
 const UPDATE_INSTALL_PATH: &str = "AXON_UPDATE_INSTALL_PATH";
 const DEV_TARGET_DIR: &str = "AXON_DEV_TARGET_DIR";
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ReleaseAssetNames {
@@ -59,6 +64,7 @@ struct UpdateReport {
 struct SyncCommand {
     program: &'static str,
     args: Vec<String>,
+    current_dir: PathBuf,
     env_name: &'static str,
     env_value: PathBuf,
 }
@@ -162,35 +168,46 @@ fn default_install_path() -> PathBuf {
 async fn perform_update(options: UpdateOptions) -> Result<UpdateReport, Box<dyn Error>> {
     let names = release_asset_names(env::consts::OS, env::consts::ARCH)?;
     let temp = tempfile::tempdir()?;
+    let archive_path = temp.path().join(names.archive);
+    let compose_paths = if options.sync_container {
+        Some(resolve_compose_paths()?)
+    } else {
+        None
+    };
 
-    let (version, archive_bytes, checksum_body) = if let Some(dir) = &options.file_release_dir {
-        let archive = fs::read(dir.join(names.archive))?;
+    let (version, checksum_body) = if let Some(dir) = &options.file_release_dir {
+        fs::copy(dir.join(names.archive), &archive_path)?;
         let checksum = fs::read_to_string(dir.join(names.checksum))?;
         (
             options
                 .version
                 .clone()
                 .unwrap_or_else(|| "local-test-release".to_string()),
-            archive,
             checksum,
         )
     } else {
-        download_release_assets(&options.repo, options.version.as_deref(), &names).await?
+        download_release_assets(
+            &options.repo,
+            options.version.as_deref(),
+            &names,
+            &archive_path,
+        )
+        .await?
     };
 
     let expected = parse_sha256_sidecar(&checksum_body)?;
-    verify_sha256(&archive_bytes, &expected)?;
+    verify_sha256_file(&archive_path, &expected)?;
 
     let already_current =
-        !options.force && installed_binary_reports_version(&options.install_path, &version);
+        !options.force && installed_binary_reports_version(&options.install_path, &version).await;
     if !already_current {
-        let extracted = extract_axon_binary(&archive_bytes, temp.path())?;
+        let extracted = extract_axon_binary(&archive_path, temp.path())?;
         install_binary_atomically(&extracted, &options.install_path)?;
     }
 
     let mut container_synced = false;
-    if options.sync_container {
-        sync_container_from_installed_binary(&options.install_path)?;
+    if let Some(compose_paths) = compose_paths {
+        sync_container_from_installed_binary(&options.install_path, compose_paths).await?;
         container_synced = true;
     }
 
@@ -206,7 +223,8 @@ async fn download_release_assets(
     repo: &str,
     version: Option<&str>,
     names: &ReleaseAssetNames,
-) -> Result<(String, Vec<u8>, String), Box<dyn Error>> {
+    archive_path: &Path,
+) -> Result<(String, String), Box<dyn Error>> {
     let client = http_client()?;
     let api_url = match version {
         Some(tag) => format!("https://api.github.com/repos/{repo}/releases/tags/{tag}"),
@@ -223,14 +241,7 @@ async fn download_release_assets(
 
     let archive_url = find_asset_url(&release, names.archive)?;
     let checksum_url = find_asset_url(&release, names.checksum)?;
-    let archive = client
-        .get(archive_url)
-        .send()
-        .await?
-        .error_for_status()?
-        .bytes()
-        .await?
-        .to_vec();
+    download_to_file(client, archive_url, archive_path).await?;
     let checksum = client
         .get(checksum_url)
         .send()
@@ -239,7 +250,22 @@ async fn download_release_assets(
         .text()
         .await?;
 
-    Ok((release.tag_name, archive, checksum))
+    Ok((release.tag_name, checksum))
+}
+
+async fn download_to_file(
+    client: &reqwest::Client,
+    url: &str,
+    dest: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let response = client.get(url).send().await?.error_for_status()?;
+    let mut file = tokio::fs::File::create(dest).await?;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        file.write_all(&chunk?).await?;
+    }
+    file.flush().await?;
+    Ok(())
 }
 
 fn find_asset_url<'a>(release: &'a GithubRelease, name: &str) -> Result<&'a str, Box<dyn Error>> {
@@ -279,6 +305,7 @@ fn parse_sha256_sidecar(body: &str) -> Result<String, Box<dyn Error>> {
     Ok(hash.to_ascii_lowercase())
 }
 
+#[cfg(test)]
 fn verify_sha256(bytes: &[u8], expected: &str) -> Result<(), Box<dyn Error>> {
     let actual = hex::encode(Sha256::digest(bytes));
     if actual != expected.to_ascii_lowercase() {
@@ -289,8 +316,29 @@ fn verify_sha256(bytes: &[u8], expected: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn extract_axon_binary(archive_bytes: &[u8], temp_dir: &Path) -> Result<PathBuf, Box<dyn Error>> {
-    let gz = GzDecoder::new(Cursor::new(archive_bytes));
+fn verify_sha256_file(path: &Path, expected: &str) -> Result<(), Box<dyn Error>> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let actual = hex::encode(hasher.finalize());
+    if actual != expected.to_ascii_lowercase() {
+        return Err(err(format!(
+            "checksum mismatch: expected {expected}, got {actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn extract_axon_binary(archive_path: &Path, temp_dir: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    let file = fs::File::open(archive_path)?;
+    let gz = GzDecoder::new(BufReader::new(file));
     let mut archive = Archive::new(gz);
 
     for entry in archive.entries()? {
@@ -340,11 +388,16 @@ fn unique_suffix() -> u128 {
         .unwrap_or_default()
 }
 
-fn installed_binary_reports_version(installed_binary: &Path, version: &str) -> bool {
+async fn installed_binary_reports_version(installed_binary: &Path, version: &str) -> bool {
     if !installed_binary.is_file() {
         return false;
     }
-    let Ok(output) = Command::new(installed_binary).arg("--version").output() else {
+    let Ok(Ok(output)) = timeout(
+        COMMAND_TIMEOUT,
+        Command::new(installed_binary).arg("--version").output(),
+    )
+    .await
+    else {
         return false;
     };
     if !output.status.success() {
@@ -352,14 +405,24 @@ fn installed_binary_reports_version(installed_binary: &Path, version: &str) -> b
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let normalized = version.trim_start_matches('v');
-    stdout.contains(version)
-        || stderr.contains(version)
-        || stdout.contains(normalized)
-        || stderr.contains(normalized)
+    output_reports_version(&stdout, version) || output_reports_version(&stderr, version)
 }
 
-fn build_container_sync_command(installed_binary: &Path) -> Result<SyncCommand, Box<dyn Error>> {
+fn output_reports_version(output: &str, version: &str) -> bool {
+    let target = normalize_version(version);
+    output
+        .split_whitespace()
+        .any(|token| normalize_version(token) == target)
+}
+
+fn normalize_version(version: &str) -> &str {
+    version.trim().trim_start_matches('v')
+}
+
+fn build_container_sync_command_with_paths(
+    installed_binary: &Path,
+    paths: ComposePaths,
+) -> Result<SyncCommand, Box<dyn Error>> {
     let bin_dir = installed_binary
         .parent()
         .ok_or_else(|| {
@@ -372,73 +435,114 @@ fn build_container_sync_command(installed_binary: &Path) -> Result<SyncCommand, 
 
     Ok(SyncCommand {
         program: "docker",
-        args: compose_args(resolve_axon_env_file().as_deref(), true),
+        args: compose_args(&paths, true),
+        current_dir: paths.compose_dir,
         env_name: DEV_TARGET_DIR,
         env_value: bin_dir,
     })
 }
 
-fn compose_args(env_file: Option<&Path>, include_up: bool) -> Vec<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ComposePaths {
+    compose_dir: PathBuf,
+    compose_file: PathBuf,
+    env_file: Option<PathBuf>,
+}
+
+fn compose_args(paths: &ComposePaths, include_up: bool) -> Vec<String> {
     let mut args = vec!["compose".to_string()];
-    if let Some(env_file) = env_file {
+    if let Some(env_file) = &paths.env_file {
         args.push("--env-file".to_string());
         args.push(env_file.display().to_string());
     }
-    args.extend(["-f", "docker-compose.yaml"].into_iter().map(String::from));
+    args.push("-f".to_string());
+    args.push(paths.compose_file.display().to_string());
     if include_up {
         args.extend(
-            ["up", "-d", "axon", "--no-deps", "--no-build"]
-                .into_iter()
-                .map(String::from),
+            [
+                "up",
+                "-d",
+                "axon",
+                "--no-deps",
+                "--no-build",
+                "--force-recreate",
+            ]
+            .into_iter()
+            .map(String::from),
         );
     }
     args
 }
 
-fn resolve_axon_env_file() -> Option<PathBuf> {
-    if let Some(path) = env::var_os("AXON_ENV_FILE").map(PathBuf::from)
-        && path.is_file()
-    {
-        return Some(path);
+fn resolve_compose_paths() -> Result<ComposePaths, Box<dyn Error>> {
+    let axon_home = axon_home_dir().ok_or_else(|| {
+        err("HOME is unset or invalid; cannot resolve trusted ~/.axon compose assets")
+    })?;
+    resolve_compose_paths_from_home(&axon_home, env::var_os("AXON_ENV_FILE").map(PathBuf::from))
+}
+
+fn resolve_compose_paths_from_home(
+    axon_home: &Path,
+    explicit_env_file: Option<PathBuf>,
+) -> Result<ComposePaths, Box<dyn Error>> {
+    let compose_dir = axon_home.join("compose");
+    let compose_file = compose_dir.join("docker-compose.yaml");
+    if !compose_file.is_file() {
+        return Err(err(format!(
+            "trusted compose file is missing: {}; run axon setup init",
+            compose_file.display()
+        )));
     }
-    let axon_home = env::var_os("AXON_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            env::var_os("HOME")
-                .map(PathBuf::from)
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join(".axon")
-        });
+    Ok(ComposePaths {
+        compose_dir,
+        compose_file,
+        env_file: resolve_axon_env_file(axon_home, explicit_env_file.as_deref()),
+    })
+}
+
+fn resolve_axon_env_file(axon_home: &Path, explicit_env_file: Option<&Path>) -> Option<PathBuf> {
+    if let Some(path) = explicit_env_file {
+        if path.is_absolute() && path.is_file() {
+            return Some(path.to_path_buf());
+        }
+        return None;
+    }
     let home_env = axon_home.join(".env");
     if home_env.is_file() {
         return Some(home_env);
     }
-    let repo_env = PathBuf::from(".env");
-    repo_env.is_file().then_some(repo_env)
+    None
 }
 
-fn sync_container_from_installed_binary(installed_binary: &Path) -> Result<(), Box<dyn Error>> {
-    let sync = build_container_sync_command(installed_binary)?;
-    let status = Command::new(sync.program)
+async fn sync_container_from_installed_binary(
+    installed_binary: &Path,
+    paths: ComposePaths,
+) -> Result<(), Box<dyn Error>> {
+    let sync = build_container_sync_command_with_paths(installed_binary, paths)?;
+    let mut command = Command::new(sync.program);
+    command
         .args(&sync.args)
-        .env(sync.env_name, sync.env_value)
-        .status()?;
+        .current_dir(&sync.current_dir)
+        .env(sync.env_name, sync.env_value);
+    let status = run_command(command, "container sync").await?;
     if !status.success() {
         return Err(err(format!("container sync failed with status {status}")));
     }
 
-    let restart_args = compose_args(resolve_axon_env_file().as_deref(), false);
-    let mut restart = Command::new("docker");
-    restart.args(&restart_args);
-    restart.args(["restart", "axon"]);
-    let restart_status = restart.status()?;
-    if !restart_status.success() {
-        return Err(err(format!(
-            "container restart failed with status {restart_status}"
-        )));
-    }
-
     Ok(())
+}
+
+async fn run_command(
+    mut command: Command,
+    description: &str,
+) -> Result<std::process::ExitStatus, Box<dyn Error>> {
+    match timeout(COMMAND_TIMEOUT, command.status()).await {
+        Ok(result) => Ok(result?),
+        Err(_) => Err(err(format!(
+            "{description} timed out after {} seconds",
+            COMMAND_TIMEOUT.as_secs()
+        ))),
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/commands/update_tests.rs
+++ b/src/cli/commands/update_tests.rs
@@ -1,0 +1,236 @@
+use super::*;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use sha2::Sha256;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use tar::{Builder, Header};
+
+#[test]
+fn linux_x86_64_release_asset_names_are_expected() {
+    let names = release_asset_names("linux", "x86_64").unwrap();
+
+    assert_eq!(names.archive, "axon-linux-x86_64.tar.gz");
+    assert_eq!(names.checksum, "axon-linux-x86_64.tar.gz.sha256");
+}
+
+#[test]
+fn unsupported_platform_returns_clear_error() {
+    let err = release_asset_names("darwin", "aarch64").unwrap_err();
+
+    assert!(err.to_string().contains("unsupported platform"));
+    assert!(err.to_string().contains("darwin/aarch64"));
+}
+
+#[test]
+fn parses_sha256_sidecar_with_filename() {
+    let parsed = parse_sha256_sidecar(
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08  axon-linux-x86_64.tar.gz\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        parsed,
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    );
+}
+
+#[test]
+fn checksum_mismatch_is_rejected() {
+    let err = verify_sha256(
+        b"test",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("checksum mismatch"));
+}
+
+#[test]
+fn checksum_match_is_accepted() {
+    verify_sha256(
+        b"test",
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+    )
+    .unwrap();
+}
+
+fn make_release_archive(script_body: &str) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = Builder::new(&mut tar_bytes);
+        let mut header = Header::new_gnu();
+        header.set_path("axon").unwrap();
+        header.set_size(script_body.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append(&header, script_body.as_bytes())
+            .expect("append axon");
+        builder.finish().expect("finish tar");
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_bytes).unwrap();
+    encoder.finish().unwrap()
+}
+
+#[test]
+fn extracts_axon_binary_from_release_archive() {
+    let archive = make_release_archive("#!/usr/bin/env sh\necho axon 5.9.2\n");
+    let temp = tempfile::tempdir().unwrap();
+    let extracted = extract_axon_binary(&archive, temp.path()).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&extracted).unwrap(),
+        "#!/usr/bin/env sh\necho axon 5.9.2\n"
+    );
+}
+
+#[test]
+fn atomic_install_replaces_destination_and_sets_executable_mode() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("axon-new");
+    let dest = temp.path().join("bin").join("axon");
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    fs::write(&source, "#!/usr/bin/env sh\necho new\n").unwrap();
+    fs::write(&dest, "#!/usr/bin/env sh\necho old\n").unwrap();
+
+    install_binary_atomically(&source, &dest).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&dest).unwrap(),
+        "#!/usr/bin/env sh\necho new\n"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&dest).unwrap().permissions().mode();
+        assert_eq!(mode & 0o111, 0o111);
+    }
+}
+
+#[tokio::test]
+async fn update_installs_from_file_release_dir_without_container_sync() {
+    let temp = tempfile::tempdir().unwrap();
+    let release = make_release_archive("#!/usr/bin/env sh\necho axon 5.9.2\n");
+    let checksum = hex::encode(Sha256::digest(&release));
+    let archive_path = temp.path().join("axon-linux-x86_64.tar.gz");
+    let checksum_path = temp.path().join("axon-linux-x86_64.tar.gz.sha256");
+    fs::write(&archive_path, &release).unwrap();
+    fs::write(
+        &checksum_path,
+        format!("{checksum}  axon-linux-x86_64.tar.gz\n"),
+    )
+    .unwrap();
+
+    let install_dir = temp.path().join("install");
+    let options = UpdateOptions {
+        repo: "jmagar/axon".to_string(),
+        version: Some("v5.9.2".to_string()),
+        force: true,
+        sync_container: false,
+        install_path: install_dir.join("axon"),
+        file_release_dir: Some(temp.path().to_path_buf()),
+    };
+
+    let report = perform_update(options).await.unwrap();
+
+    assert_eq!(report.version, "v5.9.2");
+    assert!(report.installed);
+    assert_eq!(
+        fs::read_to_string(install_dir.join("axon")).unwrap(),
+        "#!/usr/bin/env sh\necho axon 5.9.2\n"
+    );
+    assert!(!report.container_synced);
+}
+
+#[tokio::test]
+async fn update_skips_install_when_existing_binary_reports_target_version() {
+    let temp = tempfile::tempdir().unwrap();
+    let release = make_release_archive("#!/usr/bin/env sh\necho replacement\n");
+    let checksum = hex::encode(Sha256::digest(&release));
+    fs::write(temp.path().join("axon-linux-x86_64.tar.gz"), &release).unwrap();
+    fs::write(
+        temp.path().join("axon-linux-x86_64.tar.gz.sha256"),
+        format!("{checksum}  axon-linux-x86_64.tar.gz\n"),
+    )
+    .unwrap();
+
+    let install_path = temp.path().join("install").join("axon");
+    fs::create_dir_all(install_path.parent().unwrap()).unwrap();
+    fs::write(&install_path, "#!/usr/bin/env sh\necho axon 5.9.2\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&install_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&install_path, permissions).unwrap();
+    }
+
+    let report = perform_update(UpdateOptions {
+        repo: "jmagar/axon".to_string(),
+        version: Some("v5.9.2".to_string()),
+        force: false,
+        sync_container: false,
+        install_path: install_path.clone(),
+        file_release_dir: Some(temp.path().to_path_buf()),
+    })
+    .await
+    .unwrap();
+
+    assert!(!report.installed);
+    assert_eq!(
+        fs::read_to_string(install_path).unwrap(),
+        "#!/usr/bin/env sh\necho axon 5.9.2\n"
+    );
+}
+
+#[test]
+fn sync_container_uses_installed_binary_directory_as_dev_target() {
+    let temp = tempfile::tempdir().unwrap();
+    let fake_bin = temp.path().join("bin").join("axon");
+    fs::create_dir_all(fake_bin.parent().unwrap()).unwrap();
+    fs::write(&fake_bin, "#!/usr/bin/env sh\necho axon 5.9.2\n").unwrap();
+
+    let sync = build_container_sync_command(&fake_bin).unwrap();
+
+    assert_eq!(sync.env_name, "AXON_DEV_TARGET_DIR");
+    assert_eq!(sync.env_value, fake_bin.parent().unwrap());
+    assert_eq!(sync.program, "docker");
+    assert_eq!(sync.args.first().map(String::as_str), Some("compose"));
+    assert!(
+        sync.args
+            .windows(2)
+            .any(|args| args == ["-f", "docker-compose.yaml"])
+    );
+    assert!(sync.args.ends_with(&[
+        "up".to_string(),
+        "-d".to_string(),
+        "axon".to_string(),
+        "--no-deps".to_string(),
+        "--no-build".to_string(),
+    ]));
+}
+
+#[test]
+fn env_file_args_are_inserted_before_compose_file() {
+    let args = compose_args(Some(Path::new("/home/j/.axon/.env")), true);
+
+    assert_eq!(
+        args,
+        vec![
+            "compose",
+            "--env-file",
+            "/home/j/.axon/.env",
+            "-f",
+            "docker-compose.yaml",
+            "up",
+            "-d",
+            "axon",
+            "--no-deps",
+            "--no-build",
+        ]
+    );
+}

--- a/src/cli/commands/update_tests.rs
+++ b/src/cli/commands/update_tests.rs
@@ -4,7 +4,7 @@ use flate2::write::GzEncoder;
 use sha2::Sha256;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tar::{Builder, Header};
 
 #[test]
@@ -80,7 +80,9 @@ fn make_release_archive(script_body: &str) -> Vec<u8> {
 fn extracts_axon_binary_from_release_archive() {
     let archive = make_release_archive("#!/usr/bin/env sh\necho axon 5.9.2\n");
     let temp = tempfile::tempdir().unwrap();
-    let extracted = extract_axon_binary(&archive, temp.path()).unwrap();
+    let archive_path = temp.path().join("axon-linux-x86_64.tar.gz");
+    fs::write(&archive_path, archive).unwrap();
+    let extracted = extract_axon_binary(&archive_path, temp.path()).unwrap();
 
     assert_eq!(
         fs::read_to_string(&extracted).unwrap(),
@@ -188,35 +190,111 @@ async fn update_skips_install_when_existing_binary_reports_target_version() {
 }
 
 #[test]
+fn version_output_requires_exact_normalized_token_match() {
+    assert!(output_reports_version("axon 5.9.2\n", "v5.9.2"));
+    assert!(output_reports_version("axon v5.9.2\n", "5.9.2"));
+    assert!(!output_reports_version("axon 5.9.20\n", "v5.9.2"));
+    assert!(!output_reports_version("axon 15.9.2\n", "v5.9.2"));
+}
+
+#[tokio::test]
+async fn update_replaces_binary_when_existing_version_is_only_a_prefix_match() {
+    let temp = tempfile::tempdir().unwrap();
+    let release = make_release_archive("#!/usr/bin/env sh\necho axon 5.9.2\n");
+    let checksum = hex::encode(Sha256::digest(&release));
+    fs::write(temp.path().join("axon-linux-x86_64.tar.gz"), &release).unwrap();
+    fs::write(
+        temp.path().join("axon-linux-x86_64.tar.gz.sha256"),
+        format!("{checksum}  axon-linux-x86_64.tar.gz\n"),
+    )
+    .unwrap();
+
+    let install_path = temp.path().join("install").join("axon");
+    fs::create_dir_all(install_path.parent().unwrap()).unwrap();
+    fs::write(&install_path, "#!/usr/bin/env sh\necho axon 5.9.20\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&install_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&install_path, permissions).unwrap();
+    }
+
+    let report = perform_update(UpdateOptions {
+        repo: "jmagar/axon".to_string(),
+        version: Some("v5.9.2".to_string()),
+        force: false,
+        sync_container: false,
+        install_path: install_path.clone(),
+        file_release_dir: Some(temp.path().to_path_buf()),
+    })
+    .await
+    .unwrap();
+
+    assert!(report.installed);
+    assert_eq!(
+        fs::read_to_string(install_path).unwrap(),
+        "#!/usr/bin/env sh\necho axon 5.9.2\n"
+    );
+}
+
+#[test]
 fn sync_container_uses_installed_binary_directory_as_dev_target() {
     let temp = tempfile::tempdir().unwrap();
+    let compose_dir = temp.path().join(".axon").join("compose");
+    let compose_file = compose_dir.join("docker-compose.yaml");
+    let env_file = temp.path().join(".axon").join(".env");
+    fs::create_dir_all(&compose_dir).unwrap();
+    fs::write(&compose_file, "services: {}\n").unwrap();
+    fs::write(&env_file, "TEST_KEY=1\n").unwrap();
+
     let fake_bin = temp.path().join("bin").join("axon");
     fs::create_dir_all(fake_bin.parent().unwrap()).unwrap();
     fs::write(&fake_bin, "#!/usr/bin/env sh\necho axon 5.9.2\n").unwrap();
 
-    let sync = build_container_sync_command(&fake_bin).unwrap();
+    let sync = build_container_sync_command_with_paths(
+        &fake_bin,
+        ComposePaths {
+            compose_dir: compose_dir.clone(),
+            compose_file: compose_file.clone(),
+            env_file: Some(env_file.clone()),
+        },
+    )
+    .unwrap();
 
     assert_eq!(sync.env_name, "AXON_DEV_TARGET_DIR");
     assert_eq!(sync.env_value, fake_bin.parent().unwrap());
     assert_eq!(sync.program, "docker");
+    assert_eq!(sync.current_dir, compose_dir);
     assert_eq!(sync.args.first().map(String::as_str), Some("compose"));
-    assert!(
-        sync.args
-            .windows(2)
-            .any(|args| args == ["-f", "docker-compose.yaml"])
-    );
+    assert!(sync.args.windows(2).any(|args| {
+        args == [
+            "-f",
+            &sync
+                .current_dir
+                .join("docker-compose.yaml")
+                .display()
+                .to_string(),
+        ]
+    }));
     assert!(sync.args.ends_with(&[
         "up".to_string(),
         "-d".to_string(),
         "axon".to_string(),
         "--no-deps".to_string(),
         "--no-build".to_string(),
+        "--force-recreate".to_string(),
     ]));
 }
 
 #[test]
-fn env_file_args_are_inserted_before_compose_file() {
-    let args = compose_args(Some(Path::new("/home/j/.axon/.env")), true);
+fn env_file_args_are_inserted_before_absolute_compose_file() {
+    let paths = ComposePaths {
+        compose_dir: PathBuf::from("/home/j/.axon/compose"),
+        compose_file: PathBuf::from("/home/j/.axon/compose/docker-compose.yaml"),
+        env_file: Some(PathBuf::from("/home/j/.axon/.env")),
+    };
+    let args = compose_args(&paths, true);
 
     assert_eq!(
         args,
@@ -225,12 +303,55 @@ fn env_file_args_are_inserted_before_compose_file() {
             "--env-file",
             "/home/j/.axon/.env",
             "-f",
-            "docker-compose.yaml",
+            "/home/j/.axon/compose/docker-compose.yaml",
             "up",
             "-d",
             "axon",
             "--no-deps",
             "--no-build",
+            "--force-recreate",
         ]
+    );
+}
+
+#[test]
+fn compose_resolution_rejects_caller_cwd_files() {
+    let temp = tempfile::tempdir().unwrap();
+    let cwd = tempfile::tempdir().unwrap();
+    fs::write(
+        cwd.path().join("docker-compose.yaml"),
+        "services: {evil: {}}\n",
+    )
+    .unwrap();
+    fs::write(cwd.path().join(".env"), "EVIL=1\n").unwrap();
+
+    let result = resolve_compose_paths_from_home(&temp.path().join(".axon"), None);
+
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("trusted compose file is missing"));
+    assert!(
+        err.contains(
+            temp.path()
+                .join(".axon/compose/docker-compose.yaml")
+                .to_string_lossy()
+                .as_ref()
+        )
+    );
+}
+
+#[test]
+fn explicit_env_file_must_be_absolute() {
+    let temp = tempfile::tempdir().unwrap();
+    let axon_home = temp.path().join(".axon");
+    fs::create_dir_all(&axon_home).unwrap();
+    fs::write(axon_home.join(".env"), "TEST_KEY=1\n").unwrap();
+
+    assert_eq!(
+        resolve_axon_env_file(&axon_home, Some(Path::new("relative.env"))),
+        None
+    );
+    assert_eq!(
+        resolve_axon_env_file(&axon_home, None),
+        Some(axon_home.join(".env"))
     );
 }

--- a/src/core/config/cli.rs
+++ b/src/core/config/cli.rs
@@ -108,6 +108,8 @@ pub(super) enum CliCommand {
     Config(ConfigArgs),
     /// Reconcile locally produced server-mode artifacts
     Sync(SyncArgs),
+    /// Download and install the latest GitHub Release binary, then sync the local container
+    Update(UpdateArgs),
     /// Resolve, launch, and optionally install the axon-palette desktop binary
     Palette(PaletteArgs),
 }
@@ -257,6 +259,25 @@ pub(super) struct PaletteArgs {
     /// Binary acquisition method when the palette binary is missing or during install
     #[arg(long, value_enum)]
     pub(super) method: Option<SetupMethod>,
+}
+
+#[derive(Debug, Args)]
+pub(super) struct UpdateArgs {
+    /// GitHub repository in owner/name form.
+    #[arg(long, default_value = "jmagar/axon")]
+    pub(super) repo: String,
+
+    /// Release tag to install. Defaults to the latest GitHub Release.
+    #[arg(long)]
+    pub(super) version: Option<String>,
+
+    /// Install even when the destination already reports the target version.
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub(super) force: bool,
+
+    /// Do not restart/sync the local Axon container after installing.
+    #[arg(long = "no-container", action = ArgAction::SetTrue)]
+    pub(super) no_container: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/core/config/help.rs
+++ b/src/core/config/help.rs
@@ -60,6 +60,7 @@ const COMMAND_SECTIONS: &[(&str, &[&str])] = &[
             "compose",
             "completions",
             "config",
+            "update",
             "palette",
         ],
     ),

--- a/src/core/config/parse/build_config.rs
+++ b/src/core/config/parse/build_config.rs
@@ -52,6 +52,7 @@ pub(super) fn into_config_with_sources(
             | CommandKind::Compose
             | CommandKind::Setup
             | CommandKind::Config
+            | CommandKind::Update
             | CommandKind::Palette
     ) {
         return Ok(Config {

--- a/src/core/config/parse/build_config/command_dispatch.rs
+++ b/src/core/config/parse/build_config/command_dispatch.rs
@@ -8,7 +8,7 @@ use super::super::super::cli::{
     CliCommand, ComposeArgs, ComposeSubcommand, ConfigArgs, ConfigSubcommand, DoctorSubcommand,
     IngestArgs, MemoryCliSubcommand, MonitorSubcommand, PaletteArgs, ServeArgs, ServeSubcommand,
     SessionWatchServiceSubcommand, SessionsArgs, SessionsSubcommand, SetupArgs, SetupAuthMode,
-    SetupInitArgs, SetupSubcommand, SyncSubcommand,
+    SetupInitArgs, SetupSubcommand, SyncSubcommand, UpdateArgs,
 };
 use super::super::super::types::{
     CommandKind, EvaluateResponsesMode, MapFallback, McpTransport, RedditSort, RedditTime,
@@ -316,6 +316,7 @@ pub(super) fn dispatch(cli_command: CliCommand) -> DispatchOutput {
                 SyncSubcommand::Pending => vec!["pending".to_string()],
             };
         }
+        CliCommand::Update(args) => apply_update(&mut out, args),
         CliCommand::Palette(args) => apply_palette(&mut out, args),
     }
     out
@@ -345,6 +346,24 @@ fn apply_monitor(out: &mut DispatchOutput, action: MonitorSubcommand) {
             }
             out.positional = positional;
         }
+    }
+}
+
+fn apply_update(out: &mut DispatchOutput, args: UpdateArgs) {
+    out.command = CommandKind::Update;
+    if let Some(version) = args.version {
+        out.positional.push("--version".to_string());
+        out.positional.push(version);
+    }
+    if args.repo != "jmagar/axon" {
+        out.positional.push("--repo".to_string());
+        out.positional.push(args.repo);
+    }
+    if args.no_container {
+        out.positional.push("--no-container".to_string());
+    }
+    if args.force {
+        out.positional.push("--force".to_string());
     }
 }
 

--- a/src/core/config/parse/env_registry/advanced.rs
+++ b/src/core/config/parse/env_registry/advanced.rs
@@ -69,6 +69,14 @@ pub(crate) const ADVANCED_ENV_KEY_SPECS: &[EnvKeySpec] = &[
         false,
     ),
     spec(
+        "AXON_UPDATE_INSTALL_PATH",
+        TrustedOperatorBootstrap,
+        HostOnly,
+        None,
+        Advanced,
+        false,
+    ),
+    spec(
         "AXON_LOG_COLOR",
         ComposeEnv,
         ComposeInterpolation,

--- a/src/core/config/parse_tests.rs
+++ b/src/core/config/parse_tests.rs
@@ -216,6 +216,43 @@ fn parse_retrieve_max_points_into_config() {
     assert_eq!(cfg.retrieve_max_points, Some(25));
 }
 
+#[test]
+fn update_defaults_to_latest_release_and_container_sync() {
+    let cli = super::Cli::parse_from(["axon", "update"]);
+    let cfg = super::build_config::into_config(cli).expect("update should parse");
+
+    assert!(matches!(cfg.command, CommandKind::Update));
+    assert_eq!(cfg.positional, Vec::<String>::new());
+}
+
+#[test]
+fn update_accepts_version_repo_no_container_and_force_flags() {
+    let cli = super::Cli::parse_from([
+        "axon",
+        "update",
+        "--version",
+        "v5.9.2",
+        "--repo",
+        "jmagar/axon-fork",
+        "--no-container",
+        "--force",
+    ]);
+    let cfg = super::build_config::into_config(cli).expect("update flags should parse");
+
+    assert!(matches!(cfg.command, CommandKind::Update));
+    assert_eq!(
+        cfg.positional,
+        vec![
+            "--version".to_string(),
+            "v5.9.2".to_string(),
+            "--repo".to_string(),
+            "jmagar/axon-fork".to_string(),
+            "--no-container".to_string(),
+            "--force".to_string(),
+        ]
+    );
+}
+
 // --- ask session-management flag tests ---
 
 fn ask_cli(extra: &[&str]) -> super::Cli {

--- a/src/core/config/types/enums.rs
+++ b/src/core/config/types/enums.rs
@@ -44,6 +44,7 @@ pub enum CommandKind {
     Migrate,
     Config,
     Sync,
+    Update,
     Palette,
 }
 
@@ -91,6 +92,7 @@ impl CommandKind {
             Self::Migrate => "migrate",
             Self::Config => "config",
             Self::Sync => "sync",
+            Self::Update => "update",
             Self::Palette => "palette",
         }
     }

--- a/src/core/config/types_tests.rs
+++ b/src/core/config/types_tests.rs
@@ -40,6 +40,11 @@ fn test_command_kind_completions_as_str() {
 }
 
 #[test]
+fn test_command_kind_update_as_str() {
+    assert_eq!(CommandKind::Update.as_str(), "update");
+}
+
+#[test]
 fn config_default_screenshot_settings() {
     let cfg = Config::default();
     assert!(cfg.screenshot_full_page);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use self::cli::commands::{
     run_map, run_mcp, run_memory, run_migrate, run_monitor, run_palette, run_query, run_refresh,
     run_research, run_retrieve, run_scrape, run_screenshot, run_search, run_serve, run_sessions,
     run_setup, run_sources, run_stats, run_status, run_suggest, run_summarize, run_sync, run_train,
-    run_watch, start_url_from_cfg,
+    run_update, run_watch, start_url_from_cfg,
 };
 use self::core::config::{CommandKind, Config, parse_args};
 use self::core::logging::{init_tracing, log_done, log_info, log_warn};
@@ -84,6 +84,7 @@ async fn run_once(
         CommandKind::Migrate => run_migrate(cfg).await?,
         CommandKind::Config => run_config(cfg).await?,
         CommandKind::Sync => run_sync(cfg, service_context).await?,
+        CommandKind::Update => run_update(cfg).await?,
         CommandKind::Palette => run_palette(cfg).await?,
     }
     Ok(())


### PR DESCRIPTION
## Summary
- add `axon update` to download the selected GitHub Release binary, verify its checksum, and atomically install it into the local PATH
- sync the installed binary into the local Axon container by updating `AXON_DEV_TARGET_DIR` and restarting the compose service
- document the update workflow and cover parsing, local-file release, idempotency, and failure behavior with focused tests

## Verification
- `cargo fmt --all -- --check`
- `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo test --locked update_`
- fake release smoke with `AXON_UPDATE_FILE_RELEASE_DIR` + `AXON_UPDATE_INSTALL_PATH`
- `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked curated_command_sections_cover_current_clap_surface -- --nocapture`
- `just web-build`
- pre-push hook: clippy + nextest, 2895 passed / 6 skipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `axon update`, a CLI command to install the latest GitHub Release binary with checksum verification and optional container sync for fast, safe local upgrades. Linux x86_64 only.

- **New Features**
  - New command: `axon update`.
  - Flags: `--version`, `--repo`, `--no-container`, `--force`.
  - Downloads `axon-linux-x86_64.tar.gz`, verifies `.sha256`, and installs atomically to `~/.local/bin/axon` (keeps existing binary on failure).
  - Skips reinstall if the target version is already installed; `--force` overrides.
  - Optional container sync sets `AXON_DEV_TARGET_DIR` and runs `docker compose up -d axon --no-deps --no-build --force-recreate` using trusted `~/.axon/compose` and `AXON_ENV_FILE` or `~/.axon/.env`.
  - Local/CI mode via `AXON_UPDATE_FILE_RELEASE_DIR` and `AXON_UPDATE_INSTALL_PATH`.
  - Docs updated in `docs/operations/deployment.md`; command listed in README and curated help; env keys classified in `docs/reference/env-matrix.toml`.

- **Bug Fixes**
  - Hardened sync: resolves compose from `~/.axon/compose` (ignores CWD files), honors `AXON_ENV_FILE` or `~/.axon/.env`, adds command timeouts, and uses `--force-recreate` for reliable updates.

<sup>Written for commit a122345bc93c440f0bf885c0b03b083a43972e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `axon update` command to download and install the latest GitHub Release binary with optional container synchronization.
  * Supports options: `--version` (pin a specific release), `--repo` (select repository), `--force` (force reinstall), and `--no-container` (skip container sync).

* **Documentation**
  * Updated deployment documentation with new upgrade procedure for the update command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->