### PR TITLE
Guard destructive palette actions

### DIFF
--- a/apps/palette-tauri/CHANGELOG.md
+++ b/apps/palette-tauri/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.11.4] - 2026-06-25
+
+### Fixed
+
+- Guard destructive actions
+- Satisfy sqlite hardening release gates
+
 ## [5.11.3] - 2026-06-25
 
 ### Fixed

--- a/apps/palette-tauri/package.json
+++ b/apps/palette-tauri/package.json
@@ -54,5 +54,5 @@
     "vite:dev": "vite --host 127.0.0.1"
   },
   "type": "module",
-  "version": "5.11.3"
+  "version": "5.11.4"
 }

--- a/apps/palette-tauri/src-tauri/Cargo.lock
+++ b/apps/palette-tauri/src-tauri/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axon-palette-tauri"
-version = "5.11.3"
+version = "5.11.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/apps/palette-tauri/src-tauri/Cargo.toml
+++ b/apps/palette-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axon-palette-tauri"
-version = "5.11.3"
+version = "5.11.4"
 description = "Tauri command palette for the Axon REST API"
 edition = "2024"
 rust-version = "1.94.0"

--- a/apps/palette-tauri/src-tauri/tauri.conf.json
+++ b/apps/palette-tauri/src-tauri/tauri.conf.json
@@ -59,5 +59,5 @@
   },
   "identifier": "tv.tootie.axon.palette",
   "productName": "Axon Palette",
-  "version": "5.11.3"
+  "version": "5.11.4"
 }

--- a/apps/palette-tauri/src/App.test.tsx
+++ b/apps/palette-tauri/src/App.test.tsx
@@ -212,6 +212,40 @@ describe("App command palette accessibility + keyboard nav", () => {
     expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("axon_http_request", expect.anything());
   });
 
+  it("requires a second Enter before running guarded actions", async () => {
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === "load_palette_config" || command === "load_palette_default_config") return config;
+      if (command === "axon_http_request") {
+        return {
+          ok: true,
+          status: 200,
+          method: "POST",
+          path: "/v1/dedupe",
+          payload: { collection: "axon", scanned: 10, removed: 0 },
+        };
+      }
+      return undefined;
+    });
+    const user = userEvent.setup();
+    const input = await renderApp();
+    await user.type(input, "dedupe");
+    await user.keyboard("{Enter}");
+
+    expect(await screen.findByText(/confirmation armed/i)).toBeInTheDocument();
+    expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("axon_http_request", expect.anything());
+
+    await user.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expect(vi.mocked(invoke)).toHaveBeenCalledWith(
+        "axon_http_request",
+        expect.objectContaining({
+          request: expect.objectContaining({ path: "/v1/dedupe", method: "POST" }),
+        }),
+      ),
+    );
+  });
+
   // T-H1 — Escape backs out of argument mode rather than submitting.
   it("clears argument mode on Escape", async () => {
     const user = userEvent.setup();

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -18,6 +18,13 @@ import {
   type PaletteAction,
   actionMatches,
 } from "@/lib/actions";
+import {
+  actionConfirmationArmed,
+  actionConfirmationMessage,
+  actionNeedsConfirmation,
+  confirmationFor,
+  type PendingActionConfirmation,
+} from "@/lib/actionGuard";
 import { buildHelpRun, helpAction } from "@/lib/actionHelp";
 import { currentOutputTarget } from "@/lib/appHelpers";
 import { type PaletteConfig, createAxonClient } from "@/lib/axonClient";
@@ -65,6 +72,7 @@ export default function App() {
   const [run, setRun] = useState<RunState>({ kind: "idle" });
   const [copied, setCopied] = useState(false);
   const [shownTick, setShownTick] = useState(0);
+  const [pendingConfirmation, setPendingConfirmation] = useState<PendingActionConfirmation | null>(null);
 
   const modeAction = modeOf(view);
   const settingsOpen = isSettingsOpen(view);
@@ -165,6 +173,12 @@ export default function App() {
   const active = modeAction ?? suggestedAction;
   const activeArgument = active ? argumentFor(active, modeAction, parsed, query) : "";
   const validation = active ? validationMessage(active, activeArgument) : "No matching action";
+  const confirmationArmed =
+    active && !validation ? actionConfirmationArmed(pendingConfirmation, active, activeArgument) : false;
+  const guardMessage =
+    active && !validation && actionNeedsConfirmation(active)
+      ? actionConfirmationMessage(active, Boolean(confirmationArmed))
+      : "";
   const canRunLocalAction = active?.kind === "local";
   const jobMinimized = run.kind === "job" && run.minimized;
   const jobExpanded = run.kind === "job" && !run.minimized;
@@ -228,6 +242,25 @@ export default function App() {
     query,
   });
 
+  const requestSubmit = useCallback(
+    (action: PaletteAction, argumentOverride?: string) => {
+      const argument = argumentOverride ?? argumentFor(action, modeAction, parsed, query);
+      const validationMessageText = validationMessage(action, argument);
+      if (!validationMessageText && actionNeedsConfirmation(action)) {
+        if (!actionConfirmationArmed(pendingConfirmation, action, argument)) {
+          setPendingConfirmation(confirmationFor(action, argument));
+          focusInput(true);
+          return;
+        }
+        setPendingConfirmation(null);
+      } else if (pendingConfirmation) {
+        setPendingConfirmation(null);
+      }
+      void submit(action, argumentOverride);
+    },
+    [modeAction, parsed, pendingConfirmation, query, submit],
+  );
+
   // A-M2 — useCrawlJob's 6 setters collapse to 3 view intents + the query reset
   // each implies. setRun stays (it owns the live poll snapshot, which is run state).
   const onMinimizeJob = useCallback(() => {
@@ -249,6 +282,7 @@ export default function App() {
   });
 
   function enterActionMode(action: PaletteAction) {
+    setPendingConfirmation(null);
     dispatchView({ type: "enterMode", action });
     setQuery(parsed.invoked?.subcommand === action.subcommand ? parsed.arg : "");
     setSelected(0);
@@ -265,9 +299,10 @@ export default function App() {
       setQuery("");
       setSelected(0);
       setRun({ kind: "idle" });
-      void submit(action, "");
+      requestSubmit(action, "");
       return;
     }
+    setPendingConfirmation(null);
     dispatchView({ type: "switchMode", action });
     setSelected(0);
     setRun({ kind: "idle" });
@@ -302,6 +337,7 @@ export default function App() {
       setConfig(nextConfig);
       setDraftConfig(nextConfig);
       setConfigError(null);
+      setPendingConfirmation(null);
       dispatchView({ type: "closeSettings" });
       focusInput(true);
     } catch (err) {
@@ -325,13 +361,13 @@ export default function App() {
       if (!modeAction && !parsed.invoked && active.argMode !== "none" && !looksLikeUrl(parsed.search)) {
         enterActionMode(active);
       } else {
-        void submit(active);
+        requestSubmit(active);
       }
     } else if (event.key === "Tab") {
       event.preventDefault();
       if (!active) return;
       // No-input actions run immediately rather than entering an empty arg mode.
-      if (active.argMode === "none") void submit(active);
+      if (active.argMode === "none") requestSubmit(active);
       else enterActionMode(active);
     }
   }
@@ -346,6 +382,7 @@ export default function App() {
     (!client && !canRunLocalAction) || !active || commandRunning || Boolean(validation);
 
   function goBackToBrowse() {
+    setPendingConfirmation(null);
     dispatchView({ type: "goToBrowse" });
     setRun({ kind: "idle" });
     setQuery("");
@@ -353,10 +390,11 @@ export default function App() {
   }
 
   // P-M2 — stable callbacks for the memoized children (CommandBar/OutputPanel).
-  const onSubmitAction = useCallback((action: PaletteAction) => void submit(action), [submit]);
+  const onSubmitAction = useCallback((action: PaletteAction) => requestSubmit(action), [requestSubmit]);
   const onReset = useCallback(() => {
     setQuery("");
     setRun({ kind: "idle" });
+    setPendingConfirmation(null);
     dispatchView({ type: "reset" });
   }, []);
   const onToggleSettings = useCallback(() => dispatchView({ type: "toggleSettings" }), []);
@@ -411,7 +449,7 @@ export default function App() {
         settingsOpen={settingsOpen}
         showBackButton={showBackButton}
         submitDisabled={submitDisabled}
-        validation={validation}
+        validation={validation || guardMessage}
         onBack={goBackToBrowse}
         onHelp={showHelpFor}
         onInputKeyDown={onInputKeyDown}
@@ -457,7 +495,7 @@ export default function App() {
             selected={selected}
             setSelected={setSelected}
             parsed={parsed}
-            onSubmit={(action) => void submit(action)}
+            onSubmit={requestSubmit}
             onEnterMode={enterActionMode}
             onHelp={showHelpFor}
           />

--- a/apps/palette-tauri/src/lib/actionGuard.test.ts
+++ b/apps/palette-tauri/src/lib/actionGuard.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  actionConfirmationArmed,
+  actionConfirmationMessage,
+  actionGuard,
+  actionNeedsConfirmation,
+} from "./actionGuard";
+import { ACTIONS } from "./actions";
+
+function action(subcommand: string) {
+  const found = ACTIONS.find((candidate) => candidate.subcommand === subcommand);
+  if (!found) throw new Error(`missing action ${subcommand}`);
+  return found;
+}
+
+describe("action safety guards", () => {
+  it("marks destructive/stateful commands that must not run from an accidental first Enter", () => {
+    for (const subcommand of ["dedupe", "crawl-clear", "crawl-cleanup", "crawl-cancel", "watch-create", "watch-run"]) {
+      expect(actionNeedsConfirmation(action(subcommand)), subcommand).toBe(true);
+      expect(actionGuard(action(subcommand))?.label, subcommand).toMatch(/confirm|review/i);
+    }
+  });
+
+  it("does not guard read-only discovery actions", () => {
+    for (const subcommand of ["status", "stats", "sources", "domains", "query", "search"]) {
+      expect(actionNeedsConfirmation(action(subcommand)), subcommand).toBe(false);
+      expect(actionGuard(action(subcommand)), subcommand).toBeNull();
+    }
+  });
+
+  it("arms confirmation for the exact action and argument only", () => {
+    const dedupe = action("dedupe");
+    const watchRun = action("watch-run");
+    const pending = { subcommand: "watch-run", argument: "00000000-0000-4000-8000-000000000000" };
+
+    expect(actionConfirmationArmed(pending, watchRun, "00000000-0000-4000-8000-000000000000")).toBe(true);
+    expect(actionConfirmationArmed(pending, watchRun, "11111111-1111-4111-8111-111111111111")).toBe(false);
+    expect(actionConfirmationArmed(pending, dedupe, "")).toBe(false);
+  });
+
+  it("uses different copy for the review step and the armed step", () => {
+    const dedupe = action("dedupe");
+
+    expect(actionConfirmationMessage(dedupe, false)).toMatch(/review/i);
+    expect(actionConfirmationMessage(dedupe, true)).toMatch(/press enter again/i);
+  });
+});

--- a/apps/palette-tauri/src/lib/actionGuard.ts
+++ b/apps/palette-tauri/src/lib/actionGuard.ts
@@ -1,0 +1,80 @@
+import type { PaletteAction } from "./actions";
+
+export interface ActionGuard {
+  label: "Confirm" | "Review";
+  tone: "warn" | "danger";
+  message: string;
+}
+
+export interface PendingActionConfirmation {
+  subcommand: string;
+  argument: string;
+}
+
+const DESTRUCTIVE_SUBCOMMANDS = new Set([
+  "dedupe",
+  "crawl-clear",
+  "embed-clear",
+  "extract-clear",
+  "ingest-clear",
+]);
+
+const STATEFUL_SUBCOMMANDS = new Set([
+  "crawl-cancel",
+  "embed-cancel",
+  "extract-cancel",
+  "ingest-cancel",
+  "crawl-cleanup",
+  "embed-cleanup",
+  "extract-cleanup",
+  "ingest-cleanup",
+  "watch-create",
+  "watch-run",
+]);
+
+export function actionGuard(action: PaletteAction): ActionGuard | null {
+  if (DESTRUCTIVE_SUBCOMMANDS.has(action.subcommand)) {
+    return {
+      label: "Confirm",
+      tone: "danger",
+      message: "Review before running; this can delete or rewrite stored state.",
+    };
+  }
+  if (STATEFUL_SUBCOMMANDS.has(action.subcommand)) {
+    return {
+      label: "Review",
+      tone: "warn",
+      message: "Review before running; this changes queued or scheduled work.",
+    };
+  }
+  return null;
+}
+
+export function actionNeedsConfirmation(action: PaletteAction): boolean {
+  return actionGuard(action) !== null;
+}
+
+export function confirmationFor(action: PaletteAction, argument: string): PendingActionConfirmation {
+  return { subcommand: action.subcommand, argument: normalizedArgument(argument) };
+}
+
+export function actionConfirmationArmed(
+  pending: PendingActionConfirmation | null,
+  action: PaletteAction,
+  argument: string,
+): boolean {
+  return (
+    pending?.subcommand === action.subcommand &&
+    pending.argument === normalizedArgument(argument)
+  );
+}
+
+export function actionConfirmationMessage(action: PaletteAction, armed: boolean): string {
+  const guard = actionGuard(action);
+  if (!guard) return "";
+  return armed ? "Confirmation armed. Press Enter again to run." : guard.message;
+}
+
+function normalizedArgument(argument: string): string {
+  return argument.trim();
+}


### PR DESCRIPTION
## Summary
- add a palette action guard for destructive/stateful actions
- require a second Enter/click with the same action and argument before running guarded operations
- cover guard behavior with unit and App-level tests

## Verification
- pnpm -C apps/palette-tauri exec vitest run src/lib/actionGuard.test.ts src/App.test.tsx
- pnpm -C apps/palette-tauri exec vitest run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-step confirmation for destructive and stateful palette actions to prevent accidental runs. Users must press Enter or click twice on the same action and argument; the UI shows clear review/confirm prompts.

- **New Features**
  - Guard risky actions including `dedupe`, all clears (`crawl|embed|extract|ingest`), cancels and cleanups, and watches (`watch-create`, `watch-run`) with a confirm tied to the exact action+argument.
  - Inline guidance: first shows a review message; once armed, shows “Confirmation armed. Press Enter again to run.”
  - Clear the pending confirmation on mode changes, settings save/close, back/reset; add unit/app tests; bump app version to 5.11.4.

<sup>Written for commit 9f9ebd704516cd2eede9ac8c1c38e412236d6aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

