### PR TITLE
chore: harden binary artifact wrapper

### DIFF
--- a/scripts/cargo-rustc-wrapper
+++ b/scripts/cargo-rustc-wrapper
@@ -126,14 +126,7 @@ fi
 
 bin_dir="${AXON_ARTIFACT_BIN_DIR:-$repo_root/bin}"
 mkdir -p "$bin_dir"
-cp -f "$out" "$bin_dir/$artifact_name"
-if [ "$ext" != ".exe" ]; then
-  chmod 755 "$bin_dir/$artifact_name"
-else
-  chmod 755 "$bin_dir/$artifact_name" 2>/dev/null || {
-    echo "warning: copied Windows artifact but could not chmod $bin_dir/$artifact_name" >&2
-  }
-fi
+install -m 755 "$out" "$bin_dir/$artifact_name"
 
 if [ "$crate_name" != "axon" ]; then
   exit 0
@@ -142,4 +135,4 @@ fi
 local_bin="${AXON_RUSTC_WRAPPER_LOCAL_BIN:-$HOME/.local/bin/axon}"
 
 mkdir -p "$(dirname "$local_bin")"
-cp -f "$out" "$local_bin"
+install -m 755 "$out" "$local_bin"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace cp+chmod with `install -m 755` in `scripts/cargo-rustc-wrapper` to copy artifacts with correct permissions in one step. Simplifies the wrapper and reduces permission-related edge cases.

- **Refactors**
  - Use `install -m 755` when copying to `$bin_dir/$artifact_name` and `$HOME/.local/bin/axon`.
  - Remove separate chmod and Windows-specific branch.

<sup>Written for commit cafe1a5045a19550b63b215e4c49f1b9ad3f1b62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

