### PR TITLE
ci: speed up pipeline (cache sharing, cancel-in-progress, drop redundant jobs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,7 +531,10 @@ jobs:
   windows-check:
     name: windows-check (xtask only)
     runs-on: windows-latest
-    timeout-minutes: 25
+    # `cargo check -p xtask` transitively compiles axon (bench_embed dep); on a
+    # cold Windows cache this lands right at the old 25-min cap (observed
+    # 25m08s — a timeout despite all real steps passing). Give it headroom.
+    timeout-minutes: 40
     needs: [changes]
     if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # On PRs, cancel superseded runs so the strict-up-to-date re-run treadmill
+  # doesn't pile up 30-min runs. Never cancel on main/schedule.
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: ""
@@ -981,87 +987,11 @@ jobs:
       - name: cargo fmt check
         run: cargo fmt --all -- --check
 
-  check:
-    name: check
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: ${{ needs.changes.outputs.rust == 'true' }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          sparse-checkout: |
-            src
-            xtask
-            benches
-            apps/web
-            apps/palette-tauri
-            apps/android
-            apps/chrome-extension
-            assets
-            migrations
-            plugins
-            docs
-            .github
-            tests
-            scripts
-            config
-            vendor
-            .cargo
-            release
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.94.0
-      - uses: Swatinem/rust-cache@v2
-      - name: create web assets placeholder
-        run: |
-          mkdir -p apps/web/out
-          echo "AXON_ALLOW_FALLBACK_WEB_ASSETS=1" >> "$GITHUB_ENV"
-      - name: cargo check (warnings are errors)
-        env:
-          RUSTFLAGS: -D warnings
-        run: cargo check --workspace --all-targets --locked --features test-helpers
-
-  msrv:
-    name: msrv
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: ${{ needs.changes.outputs.rust == 'true' }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          # Cone mode keeps root-level files such as `.gitignore` available.
-          # Non-cone sparse checkouts can make older Cargo/gix fail while
-          # fingerprinting the root build script.
-          sparse-checkout: |
-            src
-            xtask
-            benches
-            apps/web
-            apps/palette-tauri
-            apps/android
-            apps/chrome-extension
-            assets
-            migrations
-            plugins
-            docs
-            .github
-            tests
-            scripts
-            config
-            vendor
-            .cargo
-            release
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.94.0
-      - uses: Swatinem/rust-cache@v2
-      - name: create web assets placeholder
-        run: |
-          mkdir -p apps/web/out
-          echo "AXON_ALLOW_FALLBACK_WEB_ASSETS=1" >> "$GITHUB_ENV"
-      - name: cargo check (MSRV)
-        run: cargo check --workspace --all-targets --locked --features test-helpers
-
+  # `check` and `msrv` were removed: both ran `cargo check --workspace
+  # --all-targets --locked --features test-helpers` (byte-identical, and the
+  # 1.94.0 pin was silently overridden to rust-toolchain.toml's channel, so
+  # `msrv` validated nothing). `clippy -D warnings` is a strict superset of
+  # `cargo check -D warnings`, so the `clippy` job below covers them.
   clippy:
     name: clippy
     runs-on: ubuntu-latest
@@ -1094,6 +1024,13 @@ jobs:
           toolchain: 1.94.0
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Shared with `test` (same toolchain + features, no RUSTFLAGS) and
+          # warmed from main, so PRs restore a hot dep cache instead of each job
+          # recompiling the workspace. `clippy -D warnings` also denies rustc
+          # warnings, so this job subsumes the removed `check`/`msrv` jobs.
+          shared-key: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: create web assets placeholder
         run: |
           mkdir -p apps/web/out
@@ -1149,6 +1086,11 @@ jobs:
         with:
           tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Shared with `clippy` (same toolchain + features, no RUSTFLAGS);
+          # warmed from main.
+          shared-key: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: create web assets placeholder
         run: |
           mkdir -p apps/web/out
@@ -1588,6 +1530,12 @@ jobs:
         with:
           toolchain: 1.94.0
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Release-profile artifacts (distinct from the debug `rust` cache);
+          # warmed from main so the PR release build + serialized mcp-smoke start
+          # sooner.
+          shared-key: release
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@v5
         with:
           node-version: 22
@@ -1648,8 +1596,6 @@ jobs:
       - ban-skip-validation
       - monolith
       - fmt
-      - check
-      - msrv
       - clippy
       - test
       - security
@@ -1692,8 +1638,6 @@ jobs:
           require_success_or_skipped ban-skip-validation "${{ needs.ban-skip-validation.result }}"
           require_success_or_skipped monolith "${{ needs.monolith.result }}"
           require_success_or_skipped fmt "${{ needs.fmt.result }}"
-          require_success_or_skipped check "${{ needs.check.result }}"
-          require_success_or_skipped msrv "${{ needs.msrv.result }}"
           require_success_or_skipped clippy "${{ needs.clippy.result }}"
           require_success_or_skipped test "${{ needs.test.result }}"
           require_success_or_skipped security "${{ needs.security.result }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded CodeQL runs on PRs (heavy rust/kotlin build-mode analyze).
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   AURORA_REPO: ${{ vars.AURORA_REPO || 'jmagar/aurora-design-system' }}
   AURORA_REF: ${{ vars.AURORA_REF || '8748eb6434b3bbe4c75f25bfff71950b7efc051b' }}

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: compose-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     name: changes

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -121,7 +121,9 @@ def classify(event: str, paths: list[str]) -> dict[str, bool]:
     codeql_javascript_typescript = web or palette or any_match(
         paths, lambda p: p.endswith((".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"))
     )
-    codeql_python = any_match(paths, lambda p: p.endswith(".py") or starts(p, "scripts/"))
+    # Python CodeQL only analyzes .py sources; `scripts/` is mostly shell, so
+    # gating on the prefix triggered a full Python analyze on unrelated changes.
+    codeql_python = any_match(paths, lambda p: p.endswith(".py"))
     codeql_rust = rust or palette
     codeql_java_kotlin = android or any_match(paths, lambda p: p.endswith((".java", ".kt", ".kts")))
 

--- a/scripts/ci/pre_push.py
+++ b/scripts/ci/pre_push.py
@@ -224,11 +224,18 @@ def main() -> int:
     full = truthy(os.environ.get("AXON_FULL_PRE_PUSH"))
     base = resolve_base()
     paths = changed_files(base)
-    if paths is None and not full:
-        print("Could not determine changed files; set AXON_FULL_PRE_PUSH=1 for full validation.", file=sys.stderr)
-        full = True
-        paths = []
-    elif paths is None:
+    if paths is None:
+        # The diff base couldn't be resolved (e.g. a fresh worktree without an
+        # origin/main upstream). Do NOT silently escalate to the ~10-min full
+        # build — CI is the authoritative gate. Run the minimal plan and warn;
+        # set AXON_FULL_PRE_PUSH=1 to force full local validation.
+        if not full:
+            print(
+                "pre-push: could not determine changed files; running minimal "
+                "checks only (CI is authoritative). Set AXON_FULL_PRE_PUSH=1 for "
+                "full local validation.",
+                file=sys.stderr,
+            )
         paths = []
 
     categories = classify(paths, full)

--- a/tests/ci_changed_paths.rs
+++ b/tests/ci_changed_paths.rs
@@ -249,8 +249,13 @@ fn rust_ci_helper_scripts_enable_the_jobs_that_execute_them() {
             "{file} should enable security checks"
         );
         assert_eq!(
-            out["codeql_python"], "true",
-            "{file} should enable Python CodeQL"
+            out["codeql_python"],
+            if file.ends_with(".py") {
+                "true"
+            } else {
+                "false"
+            },
+            "{file} codeql_python should track the .py extension"
         );
         assert_eq!(
             out["codeql_rust"], "true",

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -186,7 +186,7 @@ fn windows_xtask_check_avoids_duplicate_repository_scans() {
     let job = workflow_job_block(workflow, "windows-check");
 
     assert!(
-        job.contains("timeout-minutes: 25"),
+        job.contains("timeout-minutes: 40"),
         "windows-check must have a bounded timeout because Windows runners can hang on repo scans"
     );
     assert!(

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -154,7 +154,7 @@ fn ci_runs_release_version_gate_before_merge() {
 #[test]
 fn ci_xtask_compiling_jobs_checkout_release_manifest() {
     let workflow = include_str!("../.github/workflows/ci.yml");
-    for job_name in ["check", "msrv", "clippy", "test", "windows-check"] {
+    for job_name in ["clippy", "test", "windows-check"] {
         let job = workflow_job_block(workflow, job_name);
         if job.contains("cargo check --workspace --all-targets")
             || job.contains("cargo clippy --workspace --all-targets")
@@ -393,8 +393,6 @@ fn ci_gate_covers_expensive_and_contract_jobs() {
         "ban-skip-validation",
         "monolith",
         "fmt",
-        "check",
-        "msrv",
         "clippy",
         "test",
         "security",


### PR DESCRIPTION
## Summary

Cuts a typical Rust PR from ~30 min toward ~18-20 min and kills the strict-up-to-date re-run treadmill, from the 2026-06-21 CI audit. **No `axon` source touched** — only workflows, CI scripts, and the tests that pin their shapes. Cuts no release.

## Changes

- **Share the Rust cache + drop redundant compiles.** `clippy` and `test` now share a warm `rust` Swatinem cache (`save-if: main`) instead of each populating a separate cache and recompiling the workspace. **Removed `check` and `msrv`**: both ran a byte-identical `cargo check --workspace --all-targets --locked --features test-helpers`, and `msrv`'s `1.94.0` pin was silently overridden by `rust-toolchain.toml`, so it validated nothing. `cargo clippy -- -D warnings` is a strict superset of `cargo check -D warnings`, so the `clippy` job covers them. `ci-gate`'s `needs` + verify step updated accordingly.
- **Cancel superseded PR runs.** Added `concurrency: { cancel-in-progress: PR }` to `ci.yml`, `codeql.yml`, and `compose-smoke.yml`. With `strict` branch protection, every push/branch-update previously left a full ~30-min run burning; now superseded PR runs cancel.
- **Warm the release cache.** The `release` job (which the serialized `mcp-smoke` depends on) gets a warm `release`-profile cache so it starts sooner on PRs.
- **Narrow CodeQL Python trigger.** `codeql_python` now fires on `.py` changes only (was any `scripts/` change, mostly shell).
- **Pre-push: stop the silent full-build escalation.** When the diff base can't be resolved (e.g. a fresh worktree without an `origin/main` upstream), `scripts/ci/pre_push.py` no longer escalates to the ~10-min full build — it runs the minimal plan and warns. CI remains the authoritative gate; `AXON_FULL_PRE_PUSH=1` still forces full.

## Validation

- `actionlint` clean on all three workflows
- `python3 -m py_compile` clean on both edited scripts
- `cargo test --test ci_changed_paths --test workflow_shapes` — pass (both updated to match the dropped jobs + narrowed Python trigger)
- `cargo fmt --check` clean

## Deliberately deferred (see PR discussion)

- Decoupling `mcp-smoke` from the full `release` build (delicate Docker/TEI smoke job — did the warm-cache proxy instead)
- sccache wiring (complex on ephemeral runners; cache-key fix captures most of it)
- Collapsing the ~10 tiny guard jobs (lower ROI)
- Moving heavy CodeQL off the PR path (security-posture tradeoff)
- Self-hosted runner on dookie (infra; biggest remaining lever)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up CI by sharing Rust caches, canceling superseded runs, dropping redundant jobs, and fixing Windows timeout flakiness. Typical Rust PRs drop from ~30 min to ~18–20 min; no source or release changes.

- **CI Improvements**
  - Share the Rust cache between `clippy` and `test`; remove `check` and `msrv` (covered by `clippy -D warnings`, and the toolchain pin made `msrv` ineffective).
  - Add `concurrency` with `cancel-in-progress` on PRs in `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, and `.github/workflows/compose-smoke.yml`.
  - Warm a release-profile cache so `release` and serialized `mcp-smoke` start faster on PRs.
  - Narrow Python CodeQL to `.py` changes only (was any `scripts/` change).
  - Pre-push: when the diff base can’t be resolved, run minimal checks and warn; set `AXON_FULL_PRE_PUSH=1` to force a full local run.
  - Raise `windows-check` timeout from 25 to 40 minutes to avoid false timeouts on cold caches.

<sup>Written for commit 0492da6ef569c50e59d4ef8207ff863e4f3bedc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

