### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-06-25-merge-release-worktree-cleanup.md
+++ b/docs/sessions/2026-06-25-merge-release-worktree-cleanup.md
@@ -1,0 +1,227 @@
+---
+date: 2026-06-25 07:46:35 EST
+repo: git@github.com:jmagar/axon.git
+branch: main
+head: 393dfdfa
+working directory: /home/jmagar/workspace/axon
+worktree: /home/jmagar/workspace/axon 393dfdfa [main]
+---
+
+# Merge, release, and worktree cleanup
+
+## User Request
+
+Finish preserving and merging all dirty Axon worktrees and branches into `main`, lose no work, build the latest release binary, sync it to the user PATH and the container, then save the session.
+
+## Session Overview
+
+The session merged the remaining active PR stack, built and deployed the current release binary, and cleaned branch/worktree state down to `main` and the protected `marketplace-no-mcp` branch. Non-PR preservation snapshots were archived as tags before their remote branches were deleted.
+
+## Sequence of Events
+
+1. Preserved dirty worktrees by committing and pushing their branch state before any merge or cleanup.
+2. Verified prior merged PRs and merged the remaining PRs: #270, #271, and #273.
+3. Built `axon 6.0.2` from current `origin/main` and installed it to `/home/jmagar/.local/bin/axon`.
+4. Recreated the `axon` container with `/home/jmagar/.local/bin` mounted at `/home/axon/.axon/dev`.
+5. Removed stale local worktrees, deleted stale local branches, archived non-PR preservation tips as tags, and deleted stale remote branches.
+6. Verified branch/worktree state, container health, and release binary versions.
+
+## Key Findings
+
+- `marketplace-no-mcp` is a protected long-lived branch per `CLAUDE.md`; it was fast-forwarded but not merged into `main`.
+- The running container had been mounted to an old debug target from `claude/recursing-keller-021b55`; it now mounts `/home/jmagar/.local/bin`.
+- Public `curl http://127.0.0.1:40090/healthz` returned `403`, while the container-internal healthcheck endpoint returned `ok`.
+- The stale local branch/worktree inventory was larger than expected, but all dirty state had already been committed and pushed before cleanup.
+- No open PRs remained after #273 merged.
+
+## Technical Decisions
+
+- Used the clean `main` state as the release source: `origin/main` at `393dfdfa`.
+- Installed the release binary by copying `target/release/axon` to `/home/jmagar/.local/bin/axon`.
+- Mounted `/home/jmagar/.local/bin` into the container instead of `/tmp/axon-save-session-260/target/release` so the container uses the same durable binary as the host PATH.
+- Archived the two non-PR preservation branch tips as remote tags before deleting their branches:
+  - `archive/2026-06-25-palette-full-qa-preserved`
+  - `archive/2026-06-25-preserve-dirty-after-260`
+- Deleted stale remote branches only after confirming there were no open PRs.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| created | `docs/sessions/2026-06-25-merge-release-worktree-cleanup.md` | - | Session log and maintenance record | Created by this save-to-md pass |
+| modified | `/home/jmagar/.local/bin/axon` | - | Installed latest release binary into PATH | `/home/jmagar/.local/bin/axon --version` returned `axon 6.0.2` |
+| modified | Docker container `axon` configuration | - | Recreated service with durable PATH mount | `docker inspect axon` showed `/home/jmagar/.local/bin -> /home/axon/.axon/dev` |
+
+Merged PRs changed additional tracked files in prior commits:
+
+| PR | title | merge commit | file evidence |
+|---|---|---|---|
+| #270 | Align no-MCP marketplace variant | `eea29342` | `gh pr view 270` reported `state: MERGED` |
+| #271 | Harden SQLite IOERR diagnostics and recovery | `5b8f2927` | `gh pr view 271` reported `state: MERGED` |
+| #273 | Guard destructive palette actions | `393dfdfa` | `gh pr view 273` reported `state: MERGED` |
+
+## Beads Activity
+
+No bead changes were made during this closeout. `bd list --all --sort updated --reverse --limit 20 --json` returned older closed issues, and `.beads/interactions.jsonl` was not present in this checkout.
+
+## Repository Maintenance
+
+### Plans
+
+Plan files were inspected with `git ls-files docs/plans docs/superpowers/plans`. No plan files were moved because the listed active plan context pointed to an older `/home/jmagar/workspace/axon_rust/...` path and the remaining plan inventory was too broad to classify safely during this closeout.
+
+### Beads
+
+No beads were created, edited, claimed, assigned, commented on, or closed. The tracker read succeeded, but no directly relevant active bead was identified from the observed output.
+
+### Worktrees and branches
+
+Removed stale local worktrees:
+
+- `/home/jmagar/workspace/_fix_worktrees/axon-no-mcp-dendrite`
+- `/home/jmagar/workspace/axon/.claude/worktrees/recursing-keller-021b55`
+- `/home/jmagar/workspace/axon/.worktrees/android-full-app-qa-20260621-235838`
+- `/home/jmagar/workspace/axon/.worktrees/debug-disk-io-ingest`
+- `/home/jmagar/workspace/axon/.worktrees/palette-full-qa-20260621-235838`
+- `/home/jmagar/workspace/axon/.worktrees/port-preserved-wip-20260625`
+- `/home/jmagar/workspace/axon/.worktrees/pr259-merge`
+- `/home/jmagar/workspace/axon/.worktrees/suggest-500-fix-20260622-075812`
+- `/home/jmagar/workspace/axon/.worktrees/triage-after-260-20260624`
+- `/tmp/axon-save-session-260`
+
+Deleted stale local branches:
+
+- `claude/recursing-keller-021b55`
+- `codex/android-full-app-qa-20260621-235838`
+- `codex/debug-disk-io-ingest`
+- `codex/palette-full-qa-20260621-235838`
+- `codex/port-preserved-wip-20260625`
+- `codex/prepush-router-noop`
+- `codex/preserve-dirty-after-260-20260624`
+- `codex/suggest-500-fix-20260622-075812`
+- `codex/triage-after-260-20260624`
+- `fix/no-mcp-dendrite-pattern`
+
+Archived preservation tips before remote branch deletion:
+
+- `archive/2026-06-25-palette-full-qa-preserved` at `3b787d47`
+- `archive/2026-06-25-preserve-dirty-after-260` at `35ac100b`
+
+Deleted stale remote branches:
+
+- `add-claude-github-actions-1782363872132`
+- `claude/recursing-keller-021b55`
+- `codex/android-full-app-qa-20260621-235838`
+- `codex/debug-disk-io-ingest`
+- `codex/palette-full-qa-20260621-235838`
+- `codex/port-preserved-wip-20260625`
+- `codex/prepush-router-noop`
+- `codex/preserve-dirty-after-260-20260624`
+- `codex/suggest-500-fix-20260622-075812`
+- `codex/triage-after-260-20260624`
+- `fix/no-mcp-dendrite-pattern`
+
+Final observed branch/worktree state:
+
+- Local worktrees: `/home/jmagar/workspace/axon` on `main`, `/home/jmagar/workspace/_no_mcp_worktrees/axon` on `marketplace-no-mcp`.
+- Local branches: `main`, `marketplace-no-mcp`.
+- Remote branches: `origin/main`, `origin/marketplace-no-mcp`.
+- Open PRs: `[]`.
+
+### Stale docs
+
+No stale docs were edited in this save pass. The session did create this session log. Broader docs cleanup was not attempted because it would require separate review of older plan and operations material.
+
+## Tools and Skills Used
+
+- **Skill:** `vibin:save-to-md` for this session artifact and required maintenance pass.
+- **Shell and Git:** Used for branch, worktree, tag, commit, push, and release build operations.
+- **GitHub CLI:** Used to inspect and merge PRs and confirm open PR state.
+- **Cargo:** Used to build the release binary with `cargo build --release --locked --bin axon`.
+- **Docker Compose and Docker CLI:** Used to recreate the `axon` service and verify mounts, process status, binary version, and health.
+- **Lumen MCP:** Used for initial workflow discovery around release install and container sync conventions.
+- **Beads CLI:** Used read-only to inspect tracker state.
+- **HTTP/curl:** Used for health checks; external published `/healthz` returned `403`, internal container health returned `ok`.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `gh pr checks 273` | All checks passed before merge |
+| `gh pr merge 270 --merge --delete-branch=false` | Merged #270 |
+| `gh pr merge 271 --merge --delete-branch=false` | Merged #271 |
+| `gh pr merge 273 --merge --delete-branch=false` | Merged #273 |
+| `git fetch origin` | Updated `origin/main` to `393dfdfa` after #273 |
+| `cargo build --release --locked --bin axon` | Built release binary successfully in 15m 11s |
+| `cp target/release/axon /home/jmagar/.local/bin/axon` | Installed host PATH binary |
+| `AXON_DEV_TARGET_DIR=/home/jmagar/.local/bin docker compose --env-file /home/jmagar/.axon/.env -f docker-compose.yaml up -d axon --no-deps --no-build --force-recreate` | Recreated `axon` container with durable PATH mount |
+| `docker exec axon /home/axon/.axon/dev/axon --version` | Returned `axon 6.0.2` |
+| `docker exec axon curl -fsS http://127.0.0.1:8001/healthz` | Returned `ok` |
+| `git worktree remove ...` | Removed stale clean worktrees |
+| `git branch -D ...` | Deleted stale local branches |
+| `git tag archive/2026-06-25-palette-full-qa-preserved origin/codex/palette-full-qa-20260621-235838` | Archived preservation tip |
+| `git tag archive/2026-06-25-preserve-dirty-after-260 origin/codex/preserve-dirty-after-260-20260624` | Archived preservation tip |
+| `git push origin --delete ...` | Deleted stale remote branches |
+| `git branch -r -vv` | Verified only `origin/main` and `origin/marketplace-no-mcp` remain |
+
+## Errors Encountered
+
+- `git pull --ff-only` in `/tmp/axon-save-session-260` initially failed because another concurrent fetch updated `origin/marketplace-no-mcp`; rerunning the pull succeeded.
+- External `curl -fsS http://127.0.0.1:40090/healthz` returned `403`; internal container healthcheck against `127.0.0.1:8001/healthz` returned `ok`, matching Compose health behavior.
+- The Claude transcript glob failed under zsh because no matching `~/.claude/projects/-tmp-axon-save-session-260/*.jsonl` path existed; no transcript path was available from that source.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| PR state | Remaining PRs #270, #271, and #273 still needed merge sequencing | All observed PRs merged; no open PRs remained |
+| Host binary | Existing `/home/jmagar/.local/bin/axon` reported `axon 6.0.2` before install, but not from the freshly built release artifact | Replaced with freshly built release binary from `393dfdfa`; still reports `axon 6.0.2` |
+| Container binary | Container mounted an old debug target from `claude/recursing-keller-021b55` | Container mounts `/home/jmagar/.local/bin` and runs `axon 6.0.2` |
+| Branch/worktree state | Many stale local and remote branches/worktrees existed | Only `main` and `marketplace-no-mcp` remain as local and remote branches/worktrees |
+| Preservation snapshots | Non-PR snapshots existed as branches | Exact tips preserved as archive tags, branches removed |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `gh pr list --state open --json number,title,headRefName,url` | No open PRs | `[]` | pass |
+| `git worktree list --porcelain` | Only `main` and `marketplace-no-mcp` worktrees | Exactly those two worktrees | pass |
+| `git branch -vv` | Only local `main` and `marketplace-no-mcp` | Exactly those two branches | pass |
+| `git branch -r -vv` | Only `origin/main` and `origin/marketplace-no-mcp` | Exactly those two remote branches plus `origin/HEAD` | pass |
+| `git tag -l 'archive/2026-06-25-*'` | Preservation archive tags exist | Both archive tags listed | pass |
+| `/home/jmagar/.local/bin/axon --version` | `axon 6.0.2` | `axon 6.0.2` | pass |
+| `docker exec axon /home/axon/.axon/dev/axon --version` | `axon 6.0.2` | `axon 6.0.2` | pass |
+| `docker inspect axon --format '{{range .Mounts}}{{println .Source "->" .Destination}}{{end}}'` | PATH mount visible | `/home/jmagar/.local/bin -> /home/axon/.axon/dev` | pass |
+| `docker exec axon curl -fsS http://127.0.0.1:8001/healthz` | `ok` | `ok` | pass |
+| `docker ps --filter name=axon --format ...` | `axon` healthy | `axon` reported healthy | pass |
+
+## Risks and Rollback
+
+- Remote branch cleanup is irreversible in normal day-to-day GitHub usage, but the two non-PR preservation branch tips were pushed as archive tags before deletion.
+- Roll back the deployed binary by copying a known-good binary to `/home/jmagar/.local/bin/axon` and recreating the compose service with `AXON_DEV_TARGET_DIR=/home/jmagar/.local/bin`.
+- Restore an archived preservation tip with `git checkout -b <branch> archive/2026-06-25-palette-full-qa-preserved` or `git checkout -b <branch> archive/2026-06-25-preserve-dirty-after-260`.
+
+## Decisions Not Taken
+
+- Did not merge `marketplace-no-mcp` into `main`; repo instructions mark it as an intentional long-lived variant.
+- Did not move old plan files to `docs/plans/complete/`; the plan inventory was broad and not safe to classify from this closeout alone.
+- Did not rely on the public `40090/healthz` result because it returned `403`; used the container-internal healthcheck path that Compose uses.
+
+## References
+
+- PR #270: `https://github.com/jmagar/axon/pull/270`
+- PR #271: `https://github.com/jmagar/axon/pull/271`
+- PR #273: `https://github.com/jmagar/axon/pull/273`
+- Archive tags:
+  - `archive/2026-06-25-palette-full-qa-preserved`
+  - `archive/2026-06-25-preserve-dirty-after-260`
+
+## Open Questions
+
+- Whether older plan files under `docs/plans/` and `docs/superpowers/plans/` should be audited and moved to `complete/` in a dedicated docs hygiene pass.
+
+## Next Steps
+
+- Use `/home/jmagar/workspace/axon` as the normal `main` checkout.
+- Use `/home/jmagar/workspace/_no_mcp_worktrees/axon` only for the protected `marketplace-no-mcp` variant.
+- For a follow-up cleanup, audit old plan files and either move completed ones to `docs/plans/complete/` or create beads for ambiguous docs hygiene work.


### PR DESCRIPTION
## Summary
- save the merge/release/worktree cleanup session log
- document branch cleanup, release binary deployment, and verification evidence

## Verification
- path-limited docs commit only
- pre-push router found docs-only changes and no required plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a session log that documents the 2026-06-25 merge/release/worktree cleanup, including evidence for merging PRs #270, #271, and #273, building/deploying the `axon 6.0.2` binary, updating the container mount, and cleaning branches/worktrees with archive tags for preserved tips. Docs-only: adds `docs/sessions/2026-06-25-merge-release-worktree-cleanup.md`.

<sup>Written for commit 3faa715d073542bd120ed1a4dfc0185d1f43e5c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

