### PR TITLE
docs: save session log (palette compact-bar floating glow)

### DIFF
--- a/docs/sessions/2026-06-21-palette-compact-bar-floating-glow.md
+++ b/docs/sessions/2026-06-21-palette-compact-bar-floating-glow.md
@@ -1,0 +1,133 @@
+---
+date: 2026-06-21 08:37:17 EST
+repo: git@github.com:jmagar/axon.git
+branch: main
+head: 458d349e
+working directory: /home/jmagar/workspace/axon/.claude/worktrees/interesting-vaughan-78454d
+worktree: /home/jmagar/workspace/axon/.claude/worktrees/interesting-vaughan-78454d
+pr: "#249 fix(palette): float the compact launcher bar so its glow isn't clipped — https://github.com/jmagar/axon/pull/249 (merged)"
+beads: axon_rust-mwdl
+---
+
+# Palette compact bar — floating glow fix
+
+## User Request
+From a screenshot of the Axon palette: "i need you to fix this glow - its getting like cut off.. and it makes the input bar look too big." The compact launcher bar's glow was clipped, making the bar look oversized.
+
+## Session Overview
+Diagnosed the clipped glow as a window-sizing problem (the borderless window hugged the bar exactly at 680×56, leaving no room for the drop shadow, with `overflow:hidden` on every ancestor). Confirmed the design direction with the user (floating glow vs. edge-to-edge vs. inset-only) → **floating glow**. Implemented it as a floating rounded card with a soft contained glow, a grown window with a transparent inset, and a per-view native-shadow toggle. Discussed (and, per the user, deferred) two architectural cleanups raised mid-session. Then shipped end-to-end: patch version bump, commit through hooks, PR #249, green CI, squash-merge to `main`, and an auto-cut `palette-v5.10.5` release.
+
+## Sequence of Events
+1. Located the palette frontend; read `styles.css`, `useWindowChrome.ts`, `src-tauri/src/lib.rs`, `invoke.ts`; git-blamed the edge-to-edge override; established the root cause.
+2. Asked the user to choose the glow approach via `AskUserQuestion` → "Floating glow."
+3. Implemented CSS (inset + glow tokens, slimmed bar 56→52, removed the `.tauri-runtime` edge-to-edge override, `justify-content:center`), JS (`COMPACT`/`TRAY` window sizes + native-shadow toggle), Rust (`resize_palette` gains a `shadow` param; `show_main_window` initial size).
+4. Verified locally; corrected three churn/limit issues (see Errors): biome reformatting of untouched lines, the `lib.rs` 500-line monolith limit, and `xtask` JSON reformatting.
+5. User: "should we be hard-sizing like that?" → discussed the hard-size coupling smell, the CSS-glow-vs-native-shadow tradeoff, and cleanup options.
+6. User: "invoke ?" → discussed the custom Rust `resize_palette` command vs. the Tauri JS window API and the `invoke.ts` seam convention.
+7. User: "ship it as is" → bumped palette patch, committed (hooks green), opened PR #249, watched CI to green, squash-merged with branch delete; `palette-v5.10.5` auto-tag confirmed.
+
+## Key Findings
+- Root cause: the compact window is hard-pinned to 680×56 (`show_main_window` in `src-tauri/src/lib.rs` and `COMPACT` in `src/lib/useWindowChrome.ts:27`); the compact `.command-bar` (`src/styles.css`) carried `box-shadow: 0 16px 42px` (~58px downward reach) with `#app`/`html`/`body` all `overflow:hidden`, so the glow was clipped at the window edge.
+- The user's build rendered the non-`tauri-runtime` floating style; `main` already had an edge-to-edge override (commit `f4231f46`) that deletes the CSS glow and relies on the native OS shadow, explicitly to avoid transparent rounded corners reading as gray over light apps.
+- A CSS outer glow must live *inside* the window, so the window must exceed the bar (the inset). The native OS shadow renders *outside* the window bounds (no inset needed) — that is the core tradeoff between the two approaches.
+- `cargo xtask bump-version palette patch` re-serializes the JSON version files with alphabetized keys and strips the trailing newline (~124 lines of churn); `Cargo.toml`/`Cargo.lock` it edits cleanly.
+- Building `xtask` compiles the `axon` crate, whose `build.rs` panics on an empty `apps/web/out` unless `AXON_ALLOW_FALLBACK_WEB_ASSETS=1` is set — required for the commit/push hooks.
+
+## Technical Decisions
+- **Floating glow** (user choice). Single source-ish tokens `--axon-launcher-inset: 20px` and `--axon-launcher-glow`; window = bar + 2×inset (compact 720×92, tray 720×128, bar content stays 680px).
+- **Folded the native-shadow toggle into `resize_palette`** (new `shadow` param) instead of a separate `set_window_shadow` command — fewer lines (kept `lib.rs` under the 500-line monolith limit), reverted the `invoke.ts` change entirely, and shadow now travels with each per-view resize.
+- **Minimal-diff discipline**: reverted biome's reformatting of pre-existing lines and `xtask`'s JSON churn, bumping versions in place.
+- **Deferred two refactors** (per "ship it as is"): (a) single-source window sizing (read `--axon-launcher-inset` from CSS / derive height) and (b) moving window ops onto the `appWindow` seam handle instead of the custom Rust command.
+
+## Files Changed
+All in squash commit `458d349e` (PR #249).
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | apps/palette-tauri/src/styles.css | — | inset + glow tokens; slim bar 56→52; remove `.tauri-runtime` edge-to-edge override; `justify-content:center` | 458d349e |
+| modified | apps/palette-tauri/src/lib/useWindowChrome.ts | — | `COMPACT` 680×56→720×92, `TRAY`→720×128; pass `shadow:!floating` in the resize call | 458d349e |
+| modified | apps/palette-tauri/src-tauri/src/lib.rs | — | `resize_palette` `shadow` param + `set_shadow`; `show_main_window` 720×92 + initial `set_shadow(false)`; trimmed to 499 lines | 458d349e |
+| modified | apps/palette-tauri/src-tauri/Cargo.toml | — | version 5.10.4→5.10.5 | 458d349e |
+| modified | apps/palette-tauri/src-tauri/Cargo.lock | — | `axon-palette-tauri` 5.10.4→5.10.5 | 458d349e |
+| modified | apps/palette-tauri/src-tauri/tauri.conf.json | — | version 5.10.4→5.10.5 | 458d349e |
+| modified | apps/palette-tauri/package.json | — | version 5.10.4→5.10.5 | 458d349e |
+
+## Beads Activity
+| id | title | action | status | why |
+|---|---|---|---|---|
+| axon_rust-mwdl | Verify palette compact-bar floating glow on a built release (shipped unverified in #249) | created (P2) | open | The fix shipped CI-green but was never visually confirmed; captures the verification + token-tuning follow-up so it isn't lost in prose. |
+
+No other bead activity occurred during the session.
+
+## Repository Maintenance
+- **Plans**: none created/completed this session. The injected "Active plan" path (`/home/jmagar/workspace/axon_rust/docs/plans/...`) is in the stale external `axon_rust` checkout, not this repo — not in scope. No moves under `docs/plans/`.
+- **Beads**: created `axon_rust-mwdl` (above). No existing beads were claimed/closed (none matched this work).
+- **Worktrees/branches**: the work branch `claude/interesting-vaughan-78454d` was squash-merged and `gh pr merge --delete-branch` removed it locally and remotely (`git ls-remote --heads origin claude/interesting-vaughan-78454d` returned empty). Other listed worktrees/branches (e.g. `worktree-agent-aac3cfb1ad96b7d56`, `claude/goofy-hoover-9affda`, `claude/jolly-brahmagupta-ec0a02`) belong to other agents — one is actively locked — so they were left untouched. Side effect: this worktree (`interesting-vaughan-78454d`) is now checked out on `main`; left as-is (user's call to remove/switch).
+- **Stale docs**: none. The fix's rationale lives in in-code comments; no markdown docs were contradicted. The reusable `xtask bump-version` JSON-churn gotcha was recorded to agent memory (`palette-build-and-merge-workflow`), outside the repo.
+
+## Tools and Skills Used
+- **Bash**: git (status/log/blame/rebase/push), `gh` (pr create/checks/merge), cargo (check/fmt/xtask), pnpm (typecheck/test), biome (lint/format), `python3 scripts/enforce_monoliths.py`, `bd` (ready/create). Used for diagnosis, verification, version bump, and the full ship.
+- **Read/Edit/Write**: source inspection and edits across CSS/TS/Rust/JSON/TOML + this session doc.
+- **AskUserQuestion**: to choose the glow approach (floating vs. edge-to-edge vs. inset).
+- **mcp__visualize__read_me**: loaded the mockup module to consider a before/after preview; not rendered — its design system forbids glows/shadows, which would have misrepresented the effect. No other MCP tools, subagents, or browser tools were used.
+
+## Commands Executed
+| command | result |
+|---|---|
+| `pnpm typecheck` / `pnpm test` | typecheck OK; 227/227 vitest pass |
+| `cargo check` (src-tauri) / `cargo fmt --check` | compiles; rustfmt clean |
+| `python3 scripts/enforce_monoliths.py --staged` | passed (`lib.rs` 499 ≤ 500) |
+| `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo xtask bump-version palette patch` | bumped (then JSON churn reverted, bumped in place) |
+| `AXON_ALLOW_FALLBACK_WEB_ASSETS=1 git commit …` | `2531f235`; pre-commit hooks green |
+| `./target/debug/xtask check-release-versions --base origin/main --head HEAD --mode pr` | `palette changed=true version=5.10.5` — pass |
+| `git rebase origin/main` / `git push -u origin claude/interesting-vaughan-78454d` | clean rebase; pushed; pre-push green (~252s) |
+| `gh pr create` / `gh pr checks 249 --watch` / `gh pr merge 249 --squash --delete-branch` | PR #249; all checks pass; squash-merged to `458d349e` |
+
+## Errors Encountered
+- **`xtask` build panic** — `apps/web/out is empty; run the web build before compiling axon`. Root cause: `axon` `build.rs` requires web assets. Fix: `AXON_ALLOW_FALLBACK_WEB_ASSETS=1` for the bump and the git hooks.
+- **Monolith limit** — `lib.rs` reached 515 > 500 after adding a standalone `set_window_shadow` command. Fix: folded the toggle into `resize_palette` and trimmed comments → 499.
+- **biome reformatting churn** — `biome format --write` reflowed pre-existing lines in `invoke.ts`/`useWindowChrome.ts` (lineWidth 100; format isn't CI-enforced, only `biome lint`). Fix: reverted the untouched-line reformatting, keeping only intended changes.
+- **`xtask bump-version` JSON churn** — alphabetized keys + stripped newline in `package.json`/`tauri.conf.json`. Fix: `git restore` both, bumped the version string in place.
+
+## Behavior Changes (Before/After)
+| area | before | after |
+|---|---|---|
+| compact bar glow | heavy `0 16px 42px` shadow clipped at the window edge; bar looked oversized | soft contained `--axon-launcher-glow` rendered fully inside a 20px transparent inset; slimmer bar |
+| compact window size | 680×56 (hugs the bar) | 720×92 (compact) / 720×128 (tray) |
+| native OS window shadow | on for the compact bar (edge-to-edge intent on `main`) | off for compact/tray (CSS glow owns the float), on for roomy views |
+
+## Verification Evidence
+| command | expected | actual | status |
+|---|---|---|---|
+| `pnpm typecheck` | no TS errors | clean | pass |
+| `pnpm test` | all pass | 227/227 | pass |
+| `cargo check` (src-tauri) | compiles | Finished | pass |
+| `cargo fmt --check` | no diff | clean | pass |
+| `enforce_monoliths.py --staged` | ≤500/file | `lib.rs` 499 | pass |
+| `xtask check-release-versions --mode pr` | palette bumped | `changed=true version=5.10.5` | pass |
+| PR #249 CI | all required green | palette-tauri, version-sync, rest-api-parity, analyze, gates green | pass |
+| merge + tag | on main + tag | `458d349e` on main; `palette-v5.10.5` cut | pass |
+
+## Risks and Rollback
+- **Visual unverified** (tracked in `axon_rust-mwdl`): the pixels were never seen on a running build. The glow could read weak on dark wallpaper, or transparent corners could look gray over very light apps (the tradeoff that motivated the edge-to-edge approach).
+- **Rollback**: `git revert 458d349e` + a palette patch bump; or re-apply the `.tauri-runtime` edge-to-edge override and revert the window-size growth.
+
+## Decisions Not Taken
+- **Edge-to-edge slim bar** (the `main` behavior) — would remove the glow the user wanted to keep.
+- **Inset-only, same window size** — can't fit a real outer glow without growing the window.
+- **Separate `set_window_shadow` command** — folded into `resize_palette` to stay under the monolith limit.
+- **Refactors (a) single-source sizing and (b) `appWindow` seam for window ops** — deferred per "ship it as is."
+
+## References
+- PR: https://github.com/jmagar/axon/pull/249
+- Squash commit: `458d349e`; prior edge-to-edge override: `f4231f46`
+- Release tag: `palette-v5.10.5`
+- Follow-up bead: `axon_rust-mwdl`
+
+## Open Questions
+- Does the soft dark glow read well on a dark desktop (dark-on-dark), and is the 20px inset enough to avoid any visible clip at fractional DPI? (verify in `axon_rust-mwdl`)
+
+## Next Steps
+1. **Verify visually** (`axon_rust-mwdl`): build the palette (`pnpm tauri dev`, or the cross-compile recipe) or pull the `palette-v5.10.5` release `.exe`; confirm the glow renders fully, the bar reads slimmer, and corners are clean. Tune `--axon-launcher-glow` / `--axon-launcher-inset` if needed (keep the window sizes in `useWindowChrome.ts` + `lib.rs` in sync with the inset).
+2. Optionally tackle the deferred refactors as their own passes: (a) single-source window sizing; (b) `appWindow` seam for window ops to drop the JS↔Rust signature coupling.
+3. Housekeeping: remove or switch this worktree off `main` when done.


### PR DESCRIPTION
Session log for PR #249 (palette compact-bar floating glow). Docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs session log capturing the palette compact bar floating glow fix shipped in PR #249, including root cause, decisions, and follow-up verification tasks. This improves traceability and context for the glow implementation and related window sizing changes.

<sup>Written for commit 38191539740f1dca0e24e5ead268acd4f87e3017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

