### PR TITLE
fix: split active job progress backfill migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.16.3] - 2026-06-20
+
+### Changed
+- Release version bump.
+
 ## [5.16.2] - 2026-06-18
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "5.16.2"
+version = "5.16.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "5.16.2"
+version = "5.16.3"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 5.16.2
+Version: 5.16.3
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "5.16.2"
+    "version": "5.16.3"
   },
   "paths": {
     "/healthz": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -18,7 +18,7 @@
         "vitest": "^4.1.9"
       },
       "name": "@axon/admin-panel",
-      "version": "5.16.2"
+      "version": "5.16.3"
     },
     "node_modules/@asamuzakjp/css-color": {
       "dependencies": {
@@ -2701,5 +2701,5 @@
     }
   },
   "requires": true,
-  "version": "5.16.2"
+  "version": "5.16.3"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,5 +28,5 @@
     "openapi:types": "node scripts/generate-openapi-types.mjs openapi/axon.json lib/generated/axon-api.ts",
     "test": "vitest run"
   },
-  "version": "5.16.2"
+  "version": "5.16.3"
 }

--- a/src/jobs/migrations/0013_add_job_progress_json.sql
+++ b/src/jobs/migrations/0013_add_job_progress_json.sql
@@ -3,23 +3,3 @@ ALTER TABLE axon_crawl_jobs ADD COLUMN progress_json TEXT;
 ALTER TABLE axon_embed_jobs ADD COLUMN progress_json TEXT;
 ALTER TABLE axon_extract_jobs ADD COLUMN progress_json TEXT;
 ALTER TABLE axon_ingest_jobs ADD COLUMN progress_json TEXT;
-
-UPDATE axon_crawl_jobs
-SET progress_json = result_json,
-    result_json = NULL
-WHERE status IN ('pending', 'running') AND progress_json IS NULL AND result_json IS NOT NULL;
-
-UPDATE axon_embed_jobs
-SET progress_json = result_json,
-    result_json = NULL
-WHERE status IN ('pending', 'running') AND progress_json IS NULL AND result_json IS NOT NULL;
-
-UPDATE axon_extract_jobs
-SET progress_json = result_json,
-    result_json = NULL
-WHERE status IN ('pending', 'running') AND progress_json IS NULL AND result_json IS NOT NULL;
-
-UPDATE axon_ingest_jobs
-SET progress_json = result_json,
-    result_json = NULL
-WHERE status IN ('pending', 'running') AND progress_json IS NULL AND result_json IS NOT NULL;

--- a/src/jobs/migrations/0014_backfill_active_job_progress_json.sql
+++ b/src/jobs/migrations/0014_backfill_active_job_progress_json.sql
@@ -1,0 +1,20 @@
+-- Move active progress snapshots out of terminal result storage.
+UPDATE axon_crawl_jobs
+SET progress_json = result_json,
+    result_json = NULL
+WHERE status IN ('pending', 'running') AND progress_json IS NULL AND result_json IS NOT NULL;
+
+UPDATE axon_embed_jobs
+SET progress_json = result_json,
+    result_json = NULL
+WHERE status IN ('pending', 'running') AND progress_json IS NULL AND result_json IS NOT NULL;
+
+UPDATE axon_extract_jobs
+SET progress_json = result_json,
+    result_json = NULL
+WHERE status IN ('pending', 'running') AND progress_json IS NULL AND result_json IS NOT NULL;
+
+UPDATE axon_ingest_jobs
+SET progress_json = result_json,
+    result_json = NULL
+WHERE status IN ('pending', 'running') AND progress_json IS NULL AND result_json IS NOT NULL;

--- a/src/jobs/store_tests.rs
+++ b/src/jobs/store_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use uuid::Uuid;
 
 #[tokio::test]
-async fn migration_0013_moves_only_active_result_json_to_progress_json() {
+async fn migration_0014_moves_only_active_result_json_to_progress_json() {
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         .connect(":memory:")
@@ -43,15 +43,20 @@ async fn migration_0013_moves_only_active_result_json_to_progress_json() {
         .expect("insert completed row");
     }
 
-    for statement in include_str!("migrations/0013_add_job_progress_json.sql")
-        .split(';')
-        .map(str::trim)
-        .filter(|statement| !statement.is_empty())
-    {
-        sqlx::query(statement)
-            .execute(&pool)
-            .await
-            .expect("run migration statement");
+    for migration in [
+        include_str!("migrations/0013_add_job_progress_json.sql"),
+        include_str!("migrations/0014_backfill_active_job_progress_json.sql"),
+    ] {
+        for statement in migration
+            .split(';')
+            .map(str::trim)
+            .filter(|statement| !statement.is_empty())
+        {
+            sqlx::query(statement)
+                .execute(&pool)
+                .await
+                .expect("run migration statement");
+        }
     }
 
     for table in [


### PR DESCRIPTION
## Summary
- Restore migration 0013 to the checksum already applied in live SQLite databases.
- Add migration 0014 for the active job progress backfill that had been appended to 0013.
- Update the focused migration test to run 0013 then 0014.

## Root cause
The live axon container was restarting because sqlx refused to open ~/.axon/jobs.db: migration 13 had already been applied, then the migration file was edited in a later commit.

## Verification
- sha384sum for 0013 now matches the live DB checksum: 4a38135866c37ed8e6aaec8d6a3e4a85635796aca1413630af47239a520cee6a2055c105a411b78fab319b16a04a3ea0
- cargo test --locked migration_0014_moves_only_active_result_json_to_progress_json
- cargo build --locked --bin axon
- docker compose --env-file ~/.axon/.env -f docker-compose.yaml up -d axon
- docker inspect axon: running, healthy, RestartCount=0
- sqlite migration table shows version 14 applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored migration 0013 to its original checksum and moved the active job progress backfill into a new 0014 migration. This fixes `sqlx` refusing to open existing SQLite DBs and stops the axon container restart loop.

- **Migration**
  - 0013 is now schema-only (adds `progress_json` columns) to match live DB checksum.
  - New 0014 backfills active jobs: moves `result_json` to `progress_json` for `pending`/`running` jobs and clears `result_json`.
  - Updated test to run 0013 then 0014 and renamed it accordingly.

- **Dependencies**
  - Bumped `axon` to 5.16.3 and updated CHANGELOG/README.
  - Updated `@axon/admin-panel` and OpenAPI spec version to 5.16.3.

<sup>Written for commit 36a596bc954ccf71126c86be58ced2ac45540852. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

