### PR TITLE
Route CI by changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,26 @@ jobs:
           set -euo pipefail
           classifier="scripts/ci/changed_paths.py"
           trusted="/tmp/axon-changed-paths.py"
-          if [[ "${{ github.event_name }}" != "pull_request" ]] \
-            || ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+              cat > "$trusted" <<'PY'
+          #!/usr/bin/env python3
+          import argparse
+          from pathlib import Path
+          keys = "all docs workflow rust web android palette chrome docker compose mcp security release openapi codeql_actions codeql_javascript_typescript codeql_python codeql_rust codeql_java_kotlin".split()
+          parser = argparse.ArgumentParser()
+          parser.add_argument("--event", required=True)
+          parser.add_argument("--output", type=Path, required=True)
+          parser.add_argument("--write-changed-files", type=Path)
+          args, _ = parser.parse_known_args()
+          if args.write_changed_files:
+              args.write_changed_files.write_text("")
+          args.output.write_text("".join(f"{key}=true\n" for key in keys))
+          for key in keys:
+              print(f"{key}=true")
+          PY
+            fi
+          else
             cp "$classifier" "$trusted"
           fi
           chmod +x "$trusted"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,11 @@ jobs:
           set -euo pipefail
           classifier="scripts/ci/changed_paths.py"
           trusted="/tmp/axon-changed-paths.py"
-          if [[ "${{ github.event_name }}" == "pull_request" ]] \
-            && git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
-            chmod +x "$trusted"
-          else
+          if [[ "${{ github.event_name }}" != "pull_request" ]] \
+            || ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
             cp "$classifier" "$trusted"
-            chmod +x "$trusted"
           fi
+          chmod +x "$trusted"
           echo "AXON_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
       - name: Classify changed paths
         id: classify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,7 @@ jobs:
   windows-check:
     name: windows-check (xtask only)
     runs-on: windows-latest
+    timeout-minutes: 25
     needs: [changes]
     if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
@@ -522,8 +523,6 @@ jobs:
         run: cargo check -p xtask --locked
       - name: cargo test -p xtask
         run: cargo test -p xtask --locked
-      - name: cargo xtask check-no-mod-rs
-        run: cargo xtask check-no-mod-rs
       - name: cargo xtask check-mcp-http
         run: cargo xtask check-mcp-http
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,66 @@ env:
   AURORA_REF: ${{ vars.AURORA_REF || '8748eb6434b3bbe4c75f25bfff71950b7efc051b' }}
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      all: ${{ steps.classify.outputs.all }}
+      docs: ${{ steps.classify.outputs.docs }}
+      workflow: ${{ steps.classify.outputs.workflow }}
+      rust: ${{ steps.classify.outputs.rust }}
+      web: ${{ steps.classify.outputs.web }}
+      android: ${{ steps.classify.outputs.android }}
+      palette: ${{ steps.classify.outputs.palette }}
+      chrome: ${{ steps.classify.outputs.chrome }}
+      docker: ${{ steps.classify.outputs.docker }}
+      compose: ${{ steps.classify.outputs.compose }}
+      mcp: ${{ steps.classify.outputs.mcp }}
+      security: ${{ steps.classify.outputs.security }}
+      release: ${{ steps.classify.outputs.release }}
+      openapi: ${{ steps.classify.outputs.openapi }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Resolve changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            base="$PUSH_BEFORE_SHA"
+            head="$HEAD_SHA"
+          else
+            : > changed-files.txt
+            exit 0
+          fi
+          if [[ -z "${base:-}" || "$base" =~ ^0+$ ]] || ! git cat-file -e "$base" 2>/dev/null; then
+            base="$(git rev-parse HEAD^ 2>/dev/null || true)"
+          fi
+          if [[ -z "${base:-}" ]]; then
+            echo "Could not resolve base; leaving changed-files.txt empty so classifier runs fail-safe."
+            : > changed-files.txt
+          else
+            git diff --name-only "$base" "$head" > changed-files.txt
+          fi
+          cat changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+
   mcp-transport-modes:
     name: mcp-transport-modes
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -70,6 +127,8 @@ jobs:
   version-sync:
     name: version-sync
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.release == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.chrome == 'true' || needs.changes.outputs.docs == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -107,6 +166,8 @@ jobs:
   aurora-primitive-inventory:
     name: aurora-primitive-inventory
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.docs == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -121,6 +182,8 @@ jobs:
   android:
     name: android
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.android == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -192,6 +255,8 @@ jobs:
   android-openapi-client:
     name: android-openapi-client
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.android == 'true' || needs.changes.outputs.openapi == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -229,6 +294,8 @@ jobs:
   no-mod-rs:
     name: no-mod-rs
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -265,6 +332,8 @@ jobs:
   toml-fmt:
     name: toml-fmt
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true' || needs.changes.outputs.release == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -312,6 +381,8 @@ jobs:
   lefthook-pre-commit-speed:
     name: lefthook pre-commit speed guard
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.workflow == 'true' || needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - name: enforce pre-commit stays fast
@@ -320,6 +391,8 @@ jobs:
   palette-tauri:
     name: palette-tauri
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.palette == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -403,6 +476,8 @@ jobs:
   windows-check:
     name: windows-check (xtask only)
     runs-on: windows-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -464,6 +539,8 @@ jobs:
     # src/core/paths_tests.rs and was confirmed passing on Windows 11 against
     # this cross-compiled binary.
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true' }}
     env:
       CC_x86_64_pc_windows_gnu: x86_64-w64-mingw32-gcc
       CXX_x86_64_pc_windows_gnu: x86_64-w64-mingw32-g++
@@ -523,6 +600,8 @@ jobs:
   shell-completions-smoke:
     name: shell-completions-smoke
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -557,6 +636,8 @@ jobs:
   web-panel:
     name: web-panel
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.web == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -577,6 +658,8 @@ jobs:
   mcp-schema-doc-sync:
     name: mcp-schema-doc-sync
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.mcp == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - name: Restore schema doc for drift comparison
@@ -587,6 +670,8 @@ jobs:
   rest-api-parity:
     name: rest-api-parity
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.openapi == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -641,6 +726,8 @@ jobs:
   mcp-oauth-smoke:
     name: mcp-oauth-smoke
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true' }}
     env:
       # TEI_URL must be set to pass startup validation even though TEI is not
       # actually running — this test exercises only the auth layer (/mcp 401).
@@ -678,6 +765,8 @@ jobs:
   advisory-lock-policy:
     name: advisory-lock-policy
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -720,6 +809,8 @@ jobs:
   ban-skip-validation:
     name: ban-skip-validation
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -751,6 +842,8 @@ jobs:
   monolith:
     name: monolith
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -814,6 +907,8 @@ jobs:
   fmt:
     name: fmt
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -841,6 +936,8 @@ jobs:
   check:
     name: check
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -879,6 +976,8 @@ jobs:
   msrv:
     name: msrv
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -918,6 +1017,8 @@ jobs:
   clippy:
     name: clippy
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -955,6 +1056,8 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     env:
       # Match the 8 MiB runtime thread stack from main.rs — deep scrape/extract
       # async chains overflow the 2 MiB rustc-test-harness default
@@ -1207,6 +1310,8 @@ jobs:
   security:
     name: security
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.security == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -1247,7 +1352,8 @@ jobs:
   mcp-smoke:
     name: mcp-smoke
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [changes, release]
+    if: ${{ needs.release.result == 'success' && (needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rust == 'true') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v5
@@ -1426,6 +1532,8 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.release == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -1453,7 +1561,8 @@ jobs:
   release-smoke:
     name: release-smoke
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [changes, release]
+    if: ${{ needs.release.result == 'success' }}
     steps:
       - uses: actions/download-artifact@v5
         with:
@@ -1464,38 +1573,78 @@ jobs:
           chmod +x ./target/release/axon
           ./target/release/axon --help
 
-  production-gate:
-    name: production-gate
+  ci-gate:
+    name: ci-gate
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - monolith
-      - no-mod-rs
+      - changes
+      - mcp-transport-modes
       - version-sync
       - aurora-primitive-inventory
+      - android
+      - android-openapi-client
+      - no-mod-rs
+      - toml-fmt
+      - lefthook-pre-commit-speed
+      - palette-tauri
+      - windows-check
+      - windows-build
+      - shell-completions-smoke
+      - web-panel
+      - mcp-schema-doc-sync
+      - rest-api-parity
+      - mcp-oauth-smoke
+      - advisory-lock-policy
+      - ban-skip-validation
+      - monolith
       - fmt
       - check
+      - msrv
       - clippy
       - test
-      - web-panel
-      - android
-      - palette-tauri
       - security
+      - mcp-smoke
       - release
       - release-smoke
     steps:
-      - name: verify all required jobs passed
+      - name: verify required jobs passed or were intentionally skipped
         run: |
-          test "${{ needs.monolith.result }}" = "success"
-          test "${{ needs.no-mod-rs.result }}" = "success"
-          test "${{ needs.version-sync.result }}" = "success"
-          test "${{ needs.aurora-primitive-inventory.result }}" = "success"
-          test "${{ needs.fmt.result }}" = "success"
-          test "${{ needs.check.result }}" = "success"
-          test "${{ needs.clippy.result }}" = "success"
-          test "${{ needs.test.result }}" = "success"
-          test "${{ needs.web-panel.result }}" = "success"
-          test "${{ needs.palette-tauri.result }}" = "success"
-          test "${{ needs.security.result }}" = "success"
-          test "${{ needs.release.result }}" = "success"
-          test "${{ needs.release-smoke.result }}" = "success"
+          set -euo pipefail
+          require_success_or_skipped() {
+            local name="$1"
+            local result="$2"
+            case "$result" in
+              success|skipped) printf '%s=%s\n' "$name" "$result" ;;
+              *) echo "::error::$name concluded $result" >&2; exit 1 ;;
+            esac
+          }
+          require_success_or_skipped changes "${{ needs.changes.result }}"
+          require_success_or_skipped mcp-transport-modes "${{ needs.mcp-transport-modes.result }}"
+          require_success_or_skipped version-sync "${{ needs.version-sync.result }}"
+          require_success_or_skipped aurora-primitive-inventory "${{ needs.aurora-primitive-inventory.result }}"
+          require_success_or_skipped android "${{ needs.android.result }}"
+          require_success_or_skipped android-openapi-client "${{ needs.android-openapi-client.result }}"
+          require_success_or_skipped no-mod-rs "${{ needs.no-mod-rs.result }}"
+          require_success_or_skipped toml-fmt "${{ needs.toml-fmt.result }}"
+          require_success_or_skipped lefthook-pre-commit-speed "${{ needs.lefthook-pre-commit-speed.result }}"
+          require_success_or_skipped palette-tauri "${{ needs.palette-tauri.result }}"
+          require_success_or_skipped windows-check "${{ needs.windows-check.result }}"
+          require_success_or_skipped windows-build "${{ needs.windows-build.result }}"
+          require_success_or_skipped shell-completions-smoke "${{ needs.shell-completions-smoke.result }}"
+          require_success_or_skipped web-panel "${{ needs.web-panel.result }}"
+          require_success_or_skipped mcp-schema-doc-sync "${{ needs.mcp-schema-doc-sync.result }}"
+          require_success_or_skipped rest-api-parity "${{ needs.rest-api-parity.result }}"
+          require_success_or_skipped mcp-oauth-smoke "${{ needs.mcp-oauth-smoke.result }}"
+          require_success_or_skipped advisory-lock-policy "${{ needs.advisory-lock-policy.result }}"
+          require_success_or_skipped ban-skip-validation "${{ needs.ban-skip-validation.result }}"
+          require_success_or_skipped monolith "${{ needs.monolith.result }}"
+          require_success_or_skipped fmt "${{ needs.fmt.result }}"
+          require_success_or_skipped check "${{ needs.check.result }}"
+          require_success_or_skipped msrv "${{ needs.msrv.result }}"
+          require_success_or_skipped clippy "${{ needs.clippy.result }}"
+          require_success_or_skipped test "${{ needs.test.result }}"
+          require_success_or_skipped security "${{ needs.security.result }}"
+          require_success_or_skipped mcp-smoke "${{ needs.mcp-smoke.result }}"
+          require_success_or_skipped release "${{ needs.release.result }}"
+          require_success_or_skipped release-smoke "${{ needs.release-smoke.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,38 +52,28 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Resolve changed files
+      - name: Prepare trusted changed path classifier
+        run: |
+          set -euo pipefail
+          classifier="scripts/ci/changed_paths.py"
+          trusted="/tmp/axon-changed-paths.py"
+          if [[ "${{ github.event_name }}" == "pull_request" ]] \
+            && git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+            chmod +x "$trusted"
+          else
+            cp "$classifier" "$trusted"
+            chmod +x "$trusted"
+          fi
+          echo "AXON_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
+      - name: Classify changed paths
+        id: classify
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            base="$PR_BASE_SHA"
-            head="$PR_HEAD_SHA"
-          elif [[ "$EVENT_NAME" == "push" ]]; then
-            base="$PUSH_BEFORE_SHA"
-            head="$HEAD_SHA"
-          else
-            : > changed-files.txt
-            exit 0
-          fi
-          if [[ -z "${base:-}" || "$base" =~ ^0+$ ]] || ! git cat-file -e "$base" 2>/dev/null; then
-            base="$(git rev-parse HEAD^ 2>/dev/null || true)"
-          fi
-          if [[ -z "${base:-}" ]]; then
-            echo "Could not resolve base; leaving changed-files.txt empty so classifier runs fail-safe."
-            : > changed-files.txt
-          else
-            git diff --name-only "$base" "$head" > changed-files.txt
-          fi
-          cat changed-files.txt
-      - name: Classify changed paths
-        id: classify
-        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+        run: python3 "$AXON_CHANGED_PATHS" --event "$EVENT_NAME" --output "$GITHUB_OUTPUT" --write-changed-files changed-files.txt
 
   mcp-transport-modes:
     name: mcp-transport-modes
@@ -1605,6 +1595,8 @@ jobs:
       - test
       - security
       - mcp-smoke
+      - rag-changes
+      - live-rag-pr
       - release
       - release-smoke
     steps:
@@ -1646,5 +1638,7 @@ jobs:
           require_success_or_skipped test "${{ needs.test.result }}"
           require_success_or_skipped security "${{ needs.security.result }}"
           require_success_or_skipped mcp-smoke "${{ needs.mcp-smoke.result }}"
+          require_success_or_skipped rag-changes "${{ needs.rag-changes.result }}"
+          require_success_or_skipped live-rag-pr "${{ needs.live-rag-pr.result }}"
           require_success_or_skipped release "${{ needs.release.result }}"
           require_success_or_skipped release-smoke "${{ needs.release-smoke.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,11 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
+        with:
+          # The Gradle build uses the hosted runner SDK; installing the legacy
+          # `tools` package pulls the emulator and has failed on corrupt
+          # downloads before tests even start.
+          packages: ""
 
       - name: Run Android unit tests, lint, and APK builds
         run: >

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,26 +17,72 @@ env:
   AURORA_REF: ${{ vars.AURORA_REF || '8748eb6434b3bbe4c75f25bfff71950b7efc051b' }}
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Resolve changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" > changed-files.txt
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            git diff --name-only "$PUSH_BEFORE_SHA" "$HEAD_SHA" > changed-files.txt
+          else
+            : > changed-files.txt
+          fi
+          cat changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output changed-paths.out
+      - name: Build CodeQL matrix
+        id: matrix
+        run: |
+          set -euo pipefail
+          source changed-paths.out
+          jq -nc \
+            --arg actions "$codeql_actions" \
+            --arg js "$codeql_javascript_typescript" \
+            --arg py "$codeql_python" \
+            --arg rust "$codeql_rust" \
+            --arg kotlin "$codeql_java_kotlin" \
+            '{
+              include:
+                ([]
+                + (if $actions == "true" then [{language:"actions", build_mode:"none"}] else [] end)
+                + (if $js == "true" then [{language:"javascript-typescript", build_mode:"none"}] else [] end)
+                + (if $py == "true" then [{language:"python", build_mode:"none"}] else [] end)
+                + (if $rust == "true" then [{language:"rust", build_mode:"none"}] else [] end)
+                + (if $kotlin == "true" then [{language:"java-kotlin", build_mode:"manual"}] else [] end))
+            }' > matrix.json
+          if [[ "$(jq '.include | length' matrix.json)" == "0" ]]; then
+            jq -nc '{include: [{language:"actions", build_mode:"none"}]}' > matrix.json
+          fi
+          echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
+          cat matrix.json
+
   analyze:
     name: analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    needs: [changes]
     permissions:
       security-events: write
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: javascript-typescript
-            build-mode: none
-          - language: python
-            build-mode: none
-          - language: rust
-            build-mode: none
-          - language: java-kotlin
-            build-mode: manual
+      matrix: ${{ fromJson(needs.changes.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v5
@@ -95,7 +141,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          build-mode: ${{ matrix.build_mode }}
           dependency-caching: true
 
       - name: Build Android app for Java/Kotlin analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,8 +32,26 @@ jobs:
           set -euo pipefail
           classifier="scripts/ci/changed_paths.py"
           trusted="/tmp/axon-changed-paths.py"
-          if [[ "${{ github.event_name }}" != "pull_request" ]] \
-            || ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+              cat > "$trusted" <<'PY'
+          #!/usr/bin/env python3
+          import argparse
+          from pathlib import Path
+          keys = "all docs workflow rust web android palette chrome docker compose mcp security release openapi codeql_actions codeql_javascript_typescript codeql_python codeql_rust codeql_java_kotlin".split()
+          parser = argparse.ArgumentParser()
+          parser.add_argument("--event", required=True)
+          parser.add_argument("--output", type=Path, required=True)
+          parser.add_argument("--write-changed-files", type=Path)
+          args, _ = parser.parse_known_args()
+          if args.write_changed_files:
+              args.write_changed_files.write_text("")
+          args.output.write_text("".join(f"{key}=true\n" for key in keys))
+          for key in keys:
+              print(f"{key}=true")
+          PY
+            fi
+          else
             cp "$classifier" "$trusted"
           fi
           chmod +x "$trusted"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,37 +27,44 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Resolve changed files
+      - name: Prepare trusted changed path classifier
+        run: |
+          set -euo pipefail
+          classifier="scripts/ci/changed_paths.py"
+          trusted="/tmp/axon-changed-paths.py"
+          if [[ "${{ github.event_name }}" == "pull_request" ]] \
+            && git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+            chmod +x "$trusted"
+          else
+            cp "$classifier" "$trusted"
+            chmod +x "$trusted"
+          fi
+          echo "AXON_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
+      - name: Classify changed paths
+        id: classify
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" > changed-files.txt
-          elif [[ "$EVENT_NAME" == "push" ]]; then
-            git diff --name-only "$PUSH_BEFORE_SHA" "$HEAD_SHA" > changed-files.txt
-          else
-            : > changed-files.txt
-          fi
-          cat changed-files.txt
-      - name: Classify changed paths
-        id: classify
-        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output changed-paths.out
+        run: python3 "$AXON_CHANGED_PATHS" --event "$EVENT_NAME" --output "$GITHUB_OUTPUT" --write-changed-files changed-files.txt
       - name: Build CodeQL matrix
         id: matrix
+        env:
+          CODEQL_ACTIONS: ${{ steps.classify.outputs.codeql_actions }}
+          CODEQL_JAVASCRIPT_TYPESCRIPT: ${{ steps.classify.outputs.codeql_javascript_typescript }}
+          CODEQL_PYTHON: ${{ steps.classify.outputs.codeql_python }}
+          CODEQL_RUST: ${{ steps.classify.outputs.codeql_rust }}
+          CODEQL_JAVA_KOTLIN: ${{ steps.classify.outputs.codeql_java_kotlin }}
         run: |
           set -euo pipefail
-          source changed-paths.out
           jq -nc \
-            --arg actions "$codeql_actions" \
-            --arg js "$codeql_javascript_typescript" \
-            --arg py "$codeql_python" \
-            --arg rust "$codeql_rust" \
-            --arg kotlin "$codeql_java_kotlin" \
+            --arg actions "$CODEQL_ACTIONS" \
+            --arg js "$CODEQL_JAVASCRIPT_TYPESCRIPT" \
+            --arg py "$CODEQL_PYTHON" \
+            --arg rust "$CODEQL_RUST" \
+            --arg kotlin "$CODEQL_JAVA_KOTLIN" \
             '{
               include:
                 ([]
@@ -152,3 +159,25 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+
+  codeql-gate:
+    name: codeql-gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - analyze
+    steps:
+      - name: verify CodeQL jobs passed or were intentionally skipped
+        run: |
+          set -euo pipefail
+          require_success_or_skipped() {
+            local name="$1"
+            local result="$2"
+            case "$result" in
+              success|skipped) printf '%s=%s\n' "$name" "$result" ;;
+              *) echo "::error::$name concluded $result" >&2; exit 1 ;;
+            esac
+          }
+          require_success_or_skipped changes "${{ needs.changes.result }}"
+          require_success_or_skipped analyze "${{ needs.analyze.result }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,11 @@ jobs:
           set -euo pipefail
           classifier="scripts/ci/changed_paths.py"
           trusted="/tmp/axon-changed-paths.py"
-          if [[ "${{ github.event_name }}" == "pull_request" ]] \
-            && git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
-            chmod +x "$trusted"
-          else
+          if [[ "${{ github.event_name }}" != "pull_request" ]] \
+            || ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
             cp "$classifier" "$trusted"
-            chmod +x "$trusted"
           fi
+          chmod +x "$trusted"
           echo "AXON_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
       - name: Classify changed paths
         id: classify

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -6,9 +6,39 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      compose: ${{ steps.classify.outputs.compose }}
+      docker: ${{ steps.classify.outputs.docker }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+      - name: Resolve changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" > changed-files.txt
+          else
+            : > changed-files.txt
+          fi
+          cat changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+
   compose-config:
     name: compose-config
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.compose == 'true' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -44,6 +74,8 @@ jobs:
   image-build-smoke:
     name: image-build-smoke
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.docker == 'true' }}
     steps:
       # Full checkout: Dockerfile runs cargo build inside the container,
       # so the entire source tree must be in the Docker build context.

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -16,23 +16,27 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - name: Resolve changed files
+      - name: Prepare trusted changed path classifier
+        run: |
+          set -euo pipefail
+          classifier="scripts/ci/changed_paths.py"
+          trusted="/tmp/axon-changed-paths.py"
+          if [[ "${{ github.event_name }}" == "pull_request" ]] \
+            && git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+            chmod +x "$trusted"
+          else
+            cp "$classifier" "$trusted"
+            chmod +x "$trusted"
+          fi
+          echo "AXON_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
+      - name: Classify changed paths
+        id: classify
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" > changed-files.txt
-          else
-            : > changed-files.txt
-          fi
-          cat changed-files.txt
-      - name: Classify changed paths
-        id: classify
-        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+        run: python3 "$AXON_CHANGED_PATHS" --event "$EVENT_NAME" --output "$GITHUB_OUTPUT" --write-changed-files changed-files.txt
 
   compose-config:
     name: compose-config
@@ -91,3 +95,27 @@ jobs:
           tags: axon:smoke
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  compose-smoke-gate:
+    name: compose-smoke-gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - compose-config
+      - image-build-smoke
+    steps:
+      - name: verify compose smoke jobs passed or were intentionally skipped
+        run: |
+          set -euo pipefail
+          require_success_or_skipped() {
+            local name="$1"
+            local result="$2"
+            case "$result" in
+              success|skipped) printf '%s=%s\n' "$name" "$result" ;;
+              *) echo "::error::$name concluded $result" >&2; exit 1 ;;
+            esac
+          }
+          require_success_or_skipped changes "${{ needs.changes.result }}"
+          require_success_or_skipped compose-config "${{ needs.compose-config.result }}"
+          require_success_or_skipped image-build-smoke "${{ needs.image-build-smoke.result }}"

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -24,8 +24,26 @@ jobs:
           set -euo pipefail
           classifier="scripts/ci/changed_paths.py"
           trusted="/tmp/axon-changed-paths.py"
-          if [[ "${{ github.event_name }}" != "pull_request" ]] \
-            || ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+              cat > "$trusted" <<'PY'
+          #!/usr/bin/env python3
+          import argparse
+          from pathlib import Path
+          keys = "all docs workflow rust web android palette chrome docker compose mcp security release openapi codeql_actions codeql_javascript_typescript codeql_python codeql_rust codeql_java_kotlin".split()
+          parser = argparse.ArgumentParser()
+          parser.add_argument("--event", required=True)
+          parser.add_argument("--output", type=Path, required=True)
+          parser.add_argument("--write-changed-files", type=Path)
+          args, _ = parser.parse_known_args()
+          if args.write_changed_files:
+              args.write_changed_files.write_text("")
+          args.output.write_text("".join(f"{key}=true\n" for key in keys))
+          for key in keys:
+              print(f"{key}=true")
+          PY
+            fi
+          else
             cp "$classifier" "$trusted"
           fi
           chmod +x "$trusted"
@@ -117,6 +135,17 @@ jobs:
               *) echo "::error::$name concluded $result" >&2; exit 1 ;;
             esac
           }
+          require_success_or_intentional_skip() {
+            local name="$1"
+            local result="$2"
+            local should_run="$3"
+            case "$result:$should_run" in
+              success:*) printf '%s=%s\n' "$name" "$result" ;;
+              skipped:false) printf '%s=%s\n' "$name" "$result" ;;
+              skipped:true) echo "::error::$name was skipped even though its path category is true" >&2; exit 1 ;;
+              *) echo "::error::$name concluded $result" >&2; exit 1 ;;
+            esac
+          }
           require_success_or_skipped changes "${{ needs.changes.result }}"
-          require_success_or_skipped compose-config "${{ needs.compose-config.result }}"
-          require_success_or_skipped image-build-smoke "${{ needs.image-build-smoke.result }}"
+          require_success_or_intentional_skip compose-config "${{ needs.compose-config.result }}" "${{ needs.changes.outputs.compose }}"
+          require_success_or_intentional_skip image-build-smoke "${{ needs.image-build-smoke.result }}" "${{ needs.changes.outputs.docker }}"

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -21,13 +21,11 @@ jobs:
           set -euo pipefail
           classifier="scripts/ci/changed_paths.py"
           trusted="/tmp/axon-changed-paths.py"
-          if [[ "${{ github.event_name }}" == "pull_request" ]] \
-            && git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
-            chmod +x "$trusted"
-          else
+          if [[ "${{ github.event_name }}" != "pull_request" ]] \
+            || ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
             cp "$classifier" "$trusted"
-            chmod +x "$trusted"
           fi
+          chmod +x "$trusted"
           echo "AXON_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
       - name: Classify changed paths
         id: classify

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: changes

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,22 +20,21 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Resolve changed files
+      - name: Prepare trusted changed path classifier
+        run: |
+          set -euo pipefail
+          classifier="scripts/ci/changed_paths.py"
+          trusted="/tmp/axon-changed-paths.py"
+          cp "$classifier" "$trusted"
+          chmod +x "$trusted"
+          echo "AXON_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
+      - name: Classify changed paths
+        id: classify
         env:
           EVENT_NAME: ${{ github.event_name }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if [[ "$EVENT_NAME" == "push" && "${GITHUB_REF}" != refs/tags/v* ]]; then
-            git diff --name-only "$PUSH_BEFORE_SHA" "$HEAD_SHA" > changed-files.txt
-          else
-            : > changed-files.txt
-          fi
-          cat changed-files.txt
-      - name: Classify changed paths
-        id: classify
-        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+        run: python3 "$AXON_CHANGED_PATHS" --event "$EVENT_NAME" --output "$GITHUB_OUTPUT" --write-changed-files changed-files.txt
 
   build:
     name: build-and-push

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,9 +11,37 @@ permissions:
   packages: write
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.classify.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Resolve changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "push" && "${GITHUB_REF}" != refs/tags/v* ]]; then
+            git diff --name-only "$PUSH_BEFORE_SHA" "$HEAD_SHA" > changed-files.txt
+          else
+            : > changed-files.txt
+          fi
+          cat changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+
   build:
     name: build-and-push
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || needs.changes.outputs.docker == 'true' }}
     steps:
       - uses: actions/checkout@v5
 

--- a/docs/superpowers/plans/2026-06-19-ci-path-gating.md
+++ b/docs/superpowers/plans/2026-06-19-ci-path-gating.md
@@ -4,9 +4,11 @@
 
 **Goal:** Make Axon's CI run the checks that match the files changed, while keeping scheduled/manual runs broad and preserving a single branch-protection-friendly gate.
 
-**Execution status:** Tasks 1-4 implemented and locally verified on `codex/ci-path-gating`. Task 5 branch-protection mutation is intentionally pending coordinator follow-up after the branch is pushed and a completed `ci-gate` check context exists.
+**Origin:** Jacob explicitly asked for the `superpowers:writing-plans` and `work-it` workflow for this PR.
 
-**Architecture:** Add one tested path-classifier script that maps changed files into CI categories, then consume those outputs from GitHub Actions jobs. Keep one always-running aggregate gate (`ci-gate`) so branch protection can require a stable check even when expensive jobs are intentionally skipped. Apply the same path-gating model to `CI`, `CodeQL`, `Compose smoke`, `Docker image`, and GitHub branch protection.
+**Execution status:** Tasks 1-4 implemented and locally verified on `codex/ci-path-gating`. Later review tightened the implementation so workflows run the classifier from the trusted base revision when available, and the classifier owns changed-file resolution. Task 5 branch-protection configuration is intentionally pending maintainer follow-up after the branch is pushed and a completed `ci-gate` check context exists.
+
+**Architecture:** Add one tested path-classifier script that maps changed files into CI categories, then consume those outputs from GitHub Actions jobs. Keep stable always-running aggregate gates (`ci-gate`, `codeql-gate`, and `compose-smoke-gate`) so branch protection can require predictable checks even when expensive jobs are intentionally skipped. Apply the same path-gating model to `CI`, `CodeQL`, `Compose smoke`, `Docker image`, and GitHub branch protection.
 
 **Tech Stack:** GitHub Actions YAML, Python 3 standard library, Rust workflow-shape tests, `gh` CLI for live GitHub protection configuration.
 
@@ -30,7 +32,7 @@
 - Modify `.github/workflows/compose-smoke.yml`: path-gate compose config and image smoke jobs independently.
 - Modify `.github/workflows/docker-image.yml`: skip image publishing unless container/runtime inputs changed or the run is a release tag/manual dispatch.
 - Modify `tests/workflow_shapes.rs`: assert the new classifier, gates, and aggregate check shape remain intact.
-- Live configuration step: update GitHub branch protection/ruleset to require `ci-gate`.
+- Live configuration step: update GitHub branch protection/ruleset to require `ci-gate`, `codeql-gate`, and `compose-smoke-gate`, preserving any existing review, conversation-resolution, and restriction settings.
 
 ---
 
@@ -1036,9 +1038,9 @@ Expected: commit succeeds with CodeQL workflow and workflow-shape test changes s
 
 **Interfaces:**
 - Consumes: GitHub check context `ci-gate` created by Task 2 after one pushed CI run.
-- Produces: main-branch protection requiring `ci-gate`.
+- Produces: main-branch protection requiring `ci-gate`, `codeql-gate`, and `compose-smoke-gate`.
 
-- [ ] **Step 1: Confirm the current protection state**
+- [ ] **Step 1: Confirm the current protection state and ruleset owner**
 
 Run:
 
@@ -1047,7 +1049,7 @@ gh api repos/jmagar/axon/branches/main/protection --jq '{required_status_checks:
 gh api repos/jmagar/axon/rulesets --jq '.[] | {id, name, enforcement, target}'
 ```
 
-Expected: branch protection may be absent; current ruleset may show `review` with `enforcement: disabled`.
+Expected: identify whether required checks are controlled by classic branch protection or a repository ruleset before changing anything.
 
 - [ ] **Step 2: Wait for one pushed run to create the `ci-gate` check context**
 
@@ -1057,35 +1059,23 @@ Run:
 gh run list --workflow=ci.yml --limit 1 --json databaseId,status,conclusion,headSha,url
 ```
 
-Expected: latest run exists for the branch containing Task 2 and includes a completed `ci-gate` job.
+Expected: latest runs exist for the branch containing Task 2 and include completed `ci-gate`, `codeql-gate`, and `compose-smoke-gate` jobs.
 
-- [ ] **Step 3: Require the stable gate on `main`**
+- [ ] **Step 3: Require the stable gate on `main` without resetting unrelated settings**
 
-Run:
+If a repository ruleset owns required checks, update that ruleset to require `ci-gate`, `codeql-gate`, and `compose-smoke-gate`. If classic branch protection owns required checks, fetch the current protection JSON first and preserve existing settings while replacing only the required status-check contexts with `["ci-gate", "codeql-gate", "compose-smoke-gate"]`.
+
+Do not apply a blind full `PUT` payload from this plan. In particular, preserve existing pull-request review, conversation-resolution, admin-enforcement, restriction, linear-history, force-push, deletion, branch-lock, and fork-sync settings unless Jacob explicitly asks to change them.
+
+One safe pattern for classic branch protection is:
 
 ```bash
-gh api -X PUT repos/jmagar/axon/branches/main/protection \
-  --input - <<'JSON'
-{
-  "required_status_checks": {
-    "strict": true,
-    "contexts": ["ci-gate"]
-  },
-  "enforce_admins": false,
-  "required_pull_request_reviews": null,
-  "restrictions": null,
-  "required_linear_history": false,
-  "allow_force_pushes": false,
-  "allow_deletions": false,
-  "block_creations": false,
-  "required_conversation_resolution": false,
-  "lock_branch": false,
-  "allow_fork_syncing": true
-}
-JSON
+gh api repos/jmagar/axon/branches/main/protection > /tmp/axon-main-protection.json
+# Edit only required_status_checks.contexts to ["ci-gate", "codeql-gate", "compose-smoke-gate"], preserving the other fields.
+# Then PUT the complete preserved object back through gh api.
 ```
 
-Expected: GitHub returns a JSON branch protection object with `required_status_checks.contexts` containing `ci-gate`.
+Expected: GitHub returns a protection/ruleset object that requires `ci-gate`, `codeql-gate`, and `compose-smoke-gate` and preserves unrelated protections.
 
 - [ ] **Step 4: Verify protection**
 
@@ -1103,58 +1093,24 @@ Expected:
 
 ---
 
-### Task 6: End-to-End Verification Pull Requests
+### Task 6: End-to-End Verification
 
 **Files:**
 - No permanent repository files required beyond the tasks above.
 
 **Interfaces:**
 - Consumes: completed Tasks 1-5.
-- Produces: live proof that docs-only, Android-only, Rust-only, and Docker-only changes route correctly.
+- Produces: live or local proof that docs-only, Android-only, Rust-only, and Docker-only changes route correctly.
 
-- [ ] **Step 1: Create a docs-only verification branch**
-
-Run:
-
-```bash
-git switch -c codex/ci-docs-only-routing
-printf '\n<!-- ci routing smoke: docs only -->\n' >> docs/guides/configuration.md
-git add docs/guides/configuration.md
-git commit -m "test: verify docs-only ci routing"
-git push -u origin codex/ci-docs-only-routing
-gh pr create --draft --title "CI routing smoke: docs only" --body "Temporary draft PR to verify docs-only CI routing."
-```
-
-Expected: PR opens as draft.
-
-- [ ] **Step 2: Verify docs-only CI skips expensive jobs**
+- [ ] **Step 1: Verify classifier locally for representative changes**
 
 Run:
 
 ```bash
-RUN_ID=$(gh run list --workflow=ci.yml --branch codex/ci-docs-only-routing --event pull_request --limit 1 --json databaseId --jq '.[0].databaseId')
-gh run view "$RUN_ID" --json jobs --jq '.jobs[] | {name, conclusion}'
-```
+printf 'docs/guides/configuration.md\n' > /tmp/axon-docs-change.txt
+python3 scripts/ci/changed_paths.py --event pull_request --changed-files /tmp/axon-docs-change.txt --output /tmp/axon-docs-output.txt
+cat /tmp/axon-docs-output.txt
 
-Expected: `ci-gate` succeeds; Rust, Android, Tauri, release, and MCP smoke jobs are skipped unless their paths were touched by workflow changes.
-
-- [ ] **Step 3: Close the docs-only verification PR**
-
-Run:
-
-```bash
-gh pr close --delete-branch
-git switch main
-git pull --ff-only
-```
-
-Expected: draft PR closed and remote verification branch deleted.
-
-- [ ] **Step 4: Verify classifier locally for representative changes**
-
-Run:
-
-```bash
 printf 'src/vector/ops/query.rs\n' > /tmp/axon-rust-change.txt
 python3 scripts/ci/changed_paths.py --event pull_request --changed-files /tmp/axon-rust-change.txt --output /tmp/axon-rust-output.txt
 cat /tmp/axon-rust-output.txt
@@ -1171,12 +1127,24 @@ cat /tmp/axon-docker-output.txt
 Expected:
 
 ```text
+# docs sample includes docs=true and does not enable rust/android/palette/docker unless workflow files changed
 # rust sample includes rust=true, release=true, docker=true, codeql_rust=true
 # android sample includes android=true, codeql_java_kotlin=true
-# docker sample includes compose=true or docker=true depending on the file, and does not enable android/palette unless related files changed
+# docker sample includes docker=true and does not enable android/palette unless related files changed
 ```
 
-- [ ] **Step 5: Run final local test suite for CI routing**
+- [ ] **Step 2: Verify the PR's real CI routing**
+
+Run:
+
+```bash
+RUN_ID=$(gh run list --workflow=ci.yml --branch codex/ci-path-gating --event pull_request --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run view "$RUN_ID" --json jobs --jq '.jobs[] | {name, conclusion}'
+```
+
+Expected: `ci-gate` succeeds and any skipped jobs are skipped because their changed-path category is false.
+
+- [ ] **Step 3: Run final local test suite for CI routing**
 
 Run:
 

--- a/docs/superpowers/plans/2026-06-19-ci-path-gating.md
+++ b/docs/superpowers/plans/2026-06-19-ci-path-gating.md
@@ -1,0 +1,1198 @@
+# CI Path Gating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Axon's CI run the checks that match the files changed, while keeping scheduled/manual runs broad and preserving a single branch-protection-friendly gate.
+
+**Execution status:** Tasks 1-4 implemented and locally verified on `codex/ci-path-gating`. Task 5 branch-protection mutation is intentionally pending coordinator follow-up after the branch is pushed and a completed `ci-gate` check context exists.
+
+**Architecture:** Add one tested path-classifier script that maps changed files into CI categories, then consume those outputs from GitHub Actions jobs. Keep one always-running aggregate gate (`ci-gate`) so branch protection can require a stable check even when expensive jobs are intentionally skipped. Apply the same path-gating model to `CI`, `CodeQL`, `Compose smoke`, `Docker image`, and GitHub branch protection.
+
+**Tech Stack:** GitHub Actions YAML, Python 3 standard library, Rust workflow-shape tests, `gh` CLI for live GitHub protection configuration.
+
+## Global Constraints
+
+- `CLAUDE.md` is the source of truth for agent memory; do not edit `AGENTS.md` or `GEMINI.md` directly.
+- Keep the existing Axon Rust toolchain pins in workflow jobs unless a task explicitly changes them.
+- Keep scheduled and manual CI broad: `schedule` and `workflow_dispatch` should default to all categories enabled unless an existing input intentionally narrows a live test.
+- Keep branch protection simple: require one stable aggregate check named `ci-gate`, not a list of path-skipped heavyweight jobs.
+- Keep fail-safe behavior: if the changed-file diff cannot be resolved, run the full CI category set.
+- Do not remove existing release-version gates, MCP smoke coverage, Android verification, Tauri verification, Docker image validation, CodeQL analysis, or compose validation; only route them to relevant changes.
+
+---
+
+## File Structure
+
+- Create `scripts/ci/changed_paths.py`: pure-Python path classifier. It accepts an event name plus changed file list and writes GitHub output booleans.
+- Create `tests/ci_changed_paths.rs`: Rust integration tests that execute `scripts/ci/changed_paths.py` against representative changed-file sets.
+- Modify `.github/workflows/ci.yml`: add a `changes` job, add job-level `if:` gates, rename/replace `production-gate` with `ci-gate`, and include all important jobs in the aggregate gate.
+- Modify `.github/workflows/codeql.yml`: add a `changes` job and generate a language matrix so CodeQL only analyzes languages touched by a PR/push, while schedules/manual runs analyze all languages.
+- Modify `.github/workflows/compose-smoke.yml`: path-gate compose config and image smoke jobs independently.
+- Modify `.github/workflows/docker-image.yml`: skip image publishing unless container/runtime inputs changed or the run is a release tag/manual dispatch.
+- Modify `tests/workflow_shapes.rs`: assert the new classifier, gates, and aggregate check shape remain intact.
+- Live configuration step: update GitHub branch protection/ruleset to require `ci-gate`.
+
+---
+
+### Task 1: Add Tested Changed-Path Classifier
+
+**Files:**
+- Create: `scripts/ci/changed_paths.py`
+- Create: `tests/ci_changed_paths.rs`
+
+**Interfaces:**
+- Consumes: changed file paths from a newline-delimited file and an event name string.
+- Produces: GitHub Actions output lines with keys `all`, `docs`, `workflow`, `rust`, `web`, `android`, `palette`, `chrome`, `docker`, `compose`, `mcp`, `security`, `release`, `openapi`, `codeql_actions`, `codeql_javascript_typescript`, `codeql_python`, `codeql_rust`, `codeql_java_kotlin`.
+
+- [ ] **Step 1: Write the failing Rust integration tests**
+
+Create `tests/ci_changed_paths.rs`:
+
+```rust
+use std::collections::HashMap;
+use std::fs;
+use std::process::Command;
+
+fn classify(event: &str, files: &[&str]) -> HashMap<String, String> {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "axon-ci-paths-{}-{}",
+        std::process::id(),
+        files.len()
+    ));
+    let _ = fs::remove_dir_all(&temp_dir);
+    fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let changed = temp_dir.join("changed.txt");
+    let output = temp_dir.join("github_output.txt");
+    fs::write(&changed, files.join("\n")).expect("write changed file list");
+
+    let status = Command::new("python3")
+        .arg("scripts/ci/changed_paths.py")
+        .arg("--event")
+        .arg(event)
+        .arg("--changed-files")
+        .arg(&changed)
+        .arg("--output")
+        .arg(&output)
+        .status()
+        .expect("run changed_paths.py");
+    assert!(status.success(), "changed_paths.py exited with {status}");
+
+    let raw = fs::read_to_string(&output).expect("read github output");
+    raw.lines()
+        .map(|line| {
+            let (key, value) = line.split_once('=').expect("key=value output");
+            (key.to_string(), value.to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn docs_only_changes_skip_expensive_runtime_categories() {
+    let out = classify("pull_request", &["docs/guides/configuration.md", "README.md"]);
+    assert_eq!(out["docs"], "true");
+    assert_eq!(out["rust"], "false");
+    assert_eq!(out["android"], "false");
+    assert_eq!(out["palette"], "false");
+    assert_eq!(out["docker"], "false");
+    assert_eq!(out["codeql_rust"], "false");
+}
+
+#[test]
+fn rust_core_changes_enable_runtime_release_mcp_and_rust_codeql() {
+    let out = classify("pull_request", &["src/vector/ops/query.rs"]);
+    assert_eq!(out["rust"], "true");
+    assert_eq!(out["release"], "true");
+    assert_eq!(out["mcp"], "false");
+    assert_eq!(out["security"], "true");
+    assert_eq!(out["codeql_rust"], "true");
+    assert_eq!(out["docker"], "true");
+}
+
+#[test]
+fn mcp_changes_enable_mcp_schema_and_runtime_checks() {
+    let out = classify("pull_request", &["src/mcp/server/tool_schema.rs"]);
+    assert_eq!(out["rust"], "true");
+    assert_eq!(out["mcp"], "true");
+    assert_eq!(out["release"], "true");
+    assert_eq!(out["codeql_rust"], "true");
+}
+
+#[test]
+fn openapi_changes_enable_android_palette_and_rest_contracts() {
+    let out = classify("pull_request", &["apps/web/openapi/axon.json"]);
+    assert_eq!(out["openapi"], "true");
+    assert_eq!(out["web"], "true");
+    assert_eq!(out["android"], "true");
+    assert_eq!(out["palette"], "true");
+    assert_eq!(out["rust"], "false");
+}
+
+#[test]
+fn android_changes_enable_kotlin_codeql_only_for_app_language() {
+    let out = classify("pull_request", &["apps/android/app/src/main/java/com/axon/app/MainActivity.kt"]);
+    assert_eq!(out["android"], "true");
+    assert_eq!(out["codeql_java_kotlin"], "true");
+    assert_eq!(out["codeql_rust"], "false");
+}
+
+#[test]
+fn workflow_dispatch_and_schedule_enable_everything() {
+    for event in ["workflow_dispatch", "schedule"] {
+        let out = classify(event, &[]);
+        for key in [
+            "all",
+            "rust",
+            "web",
+            "android",
+            "palette",
+            "chrome",
+            "docker",
+            "compose",
+            "mcp",
+            "security",
+            "release",
+            "openapi",
+            "codeql_actions",
+            "codeql_javascript_typescript",
+            "codeql_python",
+            "codeql_rust",
+            "codeql_java_kotlin",
+        ] {
+            assert_eq!(out[key], "true", "{event} should enable {key}");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --locked --test ci_changed_paths
+```
+
+Expected: FAIL because `scripts/ci/changed_paths.py` does not exist.
+
+- [ ] **Step 3: Implement the classifier script**
+
+Create `scripts/ci/changed_paths.py`:
+
+```python
+#!/usr/bin/env python3
+"""Classify changed files into Axon CI routing categories."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+OUTPUT_KEYS = [
+    "all",
+    "docs",
+    "workflow",
+    "rust",
+    "web",
+    "android",
+    "palette",
+    "chrome",
+    "docker",
+    "compose",
+    "mcp",
+    "security",
+    "release",
+    "openapi",
+    "codeql_actions",
+    "codeql_javascript_typescript",
+    "codeql_python",
+    "codeql_rust",
+    "codeql_java_kotlin",
+]
+
+
+def starts(path: str, *prefixes: str) -> bool:
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes)
+
+
+def any_match(paths: list[str], predicate) -> bool:
+    return any(predicate(path) for path in paths)
+
+
+def classify(event: str, paths: list[str]) -> dict[str, bool]:
+    if event in {"schedule", "workflow_dispatch"}:
+        return {key: True for key in OUTPUT_KEYS}
+
+    if not paths:
+        return {key: True for key in OUTPUT_KEYS}
+
+    workflow = any_match(paths, lambda p: starts(p, ".github/workflows/") or p == "tests/workflow_shapes.rs")
+    docs = any_match(paths, lambda p: starts(p, "docs/") or p in {"README.md", "CHANGELOG.md"})
+    openapi = any_match(paths, lambda p: starts(p, "apps/web/openapi/"))
+    web = any_match(paths, lambda p: starts(p, "apps/web/")) or openapi
+    android = any_match(paths, lambda p: starts(p, "apps/android/")) or openapi
+    palette = any_match(paths, lambda p: starts(p, "apps/palette-tauri/")) or openapi
+    chrome = any_match(paths, lambda p: starts(p, "apps/chrome-extension/", "assets/"))
+    mcp = any_match(
+        paths,
+        lambda p: starts(p, "src/mcp/", "docs/reference/mcp/")
+        or p in {"scripts/generate_mcp_schema_doc.py", "tests/workflow_shapes.rs"},
+    )
+    rust = any_match(
+        paths,
+        lambda p: starts(
+            p,
+            "src/",
+            "xtask/",
+            "benches/",
+            "tests/",
+            "migrations/",
+            "vendor/",
+            ".cargo/",
+            ".config/",
+        )
+        or p in {"Cargo.toml", "Cargo.lock", "build.rs", "rust-toolchain.toml", "Justfile"},
+    )
+    release = rust or web or any_match(paths, lambda p: starts(p, "release/") or p in {"README.md", "CHANGELOG.md"})
+    compose = any_match(
+        paths,
+        lambda p: starts(p, "config/", "scripts/")
+        or p in {".env.example", "docker-compose.yaml", "docker-compose.prod.yaml", "docker-compose.llama.yaml"},
+    )
+    docker = rust or web or compose or any_match(paths, lambda p: p == "config/Dockerfile")
+    security = any_match(paths, lambda p: p in {"Cargo.lock", "deny.toml"} or starts(p, ".cargo/", "vendor/")) or rust
+
+    codeql_actions = workflow
+    codeql_javascript_typescript = web or palette or any_match(paths, lambda p: p.endswith((".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")))
+    codeql_python = any_match(paths, lambda p: p.endswith(".py") or starts(p, "scripts/"))
+    codeql_rust = rust or palette
+    codeql_java_kotlin = android or any_match(paths, lambda p: p.endswith((".java", ".kt", ".kts")))
+
+    result = {
+        "all": False,
+        "docs": docs,
+        "workflow": workflow,
+        "rust": rust,
+        "web": web,
+        "android": android,
+        "palette": palette,
+        "chrome": chrome,
+        "docker": docker,
+        "compose": compose,
+        "mcp": mcp,
+        "security": security,
+        "release": release,
+        "openapi": openapi,
+        "codeql_actions": codeql_actions,
+        "codeql_javascript_typescript": codeql_javascript_typescript,
+        "codeql_python": codeql_python,
+        "codeql_rust": codeql_rust,
+        "codeql_java_kotlin": codeql_java_kotlin,
+    }
+
+    if workflow:
+        for key in OUTPUT_KEYS:
+            result[key] = True
+
+    return result
+
+
+def read_paths(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def write_outputs(path: Path, values: dict[str, bool]) -> None:
+    lines = [f"{key}={'true' if values[key] else 'false'}" for key in OUTPUT_KEYS]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--changed-files", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    values = classify(args.event, read_paths(args.changed_files))
+    write_outputs(args.output, values)
+    for key in OUTPUT_KEYS:
+        print(f"{key}={str(values[key]).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Make the script executable**
+
+Run:
+
+```bash
+chmod +x scripts/ci/changed_paths.py
+```
+
+Expected: no output and executable bit set.
+
+- [ ] **Step 5: Run the classifier tests**
+
+Run:
+
+```bash
+cargo test --locked --test ci_changed_paths
+```
+
+Expected: PASS for all six tests.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add scripts/ci/changed_paths.py tests/ci_changed_paths.rs
+git commit -m "ci: add changed path classifier"
+```
+
+Expected: commit succeeds with only the classifier and tests staged.
+
+---
+
+### Task 2: Path-Gate Main CI Jobs and Replace Production Gate
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `tests/workflow_shapes.rs`
+
+**Interfaces:**
+- Consumes: outputs from `jobs.changes.outputs.*` created by Task 1.
+- Produces: job-level `if:` gates and a stable aggregate job named `ci-gate`.
+
+- [ ] **Step 1: Add workflow-shape tests before editing YAML**
+
+Append these tests to `tests/workflow_shapes.rs`:
+
+```rust
+#[test]
+fn ci_has_changed_path_classifier_and_stable_gate() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    assert!(workflow.contains("changes:"), "CI must define a changes job");
+    assert!(
+        workflow.contains("scripts/ci/changed_paths.py"),
+        "CI must use the tested changed path classifier"
+    );
+    assert!(workflow.contains("ci-gate:"), "CI must expose ci-gate");
+    assert!(
+        !workflow.contains("production-gate:"),
+        "production-gate should be replaced by ci-gate so branch protection has one clear required check"
+    );
+}
+
+#[test]
+fn ci_gate_covers_expensive_and_contract_jobs() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let gate = workflow_job_block(workflow, "ci-gate");
+    for job in [
+        "mcp-transport-modes",
+        "version-sync",
+        "aurora-primitive-inventory",
+        "android",
+        "android-openapi-client",
+        "no-mod-rs",
+        "toml-fmt",
+        "lefthook-pre-commit-speed",
+        "palette-tauri",
+        "windows-check",
+        "windows-build",
+        "shell-completions-smoke",
+        "web-panel",
+        "mcp-schema-doc-sync",
+        "rest-api-parity",
+        "mcp-oauth-smoke",
+        "advisory-lock-policy",
+        "ban-skip-validation",
+        "monolith",
+        "fmt",
+        "check",
+        "msrv",
+        "clippy",
+        "test",
+        "security",
+        "mcp-smoke",
+        "release",
+        "release-smoke",
+    ] {
+        assert!(gate.contains(&format!("- {job}")), "ci-gate must need {job}");
+    }
+}
+```
+
+- [ ] **Step 2: Run the workflow-shape tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --locked --test workflow_shapes ci_has_changed_path_classifier_and_stable_gate ci_gate_covers_expensive_and_contract_jobs
+```
+
+Expected: FAIL because `ci.yml` does not yet define `changes` or `ci-gate`.
+
+- [ ] **Step 3: Add a `changes` job near the top of `.github/workflows/ci.yml`**
+
+Insert this job before `mcp-transport-modes`:
+
+```yaml
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      all: ${{ steps.classify.outputs.all }}
+      docs: ${{ steps.classify.outputs.docs }}
+      workflow: ${{ steps.classify.outputs.workflow }}
+      rust: ${{ steps.classify.outputs.rust }}
+      web: ${{ steps.classify.outputs.web }}
+      android: ${{ steps.classify.outputs.android }}
+      palette: ${{ steps.classify.outputs.palette }}
+      chrome: ${{ steps.classify.outputs.chrome }}
+      docker: ${{ steps.classify.outputs.docker }}
+      compose: ${{ steps.classify.outputs.compose }}
+      mcp: ${{ steps.classify.outputs.mcp }}
+      security: ${{ steps.classify.outputs.security }}
+      release: ${{ steps.classify.outputs.release }}
+      openapi: ${{ steps.classify.outputs.openapi }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Resolve changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            base="$PUSH_BEFORE_SHA"
+            head="$HEAD_SHA"
+          else
+            : > changed-files.txt
+            exit 0
+          fi
+          if [[ -z "${base:-}" || "$base" =~ ^0+$ ]] || ! git cat-file -e "$base" 2>/dev/null; then
+            base="$(git rev-parse HEAD^ 2>/dev/null || true)"
+          fi
+          if [[ -z "${base:-}" ]]; then
+            echo "Could not resolve base; leaving changed-files.txt empty so classifier runs fail-safe."
+            : > changed-files.txt
+          else
+            git diff --name-only "$base" "$head" > changed-files.txt
+          fi
+          cat changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 4: Add job-level gates**
+
+For each job below, add `needs: [changes]` unless it already has a `needs` list. If it already has `needs`, include `changes` in the list. Then add the specified `if:` expression:
+
+```yaml
+mcp-transport-modes:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true' }}
+
+version-sync:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.release == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.chrome == 'true' || needs.changes.outputs.docs == 'true' }}
+
+aurora-primitive-inventory:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.docs == 'true' }}
+
+android:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.android == 'true' }}
+
+android-openapi-client:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.android == 'true' || needs.changes.outputs.openapi == 'true' }}
+
+no-mod-rs:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+toml-fmt:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true' || needs.changes.outputs.release == 'true' }}
+
+lefthook-pre-commit-speed:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.workflow == 'true' || needs.changes.outputs.rust == 'true' }}
+
+palette-tauri:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.palette == 'true' }}
+
+windows-check:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+windows-build:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true' }}
+
+shell-completions-smoke:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+web-panel:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.web == 'true' }}
+
+mcp-schema-doc-sync:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.mcp == 'true' }}
+
+rest-api-parity:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.openapi == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' }}
+
+mcp-oauth-smoke:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true' }}
+
+advisory-lock-policy:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+ban-skip-validation:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+monolith:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+fmt:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+check:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+msrv:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+clippy:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+test:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+
+security:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.security == 'true' }}
+
+release:
+  needs: [changes]
+  if: ${{ needs.changes.outputs.release == 'true' }}
+
+release-smoke:
+  needs: [changes, release]
+  if: ${{ needs.release.result == 'success' }}
+
+mcp-smoke:
+  needs: [changes, release]
+  if: ${{ needs.release.result == 'success' && (needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rust == 'true') }}
+```
+
+Keep the existing `if:` expressions for `test-infra`, `live-qdrant`, `rag-changes`, and `live-rag-pr`; those are already intentionally scheduled/manual/path gated.
+
+- [ ] **Step 5: Replace `production-gate` with `ci-gate`**
+
+Replace the current `production-gate` job with:
+
+```yaml
+  ci-gate:
+    name: ci-gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - mcp-transport-modes
+      - version-sync
+      - aurora-primitive-inventory
+      - android
+      - android-openapi-client
+      - no-mod-rs
+      - toml-fmt
+      - lefthook-pre-commit-speed
+      - palette-tauri
+      - windows-check
+      - windows-build
+      - shell-completions-smoke
+      - web-panel
+      - mcp-schema-doc-sync
+      - rest-api-parity
+      - mcp-oauth-smoke
+      - advisory-lock-policy
+      - ban-skip-validation
+      - monolith
+      - fmt
+      - check
+      - msrv
+      - clippy
+      - test
+      - security
+      - mcp-smoke
+      - release
+      - release-smoke
+    steps:
+      - name: verify required jobs passed or were intentionally skipped
+        run: |
+          set -euo pipefail
+          require_success_or_skipped() {
+            local name="$1"
+            local result="$2"
+            case "$result" in
+              success|skipped) printf '%s=%s\n' "$name" "$result" ;;
+              *) echo "::error::$name concluded $result" >&2; exit 1 ;;
+            esac
+          }
+          require_success_or_skipped changes "${{ needs.changes.result }}"
+          require_success_or_skipped mcp-transport-modes "${{ needs.mcp-transport-modes.result }}"
+          require_success_or_skipped version-sync "${{ needs.version-sync.result }}"
+          require_success_or_skipped aurora-primitive-inventory "${{ needs.aurora-primitive-inventory.result }}"
+          require_success_or_skipped android "${{ needs.android.result }}"
+          require_success_or_skipped android-openapi-client "${{ needs.android-openapi-client.result }}"
+          require_success_or_skipped no-mod-rs "${{ needs.no-mod-rs.result }}"
+          require_success_or_skipped toml-fmt "${{ needs.toml-fmt.result }}"
+          require_success_or_skipped lefthook-pre-commit-speed "${{ needs.lefthook-pre-commit-speed.result }}"
+          require_success_or_skipped palette-tauri "${{ needs.palette-tauri.result }}"
+          require_success_or_skipped windows-check "${{ needs.windows-check.result }}"
+          require_success_or_skipped windows-build "${{ needs.windows-build.result }}"
+          require_success_or_skipped shell-completions-smoke "${{ needs.shell-completions-smoke.result }}"
+          require_success_or_skipped web-panel "${{ needs.web-panel.result }}"
+          require_success_or_skipped mcp-schema-doc-sync "${{ needs.mcp-schema-doc-sync.result }}"
+          require_success_or_skipped rest-api-parity "${{ needs.rest-api-parity.result }}"
+          require_success_or_skipped mcp-oauth-smoke "${{ needs.mcp-oauth-smoke.result }}"
+          require_success_or_skipped advisory-lock-policy "${{ needs.advisory-lock-policy.result }}"
+          require_success_or_skipped ban-skip-validation "${{ needs.ban-skip-validation.result }}"
+          require_success_or_skipped monolith "${{ needs.monolith.result }}"
+          require_success_or_skipped fmt "${{ needs.fmt.result }}"
+          require_success_or_skipped check "${{ needs.check.result }}"
+          require_success_or_skipped msrv "${{ needs.msrv.result }}"
+          require_success_or_skipped clippy "${{ needs.clippy.result }}"
+          require_success_or_skipped test "${{ needs.test.result }}"
+          require_success_or_skipped security "${{ needs.security.result }}"
+          require_success_or_skipped mcp-smoke "${{ needs.mcp-smoke.result }}"
+          require_success_or_skipped release "${{ needs.release.result }}"
+          require_success_or_skipped release-smoke "${{ needs.release-smoke.result }}"
+```
+
+- [ ] **Step 6: Run local validation**
+
+Run:
+
+```bash
+cargo test --locked --test ci_changed_paths
+cargo test --locked --test workflow_shapes
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add .github/workflows/ci.yml tests/workflow_shapes.rs
+git commit -m "ci: route main checks by changed paths"
+```
+
+Expected: commit succeeds with CI workflow and workflow-shape tests staged.
+
+---
+
+### Task 3: Path-Gate Compose Smoke and Docker Publishing
+
+**Files:**
+- Modify: `.github/workflows/compose-smoke.yml`
+- Modify: `.github/workflows/docker-image.yml`
+- Modify: `tests/workflow_shapes.rs`
+
+**Interfaces:**
+- Consumes: `scripts/ci/changed_paths.py` from Task 1.
+- Produces: compose and Docker workflows that skip irrelevant PR/push changes.
+
+- [ ] **Step 1: Add workflow-shape tests**
+
+Append to `tests/workflow_shapes.rs`:
+
+```rust
+#[test]
+fn compose_and_docker_workflows_use_changed_path_classifier() {
+    let compose = include_str!("../.github/workflows/compose-smoke.yml");
+    let docker = include_str!("../.github/workflows/docker-image.yml");
+    assert!(compose.contains("scripts/ci/changed_paths.py"));
+    assert!(compose.contains("needs.changes.outputs.compose == 'true'"));
+    assert!(compose.contains("needs.changes.outputs.docker == 'true'"));
+    assert!(docker.contains("scripts/ci/changed_paths.py"));
+    assert!(docker.contains("needs.changes.outputs.docker == 'true'"));
+    assert!(docker.contains("startsWith(github.ref, 'refs/tags/v')"));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test --locked --test workflow_shapes compose_and_docker_workflows_use_changed_path_classifier
+```
+
+Expected: FAIL because these workflows do not yet call the classifier.
+
+- [ ] **Step 3: Add `changes` to `.github/workflows/compose-smoke.yml`**
+
+Insert this job before `compose-config`:
+
+```yaml
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      compose: ${{ steps.classify.outputs.compose }}
+      docker: ${{ steps.classify.outputs.docker }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+      - name: Resolve changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" > changed-files.txt
+          else
+            : > changed-files.txt
+          fi
+          cat changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+```
+
+Add to `compose-config`:
+
+```yaml
+    needs: [changes]
+    if: ${{ needs.changes.outputs.compose == 'true' }}
+```
+
+Add to `image-build-smoke`:
+
+```yaml
+    needs: [changes]
+    if: ${{ needs.changes.outputs.docker == 'true' }}
+```
+
+- [ ] **Step 4: Add `changes` to `.github/workflows/docker-image.yml`**
+
+Insert before `build`:
+
+```yaml
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.classify.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Resolve changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "push" && "${GITHUB_REF}" != refs/tags/v* ]]; then
+            git diff --name-only "$PUSH_BEFORE_SHA" "$HEAD_SHA" > changed-files.txt
+          else
+            : > changed-files.txt
+          fi
+          cat changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output "$GITHUB_OUTPUT"
+```
+
+Change the `build` job header to:
+
+```yaml
+  build:
+    name: build-and-push
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || needs.changes.outputs.docker == 'true' }}
+```
+
+- [ ] **Step 5: Run local validation**
+
+Run:
+
+```bash
+cargo test --locked --test workflow_shapes compose_and_docker_workflows_use_changed_path_classifier
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add .github/workflows/compose-smoke.yml .github/workflows/docker-image.yml tests/workflow_shapes.rs
+git commit -m "ci: skip compose and docker workflows for unrelated changes"
+```
+
+Expected: commit succeeds with compose, Docker, and workflow-shape test changes staged.
+
+---
+
+### Task 4: Path-Gate CodeQL by Language
+
+**Files:**
+- Modify: `.github/workflows/codeql.yml`
+- Modify: `tests/workflow_shapes.rs`
+
+**Interfaces:**
+- Consumes: `scripts/ci/changed_paths.py` outputs from Task 1.
+- Produces: CodeQL language jobs that run only when their language changed, with full matrix preserved for schedule/manual runs.
+
+- [ ] **Step 1: Add workflow-shape test**
+
+Append to `tests/workflow_shapes.rs`:
+
+```rust
+#[test]
+fn codeql_workflow_routes_language_matrix_by_changed_paths() {
+    let workflow = include_str!("../.github/workflows/codeql.yml");
+    assert!(workflow.contains("scripts/ci/changed_paths.py"));
+    assert!(workflow.contains("codeql_actions"));
+    assert!(workflow.contains("codeql_javascript_typescript"));
+    assert!(workflow.contains("codeql_python"));
+    assert!(workflow.contains("codeql_rust"));
+    assert!(workflow.contains("codeql_java_kotlin"));
+    assert!(workflow.contains("fromJson(needs.changes.outputs.matrix)"));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test --locked --test workflow_shapes codeql_workflow_routes_language_matrix_by_changed_paths
+```
+
+Expected: FAIL because `codeql.yml` does not have a classifier-backed matrix.
+
+- [ ] **Step 3: Add a `changes` job to `codeql.yml`**
+
+Insert before `analyze`:
+
+```yaml
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Resolve changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" > changed-files.txt
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            git diff --name-only "$PUSH_BEFORE_SHA" "$HEAD_SHA" > changed-files.txt
+          else
+            : > changed-files.txt
+          fi
+          cat changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/ci/changed_paths.py --event "${{ github.event_name }}" --changed-files changed-files.txt --output changed-paths.out
+      - name: Build CodeQL matrix
+        id: matrix
+        run: |
+          set -euo pipefail
+          source changed-paths.out
+          jq -nc \
+            --arg actions "$codeql_actions" \
+            --arg js "$codeql_javascript_typescript" \
+            --arg py "$codeql_python" \
+            --arg rust "$codeql_rust" \
+            --arg kotlin "$codeql_java_kotlin" \
+            '{
+              include:
+                ([]
+                + (if $actions == "true" then [{language:"actions", build_mode:"none"}] else [] end)
+                + (if $js == "true" then [{language:"javascript-typescript", build_mode:"none"}] else [] end)
+                + (if $py == "true" then [{language:"python", build_mode:"none"}] else [] end)
+                + (if $rust == "true" then [{language:"rust", build_mode:"none"}] else [] end)
+                + (if $kotlin == "true" then [{language:"java-kotlin", build_mode:"manual"}] else [] end))
+            }' > matrix.json
+          if [[ "$(jq '.include | length' matrix.json)" == "0" ]]; then
+            jq -nc '{include: [{language:"actions", build_mode:"none"}]}' > matrix.json
+          fi
+          echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
+          cat matrix.json
+```
+
+- [ ] **Step 4: Change the `analyze` job matrix**
+
+Change `analyze` to:
+
+```yaml
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    needs: [changes]
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.changes.outputs.matrix) }}
+```
+
+Change CodeQL init to use `matrix.build_mode`:
+
+```yaml
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build_mode }}
+          dependency-caching: true
+```
+
+- [ ] **Step 5: Run local validation**
+
+Run:
+
+```bash
+cargo test --locked --test workflow_shapes codeql_workflow_routes_language_matrix_by_changed_paths
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add .github/workflows/codeql.yml tests/workflow_shapes.rs
+git commit -m "ci: route codeql by changed language paths"
+```
+
+Expected: commit succeeds with CodeQL workflow and workflow-shape test changes staged.
+
+---
+
+### Task 5: Enable Branch Protection for the Stable Gate
+
+**Files:**
+- No repository files required.
+
+**Interfaces:**
+- Consumes: GitHub check context `ci-gate` created by Task 2 after one pushed CI run.
+- Produces: main-branch protection requiring `ci-gate`.
+
+- [ ] **Step 1: Confirm the current protection state**
+
+Run:
+
+```bash
+gh api repos/jmagar/axon/branches/main/protection --jq '{required_status_checks: .required_status_checks.contexts, strict: .required_status_checks.strict}' || true
+gh api repos/jmagar/axon/rulesets --jq '.[] | {id, name, enforcement, target}'
+```
+
+Expected: branch protection may be absent; current ruleset may show `review` with `enforcement: disabled`.
+
+- [ ] **Step 2: Wait for one pushed run to create the `ci-gate` check context**
+
+Run:
+
+```bash
+gh run list --workflow=ci.yml --limit 1 --json databaseId,status,conclusion,headSha,url
+```
+
+Expected: latest run exists for the branch containing Task 2 and includes a completed `ci-gate` job.
+
+- [ ] **Step 3: Require the stable gate on `main`**
+
+Run:
+
+```bash
+gh api -X PUT repos/jmagar/axon/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["ci-gate"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+JSON
+```
+
+Expected: GitHub returns a JSON branch protection object with `required_status_checks.contexts` containing `ci-gate`.
+
+- [ ] **Step 4: Verify protection**
+
+Run:
+
+```bash
+gh api repos/jmagar/axon/branches/main/protection --jq '{contexts: .required_status_checks.contexts, strict: .required_status_checks.strict}'
+```
+
+Expected:
+
+```json
+{"contexts":["ci-gate"],"strict":true}
+```
+
+---
+
+### Task 6: End-to-End Verification Pull Requests
+
+**Files:**
+- No permanent repository files required beyond the tasks above.
+
+**Interfaces:**
+- Consumes: completed Tasks 1-5.
+- Produces: live proof that docs-only, Android-only, Rust-only, and Docker-only changes route correctly.
+
+- [ ] **Step 1: Create a docs-only verification branch**
+
+Run:
+
+```bash
+git switch -c codex/ci-docs-only-routing
+printf '\n<!-- ci routing smoke: docs only -->\n' >> docs/guides/configuration.md
+git add docs/guides/configuration.md
+git commit -m "test: verify docs-only ci routing"
+git push -u origin codex/ci-docs-only-routing
+gh pr create --draft --title "CI routing smoke: docs only" --body "Temporary draft PR to verify docs-only CI routing."
+```
+
+Expected: PR opens as draft.
+
+- [ ] **Step 2: Verify docs-only CI skips expensive jobs**
+
+Run:
+
+```bash
+RUN_ID=$(gh run list --workflow=ci.yml --branch codex/ci-docs-only-routing --event pull_request --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run view "$RUN_ID" --json jobs --jq '.jobs[] | {name, conclusion}'
+```
+
+Expected: `ci-gate` succeeds; Rust, Android, Tauri, release, and MCP smoke jobs are skipped unless their paths were touched by workflow changes.
+
+- [ ] **Step 3: Close the docs-only verification PR**
+
+Run:
+
+```bash
+gh pr close --delete-branch
+git switch main
+git pull --ff-only
+```
+
+Expected: draft PR closed and remote verification branch deleted.
+
+- [ ] **Step 4: Verify classifier locally for representative changes**
+
+Run:
+
+```bash
+printf 'src/vector/ops/query.rs\n' > /tmp/axon-rust-change.txt
+python3 scripts/ci/changed_paths.py --event pull_request --changed-files /tmp/axon-rust-change.txt --output /tmp/axon-rust-output.txt
+cat /tmp/axon-rust-output.txt
+
+printf 'apps/android/app/build.gradle.kts\n' > /tmp/axon-android-change.txt
+python3 scripts/ci/changed_paths.py --event pull_request --changed-files /tmp/axon-android-change.txt --output /tmp/axon-android-output.txt
+cat /tmp/axon-android-output.txt
+
+printf 'config/Dockerfile\n' > /tmp/axon-docker-change.txt
+python3 scripts/ci/changed_paths.py --event pull_request --changed-files /tmp/axon-docker-change.txt --output /tmp/axon-docker-output.txt
+cat /tmp/axon-docker-output.txt
+```
+
+Expected:
+
+```text
+# rust sample includes rust=true, release=true, docker=true, codeql_rust=true
+# android sample includes android=true, codeql_java_kotlin=true
+# docker sample includes compose=true or docker=true depending on the file, and does not enable android/palette unless related files changed
+```
+
+- [ ] **Step 5: Run final local test suite for CI routing**
+
+Run:
+
+```bash
+cargo test --locked --test ci_changed_paths
+cargo test --locked --test workflow_shapes
+```
+
+Expected: both commands pass.
+
+---
+
+## Self-Review
+
+**Spec coverage:** This plan covers docs-only and general path-sensitive CI routing, Docker image publishing, CodeQL routing, compose smoke routing, aggregate gate coverage, and branch protection. It keeps scheduled/manual runs broad.
+
+**Placeholder scan:** The plan contains no forbidden placeholder markers, no unfinished implementation step, and no instruction that asks an implementer to invent missing behavior.
+
+**Type consistency:** The classifier output keys in Task 1 match the workflow outputs and job gates used in Tasks 2-4.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,8 +4,8 @@
 #     misbehaving check can't wedge a commit indefinitely.
 #     Anything that requires a workspace compile (clippy, test) belongs on
 #     pre-push so it runs once before publishing, not on every WIP commit.
-#   pre-push — full workspace clippy + lib tests, serial. Runs once before
-#     a branch hits CI.
+#   pre-push — path-aware fast confidence checks. Full local validation is
+#     opt-in via AXON_FULL_PRE_PUSH=1; CI remains the authoritative merge gate.
 #
 # Regressions are enforced two ways:
 #   - lefthook-speed hook below + scripts/check_lefthook_pre_commit_speed.py
@@ -80,67 +80,7 @@ pre-commit:
       run: scripts/with_timeout.sh 10 -- python3 scripts/check_lefthook_pre_commit_speed.py
 
 pre-push:
-  # Serial: clippy and test both compile the workspace and serialize on the
-  # same target/ build lock. Running them in parallel just causes contention
-  # without any wall-clock win — clippy --all-targets already type-checks
-  # everything test needs, so the second cargo invocation reuses the cache.
   parallel: false
   commands:
-    # lefthook runs serial commands in alphabetical name order, so the numeric
-    # prefixes below pin the sequence: version-sync (cheap, fail fast) →
-    # build-web-assets (compile prerequisite) → clippy → test.
-    1-version-sync:
-      # OPS-M3: enforce CLI version parity (Cargo.toml / README / CHANGELOG /
-      # apps/web/package.json / apps/web/openapi/axon.json) before a push — same
-      # gate CI runs as `check-version-sync`.
-      # Runs first (cheap, content-only) so a version mismatch fails fast
-      # before the web build and the expensive workspace clippy/test compile.
-      # Prefer the pre-built xtask binary; fall back to `cargo xtask` on a clean
-      # target/.
-      run: >
-        if [ -x "./target/debug/xtask" ]; then
-          ./target/debug/xtask check-version-sync;
-        else
-          cargo xtask check-version-sync;
-        fi
-    2-build-web-assets:
-      # build.rs embeds apps/web/out/ (rust-embed) at compile time, so the
-      # clippy/test workspace compile below hard-fails when the Next.js static
-      # export is missing/empty/fallback-only. Build the real panel first so a
-      # push never trips on stale embedded assets. out/ stays gitignored — this
-      # regenerates it from source rather than relying on a committed copy.
-      # Idempotent (Turbopack caches); deps installed once on a fresh checkout.
-      run: >
-        if [ ! -d apps/web/node_modules ]; then npm ci --prefix apps/web; fi &&
-        npm --prefix apps/web run build
-    2-openapi-drift:
-      # Fail locally when any tracked OpenAPI artifact drifts from the Rust
-      # schema source: apps/web/openapi/axon.json, the web generated TS client,
-      # or the Palette generated TS declarations.
-      run: >
-        cargo xtask check-openapi-drift
-    android:
-      glob: "apps/android/**/*"
-      run: >
-        if [ -z "${AXON_AURORA_ANDROID_PATH:-}" ]; then
-          for candidate in "../aurora-design-system/android" "../../../aurora-design-system/android" "/home/jmagar/workspace/aurora-design-system/android"; do
-            if [ -d "$candidate" ]; then
-              export AXON_AURORA_ANDROID_PATH="$candidate";
-              break;
-            fi;
-          done;
-        fi &&
-        if [ ! -d "$AXON_AURORA_ANDROID_PATH" ]; then
-          echo "Set AXON_AURORA_ANDROID_PATH to an Aurora Android checkout before running Android validation." >&2;
-          exit 1;
-        fi &&
-        apps/android/gradlew -p apps/android :app:testDebugUnitTest :app:lintDebug --no-daemon
-    clippy:
-      run: cargo clippy --workspace --all-targets --locked -- -D warnings
-    test:
-      run: >
-        if command -v cargo-nextest >/dev/null 2>&1; then
-          cargo nextest run --workspace --locked --lib -E 'not test(/worker_e2e/)';
-        else
-          cargo test --workspace --locked --lib -- --skip worker_e2e;
-        fi
+    pre-push-router:
+      run: python3 scripts/ci/pre_push.py

--- a/scripts/check-env-config-boundary.py
+++ b/scripts/check-env-config-boundary.py
@@ -46,7 +46,10 @@ IGNORED_TOKENS = {
     "AXON_DEV_BIN_DIR",  # local shell variable in scripts/axon
     "AXON_HOME_DIR",  # local shell variable in scripts/axon
     "AXON_BACKUP_DIR",  # operational var in scripts/axon-backup.sh, not axon runtime config
+    "AXON_ALLOW_FALLBACK_WEB_ASSETS",  # local/CI build escape hatch, not runtime config
     "AXON_CHANGED_PATHS",  # workflow test fixture variable, not axon runtime config
+    "AXON_FULL_PRE_PUSH",  # local hook control variable, not axon runtime config
+    "AXON_PRE_PUSH_BASE",  # local hook control variable, not axon runtime config
     "QDRANT_DEST",  # local shell variable in scripts/axon-backup.sh
     "QDRANT_DIR",  # local shell variable in scripts/axon-backup.sh
     "QDRANT_SHA256",  # local shell variable in scripts/axon-backup.sh

--- a/scripts/check-env-config-boundary.py
+++ b/scripts/check-env-config-boundary.py
@@ -46,6 +46,7 @@ IGNORED_TOKENS = {
     "AXON_DEV_BIN_DIR",  # local shell variable in scripts/axon
     "AXON_HOME_DIR",  # local shell variable in scripts/axon
     "AXON_BACKUP_DIR",  # operational var in scripts/axon-backup.sh, not axon runtime config
+    "AXON_CHANGED_PATHS",  # workflow test fixture variable, not axon runtime config
     "QDRANT_DEST",  # local shell variable in scripts/axon-backup.sh
     "QDRANT_DIR",  # local shell variable in scripts/axon-backup.sh
     "QDRANT_SHA256",  # local shell variable in scripts/axon-backup.sh
@@ -64,6 +65,8 @@ IGNORED_TOKENS = {
     "OPENAI_COMPAT_SECRET",  # fake secret string literal in runners_tests.rs redaction test, not an env var
     "GEMINI_DEFAULT_COMPLETION_CONCURRENCY",  # Rust const (default concurrency) in core/llm/types.rs, not an env var
     "OPENAI_DEFAULT_COMPLETION_CONCURRENCY",  # Rust const (default concurrency) in core/llm/types.rs, not an env var
+    "GITHUB_REF",  # GitHub Actions runtime variable, not axon runtime config
+    "GITHUB_SHA",  # GitHub Actions runtime variable, not axon runtime config
 }
 
 VALID_CLASSIFICATIONS = {
@@ -170,7 +173,7 @@ def scan_env_tokens() -> dict[str, set[str]]:
             if path.is_dir():
                 continue
             rel = path.relative_to(ROOT)
-            if any(part in {".git", ".worktrees", "target"} for part in rel.parts):
+            if any(part in {".git", ".worktrees", "__pycache__", "target"} for part in rel.parts):
                 continue
             if str(rel) == "scripts/check_legacy_runtime_terms.sh":
                 continue

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -43,8 +43,23 @@ def any_match(paths: list[str], predicate: Callable[[str], bool]) -> bool:
 
 RUST_CI_HELPER_SCRIPTS = {
     "scripts/cargo_test_filter_guard.py",
+    "scripts/check_lefthook_pre_commit_speed.py",
     "scripts/check_shell_completions.sh",
+    "scripts/enforce_monoliths.py",
     "scripts/generate_mcp_schema_doc.py",
+    "scripts/test-ask-quality-regressions.sh",
+    "scripts/test-mcp-oauth-protection.sh",
+    "scripts/test-mcp-tools-mcporter.sh",
+}
+
+MCP_CI_HELPER_SCRIPTS = {
+    "scripts/generate_mcp_schema_doc.py",
+    "scripts/test-mcp-oauth-protection.sh",
+    "scripts/test-mcp-tools-mcporter.sh",
+}
+
+DOC_CI_HELPER_SCRIPTS = {
+    "scripts/check_aurora_primitive_inventory.py",
 }
 
 
@@ -60,16 +75,20 @@ def classify(event: str, paths: list[str]) -> dict[str, bool]:
         lambda p: starts(p, ".github/workflows/")
         or p in {"scripts/ci/changed_paths.py", "tests/workflow_shapes.rs", "tests/ci_changed_paths.rs"},
     )
-    docs = any_match(paths, lambda p: starts(p, "docs/") or p in {"README.md", "CHANGELOG.md"})
+    docs = any_match(
+        paths,
+        lambda p: starts(p, "docs/") or p in {"README.md", "CHANGELOG.md"} or p in DOC_CI_HELPER_SCRIPTS,
+    )
     openapi = any_match(paths, lambda p: starts(p, "apps/web/openapi/"))
-    web = any_match(paths, lambda p: starts(p, "apps/web/")) or openapi
+    web = any_match(paths, lambda p: starts(p, "apps/web/", "assets/")) or openapi
     android = any_match(paths, lambda p: starts(p, "apps/android/")) or openapi
     palette = any_match(paths, lambda p: starts(p, "apps/palette-tauri/")) or openapi
     chrome = any_match(paths, lambda p: starts(p, "apps/chrome-extension/", "assets/"))
     mcp = any_match(
         paths,
         lambda p: starts(p, "src/mcp/", "docs/reference/mcp/")
-        or p in {"scripts/generate_mcp_schema_doc.py", "tests/workflow_shapes.rs"},
+        or p in MCP_CI_HELPER_SCRIPTS
+        or p == "tests/workflow_shapes.rs",
     )
     rust = any_match(
         paths,
@@ -91,9 +110,10 @@ def classify(event: str, paths: list[str]) -> dict[str, bool]:
     compose = any_match(
         paths,
         lambda p: starts(p, "config/", "scripts/")
-        or p in {".env.example", "docker-compose.yaml", "docker-compose.prod.yaml", "docker-compose.llama.yaml"},
+        or p
+        in {".dockerignore", ".env.example", "docker-compose.yaml", "docker-compose.prod.yaml", "docker-compose.llama.yaml"},
     )
-    docker = rust or web or compose or any_match(paths, lambda p: p == "config/Dockerfile")
+    docker = rust or web or compose or any_match(paths, lambda p: p in {".dockerignore", "config/Dockerfile"})
     security = any_match(paths, lambda p: p in {"Cargo.lock", "deny.toml"} or starts(p, ".cargo/", "vendor/")) or rust
 
     codeql_actions = workflow

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -41,6 +41,13 @@ def any_match(paths: list[str], predicate: Callable[[str], bool]) -> bool:
     return any(predicate(path) for path in paths)
 
 
+RUST_CI_HELPER_SCRIPTS = {
+    "scripts/cargo_test_filter_guard.py",
+    "scripts/check_shell_completions.sh",
+    "scripts/generate_mcp_schema_doc.py",
+}
+
+
 def classify(event: str, paths: list[str]) -> dict[str, bool]:
     if event in {"schedule", "workflow_dispatch"}:
         return {key: True for key in OUTPUT_KEYS}
@@ -77,7 +84,8 @@ def classify(event: str, paths: list[str]) -> dict[str, bool]:
             ".cargo/",
             ".config/",
         )
-        or p in {"Cargo.toml", "Cargo.lock", "build.rs", "rust-toolchain.toml", "Justfile"},
+        or p in {"Cargo.toml", "Cargo.lock", "build.rs", "rust-toolchain.toml", "Justfile"}
+        or p in RUST_CI_HELPER_SCRIPTS,
     )
     release = rust or web or any_match(paths, lambda p: starts(p, "release/"))
     compose = any_match(

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -45,6 +45,7 @@ RUST_CI_HELPER_SCRIPTS = {
     "scripts/cargo_test_filter_guard.py",
     "scripts/check_lefthook_pre_commit_speed.py",
     "scripts/check_shell_completions.sh",
+    "scripts/ci/pre_push.py",
     "scripts/enforce_monoliths.py",
     "scripts/generate_mcp_schema_doc.py",
     "scripts/test-ask-quality-regressions.sh",

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Classify changed files into Axon CI routing categories."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+
+OUTPUT_KEYS = [
+    "all",
+    "docs",
+    "workflow",
+    "rust",
+    "web",
+    "android",
+    "palette",
+    "chrome",
+    "docker",
+    "compose",
+    "mcp",
+    "security",
+    "release",
+    "openapi",
+    "codeql_actions",
+    "codeql_javascript_typescript",
+    "codeql_python",
+    "codeql_rust",
+    "codeql_java_kotlin",
+]
+
+
+def starts(path: str, *prefixes: str) -> bool:
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes)
+
+
+def any_match(paths: list[str], predicate: Callable[[str], bool]) -> bool:
+    return any(predicate(path) for path in paths)
+
+
+def classify(event: str, paths: list[str]) -> dict[str, bool]:
+    if event in {"schedule", "workflow_dispatch"}:
+        return {key: True for key in OUTPUT_KEYS}
+
+    if not paths:
+        return {key: True for key in OUTPUT_KEYS}
+
+    workflow = any_match(paths, lambda p: starts(p, ".github/workflows/") or p == "tests/workflow_shapes.rs")
+    docs = any_match(paths, lambda p: starts(p, "docs/") or p in {"README.md", "CHANGELOG.md"})
+    openapi = any_match(paths, lambda p: starts(p, "apps/web/openapi/"))
+    web = any_match(paths, lambda p: starts(p, "apps/web/")) or openapi
+    android = any_match(paths, lambda p: starts(p, "apps/android/")) or openapi
+    palette = any_match(paths, lambda p: starts(p, "apps/palette-tauri/")) or openapi
+    chrome = any_match(paths, lambda p: starts(p, "apps/chrome-extension/", "assets/"))
+    mcp = any_match(
+        paths,
+        lambda p: starts(p, "src/mcp/", "docs/reference/mcp/")
+        or p in {"scripts/generate_mcp_schema_doc.py", "tests/workflow_shapes.rs"},
+    )
+    rust = any_match(
+        paths,
+        lambda p: starts(
+            p,
+            "src/",
+            "xtask/",
+            "benches/",
+            "tests/",
+            "migrations/",
+            "vendor/",
+            ".cargo/",
+            ".config/",
+        )
+        or p in {"Cargo.toml", "Cargo.lock", "build.rs", "rust-toolchain.toml", "Justfile"},
+    )
+    release = rust or web or any_match(paths, lambda p: starts(p, "release/") or p in {"README.md", "CHANGELOG.md"})
+    compose = any_match(
+        paths,
+        lambda p: starts(p, "config/", "scripts/")
+        or p in {".env.example", "docker-compose.yaml", "docker-compose.prod.yaml", "docker-compose.llama.yaml"},
+    )
+    docker = rust or web or compose or any_match(paths, lambda p: p == "config/Dockerfile")
+    security = any_match(paths, lambda p: p in {"Cargo.lock", "deny.toml"} or starts(p, ".cargo/", "vendor/")) or rust
+
+    codeql_actions = workflow
+    codeql_javascript_typescript = web or palette or any_match(
+        paths, lambda p: p.endswith((".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"))
+    )
+    codeql_python = any_match(paths, lambda p: p.endswith(".py") or starts(p, "scripts/"))
+    codeql_rust = rust or palette
+    codeql_java_kotlin = android or any_match(paths, lambda p: p.endswith((".java", ".kt", ".kts")))
+
+    result = {
+        "all": False,
+        "docs": docs,
+        "workflow": workflow,
+        "rust": rust,
+        "web": web,
+        "android": android,
+        "palette": palette,
+        "chrome": chrome,
+        "docker": docker,
+        "compose": compose,
+        "mcp": mcp,
+        "security": security,
+        "release": release,
+        "openapi": openapi,
+        "codeql_actions": codeql_actions,
+        "codeql_javascript_typescript": codeql_javascript_typescript,
+        "codeql_python": codeql_python,
+        "codeql_rust": codeql_rust,
+        "codeql_java_kotlin": codeql_java_kotlin,
+    }
+
+    if workflow:
+        for key in OUTPUT_KEYS:
+            result[key] = True
+
+    return result
+
+
+def read_paths(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def write_outputs(path: Path, values: dict[str, bool]) -> None:
+    lines = [f"{key}={'true' if values[key] else 'false'}" for key in OUTPUT_KEYS]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--changed-files", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    values = classify(args.event, read_paths(args.changed_files))
+    write_outputs(args.output, values)
+    for key in OUTPUT_KEYS:
+        print(f"{key}={str(values[key]).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -73,7 +73,7 @@ def classify(event: str, paths: list[str]) -> dict[str, bool]:
         )
         or p in {"Cargo.toml", "Cargo.lock", "build.rs", "rust-toolchain.toml", "Justfile"},
     )
-    release = rust or web or any_match(paths, lambda p: starts(p, "release/") or p in {"README.md", "CHANGELOG.md"})
+    release = rust or web or any_match(paths, lambda p: starts(p, "release/"))
     compose = any_match(
         paths,
         lambda p: starts(p, "config/", "scripts/")

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
@@ -46,7 +48,11 @@ def classify(event: str, paths: list[str]) -> dict[str, bool]:
     if not paths:
         return {key: True for key in OUTPUT_KEYS}
 
-    workflow = any_match(paths, lambda p: starts(p, ".github/workflows/") or p == "tests/workflow_shapes.rs")
+    workflow = any_match(
+        paths,
+        lambda p: starts(p, ".github/workflows/")
+        or p in {"scripts/ci/changed_paths.py", "tests/workflow_shapes.rs", "tests/ci_changed_paths.rs"},
+    )
     docs = any_match(paths, lambda p: starts(p, "docs/") or p in {"README.md", "CHANGELOG.md"})
     openapi = any_match(paths, lambda p: starts(p, "apps/web/openapi/"))
     web = any_match(paths, lambda p: starts(p, "apps/web/")) or openapi
@@ -125,6 +131,54 @@ def read_paths(path: Path) -> list[str]:
     return [line.strip() for line in path.read_text().splitlines() if line.strip()]
 
 
+def git_path_exists(rev: str) -> bool:
+    return subprocess.run(
+        ["git", "cat-file", "-e", rev],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode == 0
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def resolve_paths(event: str) -> list[str]:
+    if event in {"schedule", "workflow_dispatch"}:
+        return []
+
+    env = os.environ
+    base = ""
+    head = env.get("HEAD_SHA") or env.get("GITHUB_SHA") or "HEAD"
+
+    if event == "pull_request":
+        base = env.get("PR_BASE_SHA", "")
+        head = env.get("PR_HEAD_SHA") or head
+    elif event == "push":
+        if env.get("GITHUB_REF", "").startswith("refs/tags/"):
+            return []
+        base = env.get("PUSH_BEFORE_SHA", "")
+    else:
+        return []
+
+    if not base or set(base) == {"0"} or not git_path_exists(base):
+        try:
+            base = git_output("rev-parse", "HEAD^")
+        except subprocess.CalledProcessError:
+            base = ""
+
+    if not base:
+        return []
+
+    try:
+        raw = git_output("diff", "--name-only", base, head)
+    except subprocess.CalledProcessError:
+        return []
+
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
 def write_outputs(path: Path, values: dict[str, bool]) -> None:
     lines = [f"{key}={'true' if values[key] else 'false'}" for key in OUTPUT_KEYS]
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -134,11 +188,16 @@ def write_outputs(path: Path, values: dict[str, bool]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--event", required=True)
-    parser.add_argument("--changed-files", type=Path, required=True)
+    parser.add_argument("--changed-files", type=Path)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--write-changed-files", type=Path)
     args = parser.parse_args()
 
-    values = classify(args.event, read_paths(args.changed_files))
+    paths = read_paths(args.changed_files) if args.changed_files else resolve_paths(args.event)
+    if args.write_changed_files:
+        args.write_changed_files.write_text("\n".join(paths) + ("\n" if paths else ""))
+
+    values = classify(args.event, paths)
     write_outputs(args.output, values)
     for key in OUTPUT_KEYS:
         print(f"{key}={str(values[key]).lower()}")

--- a/scripts/ci/pre_push.py
+++ b/scripts/ci/pre_push.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Path-aware local pre-push checks for Axon."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import changed_paths
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_ROUTER_PATHS = {
+    "lefthook.yml",
+    "scripts/ci/changed_paths.py",
+    "scripts/ci/pre_push.py",
+    "tests/ci_changed_paths.rs",
+    "tests/workflow_shapes.rs",
+}
+
+
+def truthy(value: str | None) -> bool:
+    return value is not None and value.lower() in {"1", "true", "yes", "on"}
+
+
+def run_git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=ROOT, text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def git_ref_exists(ref: str) -> bool:
+    return subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", ref],
+        cwd=ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode == 0
+
+
+def resolve_base() -> str:
+    override = os.environ.get("AXON_PRE_PUSH_BASE")
+    if override:
+        return override
+
+    for candidate in ("@{upstream}", "origin/main"):
+        if not git_ref_exists(candidate):
+            continue
+        try:
+            return run_git("merge-base", candidate, "HEAD")
+        except subprocess.CalledProcessError:
+            continue
+
+    try:
+        return run_git("rev-parse", "HEAD^")
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def changed_files(base: str) -> list[str] | None:
+    if not base:
+        return None
+    try:
+        raw = run_git("diff", "--name-only", base, "HEAD")
+    except subprocess.CalledProcessError:
+        return None
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def is_workflow_router_path(path: str) -> bool:
+    return path.startswith(".github/workflows/") or path in WORKFLOW_ROUTER_PATHS
+
+
+def classify(paths: list[str], full: bool) -> dict[str, bool]:
+    if full:
+        return {key: True for key in changed_paths.OUTPUT_KEYS}
+
+    workflow_paths = [path for path in paths if is_workflow_router_path(path)]
+    runtime_paths = [path for path in paths if not is_workflow_router_path(path)]
+
+    if runtime_paths:
+        result = changed_paths.classify("pull_request", runtime_paths)
+    else:
+        result = {key: False for key in changed_paths.OUTPUT_KEYS}
+
+    if workflow_paths:
+        result["workflow"] = True
+        result["codeql_actions"] = True
+        if any(path.endswith(".py") for path in workflow_paths):
+            result["codeql_python"] = True
+
+    return result
+
+
+def any_path(paths: list[str], *prefixes: str) -> bool:
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for path in paths for prefix in prefixes)
+
+
+def any_file(paths: list[str], *names: str) -> bool:
+    wanted = set(names)
+    return any(path in wanted for path in paths)
+
+
+def command_plan(paths: list[str], categories: dict[str, bool], full: bool) -> list[tuple[str, str]]:
+    workflow_changed = any_path(paths, ".github/workflows/") or any_file(
+        paths,
+        "lefthook.yml",
+        "scripts/ci/changed_paths.py",
+        "scripts/ci/pre_push.py",
+        "tests/ci_changed_paths.rs",
+        "tests/workflow_shapes.rs",
+    )
+    env_boundary_changed = any_file(paths, "scripts/check-env-config-boundary.py", "tests/env_config_boundary.rs")
+    rust_api_changed = any_path(paths, "src/web/", "src/services/", "src/mcp/", "src/cli/commands/rest/")
+    android_app_changed = any_path(paths, "apps/android/")
+
+    plan: list[tuple[str, str]] = [
+        ("version-sync", "cargo xtask check-version-sync"),
+    ]
+
+    if workflow_changed:
+        plan.extend(
+            [
+                ("python-syntax", "python3 -m py_compile scripts/ci/changed_paths.py scripts/ci/pre_push.py"),
+                (
+                    "workflow-lint",
+                    "actionlint .github/workflows/ci.yml .github/workflows/codeql.yml "
+                    ".github/workflows/compose-smoke.yml .github/workflows/docker-image.yml",
+                ),
+                ("ci-path-tests", "cargo test --locked --test ci_changed_paths"),
+                ("workflow-shape-tests", "cargo test --locked --test workflow_shapes"),
+            ]
+        )
+
+    if env_boundary_changed:
+        plan.append(
+            (
+                "env-boundary-test",
+                "cargo test --locked --features test-helpers --test env_config_boundary "
+                "env_config_boundary_matrix_is_current -- --nocapture",
+            )
+        )
+
+    if categories["web"]:
+        plan.append(
+            (
+                "web-assets",
+                "if [ ! -d apps/web/node_modules ]; then npm ci --prefix apps/web; fi && "
+                "npm --prefix apps/web run build",
+            )
+        )
+
+    if categories["rust"]:
+        plan.append(("web-assets-placeholder", "mkdir -p apps/web/out"))
+        plan.append(("clippy", "AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo clippy --workspace --all-targets --locked -- -D warnings"))
+
+    if full:
+        plan.append(
+            (
+                "full-nextest",
+                "AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo nextest run --workspace --locked --lib "
+                "-E 'not test(/worker_e2e/)'",
+            )
+        )
+
+    if full or categories["openapi"] or rust_api_changed or categories["android"] or categories["palette"]:
+        plan.append(("openapi-drift", "cargo xtask check-openapi-drift"))
+
+    if android_app_changed:
+        plan.append(
+            (
+                "android",
+                "if [ -z \"${AXON_AURORA_ANDROID_PATH:-}\" ]; then "
+                "for candidate in ../aurora-design-system/android ../../../aurora-design-system/android "
+                "/home/jmagar/workspace/aurora-design-system/android; do "
+                "if [ -d \"$candidate\" ]; then export AXON_AURORA_ANDROID_PATH=\"$candidate\"; break; fi; done; fi; "
+                "if [ ! -d \"${AXON_AURORA_ANDROID_PATH:-}\" ]; then "
+                "echo 'Set AXON_AURORA_ANDROID_PATH to an Aurora Android checkout before running Android validation.' >&2; exit 1; fi; "
+                "apps/android/gradlew -p apps/android :app:testDebugUnitTest :app:lintDebug --no-daemon",
+            )
+        )
+
+    return dedupe_plan(plan)
+
+
+def dedupe_plan(plan: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    seen: set[str] = set()
+    out: list[tuple[str, str]] = []
+    for name, command in plan:
+        if name in seen:
+            continue
+        seen.add(name)
+        out.append((name, command))
+    return out
+
+
+def run_command(name: str, command: str) -> None:
+    print(f"\n==> {name}\n{command}", flush=True)
+    subprocess.run(["bash", "-lc", command], cwd=ROOT, check=True)
+
+
+def write_classifier_output(paths: list[str], categories: dict[str, bool]) -> None:
+    print("Changed files:")
+    if paths:
+        for path in paths:
+            print(f"  {path}")
+    else:
+        print("  <none relative to selected base>")
+
+    enabled = [key for key, value in categories.items() if value]
+    print("Enabled categories: " + ", ".join(enabled))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    full = truthy(os.environ.get("AXON_FULL_PRE_PUSH"))
+    base = resolve_base()
+    paths = changed_files(base)
+    if paths is None and not full:
+        print("Could not determine changed files; set AXON_FULL_PRE_PUSH=1 for full validation.", file=sys.stderr)
+        full = True
+        paths = []
+    elif paths is None:
+        paths = []
+
+    categories = classify(paths, full)
+    plan = command_plan(paths, categories, full)
+
+    write_classifier_output(paths, categories)
+    print("Pre-push plan:")
+    for name, command in plan:
+        print(f"  {name}: {command}")
+
+    if args.dry_run:
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="axon-pre-push-"):
+        for name, command in plan:
+            run_command(name, command)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(exc.returncode)

--- a/tests/ci_changed_paths.rs
+++ b/tests/ci_changed_paths.rs
@@ -51,6 +51,7 @@ fn docs_only_changes_skip_expensive_runtime_categories() {
     assert_eq!(out["android"], "false");
     assert_eq!(out["palette"], "false");
     assert_eq!(out["docker"], "false");
+    assert_eq!(out["release"], "false");
     assert_eq!(out["codeql_rust"], "false");
 }
 

--- a/tests/ci_changed_paths.rs
+++ b/tests/ci_changed_paths.rs
@@ -123,3 +123,36 @@ fn workflow_dispatch_and_schedule_enable_everything() {
         }
     }
 }
+
+#[test]
+fn changed_path_router_edits_force_full_ci() {
+    for file in [
+        "scripts/ci/changed_paths.py",
+        "tests/ci_changed_paths.rs",
+        "tests/workflow_shapes.rs",
+    ] {
+        let out = classify("pull_request", &[file]);
+        for key in [
+            "all",
+            "workflow",
+            "rust",
+            "web",
+            "android",
+            "palette",
+            "chrome",
+            "docker",
+            "compose",
+            "mcp",
+            "security",
+            "release",
+            "openapi",
+            "codeql_actions",
+            "codeql_javascript_typescript",
+            "codeql_python",
+            "codeql_rust",
+            "codeql_java_kotlin",
+        ] {
+            assert_eq!(out[key], "true", "{file} should enable {key}");
+        }
+    }
+}

--- a/tests/ci_changed_paths.rs
+++ b/tests/ci_changed_paths.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn classify(event: &str, files: &[&str]) -> HashMap<String, String> {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "axon-ci-paths-{}-{}-{}",
+        std::process::id(),
+        files.len(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos()
+    ));
+    let _ = fs::remove_dir_all(&temp_dir);
+    fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let changed = temp_dir.join("changed.txt");
+    let output = temp_dir.join("github_output.txt");
+    fs::write(&changed, files.join("\n")).expect("write changed file list");
+
+    let status = Command::new("python3")
+        .arg("scripts/ci/changed_paths.py")
+        .arg("--event")
+        .arg(event)
+        .arg("--changed-files")
+        .arg(&changed)
+        .arg("--output")
+        .arg(&output)
+        .status()
+        .expect("run changed_paths.py");
+    assert!(status.success(), "changed_paths.py exited with {status}");
+
+    let raw = fs::read_to_string(&output).expect("read github output");
+    raw.lines()
+        .map(|line| {
+            let (key, value) = line.split_once('=').expect("key=value output");
+            (key.to_string(), value.to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn docs_only_changes_skip_expensive_runtime_categories() {
+    let out = classify(
+        "pull_request",
+        &["docs/guides/configuration.md", "README.md"],
+    );
+    assert_eq!(out["docs"], "true");
+    assert_eq!(out["rust"], "false");
+    assert_eq!(out["android"], "false");
+    assert_eq!(out["palette"], "false");
+    assert_eq!(out["docker"], "false");
+    assert_eq!(out["codeql_rust"], "false");
+}
+
+#[test]
+fn rust_core_changes_enable_runtime_release_mcp_and_rust_codeql() {
+    let out = classify("pull_request", &["src/vector/ops/query.rs"]);
+    assert_eq!(out["rust"], "true");
+    assert_eq!(out["release"], "true");
+    assert_eq!(out["mcp"], "false");
+    assert_eq!(out["security"], "true");
+    assert_eq!(out["codeql_rust"], "true");
+    assert_eq!(out["docker"], "true");
+}
+
+#[test]
+fn mcp_changes_enable_mcp_schema_and_runtime_checks() {
+    let out = classify("pull_request", &["src/mcp/server/tool_schema.rs"]);
+    assert_eq!(out["rust"], "true");
+    assert_eq!(out["mcp"], "true");
+    assert_eq!(out["release"], "true");
+    assert_eq!(out["codeql_rust"], "true");
+}
+
+#[test]
+fn openapi_changes_enable_android_palette_and_rest_contracts() {
+    let out = classify("pull_request", &["apps/web/openapi/axon.json"]);
+    assert_eq!(out["openapi"], "true");
+    assert_eq!(out["web"], "true");
+    assert_eq!(out["android"], "true");
+    assert_eq!(out["palette"], "true");
+    assert_eq!(out["rust"], "false");
+}
+
+#[test]
+fn android_changes_enable_kotlin_codeql_only_for_app_language() {
+    let out = classify(
+        "pull_request",
+        &["apps/android/app/src/main/java/com/axon/app/MainActivity.kt"],
+    );
+    assert_eq!(out["android"], "true");
+    assert_eq!(out["codeql_java_kotlin"], "true");
+    assert_eq!(out["codeql_rust"], "false");
+}
+
+#[test]
+fn workflow_dispatch_and_schedule_enable_everything() {
+    for event in ["workflow_dispatch", "schedule"] {
+        let out = classify(event, &[]);
+        for key in [
+            "all",
+            "rust",
+            "web",
+            "android",
+            "palette",
+            "chrome",
+            "docker",
+            "compose",
+            "mcp",
+            "security",
+            "release",
+            "openapi",
+            "codeql_actions",
+            "codeql_javascript_typescript",
+            "codeql_python",
+            "codeql_rust",
+            "codeql_java_kotlin",
+        ] {
+            assert_eq!(out[key], "true", "{event} should enable {key}");
+        }
+    }
+}

--- a/tests/ci_changed_paths.rs
+++ b/tests/ci_changed_paths.rs
@@ -235,6 +235,7 @@ fn rust_ci_helper_scripts_enable_the_jobs_that_execute_them() {
     for file in [
         "scripts/cargo_test_filter_guard.py",
         "scripts/check_shell_completions.sh",
+        "scripts/ci/pre_push.py",
         "scripts/generate_mcp_schema_doc.py",
     ] {
         let out = classify("pull_request", &[file]);

--- a/tests/ci_changed_paths.rs
+++ b/tests/ci_changed_paths.rs
@@ -103,6 +103,7 @@ fn compose_and_docker_inputs_route_to_container_smoke_only() {
         "docker-compose.yaml",
         "docker-compose.prod.yaml",
         "docker-compose.llama.yaml",
+        ".dockerignore",
         "config/chrome/Dockerfile",
         "scripts/sync-openapi.ts",
     ] {
@@ -118,12 +119,54 @@ fn compose_and_docker_inputs_route_to_container_smoke_only() {
 }
 
 #[test]
+fn shared_assets_route_to_web_chrome_and_docker() {
+    let out = classify("pull_request", &["assets/logo.png"]);
+    assert_eq!(out["web"], "true");
+    assert_eq!(out["chrome"], "true");
+    assert_eq!(out["docker"], "true");
+    assert_eq!(out["android"], "false");
+    assert_eq!(out["palette"], "false");
+}
+
+#[test]
 fn dockerfile_change_routes_to_image_and_compose_smoke() {
     let out = classify("pull_request", &["config/Dockerfile"]);
     assert_eq!(out["docker"], "true");
     assert_eq!(out["compose"], "true");
     assert_eq!(out["android"], "false");
     assert_eq!(out["palette"], "false");
+}
+
+#[test]
+fn ci_executed_helper_scripts_enable_their_consuming_jobs() {
+    let aurora = classify(
+        "pull_request",
+        &["scripts/check_aurora_primitive_inventory.py"],
+    );
+    assert_eq!(aurora["docs"], "true");
+    assert_eq!(aurora["android"], "false");
+    assert_eq!(aurora["palette"], "false");
+
+    for file in [
+        "scripts/check_lefthook_pre_commit_speed.py",
+        "scripts/enforce_monoliths.py",
+        "scripts/test-ask-quality-regressions.sh",
+    ] {
+        let out = classify("pull_request", &[file]);
+        assert_eq!(out["rust"], "true", "{file} should enable Rust CI jobs");
+        assert_eq!(out["security"], "true", "{file} should enable security");
+        assert_eq!(out["docker"], "true", "{file} should enable image smoke");
+    }
+
+    for file in [
+        "scripts/test-mcp-oauth-protection.sh",
+        "scripts/test-mcp-tools-mcporter.sh",
+    ] {
+        let out = classify("pull_request", &[file]);
+        assert_eq!(out["rust"], "true", "{file} should enable Rust CI jobs");
+        assert_eq!(out["mcp"], "true", "{file} should enable MCP jobs");
+        assert_eq!(out["security"], "true", "{file} should enable security");
+    }
 }
 
 #[test]

--- a/tests/ci_changed_paths.rs
+++ b/tests/ci_changed_paths.rs
@@ -97,6 +97,36 @@ fn android_changes_enable_kotlin_codeql_only_for_app_language() {
 }
 
 #[test]
+fn compose_and_docker_inputs_route_to_container_smoke_only() {
+    for file in [
+        ".env.example",
+        "docker-compose.yaml",
+        "docker-compose.prod.yaml",
+        "docker-compose.llama.yaml",
+        "config/chrome/Dockerfile",
+        "scripts/sync-openapi.ts",
+    ] {
+        let out = classify("pull_request", &[file]);
+        assert_eq!(
+            out["compose"], "true",
+            "{file} should enable compose checks"
+        );
+        assert_eq!(out["docker"], "true", "{file} should enable docker checks");
+        assert_eq!(out["android"], "false", "{file} should not enable Android");
+        assert_eq!(out["palette"], "false", "{file} should not enable palette");
+    }
+}
+
+#[test]
+fn dockerfile_change_routes_to_image_and_compose_smoke() {
+    let out = classify("pull_request", &["config/Dockerfile"]);
+    assert_eq!(out["docker"], "true");
+    assert_eq!(out["compose"], "true");
+    assert_eq!(out["android"], "false");
+    assert_eq!(out["palette"], "false");
+}
+
+#[test]
 fn workflow_dispatch_and_schedule_enable_everything() {
     for event in ["workflow_dispatch", "schedule"] {
         let out = classify(event, &[]);
@@ -154,5 +184,33 @@ fn changed_path_router_edits_force_full_ci() {
         ] {
             assert_eq!(out[key], "true", "{file} should enable {key}");
         }
+    }
+}
+
+#[test]
+fn rust_ci_helper_scripts_enable_the_jobs_that_execute_them() {
+    for file in [
+        "scripts/cargo_test_filter_guard.py",
+        "scripts/check_shell_completions.sh",
+        "scripts/generate_mcp_schema_doc.py",
+    ] {
+        let out = classify("pull_request", &[file]);
+        assert_eq!(out["rust"], "true", "{file} should enable rust jobs");
+        assert_eq!(
+            out["release"], "true",
+            "{file} should enable release-version checks that compile xtask"
+        );
+        assert_eq!(
+            out["security"], "true",
+            "{file} should enable security checks"
+        );
+        assert_eq!(
+            out["codeql_python"], "true",
+            "{file} should enable Python CodeQL"
+        );
+        assert_eq!(
+            out["codeql_rust"], "true",
+            "{file} should enable Rust CodeQL"
+        );
     }
 }

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -350,6 +350,18 @@ fn compose_and_docker_workflows_use_changed_path_classifier() {
     assert!(docker.contains("startsWith(github.ref, 'refs/tags/v')"));
 }
 
+#[test]
+fn codeql_workflow_routes_language_matrix_by_changed_paths() {
+    let workflow = include_str!("../.github/workflows/codeql.yml");
+    assert!(workflow.contains("scripts/ci/changed_paths.py"));
+    assert!(workflow.contains("codeql_actions"));
+    assert!(workflow.contains("codeql_javascript_typescript"));
+    assert!(workflow.contains("codeql_python"));
+    assert!(workflow.contains("codeql_rust"));
+    assert!(workflow.contains("codeql_java_kotlin"));
+    assert!(workflow.contains("fromJson(needs.changes.outputs.matrix)"));
+}
+
 fn workflow_job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {
     let marker = format!("  {job_name}:");
     let start = workflow

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -247,6 +247,31 @@ fn ci_runs_android_generated_openapi_client_tests() {
 }
 
 #[test]
+fn android_ci_setup_does_not_install_unused_emulator_packages() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let setup = workflow
+        .split("      - name: Set up Android SDK")
+        .nth(1)
+        .and_then(|rest| rest.split("      - name: Run Android unit tests").next())
+        .expect("android SDK setup block exists");
+
+    assert!(
+        setup.contains("uses: android-actions/setup-android@v3"),
+        "android job must set up SDK licenses/tooling before Gradle runs"
+    );
+    assert!(
+        setup.contains("packages: \"\""),
+        "android job should not install default tools/emulator packages for unit/lint/APK builds"
+    );
+    assert!(
+        !setup.contains("connected")
+            && !setup.contains("sdkmanager emulator")
+            && !setup.contains("avdmanager"),
+        "android job should not require emulator setup unless connected tests are added"
+    );
+}
+
+#[test]
 fn auto_tag_uses_validated_xtask_release_plan() {
     let workflow = include_str!("../.github/workflows/auto-tag.yml");
     let plan = workflow_job_block(workflow, "plan");

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -181,6 +181,27 @@ fn ci_xtask_compiling_jobs_checkout_release_manifest() {
 }
 
 #[test]
+fn windows_xtask_check_avoids_duplicate_repository_scans() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let job = workflow_job_block(workflow, "windows-check");
+
+    assert!(
+        job.contains("timeout-minutes: 25"),
+        "windows-check must have a bounded timeout because Windows runners can hang on repo scans"
+    );
+    assert!(
+        job.contains("cargo check -p xtask --locked")
+            && job.contains("cargo test -p xtask --locked")
+            && job.contains("cargo xtask check-mcp-http"),
+        "windows-check should keep the Windows-specific xtask compile/test coverage"
+    );
+    assert!(
+        !job.contains("cargo xtask check-no-mod-rs"),
+        "check-no-mod-rs already runs in the Linux no-mod-rs job and has hung on Windows"
+    );
+}
+
+#[test]
 fn rest_api_parity_checkout_covers_openapi_drift_inputs() {
     let workflow = include_str!("../.github/workflows/ci.yml");
     let job = workflow_job_block(workflow, "rest-api-parity");

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -272,6 +272,31 @@ fn android_ci_setup_does_not_install_unused_emulator_packages() {
 }
 
 #[test]
+fn lefthook_pre_push_uses_path_aware_router() {
+    let lefthook = include_str!("../lefthook.yml");
+    let pre_push = lefthook
+        .split("pre-push:")
+        .nth(1)
+        .expect("pre-push section exists");
+
+    assert!(
+        pre_push.contains("python3 scripts/ci/pre_push.py"),
+        "pre-push should delegate to the path-aware router"
+    );
+    for always_on_heavy_command in [
+        "npm --prefix apps/web run build",
+        "cargo xtask check-openapi-drift",
+        "cargo clippy --workspace --all-targets",
+        "cargo nextest run --workspace",
+    ] {
+        assert!(
+            !pre_push.contains(always_on_heavy_command),
+            "{always_on_heavy_command} must be selected by scripts/ci/pre_push.py, not always run by lefthook"
+        );
+    }
+}
+
+#[test]
 fn auto_tag_uses_validated_xtask_release_plan() {
     let workflow = include_str!("../.github/workflows/auto-tag.yml");
     let plan = workflow_job_block(workflow, "plan");

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -328,12 +328,18 @@ fn ci_gate_covers_expensive_and_contract_jobs() {
         "test",
         "security",
         "mcp-smoke",
+        "rag-changes",
+        "live-rag-pr",
         "release",
         "release-smoke",
     ] {
         assert!(
             gate.contains(&format!("- {job}")),
             "ci-gate must need {job}"
+        );
+        assert!(
+            gate.contains(&format!("require_success_or_skipped {job}")),
+            "ci-gate must verify {job}"
         );
     }
 }
@@ -343,9 +349,18 @@ fn compose_and_docker_workflows_use_changed_path_classifier() {
     let compose = include_str!("../.github/workflows/compose-smoke.yml");
     let docker = include_str!("../.github/workflows/docker-image.yml");
     assert!(compose.contains("scripts/ci/changed_paths.py"));
+    assert!(compose.contains("AXON_CHANGED_PATHS"));
+    assert!(compose.contains("github.event.pull_request.base.sha"));
+    assert!(compose.contains("git show \"${{ github.event.pull_request.base.sha }}:$classifier\""));
+    assert!(compose.contains("python3 \"$AXON_CHANGED_PATHS\""));
     assert!(compose.contains("needs.changes.outputs.compose == 'true'"));
     assert!(compose.contains("needs.changes.outputs.docker == 'true'"));
+    assert!(compose.contains("compose-smoke-gate:"));
+    assert!(compose.contains("require_success_or_skipped compose-config"));
+    assert!(compose.contains("require_success_or_skipped image-build-smoke"));
     assert!(docker.contains("scripts/ci/changed_paths.py"));
+    assert!(docker.contains("AXON_CHANGED_PATHS"));
+    assert!(docker.contains("python3 \"$AXON_CHANGED_PATHS\""));
     assert!(docker.contains("needs.changes.outputs.docker == 'true'"));
     assert!(docker.contains("startsWith(github.ref, 'refs/tags/v')"));
 }
@@ -354,12 +369,39 @@ fn compose_and_docker_workflows_use_changed_path_classifier() {
 fn codeql_workflow_routes_language_matrix_by_changed_paths() {
     let workflow = include_str!("../.github/workflows/codeql.yml");
     assert!(workflow.contains("scripts/ci/changed_paths.py"));
+    assert!(workflow.contains("AXON_CHANGED_PATHS"));
+    assert!(workflow.contains("github.event.pull_request.base.sha"));
+    assert!(
+        workflow.contains("git show \"${{ github.event.pull_request.base.sha }}:$classifier\"")
+    );
+    assert!(workflow.contains("python3 \"$AXON_CHANGED_PATHS\""));
+    assert!(
+        !workflow.contains("source changed-paths.out"),
+        "CodeQL must not source classifier output as shell"
+    );
     assert!(workflow.contains("codeql_actions"));
     assert!(workflow.contains("codeql_javascript_typescript"));
     assert!(workflow.contains("codeql_python"));
     assert!(workflow.contains("codeql_rust"));
     assert!(workflow.contains("codeql_java_kotlin"));
     assert!(workflow.contains("fromJson(needs.changes.outputs.matrix)"));
+    assert!(workflow.contains("codeql-gate:"));
+    assert!(workflow.contains("require_success_or_skipped analyze"));
+}
+
+#[test]
+fn ci_workflow_runs_changed_path_classifier_from_trusted_base_when_available() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    assert!(workflow.contains("AXON_CHANGED_PATHS"));
+    assert!(workflow.contains("github.event.pull_request.base.sha"));
+    assert!(
+        workflow.contains("git show \"${{ github.event.pull_request.base.sha }}:$classifier\"")
+    );
+    assert!(workflow.contains("python3 \"$AXON_CHANGED_PATHS\""));
+    assert!(
+        !workflow.contains("python3 scripts/ci/changed_paths.py"),
+        "CI should call the prepared trusted classifier path"
+    );
 }
 
 fn workflow_job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -279,6 +279,65 @@ fn auto_tag_uses_validated_xtask_release_plan() {
     }
 }
 
+#[test]
+fn ci_has_changed_path_classifier_and_stable_gate() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    assert!(
+        workflow.contains("changes:"),
+        "CI must define a changes job"
+    );
+    assert!(
+        workflow.contains("scripts/ci/changed_paths.py"),
+        "CI must use the tested changed path classifier"
+    );
+    assert!(workflow.contains("ci-gate:"), "CI must expose ci-gate");
+    assert!(
+        !workflow.contains("production-gate:"),
+        "production-gate should be replaced by ci-gate so branch protection has one clear required check"
+    );
+}
+
+#[test]
+fn ci_gate_covers_expensive_and_contract_jobs() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let gate = workflow_job_block(workflow, "ci-gate");
+    for job in [
+        "mcp-transport-modes",
+        "version-sync",
+        "aurora-primitive-inventory",
+        "android",
+        "android-openapi-client",
+        "no-mod-rs",
+        "toml-fmt",
+        "lefthook-pre-commit-speed",
+        "palette-tauri",
+        "windows-check",
+        "windows-build",
+        "shell-completions-smoke",
+        "web-panel",
+        "mcp-schema-doc-sync",
+        "rest-api-parity",
+        "mcp-oauth-smoke",
+        "advisory-lock-policy",
+        "ban-skip-validation",
+        "monolith",
+        "fmt",
+        "check",
+        "msrv",
+        "clippy",
+        "test",
+        "security",
+        "mcp-smoke",
+        "release",
+        "release-smoke",
+    ] {
+        assert!(
+            gate.contains(&format!("- {job}")),
+            "ci-gate must need {job}"
+        );
+    }
+}
+
 fn workflow_job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {
     let marker = format!("  {job_name}:");
     let start = workflow

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -356,8 +356,8 @@ fn compose_and_docker_workflows_use_changed_path_classifier() {
     assert!(compose.contains("needs.changes.outputs.compose == 'true'"));
     assert!(compose.contains("needs.changes.outputs.docker == 'true'"));
     assert!(compose.contains("compose-smoke-gate:"));
-    assert!(compose.contains("require_success_or_skipped compose-config"));
-    assert!(compose.contains("require_success_or_skipped image-build-smoke"));
+    assert!(compose.contains("require_success_or_intentional_skip compose-config"));
+    assert!(compose.contains("require_success_or_intentional_skip image-build-smoke"));
     assert!(docker.contains("scripts/ci/changed_paths.py"));
     assert!(docker.contains("AXON_CHANGED_PATHS"));
     assert!(docker.contains("python3 \"$AXON_CHANGED_PATHS\""));
@@ -374,6 +374,7 @@ fn codeql_workflow_routes_language_matrix_by_changed_paths() {
     assert!(
         workflow.contains("git show \"${{ github.event.pull_request.base.sha }}:$classifier\"")
     );
+    assert!(workflow.contains("args.output.write_text"));
     assert!(workflow.contains("python3 \"$AXON_CHANGED_PATHS\""));
     assert!(
         !workflow.contains("source changed-paths.out"),

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -338,6 +338,18 @@ fn ci_gate_covers_expensive_and_contract_jobs() {
     }
 }
 
+#[test]
+fn compose_and_docker_workflows_use_changed_path_classifier() {
+    let compose = include_str!("../.github/workflows/compose-smoke.yml");
+    let docker = include_str!("../.github/workflows/docker-image.yml");
+    assert!(compose.contains("scripts/ci/changed_paths.py"));
+    assert!(compose.contains("needs.changes.outputs.compose == 'true'"));
+    assert!(compose.contains("needs.changes.outputs.docker == 'true'"));
+    assert!(docker.contains("scripts/ci/changed_paths.py"));
+    assert!(docker.contains("needs.changes.outputs.docker == 'true'"));
+    assert!(docker.contains("startsWith(github.ref, 'refs/tags/v')"));
+}
+
 fn workflow_job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {
     let marker = format!("  {job_name}:");
     let start = workflow


### PR DESCRIPTION
## Summary

Implements path-aware CI routing so Axon runs only the relevant checks for changed files while keeping scheduled/manual runs broad and fail-safe.

- Adds `scripts/ci/changed_paths.py` with tested categories for Rust, web, Android, palette, Chrome, Docker, compose, MCP, security, release, OpenAPI, docs, workflows, and CodeQL language slices.
- Routes the main `CI` workflow through a `changes` job and replaces `production-gate` with stable `ci-gate` that accepts intentionally skipped jobs but fails on real failures.
- Routes `CodeQL`, `Compose smoke`, and `Docker image` workflows through the same classifier.
- Keeps docs/README-only changes out of release builds and Docker publishing.
- Adds workflow-shape tests to keep the routing and aggregate gate from drifting.
- Records the implementation plan in `docs/superpowers/plans/2026-06-19-ci-path-gating.md`.

## Verification

Local targeted verification:

- `cargo test --locked --test ci_changed_paths` passed: 6/6
- `cargo test --locked --test workflow_shapes` passed: 11/11
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/compose-smoke.yml .github/workflows/docker-image.yml` passed

Pre-push verification:

- version sync passed
- OpenAPI drift passed
- web asset build passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` passed
- `cargo nextest run --workspace --locked --lib -E 'not test(/worker_e2e/)'` passed: 3206 passed, 6 skipped

## Follow-up After CI

After this PR branch produces a completed `ci-gate` check context and merges, update branch protection/rulesets to require `ci-gate` on `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes CI by changed paths so PRs only run jobs affected by the diff, introduces stable `ci-gate`, `codeql-gate`, and `compose-smoke-gate` for branch protection, and makes the local pre-push hook path-aware for faster checks. Also speeds up Android CI by skipping unused emulator package installs.

- **New Features**
  - Added `scripts/ci/changed_paths.py` to classify changes across Rust/Web/Android/Palette/Chrome/Docker/Compose/MCP/Security/Release/OpenAPI/Docs/Workflows and CodeQL language slices.
  - Routed `CI`, `CodeQL`, `Compose smoke`, and `Docker image` through the classifier with job-level gates; replaced `production-gate` with `ci-gate` and added `codeql-gate` and `compose-smoke-gate` that accept intentional skips. CodeQL builds a language matrix from changed paths.
  - Hardened guards: on PRs, workflows run a trusted classifier from the base ref; if the diff can’t be resolved, run all categories. Limited `compose-smoke` permissions to `contents: read`.
  - Hardened routing: `.dockerignore` and `config/Dockerfile` trigger Docker/compose; shared `assets/` route web/chrome. Kept docs/README-only changes out of release builds and image publishing. Added workflow-shape/classifier tests and recorded the plan in `docs/superpowers/plans/2026-06-19-ci-path-gating.md`.
  - Updated `scripts/check-env-config-boundary.py` to ignore GitHub Actions env vars, allow `AXON_CHANGED_PATHS`, `AXON_FULL_PRE_PUSH`, and `AXON_PRE_PUSH_BASE`, and skip `__pycache__/`. Trimmed Windows xtask coverage to avoid duplicate scans with a 25-minute timeout. Android CI no longer installs emulator packages during SDK setup.
  - Added `scripts/ci/pre_push.py` and reworked `lefthook.yml` so pre-push checks are path-aware by default; set `AXON_FULL_PRE_PUSH=1` to opt into full local validation, `AXON_PRE_PUSH_BASE` to control the base ref.

- **Migration**
  - After this merges and produces a completed `ci-gate` check, update branch protection/rulesets to require `ci-gate` on `main`.

<sup>Written for commit 3c1d756da0b57afa0b28886bd16534b8022c3201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow infrastructure with intelligent path-aware job scheduling that executes only relevant tests based on file changes, reducing build times and providing faster feedback
  * Improved validation and testing automation across local development and CI environments
  * Updated pre-push validation to perform targeted checks based on modified code areas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->