### PR TITLE
fix(palette): resync Aurora Input warning behavior

### DIFF
--- a/apps/palette-tauri/src/components/ui/aurora/input.tsx
+++ b/apps/palette-tauri/src/components/ui/aurora/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { X } from "lucide-react"
-import { cn } from "@/lib/utils"
+import { cn, devWarn } from "@/lib/utils"
 
 export type InputState = "error" | "warn" | "success"
 export type InputSize = "sm" | "default" | "lg"
@@ -119,6 +119,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     // Hold a real ref to the underlying <input> so the clear button can drive the
     // actual DOM element (native value setter + dispatched "input" event) instead
     // of fabricating a detached element. Merge it with any forwarded ref.
+    //
+    // NOTE: All hooks are declared unconditionally at the top of the component,
+    // before the `unstyled` early return. The bare input also reuses `setRefs`, so
+    // the forwarded ref resolves to the real DOM element in both modes.
     const inputRef = React.useRef<HTMLInputElement | null>(null)
     const setRefs = React.useCallback(
       (node: HTMLInputElement | null) => {
@@ -144,14 +148,27 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     )
 
     // Escape hatch: bare <input>, consumer CSS owns 100% of appearance. No wrapper,
-    // no inline skin, no imperative focus handlers, no adornment/clear logic. Declared
-    // after the hooks above so the rules-of-hooks invariant holds on every render
-    // (the styled path's ref-merge/clear state is simply unused here; `ref` forwards
-    // directly).
+    // no inline skin, no imperative focus handlers, no adornment/clear logic. Skin
+    // props are ignored in this mode, so warn if any were passed.
     if (unstyled) {
+      const ignoredSkinProps = [
+        clearable && "clearable",
+        onClear && "onClear",
+        startAdornment !== undefined && "startAdornment",
+        endAdornment !== undefined && "endAdornment",
+        stateProp !== undefined && "state",
+        error !== undefined && "error",
+        size !== "default" && "size",
+      ].filter(Boolean)
+      if (ignoredSkinProps.length > 0) {
+        devWarn(
+          `[Aurora Input] \`unstyled\` is set, so skin props are ignored: ${ignoredSkinProps.join(", ")}. ` +
+            "Remove them or drop `unstyled` to use the styled variant."
+        )
+      }
       return (
         <input
-          ref={ref}
+          ref={setRefs}
           type={type}
           className={className}
           style={style}
@@ -197,14 +214,26 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             // This keeps form-library consumers (react-hook-form, Formik, etc.)
             // working, unlike fabricating a detached element as event.target.
             const el = inputRef.current
-            if (el) {
-              const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-                window.HTMLInputElement.prototype,
-                "value"
-              )?.set
-              nativeInputValueSetter?.call(el, "")
+            const nativeInputValueSetter = el
+              ? Object.getOwnPropertyDescriptor(
+                  window.HTMLInputElement.prototype,
+                  "value"
+                )?.set
+              : undefined
+            if (el && nativeInputValueSetter) {
+              nativeInputValueSetter.call(el, "")
               el.dispatchEvent(new Event("input", { bubbles: true }))
+            } else {
+              devWarn(
+                "[Aurora Input] Could not resolve the native value setter; clear did not " +
+                  "dispatch an input event. The onChange handler was not notified."
+              )
             }
+          } else if (isControlled) {
+            devWarn(
+              "[Aurora Input] `clearable` clear button on a controlled input has no effect " +
+                "without `onClear` or `onChange`. Provide one to handle the clear."
+            )
           }
           // Always update internal state for uncontrolled
           if (!isControlled) {


### PR DESCRIPTION
## Summary
- resync Axon's Aurora Input primitive with the merged Aurora #22 warning/ref behavior
- keep unstyled inputs wired through the merged ref callback
- warn when unstyled mode silently ignores skin props or when clearable cannot notify consumers

## Context
While searching the interrupted Aurora split-brain session, the original three PRs (#227, #228, #229) were confirmed merged and green, and Android drift coverage was handled separately in #230. This patch covers the one remaining scratch/worktree delta that matches Aurora #22's merged registry behavior but was not present in Axon's copy.

## Verification
- pnpm --dir apps/palette-tauri typecheck
- pnpm --dir apps/palette-tauri test -- --run
- pnpm --dir apps/palette-tauri lint (passes with existing 20-warning baseline + Biome config infos)
- git push pre-push gate: version sync, web build, clippy, 3152 tests passed / 6 skipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resyncs Aurora Input with Aurora #22 by merging the forwarded ref in both modes and adding dev-time warnings for ignored skin props and ineffective clear actions.

- **Bug Fixes**
  - Forwarded `ref` now resolves to the real input in both styled and unstyled via merged `setRefs`.
  - Warn when `unstyled` is set but skin props are passed (`clearable`, `onClear`, adornments, `state`, `error`, `size`).
  - Warn when `clearable` can't notify consumers (missing native value setter) or on controlled inputs without `onClear`/`onChange` using `devWarn`.

<sup>Written for commit 2c50a876a0458badb963be56c545a72cadbd91da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Input component's clear button handling with improved error detection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->