### PR TITLE
fix(palette): float the compact launcher bar so its glow isn't clipped

### DIFF
--- a/apps/palette-tauri/package.json
+++ b/apps/palette-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axon-palette-tauri",
-  "version": "5.10.4",
+  "version": "5.10.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/palette-tauri/src-tauri/Cargo.lock
+++ b/apps/palette-tauri/src-tauri/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axon-palette-tauri"
-version = "5.10.4"
+version = "5.10.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/apps/palette-tauri/src-tauri/Cargo.toml
+++ b/apps/palette-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axon-palette-tauri"
-version = "5.10.4"
+version = "5.10.5"
 description = "Tauri command palette for the Axon REST API"
 edition = "2024"
 rust-version = "1.94.0"

--- a/apps/palette-tauri/src-tauri/src/lib.rs
+++ b/apps/palette-tauri/src-tauri/src/lib.rs
@@ -124,7 +124,7 @@ fn show_palette(app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn resize_palette(app: AppHandle, width: f64, height: f64) -> Result<(), String> {
+fn resize_palette(app: AppHandle, width: f64, height: f64, shadow: bool) -> Result<(), String> {
     let window = app
         .get_webview_window("main")
         .ok_or_else(|| "main window not found".to_string())?;
@@ -136,6 +136,8 @@ fn resize_palette(app: AppHandle, width: f64, height: f64) -> Result<(), String>
     window
         .set_size(Size::Logical(LogicalSize { width, height }))
         .map_err(|err| err.to_string())?;
+    // Per-view native shadow toggle (see useWindowChrome.ts for the policy).
+    let _ = window.set_shadow(shadow);
     window.center().map_err(|err| err.to_string())
 }
 
@@ -345,10 +347,13 @@ fn show_main_window(app: &AppHandle) -> Result<(), String> {
     }
     window
         .set_size(Size::Logical(LogicalSize {
-            width: 680.0,
-            height: 56.0,
+            // Compact launcher — matches COMPACT in useWindowChrome.ts (bar + inset).
+            width: 720.0,
+            height: 92.0,
         }))
         .map_err(|err| err.to_string())?;
+    // Compact floats a CSS-glowing bar; keep the native shadow off (JS re-asserts).
+    let _ = window.set_shadow(false);
     window.center().map_err(|err| err.to_string())?;
     window.show().map_err(|err| err.to_string())?;
     window.set_focus().map_err(|err| err.to_string())?;

--- a/apps/palette-tauri/src-tauri/tauri.conf.json
+++ b/apps/palette-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Axon Palette",
-  "version": "5.10.4",
+  "version": "5.10.5",
   "identifier": "tv.tootie.axon.palette",
   "build": {
     "beforeDevCommand": "pnpm vite:dev",

--- a/apps/palette-tauri/src/lib/useWindowChrome.ts
+++ b/apps/palette-tauri/src/lib/useWindowChrome.ts
@@ -24,8 +24,14 @@ type BrowseHeight = () => number;
 // The palette is a borderless window resized to hug each view; these are the
 // per-view logical-px dimensions. `resize_palette` sizes in logical px, so CSS-px
 // measurements map 1:1 across DPIs.
-const COMPACT = { width: 680, height: 56 }; // launcher input only
-const TRAY = { width: 680, height: 96 }; // minimized crawl-job tray
+// The compact/tray launcher windows are intentionally larger than the bar they
+// contain: the shell insets the floating bar by --axon-launcher-inset (20px) on
+// every side so its glow renders fully instead of clipping at the window edge.
+// Geometry must match --axon-launcher-inset in styles.css and show_main_window()
+// in src-tauri/src/lib.rs — COMPACT = 680×52 bar + 20px inset all round; TRAY =
+// 680×88 panel (52px command bar + 36px idle tray) + 20px inset all round.
+const COMPACT = { width: 720, height: 92 }; // launcher input only
+const TRAY = { width: 720, height: 128 }; // minimized crawl-job tray
 const SETTINGS = { width: 800, height: 560 };
 const HISTORY = { width: 760, height: 520 };
 const BROWSE_WIDTH = 760; // action-list browse view
@@ -151,7 +157,13 @@ export function useWindowChrome({
       return;
     }
     lastSizeRef.current = size;
-    void invoke("resize_palette", size);
+    // The native window shadow travels with the resize: off for the floating
+    // compact/tray launcher (its CSS glow owns the float; the native shadow would
+    // double the halo around the larger transparent window), on for the roomy
+    // edge-to-edge views. resolvePaletteWindowSize returns the COMPACT/TRAY
+    // singletons by reference for exactly those two views.
+    const floating = size === COMPACT || size === TRAY;
+    void invoke("resize_palette", { ...size, shadow: !floating });
   }, [jobExpanded, jobMinimized, settingsOpen, historyOpen, showResultsLayout, showContent, filteredLength, shownTick]);
 
   // Launcher states (compact/browse/mode) keep click-away-to-dismiss; while a

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -126,6 +126,15 @@
   --axon-surface: color-mix(in srgb, var(--aurora-panel-strong) 98%, transparent);
   --axon-window-border: color-mix(in srgb, var(--aurora-border-strong) 58%, transparent);
   --axon-window-radius: 14px;
+  /* Compact launcher (floating bar): the transparent breathing room kept around
+     the bar so its glow renders fully instead of clipping at the window edge,
+     plus the glow itself. The window grows to fit (window = bar + 2*inset on
+     each axis) — these MUST stay in sync with COMPACT/TRAY in
+     src/lib/useWindowChrome.ts and show_main_window() in src-tauri/src/lib.rs. */
+  --axon-launcher-inset: 20px;
+  --axon-launcher-glow:
+    0 4px 16px rgba(0, 0, 0, 0.34),
+    0 1px 3px rgba(0, 0, 0, 0.30);
 }
 
 * {
@@ -262,10 +271,17 @@ textarea {
 .palette-shell-compact {
   --ctl: 32px;
   --r-ctl: 9px;
-  width: min(94vw, 680px);
-  min-height: 56px;
-  height: 56px;
-  padding: 0;
+  width: min(94vw, 720px);
+  min-height: 92px;
+  height: 92px;
+  /* Floating launcher: inset the bar so its glow renders fully inside the window
+     instead of clipping at the edge. The window grows by the same inset on every
+     side (see --axon-launcher-inset + COMPACT/TRAY in useWindowChrome.ts), so the
+     bar's content box stays 680px wide / 52px tall. */
+  padding: var(--axon-launcher-inset);
+  /* Center the floating bar/panel in the padded area so the glow stays symmetric
+     even under fractional DPI scaling. */
+  justify-content: center;
   background: transparent;
   border: 0;
   border-radius: 0;
@@ -274,8 +290,8 @@ textarea {
 }
 
 .palette-shell-compact:has(.idle-tray) {
-  min-height: 92px;
-  height: 92px;
+  min-height: 128px;
+  height: 128px;
 }
 
 /* When the crawl tray is attached, the command bar becomes the TOP of one
@@ -287,18 +303,18 @@ textarea {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.055);
 }
 
+/* The compact shell fills the borderless window and insets the floating bar by
+   --axon-launcher-inset, leaving transparent breathing room so the bar's glow
+   renders fully (it was clipped when the window hugged the bar at 680×56). The
+   window grows to match — see COMPACT/TRAY in useWindowChrome.ts. The native
+   window shadow is turned off for this view (set_window_shadow) so it doesn't
+   cast a second halo around the larger window rect; the CSS glow owns the float.
+   This is a deliberate divergence from the roomy views, which stay edge-to-edge
+   with the native shadow to avoid transparent rounded corners over light apps. */
 .tauri-runtime .palette-shell-compact {
   width: 100vw;
-  height: 56px;
-  min-height: 56px;
-}
-
-/* Compact bar fills the window edge-to-edge too — same reason as the shell:
-   a rounded bar would leave transparent (white-on-light) window corners. */
-.tauri-runtime .palette-shell-compact .command-bar {
-  border: 0;
-  border-radius: 0;
-  box-shadow: none;
+  height: 100vh;
+  min-height: 0;
 }
 
 .palette-shell-browse {
@@ -522,15 +538,15 @@ textarea {
 }
 
 .palette-shell-compact .command-bar {
-  height: 56px;
-  min-height: 56px;
+  height: 52px;
+  min-height: 52px;
   padding: 0 8px 0 14px;
   background: color-mix(in srgb, var(--aurora-panel-strong) 98%, transparent);
   border: 1px solid color-mix(in srgb, var(--aurora-border-strong) 52%, transparent);
   border-radius: 14px;
   box-shadow:
-    0 16px 42px rgba(0, 0, 0, 0.36),
-    inset 0 1px 0 rgba(255, 255, 255, 0.055);
+    var(--axon-launcher-glow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .idle-tray {
@@ -547,7 +563,7 @@ textarea {
   border-top: 1px solid color-mix(in srgb, var(--aurora-border-strong) 24%, transparent);
   border-radius: 0 0 14px 14px;
   /* Carry the whole panel's outer shadow (command bar no longer casts its own). */
-  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.36);
+  box-shadow: var(--axon-launcher-glow);
   cursor: pointer;
   font-family: var(--aurora-font-mono);
   font-size: 11px;


### PR DESCRIPTION
## Problem
The compact launcher window hugged the bar exactly (680×56), so the bar's drop shadow had no room and was clipped at the window edge — reading as a heavy dark band that made the bar look oversized.

## Fix
- Grow the compact/tray windows to leave a 20px transparent inset (`--axon-launcher-inset`) around the bar so its glow renders fully; the bar's content box stays 680px wide.
- Slim the bar 56→52px and replace the heavy `0 16px 42px` drop shadow with a soft, contained `--axon-launcher-glow`.
- Delete the `.tauri-runtime` edge-to-edge override so the floating card renders in the real app.
- Fold a per-view native-shadow toggle into `resize_palette` (new `shadow` param): **off** for the floating compact/tray views (the CSS glow owns the float; the native OS shadow would cast a second halo around the larger window), **on** for the roomy edge-to-edge views.

**Tradeoff:** this reintroduces transparent rounded corners on the compact window (can read faintly gray over very light apps) — the reason the earlier edge-to-edge change (`f4231f46`) existed. Chosen deliberately for the floating-glow look.

## Verification
- `cargo check` + `cargo fmt --check` (palette shell), `pnpm typecheck`, `biome lint`, **227/227** vitest, monolith check (`lib.rs` 499 ≤ 500), pre-commit + pre-push hooks green.
- ⚠️ Not yet visually verified on a running build — needs a palette rebuild to confirm the pixels.

Patch bump **5.10.4 → 5.10.5** (palette component only).

Glow size/inset are tunable via the `--axon-launcher-glow` / `--axon-launcher-inset` tokens at the top of `styles.css`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Floats the compact launcher bar with a 20px transparent inset so its glow renders fully instead of clipping. Adds a per‑view native shadow toggle to prevent a double halo on floating views.

- **Bug Fixes**
  - Expand compact/tray windows to 720×92 and 720×128; bar content stays 680×52.
  - Replace heavy drop shadow with `--axon-launcher-glow`, center the bar in the padded shell, and remove the `.tauri-runtime` edge‑to‑edge override.
  - Add `shadow` param to `resize_palette` (off for compact/tray, on for roomy views) and set the default in `show_main_window`; bump to 5.10.5. Tradeoff: transparent rounded corners may show slightly on very light backgrounds.

<sup>Written for commit ee47116db5d30112448615051bd5c4b9999814dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

