### PR TITLE
ci: selective per-component releases on merge to main

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -11,7 +11,10 @@ name: android-release
 # publishes a GitHub Release with the APK + SHA256 attached.
 #
 # Manual workflow_dispatch builds + signs the APK and uploads it to the run as
-# an artifact for inspection, but does NOT create a Release (dry-run).
+# an artifact for inspection, but does NOT create a Release unless explicitly
+# called with publish=true on an android-v* tag. auto-tag.yml dispatches this
+# workflow with publish=true after creating a new android-v* tag, because tags
+# pushed with GITHUB_TOKEN do not trigger tag-push workflows.
 #
 # ---------------------------------------------------------------------------
 # Required configuration (Settings → Secrets and variables → Actions)
@@ -36,6 +39,11 @@ on:
   push:
     tags: ["android-v*"]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Create the GitHub Release when running on an android-v* tag"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -194,8 +202,14 @@ jobs:
           if-no-files-found: error
 
       - name: Create GitHub Release
-        # Only create a release on real tag pushes; workflow_dispatch is dry-run.
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/android-v')
+        # Create a release on real tag pushes; workflow_dispatch is a dry-run
+        # unless explicitly called with publish=true on an android-v* tag.
+        if: >-
+          startsWith(github.ref, 'refs/tags/android-v') &&
+          (
+            github.event_name == 'push' ||
+            (github.event_name == 'workflow_dispatch' && inputs.publish)
+          )
         uses: softprops/action-gh-release@v2
         with:
           name: Android v${{ steps.version.outputs.version }}

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -44,8 +44,16 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: write   # required to create and push component release tags
   actions: write   # required to dispatch the release workflows
+
+# Serialize runs for the same ref so two rapid merges to main cannot race on
+# creating/pushing the same component tag (which would fail one run's `git
+# push`). cancel-in-progress: false lets an in-flight release finish tagging
+# rather than being cancelled by the next push.
+concurrency:
+  group: auto-tag-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,31 +1,43 @@
 name: auto-tag
 
-# Reads the version from Cargo.toml on every push to main. If a tag for that
-# version does not yet exist, creates it and explicitly dispatches release.yml.
+# Selective, per-component auto-release detector.
+#
+# On every push to main this evaluates each releasable component independently:
+#
+#   | component | paths that ship in it                          | version source                                   | tag prefix     | release workflow              |
+#   |-----------|------------------------------------------------|--------------------------------------------------|----------------|-------------------------------|
+#   | cli       | src, Cargo.toml/lock, build.rs, migrations,    | Cargo.toml [package] version                     | v              | release.yml                   |
+#   |           | apps/web, rust-toolchain.toml, vendor          |                                                  |                |                               |
+#   | palette   | apps/palette-tauri                             | apps/palette-tauri/src-tauri/tauri.conf.json     | palette-v      | palette-release.yml           |
+#   | android   | apps/android                                   | apps/android/app/build.gradle.kts versionName    | android-v      | android-release.yml           |
+#   | chrome    | apps/chrome-extension, assets                  | apps/chrome-extension/manifest.json version      | chrome-ext-v   | chrome-extension-release.yml  |
+#
+# For each component, it diffs the component's shipping paths against that
+# component's most recent tag. If the code changed AND the version was bumped
+# (the computed tag does not exist), it waits for CI to pass on this commit,
+# creates the tag, and dispatches the component's release workflow. A component
+# whose code did NOT change since its last tag is skipped — so a CLI-only change
+# never rebuilds android, and an android-only change never cuts a CLI release.
 #
 # RELEASE GATES (OPS-M1): before a tag is created we (1) verify the new version
-# is a strictly-monotonic bump over the highest existing v* tag, and (2) wait
-# for the `CI` workflow (production-gate aggregation) to succeed for this exact
-# commit. This prevents an accidental version edit or a red CI from
-# auto-publishing a broken public release. auto-tag and CI fire on the same
-# push, so the CI wait polls until the run finishes (30 min cap).
+# is a strictly-monotonic bump over that component's highest existing tag, and
+# (2) wait for the `CI` workflow (production-gate aggregation) to succeed for
+# this exact commit. This prevents an accidental version edit or a red CI from
+# auto-publishing a broken public release.
+#
+# BUMP ENFORCEMENT: if a component's code changed but its version was NOT bumped
+# (the computed tag already exists), the component's job FAILS with a message
+# naming the component — nothing ships silently. `fail-fast: false` keeps the
+# other components releasing independently; the red job flags the missing bump.
 #
 # NOTE: tags pushed via GITHUB_TOKEN do NOT trigger other workflows (GitHub
-# security model). We therefore dispatch release.yml explicitly via the API
-# after creating the tag — no PAT required.
+# security model). We therefore dispatch each release workflow explicitly via
+# the API after creating its tag — no PAT required.
 #
-# Result: merging to main with a bumped version automatically cuts a release.
-# If the version has not changed (e.g. a docs-only fix landing on top of an
-# already-tagged version), the tag already exists and no release is cut.
-#
-# Version bumping rules (from CLAUDE.md):
+# Version bumping rules (from CLAUDE.md): bump ONLY the component you changed.
 #   feat!: / BREAKING CHANGE → major (X+1.0.0)
 #   feat / feat(...)          → minor (X.Y+1.0)
 #   everything else           → patch (X.Y.Z+1)
-#
-# All version-bearing files must be in sync before merging:
-#   Cargo.toml, README.md, CHANGELOG.md,
-#   apps/web/package.json, apps/web/openapi/axon.json
 
 on:
   push:
@@ -33,87 +45,142 @@ on:
 
 permissions:
   contents: write
-  actions: write   # required to dispatch release.yml
+  actions: write   # required to dispatch the release workflows
 
 jobs:
-  tag:
-    name: tag version from Cargo.toml
+  release:
+    name: ${{ matrix.component }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # `paths` is a space-separated list of git pathspecs (directories
+          # match everything under them) consumed unquoted by `git diff`. Only
+          # paths that change the SHIPPED artifact belong here — dev-only trees
+          # (xtask, benches, .github, docs) are intentionally excluded so a
+          # tooling/docs change never forces a version bump or a rebuild.
+          - component: cli
+            prefix: v
+            paths: "src Cargo.toml Cargo.lock build.rs migrations apps/web rust-toolchain.toml vendor"
+            workflow: release.yml
+          - component: palette
+            prefix: palette-v
+            paths: "apps/palette-tauri"
+            workflow: palette-release.yml
+          - component: android
+            prefix: android-v
+            paths: "apps/android"
+            workflow: android-release.yml
+          - component: chrome
+            prefix: chrome-ext-v
+            paths: "apps/chrome-extension assets"
+            workflow: chrome-extension-release.yml
     steps:
       - uses: actions/checkout@v5
         with:
-          # Full history so we can verify existing tags without a shallow clone.
+          # Full history + tags so we can diff against the component's last tag
+          # and verify monotonic bumps without a shallow clone.
           fetch-depth: 0
 
-      - name: Read version from Cargo.toml
+      - name: Read component version
         id: version
         run: |
-          version=$(grep '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)
+          set -euo pipefail
+          # `|| true` keeps a parse miss from aborting under `set -e` so the
+          # explicit empty-check below emits the friendly error instead.
+          case "${{ matrix.component }}" in
+            cli)
+              version=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2 || true) ;;
+            palette)
+              version=$(grep -m1 -E '"version"[[:space:]]*:' apps/palette-tauri/src-tauri/tauri.conf.json \
+                | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/' || true) ;;
+            android)
+              version=$(grep -m1 -E '^[[:space:]]*versionName[[:space:]]*=' apps/android/app/build.gradle.kts \
+                | sed -E 's/.*"([^"]+)".*/\1/' || true) ;;
+            chrome)
+              version=$(grep -m1 -E '"version"[[:space:]]*:' apps/chrome-extension/manifest.json \
+                | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/' || true) ;;
+            *)
+              echo "::error::unknown component ${{ matrix.component }}" >&2; exit 1 ;;
+          esac
           if [ -z "$version" ]; then
-            echo "ERROR: could not parse version from Cargo.toml" >&2
+            echo "::error::could not parse version for ${{ matrix.component }}" >&2
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
-          echo "Detected version: $version"
+          echo "tag=${{ matrix.prefix }}$version" >> "$GITHUB_OUTPUT"
+          echo "${{ matrix.component }} version: $version (tag ${{ matrix.prefix }}$version)"
 
-      - name: Check whether tag already exists
-        id: tag_check
-        run: |
-          tag="v${{ steps.version.outputs.version }}"
-          if git ls-remote --tags origin "refs/tags/$tag" | grep -q .; then
-            echo "Tag $tag already exists — skipping release." >&2
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Tag $tag does not exist — will create it."
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Sanity gate: the new version must be a strictly-monotonic bump over the
-      # highest existing v* tag. Blocks accidental downgrades or a re-used
-      # version with a hand-edited Cargo.toml. Uses `sort -V` (version sort).
-      - name: Verify monotonic version bump
-        if: steps.tag_check.outputs.exists == 'false'
+      - name: Detect changes since last release
+        id: changed
         run: |
           set -euo pipefail
-          new="${{ steps.version.outputs.version }}"
-          # Highest existing semver-shaped tag (strip leading v, ignore prereleases).
-          latest=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
-            | sed 's/^v//' \
-            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-            | sort -V \
-            | tail -1 || true)
-          if [ -z "$latest" ]; then
-            echo "No prior semver tag found — first release, accepting $new."
+          prefix="${{ matrix.prefix }}"
+          # Highest existing tag for this component (version sort). The glob is
+          # component-specific so `v*` never matches `palette-v*` etc.
+          last_tag=$(git tag -l "${prefix}*" | sort -V | tail -1 || true)
+          if [ -z "$last_tag" ]; then
+            echo "No prior ${prefix}* tag — first ${{ matrix.component }} release; treating as changed."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "last_tag=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "Latest existing tag: v$latest; candidate: v$new"
-          # The candidate must sort strictly after the latest tag.
-          highest=$(printf '%s\n%s\n' "$latest" "$new" | sort -V | tail -1)
-          if [ "$new" = "$latest" ] || [ "$highest" != "$new" ]; then
-            echo "ERROR: version $new is not a strictly-monotonic bump over $latest." >&2
-            echo "Bump Cargo.toml (and all version-bearing files) before merging." >&2
+          echo "last_tag=$last_tag" >> "$GITHUB_OUTPUT"
+          # `paths` is intentionally unquoted so each pathspec is a separate arg.
+          if git diff --name-only "$last_tag"..HEAD -- ${{ matrix.paths }} | grep -q .; then
+            echo "Changes detected in ${{ matrix.component }} paths since $last_tag."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No ${{ matrix.component }} changes since $last_tag — skipping."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Bump enforcement: code changed but the computed tag already exists means
+      # the version was not bumped. Fail loudly rather than ship nothing.
+      - name: Enforce version bump
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          if git ls-remote --tags origin "refs/tags/$tag" | grep -q .; then
+            echo "::error::${{ matrix.component }} code changed since ${{ steps.changed.outputs.last_tag }} but tag $tag already exists — bump the ${{ matrix.component }} version before merging." >&2
             exit 1
           fi
-          echo "OK: $new > $latest."
+          echo "Tag $tag does not exist — OK to release."
+
+      # Sanity gate: the new version must sort strictly after the component's
+      # highest existing tag. Blocks accidental downgrades. Skipped on the very
+      # first release (no prior tag). `sort -V` handles 2- and 3-part versions.
+      - name: Verify monotonic version bump
+        if: steps.changed.outputs.changed == 'true' && steps.changed.outputs.last_tag != ''
+        run: |
+          set -euo pipefail
+          prefix="${{ matrix.prefix }}"
+          new="${{ steps.version.outputs.version }}"
+          last="${{ steps.changed.outputs.last_tag }}"
+          last_ver="${last#"$prefix"}"
+          echo "Latest existing tag: $last (v$last_ver); candidate: $new"
+          highest=$(printf '%s\n%s\n' "$last_ver" "$new" | sort -V | tail -1)
+          if [ "$new" = "$last_ver" ] || [ "$highest" != "$new" ]; then
+            echo "::error::${{ matrix.component }} version $new is not a strictly-monotonic bump over $last_ver." >&2
+            exit 1
+          fi
+          echo "OK: $new > $last_ver."
 
       # CI gate: do not cut a public release until the required CI checks for
-      # this exact commit have succeeded. We poll the `production-gate` job's
-      # parent CI run (the aggregation job that needs fmt/check/clippy/test/
-      # security/etc.) for the pushed SHA. auto-tag and CI both fire on the same
+      # this exact commit have succeeded. auto-tag and CI both fire on the same
       # push, so CI may still be in progress when this runs — hence the poll.
       - name: Wait for CI to pass on this commit
-        if: steps.tag_check.outputs.exists == 'false'
+        if: steps.changed.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           sha="${{ github.sha }}"
           deadline=$(( $(date +%s) + 1800 ))  # 30 minute cap
-          echo "Waiting for CI 'production-gate' to succeed for $sha ..."
+          echo "Waiting for CI to succeed for $sha ..."
           while :; do
-            # Look up the CI workflow run for this commit. `production-gate`
-            # is a job inside the `CI` workflow; we gate on the run conclusion.
             conclusion=$(gh run list \
               --workflow=ci.yml \
               --commit "$sha" \
@@ -129,11 +196,11 @@ jobs:
               break
             fi
             if [ "$conclusion" = "failure" ] || [ "$conclusion" = "cancelled" ] || [ "$conclusion" = "timed_out" ]; then
-              echo "ERROR: CI concluded '$conclusion' for $sha — refusing to cut a release." >&2
+              echo "::error::CI concluded '$conclusion' for $sha — refusing to cut a release." >&2
               exit 1
             fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "ERROR: timed out waiting for CI to finish for $sha." >&2
+              echo "::error::timed out waiting for CI to finish for $sha." >&2
               exit 1
             fi
             echo "CI status='${status:-unknown}' conclusion='${conclusion:-pending}'; sleeping 20s ..."
@@ -141,18 +208,18 @@ jobs:
           done
 
       - name: Create and push tag
-        if: steps.tag_check.outputs.exists == 'false'
+        if: steps.changed.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
-          echo "Pushed tag v${{ steps.version.outputs.version }}"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+          echo "Pushed tag ${{ steps.version.outputs.tag }}"
 
-      - name: Dispatch release.yml
-        if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          gh workflow run release.yml --ref "v${{ steps.version.outputs.version }}" -f publish=true
-          echo "Dispatched release.yml for v${{ steps.version.outputs.version }}"
+      - name: Dispatch ${{ matrix.workflow }}
+        if: steps.changed.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "${{ matrix.workflow }}" --ref "${{ steps.version.outputs.tag }}" -f publish=true
+          echo "Dispatched ${{ matrix.workflow }} for ${{ steps.version.outputs.tag }}"

--- a/.github/workflows/chrome-extension-release.yml
+++ b/.github/workflows/chrome-extension-release.yml
@@ -11,11 +11,19 @@ name: chrome-extension-release
 # publishes a GitHub Release with the zip + SHA256 attached.
 #
 # Manual workflow_dispatch builds the zip and uploads it to the run as an
-# artifact for inspection, but does NOT create a Release (dry-run).
+# artifact for inspection, but does NOT create a Release unless explicitly
+# called with publish=true on a chrome-ext-v* tag. auto-tag.yml dispatches this
+# workflow with publish=true after creating a new chrome-ext-v* tag, because
+# tags pushed with GITHUB_TOKEN do not trigger tag-push workflows.
 on:
   push:
     tags: ["chrome-ext-v*"]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Create the GitHub Release when running on a chrome-ext-v* tag"
+        type: boolean
+        default: false
 
 permissions:
   contents: write   # required to create releases
@@ -74,8 +82,14 @@ jobs:
           if-no-files-found: error
 
       - name: Create GitHub Release
-        # Only create a release on real tag pushes; workflow_dispatch is dry-run.
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chrome-ext-v')
+        # Create a release on real tag pushes; workflow_dispatch is a dry-run
+        # unless explicitly called with publish=true on a chrome-ext-v* tag.
+        if: >-
+          startsWith(github.ref, 'refs/tags/chrome-ext-v') &&
+          (
+            github.event_name == 'push' ||
+            (github.event_name == 'workflow_dispatch' && inputs.publish)
+          )
         uses: softprops/action-gh-release@v2
         with:
           name: Chrome extension v${{ steps.build.outputs.version }}

--- a/.github/workflows/palette-release.yml
+++ b/.github/workflows/palette-release.yml
@@ -1,0 +1,228 @@
+name: palette-release
+
+# Releases the Tauri axon-palette independently of the main axon `v*` releases.
+#
+# Triggered by pushing a palette-specific tag whose version matches the
+# `version` in apps/palette-tauri/src-tauri/tauri.conf.json, e.g.:
+#
+#   git tag palette-v5.9.1 && git push origin palette-v5.9.1
+#
+# Builds the portable palette binary for Linux + Windows, packages each with a
+# SHA256 checksum, and publishes a GitHub Release with both artifacts attached.
+#
+# Manual workflow_dispatch builds + packages the binaries and uploads them to
+# the run as artifacts for inspection, but does NOT create a Release unless
+# explicitly called with publish=true on a palette-v* tag. auto-tag.yml
+# dispatches this workflow with publish=true after creating a new palette-v*
+# tag, because tags pushed with GITHUB_TOKEN do not trigger tag-push workflows.
+on:
+  push:
+    tags: ["palette-v*"]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Create the GitHub Release when running on a palette-v* tag"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  WINDOWS_PORTABLE_RUSTFLAGS: >-
+    -C target-cpu=x86-64
+    -C target-feature=-avx512f,-avx512vl,-avx512bw,-avx512dq,-avx512cd,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vnni,-avx512bitalg,-avx512vpopcntdq
+
+jobs:
+  version:
+    name: resolve and validate version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Resolve and validate version
+        id: version
+        run: |
+          set -euo pipefail
+          conf="apps/palette-tauri/src-tauri/tauri.conf.json"
+          version="$(grep -m1 -E '"version"[[:space:]]*:' "$conf" \
+            | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')"
+          if [[ -z "$version" ]]; then
+            echo "::error::could not read version from $conf" >&2
+            exit 1
+          fi
+
+          # The three palette version-bearing files must agree so the artifact,
+          # the cargo package, and the npm package never disagree on a version.
+          pkg="$(grep -m1 -E '"version"[[:space:]]*:' apps/palette-tauri/package.json \
+            | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')"
+          crate="$(grep -m1 -E '^version[[:space:]]*=' apps/palette-tauri/src-tauri/Cargo.toml \
+            | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [[ "$pkg" != "$version" || "$crate" != "$version" ]]; then
+            echo "::error::palette version mismatch — tauri.conf.json=$version package.json=$pkg src-tauri/Cargo.toml=$crate (all three must match)" >&2
+            exit 1
+          fi
+
+          # On a real tag push, the tag version must match tauri.conf.json so a
+          # release can never ship a binary the tag disagrees with.
+          if [[ "${GITHUB_REF}" == refs/tags/palette-v* ]]; then
+            tag_version="${GITHUB_REF#refs/tags/palette-v}"
+            if [[ "$tag_version" != "$version" ]]; then
+              echo "::error::tag palette-v$tag_version does not match version $version — bump $conf before tagging" >&2
+              exit 1
+            fi
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  palette-linux:
+    name: build axon-palette (linux)
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      # Full checkout: LFS blobs come down as pointers (lfs: false default) and
+      # are not needed to build.
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.3.0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: apps/palette-tauri/pnpm-lock.yaml
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/palette-tauri/src-tauri
+          shared-key: release-palette-linux
+      # Tauri on Linux links against WebKitGTK + GTK + libsoup.
+      - name: Install Tauri Linux system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential curl file libayatana-appindicator3-dev librsvg2-dev \
+            libssl-dev libwebkit2gtk-4.1-dev patchelf pkg-config wget
+      - name: Install palette dependencies
+        run: pnpm --dir apps/palette-tauri install --frozen-lockfile
+      # `tauri build --no-bundle` runs the frontend `beforeBuildCommand`
+      # (pnpm vite:build) and compiles the portable binary without packaging
+      # installers — matching the single-binary artifact shape the
+      # `axon palette install` flow expects.
+      - name: Build Tauri palette (portable binary)
+        run: pnpm --dir apps/palette-tauri exec tauri build --no-bundle --ci
+      - name: Package
+        run: |
+          set -euo pipefail
+          cd apps/palette-tauri/src-tauri/target/release
+          tar -czf axon-palette-linux-x86_64.tar.gz axon-palette-tauri
+          sha256sum axon-palette-linux-x86_64.tar.gz > axon-palette-linux-x86_64.tar.gz.sha256
+      - uses: actions/upload-artifact@v5
+        with:
+          name: axon-palette-linux-x86_64
+          path: |
+            apps/palette-tauri/src-tauri/target/release/axon-palette-linux-x86_64.tar.gz
+            apps/palette-tauri/src-tauri/target/release/axon-palette-linux-x86_64.tar.gz.sha256
+          if-no-files-found: error
+
+  palette-windows:
+    name: build axon-palette (windows)
+    needs: version
+    runs-on: windows-latest
+    steps:
+      # Full checkout: LFS blobs come down as pointers (lfs: false default) and
+      # are not needed to build.
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.3.0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: apps/palette-tauri/pnpm-lock.yaml
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/palette-tauri/src-tauri
+          shared-key: release-palette-windows
+      - name: Install palette dependencies
+        run: pnpm --dir apps/palette-tauri install --frozen-lockfile
+      # `tauri build --no-bundle` runs the frontend `beforeBuildCommand`
+      # (pnpm vite:build) and compiles the portable .exe without packaging
+      # installers. The avx512-disabling RUSTFLAGS keep the binary portable
+      # across CPUs; the rustc-wrapper is a bash script that cannot run as a
+      # Windows rustc wrapper, so it is disabled here.
+      - name: Build Tauri palette (portable binary)
+        run: pnpm --dir apps/palette-tauri exec tauri build --no-bundle --ci
+        env:
+          RUSTFLAGS: ${{ env.WINDOWS_PORTABLE_RUSTFLAGS }}
+          CARGO_BUILD_RUSTC_WRAPPER: ""
+      - name: Package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Push-Location apps/palette-tauri/src-tauri/target/release
+          Compress-Archive -Path axon-palette-tauri.exe -DestinationPath axon-palette-windows-x86_64.zip -Force
+          $hash = (Get-FileHash axon-palette-windows-x86_64.zip -Algorithm SHA256).Hash.ToLower()
+          "$hash  axon-palette-windows-x86_64.zip" | Out-File -Encoding ascii axon-palette-windows-x86_64.zip.sha256
+          Pop-Location
+      - uses: actions/upload-artifact@v5
+        with:
+          name: axon-palette-windows-x86_64
+          path: |
+            apps/palette-tauri/src-tauri/target/release/axon-palette-windows-x86_64.zip
+            apps/palette-tauri/src-tauri/target/release/axon-palette-windows-x86_64.zip.sha256
+          if-no-files-found: error
+
+  publish:
+    name: publish github release
+    needs: [version, palette-linux, palette-windows]
+    runs-on: ubuntu-latest
+    # Create a release on real tag pushes. workflow_dispatch remains a dry-run
+    # unless explicitly called with publish=true on a palette-v* tag (used by
+    # auto-tag).
+    if: >-
+      startsWith(github.ref, 'refs/tags/palette-v') &&
+      (
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish)
+      )
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          path: dist
+          merge-multiple: true
+      - name: List artifacts
+        run: ls -la dist/
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Palette v${{ needs.version.outputs.version }}
+          # Curated body instead of generate_release_notes: the palette versions
+          # independently, so auto-notes would diff against an unrelated axon v*
+          # tag and dump the whole axon PR history into the palette's notes.
+          body: |
+            Axon Palette — desktop launcher v${{ needs.version.outputs.version }}.
+
+            **Install:** download the binary for your platform and run
+            `axon palette install`, or unpack the portable binary directly.
+
+            **Verify:** `sha256sum -c axon-palette-linux-x86_64.tar.gz.sha256`
+
+            See `apps/palette-tauri/README.md` for build and configuration details.
+          files: |
+            dist/axon-palette-linux-x86_64.tar.gz
+            dist/axon-palette-linux-x86_64.tar.gz.sha256
+            dist/axon-palette-windows-x86_64.zip
+            dist/axon-palette-windows-x86_64.zip.sha256
+          fail_on_unmatched_files: true
+          # Keep the repo's "Latest release" badge pointing at axon `v*` releases.
+          make_latest: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: release
 
 # Triggered when you push a version tag (e.g. `git tag v2.0.0 && git push origin v2.0.0`).
-# Builds axon (cross-compiled) + the Tauri axon-palette for Linux + Windows,
-# packages them with SHA256 checksums, and publishes a GitHub Release with all
-# four artifacts attached.
+# Builds the axon CLI for Linux + Windows, packages each with a SHA256 checksum,
+# and publishes a GitHub Release with both artifacts attached.
+#
+# The Tauri axon-palette is released independently — see palette-release.yml
+# (fired by `palette-v*` tags). It is no longer bundled into the axon `v*`
+# release so that a palette-only change does not require a CLI version bump and
+# vice-versa.
 #
 # Manual workflow_dispatch builds everything but skips the Release creation by
 # default (artifacts are still uploaded to the workflow run for inspection).
@@ -25,9 +29,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  WINDOWS_PORTABLE_RUSTFLAGS: >-
-    -C target-cpu=x86-64
-    -C target-feature=-avx512f,-avx512vl,-avx512bw,-avx512dq,-avx512cd,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vnni,-avx512bitalg,-avx512vpopcntdq
 
 jobs:
   axon-linux:
@@ -150,111 +151,9 @@ jobs:
             target/release/axon-windows-x86_64.zip.sha256
           if-no-files-found: error
 
-  palette-linux:
-    name: build axon-palette (linux)
-    runs-on: ubuntu-latest
-    steps:
-      # Full checkout: LFS blobs come down as pointers (lfs: false default) and
-      # are not needed to build.
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.3.0
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: apps/palette-tauri/pnpm-lock.yaml
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.94.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/palette-tauri/src-tauri
-          shared-key: release-palette-linux
-      # Tauri on Linux links against WebKitGTK + GTK + libsoup.
-      - name: Install Tauri Linux system deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential curl file libayatana-appindicator3-dev librsvg2-dev \
-            libssl-dev libwebkit2gtk-4.1-dev patchelf pkg-config wget
-      - name: Install palette dependencies
-        run: pnpm --dir apps/palette-tauri install --frozen-lockfile
-      # `tauri build --no-bundle` runs the frontend `beforeBuildCommand`
-      # (pnpm vite:build) and compiles the portable binary without packaging
-      # installers — matching the single-binary artifact shape the
-      # `axon palette install` flow expects.
-      - name: Build Tauri palette (portable binary)
-        run: pnpm --dir apps/palette-tauri exec tauri build --no-bundle --ci
-      - name: Package
-        run: |
-          set -euo pipefail
-          cd apps/palette-tauri/src-tauri/target/release
-          tar -czf axon-palette-linux-x86_64.tar.gz axon-palette-tauri
-          sha256sum axon-palette-linux-x86_64.tar.gz > axon-palette-linux-x86_64.tar.gz.sha256
-      - uses: actions/upload-artifact@v5
-        with:
-          name: axon-palette-linux-x86_64
-          path: |
-            apps/palette-tauri/src-tauri/target/release/axon-palette-linux-x86_64.tar.gz
-            apps/palette-tauri/src-tauri/target/release/axon-palette-linux-x86_64.tar.gz.sha256
-          if-no-files-found: error
-
-  palette-windows:
-    name: build axon-palette (windows)
-    runs-on: windows-latest
-    steps:
-      # Full checkout: LFS blobs come down as pointers (lfs: false default) and
-      # are not needed to build.
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.3.0
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: apps/palette-tauri/pnpm-lock.yaml
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.94.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/palette-tauri/src-tauri
-          shared-key: release-palette-windows
-      - name: Install palette dependencies
-        run: pnpm --dir apps/palette-tauri install --frozen-lockfile
-      # `tauri build --no-bundle` runs the frontend `beforeBuildCommand`
-      # (pnpm vite:build) and compiles the portable .exe without packaging
-      # installers. The avx512-disabling RUSTFLAGS keep the binary portable
-      # across CPUs; the rustc-wrapper is a bash script that cannot run as a
-      # Windows rustc wrapper, so it is disabled here.
-      - name: Build Tauri palette (portable binary)
-        run: pnpm --dir apps/palette-tauri exec tauri build --no-bundle --ci
-        env:
-          RUSTFLAGS: ${{ env.WINDOWS_PORTABLE_RUSTFLAGS }}
-          CARGO_BUILD_RUSTC_WRAPPER: ""
-      - name: Package
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          Push-Location apps/palette-tauri/src-tauri/target/release
-          Compress-Archive -Path axon-palette-tauri.exe -DestinationPath axon-palette-windows-x86_64.zip -Force
-          $hash = (Get-FileHash axon-palette-windows-x86_64.zip -Algorithm SHA256).Hash.ToLower()
-          "$hash  axon-palette-windows-x86_64.zip" | Out-File -Encoding ascii axon-palette-windows-x86_64.zip.sha256
-          Pop-Location
-      - uses: actions/upload-artifact@v5
-        with:
-          name: axon-palette-windows-x86_64
-          path: |
-            apps/palette-tauri/src-tauri/target/release/axon-palette-windows-x86_64.zip
-            apps/palette-tauri/src-tauri/target/release/axon-palette-windows-x86_64.zip.sha256
-          if-no-files-found: error
-
   publish:
     name: publish github release
-    needs: [axon-linux, axon-windows, palette-linux, palette-windows]
+    needs: [axon-linux, axon-windows]
     runs-on: ubuntu-latest
     # Create a release on real tag pushes. workflow_dispatch remains a dry-run
     # unless explicitly called with publish=true on a v* tag (used by auto-tag).
@@ -291,9 +190,5 @@ jobs:
             dist/axon-linux-x86_64.tar.gz.sha256
             dist/axon-windows-x86_64.zip
             dist/axon-windows-x86_64.zip.sha256
-            dist/axon-palette-linux-x86_64.tar.gz
-            dist/axon-palette-linux-x86_64.tar.gz.sha256
-            dist/axon-palette-windows-x86_64.zip
-            dist/axon-palette-windows-x86_64.zip.sha256
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -766,43 +766,79 @@ bd close <id>         # Complete work
 
 ### How releases work
 
-Every push to `main` triggers `.github/workflows/auto-tag.yml`, which reads the
-version from `Cargo.toml` and creates a `v{version}` git tag if one doesn't
-already exist. That tag push triggers `.github/workflows/release.yml`, which
-builds `axon` for Linux and Windows, packages release tarballs with SHA256
-checksums, and publishes a GitHub Release with all artifacts attached.
+Releases are **per-component and selective**. Every push to `main` triggers
+`.github/workflows/auto-tag.yml`, which evaluates each releasable component
+independently and only cuts a release for the ones whose shipped code actually
+changed since their last release:
 
-**Implication: merging to `main` with a bumped version automatically cuts a
-release.** If the version has not changed since the last merge (e.g. a follow-up
-docs fix), the tag already exists and no release is cut.
+| Component | Shipping paths | Version source | Tag prefix | Release workflow |
+|-----------|----------------|----------------|-----------|------------------|
+| **cli** (Linux + Windows; web panel bundled in) | `src`, `Cargo.toml`/`Cargo.lock`, `build.rs`, `migrations`, `apps/web`, `rust-toolchain.toml`, `vendor` | `Cargo.toml` `[package]` version | `v` | `release.yml` |
+| **palette** (Linux + Windows) | `apps/palette-tauri` | `apps/palette-tauri/src-tauri/tauri.conf.json` | `palette-v` | `palette-release.yml` |
+| **android** (APK) | `apps/android` | `apps/android/app/build.gradle.kts` `versionName` | `android-v` | `android-release.yml` |
+| **chrome** (extension zip) | `apps/chrome-extension`, `assets` | `apps/chrome-extension/manifest.json` `version` | `chrome-ext-v` | `chrome-extension-release.yml` |
 
-To cut a release manually (e.g. re-release or hotfix without a code change):
+For each component, `auto-tag.yml` diffs that component's shipping paths against
+its most recent tag. If the code changed **and** the version was bumped (the
+computed tag does not yet exist), it waits for `CI` to pass on the commit,
+creates the tag, and dispatches the component's release workflow (which builds,
+packages with SHA256 checksums, and publishes a GitHub Release). The `axon`
+`v*` release remains the repo's "latest"; palette/android/chrome publish with
+`make_latest: false`.
+
+**Implications:**
+
+- A change touching only one component releases only that component — e.g. an
+  `apps/android/**`-only change cuts an Android release and nothing else; it
+  does **not** rebuild the CLI.
+- Dev-only trees (`xtask`, `benches`, `.github`, `docs`, top-level config) are
+  **not** in any component's shipping paths, so a tooling/docs-only merge cuts
+  no release and needs no version bump.
+- If a component's code changed but its version was **not** bumped (the tag
+  already exists), `auto-tag.yml` **fails that component's job** with a message
+  naming the component — nothing ships silently. Other components still release
+  (`fail-fast: false`).
+
+To cut a release manually (e.g. re-release or hotfix without a code change),
+push the component's tag directly:
 
 ```bash
-git tag vX.Y.Z && git push origin vX.Y.Z
+git tag vX.Y.Z         && git push origin vX.Y.Z          # cli
+git tag palette-vX.Y.Z && git push origin palette-vX.Y.Z  # palette
+git tag android-vX.Y   && git push origin android-vX.Y    # android
+git tag chrome-ext-vX.Y.Z && git push origin chrome-ext-vX.Y.Z  # chrome
 ```
 
 ### Version bumping rules
 
-**Every feature branch merge to `main` MUST bump the version in ALL
-version-bearing files.** Bump type is determined by the commit message prefix:
+**Bump ONLY the component(s) whose shipping code you changed** — versions are
+independent per component. Bump type is determined by the commit message prefix:
 
 - `feat!:` or `BREAKING CHANGE` → **major** (X+1.0.0)
 - `feat` or `feat(...)` → **minor** (X.Y+1.0)
 - Everything else (`fix`, `chore`, `refactor`, `test`, `docs`, etc.) → **patch** (X.Y.Z+1)
 
-**Files to update:**
+**CLI component — all of these MUST move together (Cargo.toml is the source of truth):**
 - `Cargo.toml` — `version = "X.Y.Z"` in `[package]` (Cargo.lock follows on next build)
 - `README.md` — version header
 - `CHANGELOG.md` — new entry under the bumped version
 - `apps/web/package.json` + `apps/web/openapi/axon.json` — `"version": "X.Y.Z"`
 
+**Palette component — all three MUST move together:**
+- `apps/palette-tauri/src-tauri/tauri.conf.json`, `apps/palette-tauri/package.json`,
+  `apps/palette-tauri/src-tauri/Cargo.toml`
+
+**Android component:** `apps/android/app/build.gradle.kts` `versionName` (bump
+`versionCode` too). **Chrome component:** `apps/chrome-extension/manifest.json`.
+
 `plugins/axon/.claude-plugin/plugin.json` must **NOT** carry a `version` key —
 `just validate-plugin` (part of `just verify`) hard-fails on it; the plugin is
 versioned by the marketplace, not the manifest.
 
-All files MUST have the same version. Never bump only one file.
-CHANGELOG.md must have an entry for every version bump.
+CHANGELOG.md must have an entry for every CLI version bump.
 
-The pre-push hook (`xtask-check`) enforces version parity across all files and
-will block a push if they are out of sync.
+The pre-push hook (`xtask-check`) enforces **CLI** version parity across
+`Cargo.toml`, `README.md`, `CHANGELOG.md`, `apps/web/package.json`, and
+`apps/web/openapi/axon.json`, and will block a push if they are out of sync.
+The palette/android/chrome release workflows validate that the pushed tag
+matches their own version at release time.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -87,8 +87,9 @@ pre-push:
   parallel: false
   commands:
     version-sync:
-      # OPS-M3: enforce version parity (Cargo.toml / README / CHANGELOG /
-      # plugin.json) before a push — same gate CI runs as `check-version-sync`.
+      # OPS-M3: enforce CLI version parity (Cargo.toml / README / CHANGELOG /
+      # apps/web/package.json / apps/web/openapi/axon.json) before a push — same
+      # gate CI runs as `check-version-sync`.
       # Runs first (cheap, content-only) so a version mismatch fails fast
       # before the expensive workspace clippy/test compile. Prefer the
       # pre-built xtask binary; fall back to `cargo xtask` on a clean target/.

--- a/xtask/src/checks/version_sync.rs
+++ b/xtask/src/checks/version_sync.rs
@@ -85,8 +85,13 @@ fn check_changelog(content: &str, expected: &str) -> Result<()> {
 }
 
 fn check_json_version(content: &str, expected: &str, path: &str) -> Result<()> {
-    let pattern = format!("\"version\": \"{expected}\"");
-    if content.contains(&pattern) {
+    // Match regardless of whitespace around the colon so a formatting-only
+    // change (pretty `"version": "x"` vs compact/minified `"version":"x"`)
+    // doesn't break the parity gate. Strip all whitespace, then match the
+    // compact form.
+    let compact: String = content.chars().filter(|c| !c.is_whitespace()).collect();
+    let pattern = format!("\"version\":\"{expected}\"");
+    if compact.contains(&pattern) {
         return Ok(());
     }
     bail!(

--- a/xtask/src/checks/version_sync.rs
+++ b/xtask/src/checks/version_sync.rs
@@ -5,10 +5,20 @@ use std::path::Path;
 ///
 /// Cargo.toml is the single source of truth — all other files are checked
 /// against the version declared there.
+///
+/// This is the **CLI component's** parity set only. Axon releases are
+/// per-component (see CLAUDE.md "Release Pipeline"): the palette, Android app,
+/// and Chrome extension version independently from their own source files and
+/// are NOT checked here — their release workflows validate that the pushed tag
+/// matches the component's own version. The web panel ships compiled into the
+/// `axon` binary, so apps/web/package.json and its OpenAPI spec are part of the
+/// CLI parity set and must track Cargo.toml.
 const VERSION_FILES: &[(&str, VersionKind)] = &[
     ("Cargo.toml", VersionKind::Cargo),
     ("README.md", VersionKind::ReadmeHeader),
     ("CHANGELOG.md", VersionKind::Changelog),
+    ("apps/web/package.json", VersionKind::JsonVersion),
+    ("apps/web/openapi/axon.json", VersionKind::JsonVersion),
     (
         "plugins/axon/.claude-plugin/plugin.json",
         VersionKind::PluginJson,
@@ -23,6 +33,8 @@ enum VersionKind {
     ReadmeHeader,
     /// `## [X.Y.Z]` heading in CHANGELOG
     Changelog,
+    /// `"version": "X.Y.Z"` JSON field anywhere in the file
+    JsonVersion,
     /// `"version": "X.Y.Z"` JSON field — must NOT be present
     PluginJson,
 }
@@ -69,6 +81,17 @@ fn check_changelog(content: &str, expected: &str) -> Result<()> {
     bail!(
         "CHANGELOG.md does not contain a '## [{expected}]' heading\n\
          Hint: add a changelog entry for version {expected}"
+    );
+}
+
+fn check_json_version(content: &str, expected: &str, path: &str) -> Result<()> {
+    let pattern = format!("\"version\": \"{expected}\"");
+    if content.contains(&pattern) {
+        return Ok(());
+    }
+    bail!(
+        "{path} does not contain '\"version\": \"{expected}\"'\n\
+         Hint: update the \"version\" field in {path} to match Cargo.toml"
     );
 }
 
@@ -123,6 +146,7 @@ pub fn check(root: &Path) -> Result<()> {
             VersionKind::Cargo => unreachable!(),
             VersionKind::ReadmeHeader => check_readme(&content, &version),
             VersionKind::Changelog => check_changelog(&content, &version),
+            VersionKind::JsonVersion => check_json_version(&content, &version, rel_path),
             VersionKind::PluginJson => check_plugin_json(&content, rel_path),
         };
 

--- a/xtask/src/checks/version_sync_tests.rs
+++ b/xtask/src/checks/version_sync_tests.rs
@@ -53,6 +53,26 @@ fn changelog_heading_missing() {
 }
 
 #[test]
+fn json_version_ok() {
+    let json = "{\n  \"name\": \"axon-web\",\n  \"version\": \"5.6.1\",\n}";
+    assert!(check_json_version(json, "5.6.1", "apps/web/package.json").is_ok());
+}
+
+#[test]
+fn json_version_nested_ok() {
+    // OpenAPI carries the version nested under info; a substring match still
+    // finds it regardless of nesting/indentation.
+    let json = "{\n  \"openapi\": \"3.1.0\",\n  \"info\": {\n    \"version\": \"5.6.1\"\n  }\n}";
+    assert!(check_json_version(json, "5.6.1", "apps/web/openapi/axon.json").is_ok());
+}
+
+#[test]
+fn json_version_mismatch_is_error() {
+    let json = "{\n  \"version\": \"5.6.0\"\n}";
+    assert!(check_json_version(json, "5.6.1", "apps/web/package.json").is_err());
+}
+
+#[test]
 fn plugin_json_no_version_ok() {
     let json = r#"{"name": "axon", "description": "..."}"#;
     assert!(check_plugin_json(json, "plugin.json").is_ok());

--- a/xtask/src/checks/version_sync_tests.rs
+++ b/xtask/src/checks/version_sync_tests.rs
@@ -67,6 +67,13 @@ fn json_version_nested_ok() {
 }
 
 #[test]
+fn json_version_compact_ok() {
+    // Compact JSON with no space after the colon must still match.
+    let json = "{\"name\":\"axon-web\",\"version\":\"5.6.1\"}";
+    assert!(check_json_version(json, "5.6.1", "apps/web/package.json").is_ok());
+}
+
+#[test]
 fn json_version_mismatch_is_error() {
     let json = "{\n  \"version\": \"5.6.0\"\n}";
     assert!(check_json_version(json, "5.6.1", "apps/web/package.json").is_err());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,7 +26,9 @@ enum Command {
     CheckBrokenSymlinks,
     /// Scan staged files for secrets and credentials.
     CheckSecrets,
-    /// Verify Cargo.toml, README.md, CHANGELOG.md, and plugin.json carry the same version.
+    /// Verify the CLI component's version-bearing files (Cargo.toml, README.md,
+    /// CHANGELOG.md, apps/web/package.json, apps/web/openapi/axon.json) carry the
+    /// same version, and that plugin.json carries none.
     CheckVersionSync,
 }
 


### PR DESCRIPTION
## What

Make merging to `main` build a release **only for the components whose shipped code actually changed**. Today the CLI + palette auto-release together on every merge, and android/chrome must be tagged by hand. After this, all four components (cli, palette, android, chrome) are evaluated independently on each push to main and release selectively — touch only the android code and only android builds.

## How

`auto-tag.yml` becomes a per-component matrix detector. For each component it diffs that component's **shipping paths** against the component's most recent tag; when the code changed **and** the version was bumped (the computed tag doesn't exist yet), it waits for CI, creates the tag, and dispatches the component's release workflow.

| Component | Shipping paths | Version source | Tag | Release workflow |
|-----------|----------------|----------------|-----|------------------|
| cli (Linux+Win, web panel bundled) | `src`, `Cargo.toml`/`lock`, `build.rs`, `migrations`, `apps/web`, `rust-toolchain.toml`, `vendor` | `Cargo.toml` | `v` | `release.yml` |
| palette (Linux+Win) | `apps/palette-tauri` | `tauri.conf.json` | `palette-v` | `palette-release.yml` *(new)* |
| android (APK) | `apps/android` | `build.gradle.kts` versionName | `android-v` | `android-release.yml` |
| chrome (zip) | `apps/chrome-extension`, `assets` | `manifest.json` | `chrome-ext-v` | `chrome-extension-release.yml` |

Key changes:
- **Palette split out** of `release.yml` into its own `palette-release.yml` (own `palette-v*` tag + GitHub Release, `make_latest: false`). The CLI `v*` release no longer bundles palette artifacts. The new workflow also validates the three palette version files agree.
- **Publish gate added** to the android, chrome, and palette workflows (a `publish` input on `workflow_dispatch`). Tags pushed via `GITHUB_TOKEN` don't trigger tag workflows, so auto-tag dispatches each release explicitly with `publish=true` — without this gate those workflows would no-op on dispatch.
- **Bump enforcement:** if a component's code changed but its tag already exists (version not bumped), that component's job fails with a message naming it. `fail-fast: false` keeps the other components releasing.
- **Per-component version policy:** docs (`CLAUDE.md`) now say "bump only the component you changed." Dev-only trees (`xtask`, `benches`, `.github`, `docs`, top-level config) are in no component's shipping paths, so tooling/docs-only merges cut no release and need no bump.
- **xtask version-sync** now also checks `apps/web/package.json` and `apps/web/openapi/axon.json` (the web panel ships compiled into the CLI binary) against `Cargo.toml`. Added unit tests for the new JSON-version helper.

## First-merge note (expected, not a bug)

The detector catches up pending releases on the next merge to main:
- **chrome** is at `0.2.0` but the last tag is `chrome-ext-v0.1.0` → a chrome release will fire.
- **palette** has no `palette-v*` tag yet → its first release (`palette-v5.9.1`) will fire to establish the baseline.

cli (`v5.12.0` = current tag) and android (`android-v1.3` = current) are already up to date and won't release.

## Validation
- All five workflows YAML-parse.
- `cargo xtask check-version-sync` passes at 5.12.0 (now including web/openapi).
- `cargo test -p xtask version_sync` — 11 passed; `cargo fmt`/`clippy` clean.
- Version-parse, prefix-strip, and monotonic-sort shell logic verified locally against the real files (handles android's 2-part `1.3` too).

https://claude.ai/code/session_01EPo24kgdBGsPpfKW29kjjZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPo24kgdBGsPpfKW29kjjZ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selective per-component releases on merge to main. CLI, palette, Android, and Chrome now release independently and only when their shipped code changes.

- **New Features**
  - `auto-tag.yml` evaluates each component separately: diffs shipping paths vs the component’s last tag; if code changed and the version was bumped, it waits for CI, creates the tag, and dispatches that component’s release workflow.
  - Serialized runs for `auto-tag.yml` with a per-ref concurrency group to prevent tag races on rapid merges.
  - Palette split to its own `palette-release.yml` with `palette-v*` tags; CLI `v*` releases no longer bundle palette artifacts (`make_latest: false` for palette).
  - Added publish gates to `android-release.yml`, `chrome-extension-release.yml`, and `palette-release.yml`; `auto-tag.yml` dispatches them with `publish=true` (since `GITHUB_TOKEN` tag pushes don’t trigger workflows).
  - Enforced per-component bumping: if code changed but the computed tag exists, that component’s job fails; others proceed (`fail-fast: false`).
  - Updated version policy and checks: bump only the component you changed. `xtask check-version-sync` for CLI now also validates `apps/web/package.json` and `apps/web/openapi/axon.json` and is whitespace-agnostic for JSON so formatting changes don’t fail the check. Docs updated in `CLAUDE.md`.

- **Migration**
  - Bump only the component you changed; tooling/docs-only changes need no bump and won’t release.
  - First merge will catch up pending releases: Chrome will tag from `0.2.0` and Palette will create its first `palette-v5.9.1`. CLI and Android are current and won’t re-release.

<sup>Written for commit 93dea5046e835ea0bcbd8380962182fd971a0521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-component independent release workflows for CLI, Palette, Android, and Chrome extension
  * Manual workflow dispatch support for dry-run and controlled release testing

* **Chores**
  * Refactored release pipeline from monolithic to component-scoped versioning and tagging
  * Expanded version validation to include additional configuration files
  * Updated release pipeline documentation and pre-push hook documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->