### PR TITLE
fix: route workspace crate changes through ci

### DIFF
--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -99,7 +99,7 @@ def classify(event: str, paths: list[str]) -> dict[str, bool]:
     chrome = any_match(paths, lambda p: starts(p, "apps/chrome-extension/", "assets/"))
     mcp = any_match(
         paths,
-        lambda p: starts(p, "src/mcp/", "docs/reference/mcp/")
+        lambda p: starts(p, "src/mcp/", "crates/axon-mcp/src/", "docs/reference/mcp/")
         or p in MCP_CI_HELPER_SCRIPTS
         or p == "tests/workflow_shapes.rs",
     )
@@ -108,6 +108,7 @@ def classify(event: str, paths: list[str]) -> dict[str, bool]:
         lambda p: starts(
             p,
             "src/",
+            "crates/",
             "xtask/",
             "benches/",
             "tests/",

--- a/tests/ci_changed_paths.rs
+++ b/tests/ci_changed_paths.rs
@@ -99,6 +99,28 @@ fn mcp_changes_enable_mcp_schema_and_runtime_checks() {
 }
 
 #[test]
+fn workspace_crate_changes_enable_rust_runtime_gates() {
+    let out = classify("pull_request", &["crates/axon-core/src/config.rs"]);
+    assert_eq!(out["rust"], "true");
+    assert_eq!(out["release"], "true");
+    assert_eq!(out["security"], "true");
+    assert_eq!(out["docker"], "true");
+    assert_eq!(out["codeql_rust"], "true");
+}
+
+#[test]
+fn axon_mcp_crate_changes_enable_mcp_schema_and_runtime_checks() {
+    let out = classify(
+        "pull_request",
+        &["crates/axon-mcp/src/server/tool_schema.rs"],
+    );
+    assert_eq!(out["rust"], "true");
+    assert_eq!(out["mcp"], "true");
+    assert_eq!(out["release"], "true");
+    assert_eq!(out["codeql_rust"], "true");
+}
+
+#[test]
 fn openapi_changes_enable_android_palette_and_rest_contracts() {
     let out = classify("pull_request", &["apps/web/openapi/axon.json"]);
     assert_eq!(out["openapi"], "true");


### PR DESCRIPTION
## Summary

- route workspace `crates/` changes through Rust/security/release/docker CI gates
- route `crates/axon-mcp/src/` changes through MCP schema/runtime checks
- add regression coverage for workspace crate and axon-mcp crate path classification

## Validation

- `cargo test --locked --test ci_changed_paths -- --nocapture`
- pre-push router ran `actionlint`, `ci_changed_paths`, `workflow_shapes`, and workspace clippy successfully before GitHub rejected direct `main` push due branch protection


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route workspace `crates/` changes through Rust, security, release, and Docker CI gates, and ensure `crates/axon-mcp/src/` changes run MCP schema and runtime checks. Adds regression tests to lock this behavior in.

- **Bug Fixes**
  - Update `scripts/ci/changed_paths.py` to classify `crates/` for Rust/security/release/Docker and `crates/axon-mcp/src/` for MCP checks.
  - Add `tests/ci_changed_paths.rs` cases for workspace crates and `axon-mcp` to assert the correct CI gates (including `codeql_rust`).

<sup>Written for commit 79ec730025a614b52f4af1c511728884485f8d91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI now recognizes changes in crate-local Rust code more accurately, so the right checks run for more repository paths.
  * MCP-related CI checks now also trigger for additional MCP source locations.
* **Tests**
  * Expanded CI path classification coverage to verify the updated check behavior for Rust and MCP-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->