### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-06-21-save-to-md-auto-merge-and-palette-ship.md
+++ b/docs/sessions/2026-06-21-save-to-md-auto-merge-and-palette-ship.md
@@ -1,0 +1,128 @@
+---
+date: 2026-06-21 09:55:33 EST
+repo: git@github.com:jmagar/axon.git
+branch: main
+head: c3a74308
+working directory: /home/jmagar/workspace/axon/.claude/worktrees/interesting-vaughan-78454d
+worktree: /home/jmagar/workspace/axon/.claude/worktrees/interesting-vaughan-78454d
+pr: "#249 fix(palette): float the compact launcher bar (merged 458d349e); #250 docs: save session log (merged c3a74308)"
+beads: axon_rust-mwdl
+---
+
+# Ship palette glow + make save-to-md auto-land session logs
+
+> The palette compact-bar floating-glow **implementation** is documented in the prior log [`docs/sessions/2026-06-21-palette-compact-bar-floating-glow.md`](2026-06-21-palette-compact-bar-floating-glow.md). This log covers the rest of the same conversation: the architecture Q&A, shipping the fix, and fixing the `save-to-md` skill itself.
+
+## User Request
+Started with "fix this glow - its getting like cut off.. and it makes the input bar look too big" (palette). Then, in order: "should we be hard-sizing like that?", "invoke ?", "ship it as is", "merge that fuckin log into main - and then update the save-to-md skill ... tired of it always putting the session logs on separate branches that I have to merge", and "claude-homelab is not the marketplace we use anymore ... we use dendrite ... update the save-to-md skill in ../dendrite/...".
+
+## Session Overview
+Diagnosed and fixed the palette compact-bar glow (floating-glow approach), shipped it as PR #249 (palette `5.10.5`, auto-released `palette-v5.10.5`), then saved + merged the session log as PR #250. Discussed two architectural cleanups (hard-size coupling; custom `invoke` command vs the Tauri JS window API) and deferred both per the user. Finally, fixed the `save-to-md` skill so session logs land on the default branch with no manual merge — applied to the live runtime copy and to the canonical source in `~/workspace/dendrite` — and recorded that dendrite (not claude-homelab) is the marketplace of record.
+
+## Sequence of Events
+1. Diagnosed the clipped glow; user chose the **floating glow** approach (via `AskUserQuestion`); implemented + verified (prior log).
+2. Architecture Q&A: explained the `window = bar + 2·inset` hard-size coupling and that it's the price of a CSS glow vs. the native OS shadow; explained the custom `resize_palette` `invoke` command vs. the Tauri JS window API + the `invoke.ts` seam. Deferred both refactors.
+3. "ship it" → reverted `xtask` JSON churn (bumped versions in place), committed through hooks, opened PR #249, watched CI green, squash-merged (`458d349e`); `palette-v5.10.5` auto-tag confirmed.
+4. First `/save-to-md` → wrote the palette log, committed it on a branch.
+5. "merge the log + fix the skill" → opened PR #250, hit a transient `version-sync` crates.io flake, re-ran the failed jobs, merged (`c3a74308`); rewrote the skill's commit/push section to auto-merge logs on the default branch (live cache).
+6. "use dendrite" → applied the same skill edit to `~/workspace/dendrite/plugins/vibin/skills/save-to-md/` (+ CHANGELOG `0.3.0`), pushed to dendrite `main` (`7d1cb1f`); saved a memory that dendrite is canonical.
+7. Second `/save-to-md` (this log) → exercised the NEW skill flow: on `main`, base a `session-log/*` branch on `origin/main`, then auto-publish via PR + auto-merge.
+
+## Key Findings
+- A CSS outer glow must live inside the window, so the window must exceed the bar (the inset coupling). The native OS shadow renders outside window bounds (no inset) — that is the core tradeoff (palette details in the prior log).
+- Plugin layering: the **live runtime copy** at `~/.claude/remote/plugins/<hash>/skills/...` is a regenerated cache (good for immediate effect, not permanence); the **canonical source** is `~/workspace/dendrite/plugins/vibin/...`; `~/workspace/lab/...` holds identical mirror copies. The active install's manifest still lists the deprecated `claude-homelab` repo.
+- `cargo xtask bump-version palette patch` re-serializes the JSON version files (alphabetized keys + stripped newline, ~124 lines churn); bump those in place instead.
+- `lib.rs` hit the 500-line monolith hard limit (515); folding `set_window_shadow` into `resize_palette` (a `shadow` param) + trimming comments brought it to 499.
+- `version-sync` on PR #250 failed on a transient `crates.io` download (`curl failed` fetching `objc2-core-foundation`), not a real version issue; a re-run was green.
+
+## Technical Decisions
+- Floating glow; fold the per-view native-shadow toggle into `resize_palette`; keep diffs minimal by reverting biome's and xtask's unrelated reformatting.
+- Deferred refactors (a) single-source window sizing and (b) moving window ops onto the `appWindow` seam — per "ship it as is".
+- `save-to-md` redesign: on the default branch, create a throwaway `session-log/<date>-<slug>` branch and either fast-forward to remote default or open AND merge the PR itself; never leave a side branch for the user. Feature-branch behavior (log rides with the branch's PR) unchanged.
+- Edited the dendrite source (canonical) rather than guessing across the lab/claude-homelab mirrors; left lab untouched per the user's instruction.
+
+## Files Changed
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | apps/palette-tauri/** (7 files) | — | palette floating-glow fix + version bump 5.10.5 | axon `458d349e` (PR #249) |
+| created | docs/sessions/2026-06-21-palette-compact-bar-floating-glow.md | — | palette session log | axon `c3a74308` (PR #250) |
+| created | docs/sessions/2026-06-21-save-to-md-auto-merge-and-palette-ship.md | — | this session log | this commit |
+| modified | plugins/vibin/skills/save-to-md/SKILL.md | — | auto-land logs on default branch | dendrite `7d1cb1f` |
+| modified | plugins/vibin/skills/save-to-md/CHANGELOG.md | — | skill bump to 0.3.0 | dendrite `7d1cb1f` |
+| modified | ~/.claude/remote/plugins/101d2a1f.../save-to-md/SKILL.md | — | same edit, live runtime copy (transient cache) | local only |
+| created | ~/.claude/.../memory/marketplace-is-dendrite.md | — | dendrite is the marketplace (claude-homelab deprecated) | agent memory |
+| modified | ~/.claude/.../memory/{MEMORY.md,palette-build-and-merge-workflow.md} | — | index entry + xtask JSON-churn gotcha | agent memory |
+
+## Beads Activity
+| id | title | action | status | why |
+|---|---|---|---|---|
+| axon_rust-mwdl | Verify palette compact-bar floating glow on a built release (shipped unverified in #249) | created (P2, in prior save-to-md) | open | Captures the still-open visual verification of the shipped glow. |
+
+No other bead activity this session. The lab-mirror sync follow-up was deliberately left to the user (see Next Steps), not filed as a bead.
+
+## Repository Maintenance
+- **Plans**: none created/completed; the injected "active plan" is in the external stale `axon_rust` checkout, not this repo. No moves under `docs/plans/`.
+- **Beads**: `axon_rust-mwdl` (above) remains open. `bd dolt push` was run in the prior save-to-md to persist it.
+- **Worktrees/branches**: both session-log branches were auto-deleted by their merges (`gh pr merge --delete-branch`); confirmed `origin/claude/session-palette-glow` is gone this run. Other worktrees/branches belong to other agents (one locked) — left untouched. This worktree is on `main` (now 1 behind `origin/main` after PR #247 landed elsewhere); the session-log branch for this log was based on fresh `origin/main`.
+- **Stale docs**: none in the axon repo. The `save-to-md` skill doc was updated in its dendrite source.
+
+## Tools and Skills Used
+- **Bash**: git (status/log/blame/rebase/fetch/branch/push), `gh` (pr create/checks/merge/run rerun), cargo (check/fmt/xtask bump-version), pnpm (typecheck/test), biome (lint/format), `python3 scripts/enforce_monoliths.py`, `bd` (ready/create/dolt push).
+- **Read/Edit/Write**: source + skill + memory edits; this log.
+- **AskUserQuestion**: glow-approach decision.
+- **Skills**: `vibin:save-to-md` (twice). **mcp__visualize__read_me** loaded but not rendered (design system forbids glows). No subagents/browser/other MCP tools.
+
+## Commands Executed
+| command | result |
+|---|---|
+| `gh pr merge 249 --squash --delete-branch` | merged palette fix → `458d349e`; `palette-v5.10.5` tag cut |
+| `gh run rerun 27904878028 --failed` | cleared the transient `version-sync` flake on PR #250 |
+| `gh pr merge 250 --squash --delete-branch` | merged palette log → `c3a74308` (fast-forward) |
+| `git -C ~/workspace/dendrite commit/push` | skill update → dendrite `7d1cb1f` on `main` (no-MCP invariant checks passed) |
+| `git checkout -b session-log/2026-06-21-... origin/main` | based this log on current `origin/main` (`2d71d7df`) |
+
+## Errors Encountered
+- **`xtask` build panic** (`apps/web/out is empty`) → set `AXON_ALLOW_FALLBACK_WEB_ASSETS=1` for the bump + git hooks.
+- **Monolith limit** (`lib.rs` 515 > 500) → folded `set_window_shadow` into `resize_palette` + trimmed comments → 499.
+- **biome + xtask reformatting churn** → reverted to keep diffs minimal (bumped versions in place).
+- **`version-sync` transient `crates.io` failure** on PR #250 → `gh run rerun --failed` → green.
+
+## Behavior Changes (Before/After)
+| area | before | after |
+|---|---|---|
+| palette compact bar | clipped glow, oversized | floating soft glow, slimmer (shipped in `palette-v5.10.5`) |
+| `save-to-md` on default branch | committed a side branch and left it for the user to merge | creates `session-log/*`, then auto-merges the PR (or fast-forwards) itself |
+
+## Verification Evidence
+| command | expected | actual | status |
+|---|---|---|---|
+| PR #249 CI | required green | palette-tauri/version-sync/analyze/gates green | pass |
+| PR #249 merge | on main + tag | `458d349e`; `palette-v5.10.5` cut | pass |
+| PR #250 CI (after rerun) | required green | ci-gate/codeql-gate/compose-smoke-gate/version-sync green | pass |
+| PR #250 merge | on main | `c3a74308` (ff) | pass |
+| dendrite push | skill + changelog on main | `7d1cb1f`; pre-push invariant checks passed | pass |
+
+## Risks and Rollback
+- **Palette pixels unverified** (`axon_rust-mwdl`): glow not seen on a running build; could read weak on dark wallpaper or show gray transparent corners over light apps. Rollback: revert `458d349e` + patch bump.
+- **save-to-md live-cache edit is transient** — the dendrite source (`7d1cb1f`) is what persists across reinstalls.
+
+## Decisions Not Taken
+- Edge-to-edge bar / inset-only glow / separate `set_window_shadow` command (palette) — see prior log.
+- Refactors (a) single-source sizing and (b) `appWindow` seam — deferred.
+- Syncing the `lab` mirror of the skill — left to the user (they said dendrite is canonical).
+
+## References
+- PRs: https://github.com/jmagar/axon/pull/249 , https://github.com/jmagar/axon/pull/250
+- Commits: axon `458d349e`, `c3a74308`; dendrite `7d1cb1f`; release tag `palette-v5.10.5`
+- Prior log: `docs/sessions/2026-06-21-palette-compact-bar-floating-glow.md`
+- Bead: `axon_rust-mwdl`
+
+## Open Questions
+- Does the floating glow read well on a dark desktop and avoid gray corners over light apps? (verify in `axon_rust-mwdl`)
+- Should the `lab` mirror of the `save-to-md` skill be synced/retired, or is dendrite the sole source going forward?
+
+## Next Steps
+1. **Verify the palette glow** on a built release (`axon_rust-mwdl`); tune `--axon-launcher-glow` / `--axon-launcher-inset` if needed.
+2. Decide on the `lab` mirror (sync the same edit or treat dendrite as sole source).
+3. Optionally do the deferred palette refactors (single-source sizing; `appWindow` seam) as their own passes.
+4. This log auto-merges to `main` via the updated `save-to-md` flow — no manual merge required.


### PR DESCRIPTION
Session log — docs only. (save-to-md, palette glow ship + skill auto-merge fix)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a session log documenting the palette compact-bar floating glow ship and the update to `save-to-md` that auto-merges session logs to the default branch. Also notes `dendrite` as the canonical marketplace.

Added: docs/sessions/2026-06-21-save-to-md-auto-merge-and-palette-ship.md

<sup>Written for commit 8fcb3cf7c37ce4e7588738627b800364ddc7bdcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

