### PR TITLE
feat(chunker): JSON/YAML/TOML structured-data chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.14.0] - 2026-06-15
 
+### Added
+
+- **Structured-data chunking for JSON, YAML, and TOML.** `.json`, `.yaml`/`.yml`,
+  and `.toml` files now route through the declaration-driven chunker via new
+  tree-sitter grammars instead of generic prose splitting. Top-level object keys
+  (JSON/YAML) and tables / array-of-tables / top-level pairs (TOML) are captured
+  as `SymbolKind::Key` chunks; nested keys stay inside their parent's chunk and
+  the shared residual-sweep / oversized-split / 2000-char cap apply. Keys are
+  searchable but excluded from the code-symbol authority boost (config keys like
+  `port`/`server` are common words). Keyless files (top-level array/scalar/
+  sequence) fall back to non-empty prose.
+
 ### Changed
 
 - **Declaration-driven code chunking (query-capture).** Reworked the code chunker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,10 +448,13 @@ dependencies = [
  "tree-sitter-bash",
  "tree-sitter-go",
  "tree-sitter-javascript",
+ "tree-sitter-json",
  "tree-sitter-language",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-toml-ng",
  "tree-sitter-typescript",
+ "tree-sitter-yaml",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -7266,6 +7269,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7292,10 +7305,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,10 +108,13 @@ tree-sitter = "0.26.9"
 tree-sitter-bash = "0.25"
 tree-sitter-go = "0.25"
 tree-sitter-javascript = "0.25"
+tree-sitter-json = "0.24"
 tree-sitter-language = "0.1"
 tree-sitter-python = "0.25"
 tree-sitter-rust = "0.24"
+tree-sitter-toml-ng = "0.7"
 tree-sitter-typescript = "0.23"
+tree-sitter-yaml = "0.7"
 tokio = { version = "1", features = [
   "macros",
   "rt-multi-thread",

--- a/src/vector/ops/input/code/chunk.rs
+++ b/src/vector/ops/input/code/chunk.rs
@@ -10,6 +10,9 @@ pub enum SymbolKind {
     Static,
     Type,
     Mod,
+    /// A top-level key/section in structured data (JSON/YAML object key, TOML
+    /// table). The "declaration" unit for config/data files.
+    Key,
     Other,
 }
 
@@ -43,6 +46,7 @@ impl SymbolKind {
             Self::Static => "static",
             Self::Type => "type",
             Self::Mod => "mod",
+            Self::Key => "key",
             Self::Other => "other",
         }
     }
@@ -69,6 +73,7 @@ impl SymbolKind {
             "static" => Self::Static,
             "type" => Self::Type,
             "mod" => Self::Mod,
+            "key" => Self::Key,
             "other" => Self::Other,
             _ => return None,
         };
@@ -77,8 +82,11 @@ impl SymbolKind {
 
     /// Whether a chunk carrying this symbol kind should be treated as a primary
     /// code-search target (and receive the symbol boost). Declaration-only kinds
-    /// (`Mod`) and the catch-all (`Other`) are deliberately excluded. Exhaustive
-    /// so adding a variant forces this decision rather than defaulting silently.
+    /// (`Mod`), structured-data keys (`Key`), and the catch-all (`Other`) are
+    /// deliberately excluded — config keys are common words (`port`, `server`,
+    /// `name`) and giving them code-symbol authority would over-rank config files
+    /// for generic queries. They stay searchable as chunks, just without the
+    /// boost. Exhaustive so adding a variant forces this decision.
     pub const fn is_source_symbol(self) -> bool {
         match self {
             Self::Function
@@ -90,7 +98,7 @@ impl SymbolKind {
             | Self::Const
             | Self::Static
             | Self::Type => true,
-            Self::Mod | Self::Other => false,
+            Self::Mod | Self::Key | Self::Other => false,
         }
     }
 }

--- a/src/vector/ops/input/code/extract.rs
+++ b/src/vector/ops/input/code/extract.rs
@@ -10,8 +10,11 @@ use super::chunk::SymbolKind;
 mod bash;
 mod go;
 mod js_ts;
+mod json;
 mod python;
 mod rust;
+mod toml;
+mod yaml;
 
 #[derive(Debug, Clone)]
 pub(super) struct SymbolInfo {
@@ -86,6 +89,9 @@ pub(super) enum Extractor {
     /// error recovery that fabricates spurious nodes (bead axon_rust-2ykl).
     Tsx,
     Bash,
+    Json,
+    Yaml,
+    Toml,
 }
 
 pub(super) fn language_for_extension(ext: &str) -> Option<LanguageSpec> {
@@ -97,6 +103,9 @@ pub(super) fn language_for_extension(ext: &str) -> Option<LanguageSpec> {
         "tsx" => Extractor::Tsx,
         "go" => Extractor::Go,
         "sh" | "bash" => Extractor::Bash,
+        "json" => Extractor::Json,
+        "yaml" | "yml" => Extractor::Yaml,
+        "toml" => Extractor::Toml,
         _ => return None,
     };
     Some(LanguageSpec { extractor })
@@ -153,6 +162,12 @@ static TSX_REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
 });
 static BASH_REGISTRY: LazyLock<Registry> =
     LazyLock::new(|| Registry::new(tree_sitter_bash::LANGUAGE, bash::RULES, bash::refine));
+static JSON_REGISTRY: LazyLock<Registry> =
+    LazyLock::new(|| Registry::new(tree_sitter_json::LANGUAGE, json::RULES, json::refine));
+static YAML_REGISTRY: LazyLock<Registry> =
+    LazyLock::new(|| Registry::new(tree_sitter_yaml::LANGUAGE, yaml::RULES, yaml::refine));
+static TOML_REGISTRY: LazyLock<Registry> =
+    LazyLock::new(|| Registry::new(tree_sitter_toml_ng::LANGUAGE, toml::RULES, toml::refine));
 
 thread_local! {
     static PARSER: RefCell<Parser> = RefCell::new(Parser::new());
@@ -167,6 +182,9 @@ fn registry_for(extractor: Extractor) -> Option<&'static Registry> {
         Extractor::TypeScript => Some(&TYPESCRIPT_REGISTRY),
         Extractor::Tsx => Some(&TSX_REGISTRY),
         Extractor::Bash => Some(&BASH_REGISTRY),
+        Extractor::Json => Some(&JSON_REGISTRY),
+        Extractor::Yaml => Some(&YAML_REGISTRY),
+        Extractor::Toml => Some(&TOML_REGISTRY),
         Extractor::None => None,
     }
 }

--- a/src/vector/ops/input/code/extract/json.rs
+++ b/src/vector/ops/input/code/extract/json.rs
@@ -1,0 +1,28 @@
+use tree_sitter::Node;
+
+use super::super::chunk::SymbolKind;
+use super::{DeclRole, DeclRule};
+
+/// JSON declaration rules: each **top-level** object key becomes a chunk named by
+/// the key (kind [`SymbolKind::Key`]). The pattern is anchored to the document
+/// root so only top-level keys match — a nested key lives inside its parent key's
+/// chunk (bounded by the oversized split). A top-level array or scalar matches
+/// nothing, so the file degrades to whole-file prose (never zero chunks).
+pub(super) static RULES: &[DeclRule] = &[DeclRule {
+    pattern: "(document (object (pair key: (string (string_content) @name)) @decl))",
+    kind: SymbolKind::Key,
+    role: DeclRole::Leaf,
+}];
+
+pub(super) fn refine(
+    _decl: Node<'_>,
+    raw_name: &str,
+    _content: &str,
+    kind: SymbolKind,
+) -> (SymbolKind, Option<String>) {
+    (kind, Some(raw_name.to_string()))
+}
+
+#[cfg(test)]
+#[path = "json_tests.rs"]
+mod tests;

--- a/src/vector/ops/input/code/extract/json_tests.rs
+++ b/src/vector/ops/input/code/extract/json_tests.rs
@@ -1,0 +1,74 @@
+use super::super::super::chunk::{ChunkSource, SymbolKind};
+use super::super::super::chunk_code_chunks;
+use super::super::{Extractor, extract_symbols};
+
+fn names(symbols: &[super::super::SymbolInfo]) -> Vec<String> {
+    symbols.iter().filter_map(|s| s.name.clone()).collect()
+}
+
+#[test]
+fn json_top_level_keys_are_keys() {
+    let src = "{\n  \"name\": \"x\",\n  \"server\": { \"port\": 8080 },\n  \"list\": [1, 2]\n}\n";
+    let symbols = extract_symbols(src, Extractor::Json);
+    let n = names(&symbols);
+    for k in ["name", "server", "list"] {
+        assert!(
+            n.iter().any(|x| x == k),
+            "top-level key {k:?} missing: {symbols:?}"
+        );
+    }
+    assert!(
+        !n.iter().any(|x| x == "port"),
+        "nested key `port` must not surface as a top-level key: {symbols:?}"
+    );
+    assert!(
+        symbols.iter().all(|s| s.kind == SymbolKind::Key),
+        "all json symbols are Key: {symbols:?}"
+    );
+}
+
+#[test]
+fn json_top_level_array_has_no_keys() {
+    let symbols = extract_symbols("[1, 2, 3]\n", Extractor::Json);
+    assert!(
+        symbols.is_empty(),
+        "top-level array yields no keys: {symbols:?}"
+    );
+}
+
+#[test]
+fn json_top_level_key_is_a_key_chunk_end_to_end() {
+    // The public chunk_code_chunks path (not just extract_symbols) must emit a
+    // Key-kinded chunk named after the top-level key.
+    let chunks = chunk_code_chunks("{\n  \"server\": { \"port\": 8080 }\n}\n", "json").unwrap();
+    assert!(
+        chunks
+            .iter()
+            .any(|c| c.symbol_name() == Some("server") && c.symbol_kind() == Some(SymbolKind::Key)),
+        "top-level key `server` must be a Key chunk: {:?}",
+        chunks
+            .iter()
+            .map(|c| (c.symbol_name(), c.symbol_kind()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn json_keyless_falls_back_to_nonempty_prose() {
+    // A top-level array or scalar yields no keys → must degrade to non-empty
+    // prose, never zero chunks (the chunk_code_chunks fallback contract).
+    for src in [
+        "[1, 2, 3, 4, 5]\n",
+        "\"just a top-level string value here\"\n",
+    ] {
+        let chunks = chunk_code_chunks(src, "json").unwrap();
+        assert!(
+            !chunks.is_empty(),
+            "keyless json must not be zero chunks: {src:?}"
+        );
+        assert!(
+            chunks.iter().all(|c| c.source == ChunkSource::Prose),
+            "keyless json must be prose: {src:?}"
+        );
+    }
+}

--- a/src/vector/ops/input/code/extract/toml.rs
+++ b/src/vector/ops/input/code/extract/toml.rs
@@ -1,0 +1,60 @@
+use tree_sitter::Node;
+
+use super::super::chunk::SymbolKind;
+use super::{DeclRole, DeclRule};
+
+/// TOML declaration rules. The natural chunk unit is a **table** (`[section]` /
+/// `[server.db]`) or an **array-of-tables element** (`[[items]]`): the whole
+/// block (header + its key-values) becomes one chunk named by the section path.
+/// Top-level key-value pairs that appear before any table are captured too. All
+/// are [`SymbolKind::Key`]. Headers are matched as direct children of the table /
+/// document node, so nested pair keys never match (they live inside their table's
+/// chunk, bounded by the oversized split).
+pub(super) static RULES: &[DeclRule] = &[
+    // Top-level key-value pairs (before the first table).
+    DeclRule {
+        pattern: "(document (pair (bare_key) @name) @decl)",
+        kind: SymbolKind::Key,
+        role: DeclRole::Leaf,
+    },
+    DeclRule {
+        pattern: "(document (pair (dotted_key) @name) @decl)",
+        kind: SymbolKind::Key,
+        role: DeclRole::Leaf,
+    },
+    // `[table]` / `[a.b.c]`.
+    DeclRule {
+        pattern: "(table (bare_key) @name) @decl",
+        kind: SymbolKind::Key,
+        role: DeclRole::Leaf,
+    },
+    DeclRule {
+        pattern: "(table (dotted_key) @name) @decl",
+        kind: SymbolKind::Key,
+        role: DeclRole::Leaf,
+    },
+    // `[[array_of_tables]]`.
+    DeclRule {
+        pattern: "(table_array_element (bare_key) @name) @decl",
+        kind: SymbolKind::Key,
+        role: DeclRole::Leaf,
+    },
+    DeclRule {
+        pattern: "(table_array_element (dotted_key) @name) @decl",
+        kind: SymbolKind::Key,
+        role: DeclRole::Leaf,
+    },
+];
+
+pub(super) fn refine(
+    _decl: Node<'_>,
+    raw_name: &str,
+    _content: &str,
+    kind: SymbolKind,
+) -> (SymbolKind, Option<String>) {
+    (kind, Some(raw_name.to_string()))
+}
+
+#[cfg(test)]
+#[path = "toml_tests.rs"]
+mod tests;

--- a/src/vector/ops/input/code/extract/toml_tests.rs
+++ b/src/vector/ops/input/code/extract/toml_tests.rs
@@ -1,0 +1,62 @@
+use super::super::super::chunk::SymbolKind;
+use super::super::super::chunk_code_chunks;
+use super::super::{Extractor, extract_symbols};
+
+fn names(symbols: &[super::super::SymbolInfo]) -> Vec<String> {
+    symbols.iter().filter_map(|s| s.name.clone()).collect()
+}
+
+#[test]
+fn toml_tables_and_top_level_pairs_are_keys() {
+    let src = "title = \"x\"\n\n[server]\nport = 8080\n\n[server.db]\nhost = \"h\"\n\n[[items]]\nid = 1\n";
+    let symbols = extract_symbols(src, Extractor::Toml);
+    let n = names(&symbols);
+    for k in ["title", "server", "server.db", "items"] {
+        assert!(n.iter().any(|x| x == k), "expected key {k:?}: {symbols:?}");
+    }
+    // Keys nested inside a table must not surface as their own top-level chunk.
+    assert!(
+        !n.iter().any(|x| x == "port" || x == "host"),
+        "table-internal keys must not surface: {symbols:?}"
+    );
+    assert!(
+        symbols.iter().all(|s| s.kind == SymbolKind::Key),
+        "all toml symbols are Key: {symbols:?}"
+    );
+}
+
+#[test]
+fn toml_top_level_dotted_pair_and_inline_table() {
+    // A top-level dotted-key pair (`a.b.c = 1`) is captured; an inline table's
+    // inner keys must NOT leak as top-level keys.
+    let src = "owner.name = \"x\"\nopts = { width = 80, height = 24 }\n";
+    let symbols = extract_symbols(src, Extractor::Toml);
+    let n = names(&symbols);
+    assert!(
+        n.iter().any(|x| x == "owner.name"),
+        "dotted top-level pair: {symbols:?}"
+    );
+    assert!(
+        n.iter().any(|x| x == "opts"),
+        "inline-table pair key: {symbols:?}"
+    );
+    assert!(
+        !n.iter().any(|x| x == "width" || x == "height"),
+        "inline-table inner keys must not leak: {symbols:?}"
+    );
+}
+
+#[test]
+fn toml_array_of_tables_is_a_key_chunk_end_to_end() {
+    let chunks = chunk_code_chunks("[[items]]\nid = 1\nname = \"a\"\n", "toml").unwrap();
+    assert!(
+        chunks
+            .iter()
+            .any(|c| c.symbol_name() == Some("items") && c.symbol_kind() == Some(SymbolKind::Key)),
+        "array-of-tables `items` must be a Key chunk: {:?}",
+        chunks
+            .iter()
+            .map(|c| (c.symbol_name(), c.symbol_kind()))
+            .collect::<Vec<_>>(),
+    );
+}

--- a/src/vector/ops/input/code/extract/yaml.rs
+++ b/src/vector/ops/input/code/extract/yaml.rs
@@ -1,0 +1,40 @@
+use tree_sitter::Node;
+
+use super::super::chunk::SymbolKind;
+use super::{DeclRole, DeclRule};
+
+/// YAML declaration rules: each **top-level** mapping key becomes a chunk named
+/// by the key (kind [`SymbolKind::Key`]). Anchored through `document → block_node
+/// → block_mapping` so only top-level keys match — a nested key lives inside its
+/// parent's chunk. Multi-document streams (`---`) match per document. A top-level
+/// sequence or scalar matches nothing → whole-file prose fallback.
+pub(super) static RULES: &[DeclRule] = &[DeclRule {
+    pattern: "(document (block_node (block_mapping (block_mapping_pair key: (flow_node) @name) @decl)))",
+    kind: SymbolKind::Key,
+    role: DeclRole::Leaf,
+}];
+
+pub(super) fn refine(
+    _decl: Node<'_>,
+    raw_name: &str,
+    _content: &str,
+    kind: SymbolKind,
+) -> (SymbolKind, Option<String>) {
+    // A quoted key (`"foo": 1` / `'foo': 1`) captures the surrounding quote
+    // tokens in the flow_node; strip them so the symbol name is the bare key.
+    let trimmed = raw_name.trim();
+    let unquoted = trimmed
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .or_else(|| {
+            trimmed
+                .strip_prefix('\'')
+                .and_then(|s| s.strip_suffix('\''))
+        })
+        .unwrap_or(trimmed);
+    (kind, Some(unquoted.to_string()))
+}
+
+#[cfg(test)]
+#[path = "yaml_tests.rs"]
+mod tests;

--- a/src/vector/ops/input/code/extract/yaml_tests.rs
+++ b/src/vector/ops/input/code/extract/yaml_tests.rs
@@ -1,0 +1,63 @@
+use super::super::super::chunk::{ChunkSource, SymbolKind};
+use super::super::super::chunk_code_chunks;
+use super::super::{Extractor, extract_symbols};
+
+fn names(symbols: &[super::super::SymbolInfo]) -> Vec<String> {
+    symbols.iter().filter_map(|s| s.name.clone()).collect()
+}
+
+#[test]
+fn yaml_top_level_keys_are_keys() {
+    let src = "name: x\nserver:\n  port: 8080\n  host: h\nlist:\n  - a\n  - b\n";
+    let symbols = extract_symbols(src, Extractor::Yaml);
+    let n = names(&symbols);
+    for k in ["name", "server", "list"] {
+        assert!(
+            n.iter().any(|x| x == k),
+            "top-level key {k:?} missing: {symbols:?}"
+        );
+    }
+    assert!(
+        !n.iter().any(|x| x == "port"),
+        "nested key `port` must not surface as top-level: {symbols:?}"
+    );
+    assert!(
+        symbols.iter().all(|s| s.kind == SymbolKind::Key),
+        "all yaml symbols are Key: {symbols:?}"
+    );
+}
+
+#[test]
+fn yaml_multi_document_stream_captures_each_doc() {
+    // `---`-separated documents: top-level keys in every document are captured.
+    let symbols = extract_symbols("a: 1\n---\nb: 2\n", Extractor::Yaml);
+    let n = names(&symbols);
+    assert!(
+        n.iter().any(|x| x == "a") && n.iter().any(|x| x == "b"),
+        "both docs: {symbols:?}"
+    );
+}
+
+#[test]
+fn yaml_quoted_key_is_unquoted() {
+    let symbols = extract_symbols("\"quoted key\": 1\nplain: 2\n", Extractor::Yaml);
+    let n = names(&symbols);
+    assert!(
+        n.iter().any(|x| x == "quoted key"),
+        "quotes stripped from key: {symbols:?}"
+    );
+    assert!(
+        !n.iter().any(|x| x.starts_with('"')),
+        "no key retains surrounding quotes: {symbols:?}"
+    );
+}
+
+#[test]
+fn yaml_top_level_sequence_falls_back_to_nonempty_prose() {
+    let chunks = chunk_code_chunks("- a\n- b\n- c\n", "yaml").unwrap();
+    assert!(
+        !chunks.is_empty(),
+        "keyless yaml sequence must not be zero chunks"
+    );
+    assert!(chunks.iter().all(|c| c.source == ChunkSource::Prose));
+}

--- a/src/vector/ops/input/code/extract_registry_tests.rs
+++ b/src/vector/ops/input/code/extract_registry_tests.rs
@@ -6,7 +6,7 @@ use super::*;
 /// proves the whole registry is well-formed.
 #[test]
 fn all_registry_queries_compile() {
-    let registries: [&Registry; 8] = [
+    let registries: [&Registry; 11] = [
         &RUST_REGISTRY,
         &GO_REGISTRY,
         &PYTHON_REGISTRY,
@@ -14,6 +14,9 @@ fn all_registry_queries_compile() {
         &TYPESCRIPT_REGISTRY,
         &TSX_REGISTRY,
         &BASH_REGISTRY,
+        &JSON_REGISTRY,
+        &YAML_REGISTRY,
+        &TOML_REGISTRY,
         // exercise the dispatch path too
         registry_for(Extractor::Rust).unwrap(),
     ];

--- a/src/vector/ops/input/code_tests.rs
+++ b/src/vector/ops/input/code_tests.rs
@@ -388,7 +388,7 @@ function App(): JSX.Element {
 fn symbol_kind_str_roundtrips_for_every_variant() {
     use SymbolKind::*;
     for kind in [
-        Function, Method, Struct, Enum, Trait, Impl, Const, Static, Type, Mod, Other,
+        Function, Method, Struct, Enum, Trait, Impl, Const, Static, Type, Mod, Key, Other,
     ] {
         assert_eq!(
             SymbolKind::from_str(kind.as_str()),
@@ -403,7 +403,7 @@ fn symbol_kind_str_roundtrips_for_every_variant() {
 }
 
 #[test]
-fn source_symbol_classification_excludes_mod_and_other() {
+fn source_symbol_classification_excludes_mod_key_and_other() {
     use SymbolKind::*;
     for kind in [
         Function, Method, Struct, Enum, Trait, Impl, Const, Static, Type,
@@ -413,7 +413,10 @@ fn source_symbol_classification_excludes_mod_and_other() {
             "{kind:?} should be a source symbol"
         );
     }
+    // Mod, Key (structured-data keys), and Other are deliberately NOT source
+    // symbols — config keys are common words and must not get the symbol boost.
     assert!(!Mod.is_source_symbol());
+    assert!(!Key.is_source_symbol());
     assert!(!Other.is_source_symbol());
 }
 

--- a/src/vector/ops/input/select.rs
+++ b/src/vector/ops/input/select.rs
@@ -50,10 +50,6 @@ const BINARY_EXTENSIONS: &[&str] = &[
     "db", "sqlite", "sqlite3",
 ];
 
-/// Extensions for which tree-sitter AST-aware chunking is available. Must stay
-/// in sync with `super::code::language_for_extension`.
-const CODE_EXTENSIONS: &[&str] = &["rs", "py", "js", "jsx", "ts", "tsx", "go", "sh", "bash"];
-
 /// Returns true if a directory with this name should be pruned (not descended
 /// into) during a recursive embed walk. Comparison is case-sensitive — these
 /// names are conventionally lowercase on every platform we target.
@@ -70,10 +66,13 @@ pub fn is_binary_ext(ext: &str) -> bool {
 
 /// Returns true if the file at `path` should chunk through tree-sitter
 /// (`code::chunk_code`) rather than the prose/markdown splitters. Matched on the
-/// path's extension, case-insensitively.
+/// path's extension, case-insensitively. Delegates to
+/// [`super::code::supports_tree_sitter_chunking`] — the single source of truth
+/// (`language_for_extension`) — so the routing predicate can never drift from the
+/// set of registered grammars.
 pub fn should_chunk_as_code(path: &str) -> bool {
     let ext = path_extension(path).to_ascii_lowercase();
-    CODE_EXTENSIONS.contains(&ext.as_str())
+    super::code::supports_tree_sitter_chunking(&ext)
 }
 
 /// Returns true when an embed input string is shaped like a filesystem path.

--- a/src/vector/ops/input/select_tests.rs
+++ b/src/vector/ops/input/select_tests.rs
@@ -43,6 +43,12 @@ fn detects_code_paths() {
         "app.tsx",
         "script.sh",
         "pkg/handler.go",
+        // Structured-data formats route through tree-sitter too (the routing
+        // predicate delegates to language_for_extension, so it stays in sync).
+        "package.json",
+        "compose.yaml",
+        "settings.YML",
+        "config.toml",
     ] {
         assert!(
             should_chunk_as_code(path),
@@ -57,7 +63,7 @@ fn non_code_paths_are_not_code() {
         "README.md",
         "notes.txt",
         "data.csv",
-        "config.toml",
+        "image.png",
         "Dockerfile",
         "Makefile",
     ] {


### PR DESCRIPTION
## Summary

Adds **JSON / YAML / TOML structured-data chunking** to the declaration-driven chunker. `.json`, `.yaml`/`.yml`, and `.toml` files now route through tree-sitter grammars instead of generic prose splitting.

> **Stacked on #219** (`claude/query-capture-chunker`). Base is that branch so this diff shows only the structured-data work; retarget to `main` after #219 merges.

## What

- Registers three tree-sitter grammars (`tree-sitter-json` 0.24, `tree-sitter-yaml` 0.7, `tree-sitter-toml-ng` 0.7, all ABI 14) into the existing query-capture registry.
- Adds `Extractor::{Json,Yaml,Toml}` + `language_for_extension` arms + a new `SymbolKind::Key` for structured-data keys.
- Rule files (`extract/{json,yaml,toml}.rs`) capture **top-level** keys: JSON/YAML object keys, TOML tables / array-of-tables / top-level pairs. Nested keys stay inside their parent's chunk; the shared residual-sweep / oversized-split / 2000-char cap apply automatically.
- **Routing fix:** `should_chunk_as_code` now delegates to `code::supports_tree_sitter_chunking` (i.e. `language_for_extension`) instead of a hardcoded extension list — so the embed routing can never drift from the registered grammar set. Without this, config files were chunked as markdown despite the grammars working.
- `Key` is excluded from `is_source_symbol` (config keys like `port`/`server` are common words that would over-rank config files for generic queries) but stays searchable as a chunk. YAML quoted keys are unquoted. Keyless files (top-level array/scalar/sequence) fall back to non-empty prose.

## Verification (empirical, real configs)

Indexed a config dir (Cargo.toml, package.json, openapi.json, GH workflow YAML, docker-compose, config.example.toml) with the built binary:

```
161 config chunks | content_type=text | code_language={json:102, yaml:31, toml:28}
code_chunk_source={tree_sitter:155, prose:6} | KEY chunks=155
sample keys: scrape, tei, chrome (TOML tables) · env (YAML) · components, paths (JSON)
```

## Tests

Per-language extract + `chunk_code_chunks` integration, nested-key suppression, multi-doc YAML (`---`), TOML dotted/inline/array-of-tables, keyless→prose fallback, `SymbolKind::Key` round-trip + classification, and routing (`should_chunk_as_code` for json/yaml/toml). Reviewed (code-reviewer validated query design across edge cases — anchors, deep nesting, empty files; pr-test-analyzer gaps addressed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds JSON/YAML/TOML structured-data chunking via tree-sitter so config files are indexed by top-level keys/tables. Also fixes routing so these formats use the code chunker instead of markdown.

- **New Features**
  - Registered `tree-sitter-json`, `tree-sitter-yaml`, and `tree-sitter-toml-ng` with new extractors (`Json`, `Yaml`, `Toml`) and `language_for_extension` mapping.
  - Capture top-level keys/tables as `SymbolKind::Key`; nested keys stay within their parent chunk; keyless files fall back to prose; YAML quoted keys are unquoted.
  - `SymbolKind::Key` is searchable but excluded from the source-symbol boost.

- **Bug Fixes**
  - `should_chunk_as_code` now delegates to `supports_tree_sitter_chunking` (single source of truth) so `.json`, `.yaml`/`.yml`, and `.toml` reliably route through the code chunker.

<sup>Written for commit a75aa4bf116e8fa1d13d614abe5522fdf20017cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

