### PR TITLE
fix(palette): keep selected action-row glow from clipping at panel edge

### DIFF
--- a/apps/palette-tauri/package.json
+++ b/apps/palette-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axon-palette-tauri",
-  "version": "5.10.3",
+  "version": "5.10.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/palette-tauri/src-tauri/Cargo.lock
+++ b/apps/palette-tauri/src-tauri/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axon-palette-tauri"
-version = "5.10.3"
+version = "5.10.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/apps/palette-tauri/src-tauri/Cargo.toml
+++ b/apps/palette-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axon-palette-tauri"
-version = "5.10.3"
+version = "5.10.4"
 description = "Tauri command palette for the Axon REST API"
 edition = "2024"
 rust-version = "1.94.0"

--- a/apps/palette-tauri/src-tauri/tauri.conf.json
+++ b/apps/palette-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Axon Palette",
-  "version": "5.10.3",
+  "version": "5.10.4",
   "identifier": "tv.tootie.axon.palette",
   "build": {
     "beforeDevCommand": "pnpm vite:dev",

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -2219,7 +2219,11 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 0 3px 6px;
+  /* Left/right gutter must clear the selected row's accent bar
+     (.action-row-selected::before: left:-4px + 11px glow) so its glow isn't
+     clipped by the ancestor overflow:hidden panels (.action-panel /
+     .palette-suggestions / .palette-shell). */
+  padding: 0 8px 6px;
 }
 
 .action-group-item {


### PR DESCRIPTION
## Summary

The palette's **selected action row** has a cyan accent bar with a glow that was being **clipped at the panel edge**. This widens the action-list gutter so the glow renders fully.

## Root cause

`.action-row-selected::before` (the accent bar) sits at `left: -4px` with an `0 0 11px` glow. The row was only ~13px from the panel edge, so the glow reached `x≈0` — right at the `overflow:hidden`, rounded edge of the ancestor panels (`.action-panel` / `.palette-suggestions` / `.palette-shell`) — and got chopped. The row's *outer* `--aurora-active-glow` (8px blur) had clearance; only the accent bar overran.

## Fix

[`src/styles.css`](apps/palette-tauri/src/styles.css) — widen the `.action-list` gutter `0 3px 6px` → `0 8px 6px`. The accent glow now starts ~5px inside the clip boundary (was 0px). No change to the bar's position/size, just breathing room. Symmetric, so rows stay balanced.

Browser-validated before/after against the production bundle.

## Version

Palette `5.10.3` → `5.10.4` (patch — all four version-bearing files move together: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`).

> On merge, `auto-tag` will cut **`palette-v5.10.4`** and publish a palette release (Linux + Windows artifacts).

## Test plan

- [x] Local `xtask check` — release version files valid
- [x] Cross-compiled a Windows build with this fix and verified the glow natively
- [ ] CI gates (`ci-gate`, `codeql-gate`, `compose-smoke-gate`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widens the action-list gutter so the selected row’s cyan accent glow no longer clips at the panel edge. Bumps `axon-palette-tauri` to 5.10.4.

- **Bug Fixes**
  - Update `.action-list` padding from `0 3px 6px` to `0 8px 6px` to keep the `.action-row-selected::before` glow (left:-4px + 11px) inside overflow-hidden panel bounds.

<sup>Written for commit fb72cdce1ed97206875a9a0aa58d626a6e7519f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

