### PR TITLE
feat(ingest): --exclude-path + fix(crawl): cache TTL (v5.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.12.0] - 2026-06-14
+
+### Added
+
+- **`--exclude-path` for git ingest** — repeatable flag that skips files whose
+  repo-relative path contains any supplied substring (e.g.
+  `--exclude-path docs/references/`). A file is excluded when its path matches.
+  Useful for repos that vendor third-party doc mirrors; re-ingesting `jmagar/lab`
+  with `--exclude-path docs/references/` cut it from ~247k to ~34k chunks.
+
+### Fixed
+
+- **Crawl cache TTL lowered from 24h to 1h** — a cached crawl manifest younger
+  than the TTL short-circuits the crawl and skips re-embedding, which silently
+  left a collection empty while reporting success after a Qdrant wipe. 1h is a
+  safer default for re-index workflows.
+
 ## [5.11.1] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "5.11.1"
+version = "5.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "5.11.1"
+version = "5.12.0"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 5.11.1
+Version: 5.12.0
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "5.11.1"
+    "version": "5.12.0"
   },
   "paths": {
     "/v1/artifacts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axon/admin-panel",
-  "version": "5.11.1",
+  "version": "5.12.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/core/config/cli/global_args.rs
+++ b/src/core/config/cli/global_args.rs
@@ -22,6 +22,12 @@ pub(in crate::core::config) struct GlobalArgs {
     #[arg(global = true, long = "exclude-path-prefix", value_delimiter = ',')]
     pub(in crate::core::config) exclude_path_prefix: Vec<String>,
 
+    /// Repo-relative path substrings to exclude from git ingest, e.g.
+    /// `--exclude-path docs/references/ --exclude-path vendor/` (repeatable).
+    /// A file is skipped when its repo-relative path contains any value.
+    #[arg(global = true, long = "exclude-path")]
+    pub(in crate::core::config) ingest_exclude_paths: Vec<String>,
+
     /// Directory for saved markdown/HTML output files
     #[arg(global = true, long, default_value = DEFAULT_OUTPUT_DIR)]
     pub(in crate::core::config) output_dir: PathBuf,

--- a/src/core/config/parse/build_config/config_literal.rs
+++ b/src/core/config/parse/build_config/config_literal.rs
@@ -82,6 +82,7 @@ fn populate_identity_and_crawl(cfg: &mut Config, inputs: &LiteralInputs<'_>) {
     cfg.max_depth = g.max_depth;
     cfg.include_subdomains = g.include_subdomains;
     cfg.exclude_path_prefix = inputs.exclude_path_prefix.clone();
+    cfg.ingest_exclude_paths = g.ingest_exclude_paths.clone();
     cfg.output_dir = g.output_dir.clone();
     cfg.output_path = g.output.clone();
     cfg.render_mode = g.render_mode;

--- a/src/core/config/types/config.rs
+++ b/src/core/config/types/config.rs
@@ -51,6 +51,11 @@ pub struct Config {
     /// URL path prefixes to skip during crawl (e.g. `/blog/`, `/legacy/`). Flag: `--exclude-path-prefix`.
     pub exclude_path_prefix: Vec<String>,
 
+    /// Repo-relative path substrings to skip during git ingest (e.g. `docs/references/`,
+    /// `vendor/`). A file is excluded when its repo-relative path contains any entry.
+    /// Flag: `--exclude-path` (repeatable). Empty = no extra exclusions.
+    pub ingest_exclude_paths: Vec<String>,
+
     /// Directory for saved markdown/HTML output files. Flag: `--output-dir`.
     pub output_dir: PathBuf,
 

--- a/src/core/config/types/config_impls.rs
+++ b/src/core/config/types/config_impls.rs
@@ -23,6 +23,7 @@ impl Default for Config {
             max_depth: 10,
             include_subdomains: false,
             exclude_path_prefix: Vec::new(),
+            ingest_exclude_paths: Vec::new(),
             output_dir: PathBuf::from(".cache/axon-rust/output"),
             output_path: None,
             warc_output: None,

--- a/src/ingest/github/files.rs
+++ b/src/ingest/github/files.rs
@@ -47,7 +47,8 @@ pub async fn embed_files(
         }))
         .await;
 
-    let file_items = collect_indexable_files(&repo_root, include_source).await?;
+    let file_items =
+        collect_indexable_files(&repo_root, include_source, &cfg.ingest_exclude_paths).await?;
     let files_total = file_items.len();
 
     log_info(&format!(

--- a/src/ingest/github/files/prepare.rs
+++ b/src/ingest/github/files/prepare.rs
@@ -46,6 +46,7 @@ pub(super) enum FileEmbedRead {
 pub(super) async fn collect_indexable_files(
     root: &Path,
     include_source: bool,
+    exclude_paths: &[String],
 ) -> Result<Vec<String>> {
     let abs = collect_files(root, SelectionPolicy::Allowlist { include_source })
         .await
@@ -57,7 +58,17 @@ pub(super) async fn collect_indexable_files(
                 .ok()
                 .map(|r| r.to_string_lossy().replace('\\', "/"))
         })
+        .filter(|rel| !is_path_excluded(rel, exclude_paths))
         .collect())
+}
+
+/// Returns true when `rel` (a repo-relative, forward-slash path) contains any of
+/// the user-supplied `--exclude-path` substrings. Empty patterns are ignored so
+/// an accidental empty value cannot exclude every file.
+pub(super) fn is_path_excluded(rel: &str, exclude_paths: &[String]) -> bool {
+    exclude_paths
+        .iter()
+        .any(|pat| !pat.is_empty() && rel.contains(pat.as_str()))
 }
 
 /// Read a single file from the cloned repo and build **one** `PreparedDoc` for the

--- a/src/ingest/github/files/prepare_tests.rs
+++ b/src/ingest/github/files/prepare_tests.rs
@@ -187,3 +187,32 @@ fn markdown_file_uses_markdown_chunking_method() {
     assert!(chunks.iter().all(|chunk| chunk.symbol.is_none()));
     assert_eq!(chunking_method("md", &chunks[0]), "markdown");
 }
+
+#[test]
+fn is_path_excluded_matches_substring() {
+    let excludes = vec!["docs/references/".to_string()];
+    assert!(is_path_excluded(
+        "docs/references/openai-codex-site/domains/x/markdown/1.md",
+        &excludes
+    ));
+    assert!(!is_path_excluded("src/main.rs", &excludes));
+    assert!(!is_path_excluded(
+        "docs/architecture/overview.md",
+        &excludes
+    ));
+}
+
+#[test]
+fn is_path_excluded_multiple_patterns() {
+    let excludes = vec!["vendor/".to_string(), "docs/references/".to_string()];
+    assert!(is_path_excluded("third_party/vendor/lib.go", &excludes));
+    assert!(is_path_excluded("docs/references/api.md", &excludes));
+    assert!(!is_path_excluded("docs/guide.md", &excludes));
+}
+
+#[test]
+fn is_path_excluded_empty_patterns_never_match() {
+    assert!(!is_path_excluded("any/path.rs", &[]));
+    // An empty string pattern must not exclude everything.
+    assert!(!is_path_excluded("any/path.rs", &["".to_string()]));
+}

--- a/src/services/crawl_sync.rs
+++ b/src/services/crawl_sync.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::sync::Arc;
 
-const DEFAULT_CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+const DEFAULT_CACHE_TTL_SECS: u64 = 60 * 60;
 
 /// Run a synchronous crawl for a single URL: cache check → HTTP crawl →
 /// optional Chrome fallback → sitemap backfill → embed → audit diff.


### PR DESCRIPTION
Two independent fixes extracted from a working session, rebased onto current main, version bumped to **5.12.0**.

## Changes
- **feat(ingest): `--exclude-path`** — repeatable flag to skip files whose repo-relative path contains any supplied substring during git ingest (GitHub path). A file is excluded when its path matches. Motivated by repos that vendor third-party doc mirrors: re-ingesting `jmagar/lab` with `--exclude-path docs/references/` cut it from ~247k to ~34k chunks (the vendored `developers.openai.com`/codex mirrors). `--no-source` was too blunt (drops all source). +3 unit tests.
- **fix(crawl): cache TTL 24h → 1h** — a cached crawl manifest younger than the TTL short-circuits the crawl and skips re-embedding, silently leaving a collection empty while reporting success after a Qdrant wipe. 1h is safer for re-index workflows.

## Notes
- A third commit from the session (a `locate_chunk` UTF-8 panic fix) was **dropped** — the RAG remediation (#216) already removed that function, fixing the panic by removal. The vulnerable `text[cursor..]` path no longer exists on main.
- Minor version bump per the `feat` in the changeset (5.11.1 → 5.12.0), all version-bearing files in sync.

## Test
- `cargo test is_path_excluded` — 3/3 pass; pre-commit gates (monolith, xtask-check version parity, rustfmt) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a repeatable --exclude-path flag to GitHub ingest to skip files by repo path substring and reduce indexing of vendored docs. Lower the crawl cache TTL from 24h to 1h to avoid stale manifests skipping re-embedding during re-index.

- **New Features**
  - --exclude-path (repeatable) skips files whose repo-relative path contains a value (e.g., --exclude-path docs/references/).

- **Bug Fixes**
  - Crawl cache TTL set to 1h (was 24h) so re-index workflows don’t silently skip embedding after a wipe.

<sup>Written for commit 4b8f5127acbbd8274a25da37f1dea84138dddae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repeatable `--exclude-path` flag for git ingest to filter and exclude files based on substring matches in repo-relative paths.

* **Bug Fixes**
  * Reduced crawl cache TTL from 24 hours to 1 hour to prevent stale cache manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->