### PR TITLE
docs: save Axon skills session log

### DIFF
--- a/docs/sessions/2026-06-27-axon-skills-rebrand-pr286.md
+++ b/docs/sessions/2026-06-27-axon-skills-rebrand-pr286.md
@@ -1,0 +1,253 @@
+---
+date: 2026-06-27 22:10:45 EST
+repo: git@github.com:jmagar/axon.git
+branch: codex/save-session-log-20260627-skills-pr286
+head: 7b351dbc4d7b29a74f91efba376b808107eca9e9
+session id: 34fb82ca-bbd6-4c0c-9a6a-2a467ee97e15
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-axon/34fb82ca-bbd6-4c0c-9a6a-2a467ee97e15.jsonl
+working directory: /home/jmagar/workspace/axon
+worktree: /home/jmagar/workspace/axon 7b351dbc4d7b29a74f91efba376b808107eca9e9 [codex/save-session-log-20260627-skills-pr286]
+pr: #286 Rebrand Axon plugin skills https://github.com/jmagar/axon/pull/286
+---
+
+# Axon skills rebrand and PR 286 closeout
+
+## User Request
+
+The session began with pulling Firecrawl skills into Axon, reviewing them, deleting or adapting unsupported capabilities, rebranding them for Axon, adding metadata, and then committing, pushing, merging, and pulling latest.
+
+## Session Overview
+
+Axon plugin skills were moved under `plugins/axon/skills/`, renamed without the `axon-` prefix, reviewed against Axon's real capabilities, and guarded with skill hygiene tests. PR #286 was created, CI issues were fixed, the PR was merged into `main`, and the main checkout was fast-forwarded to merge commit `7b351dbc4d7b29a74f91efba376b808107eca9e9`.
+
+## Sequence of Events
+
+1. Created a clean integration branch, `codex/merge-agent-skills`, because the older `codex/pull-agent-skills` branch was stale relative to `main`.
+2. Cherry-picked the usable Axon skills work onto the clean branch and pushed PR #286.
+3. Fixed CI findings in follow-up commits: skill metadata/path gates, version bumps, Android dependency verification, and compatibility with the CI-pinned Aurora Android API.
+4. Waited for the full CI workflow to finish; all required jobs completed successfully.
+5. Merged PR #286 into `main`, pulled latest into `/home/jmagar/workspace/axon`, and verified existing unrelated dirty files were preserved.
+6. During this save-session pass, removed only the proven-merged `codex/merge-agent-skills` worktree/local branch/remote branch and left other worktrees alone.
+
+## Key Findings
+
+- Firecrawl skill names needed to become Axon plugin-local folder names, so skills now live at paths such as `plugins/axon/skills/scrape/SKILL.md` rather than `axon-scrape`.
+- Each shipped skill now has `agents/openai.yaml` metadata; this is guarded by `tests/agent_skills_hygiene.rs`.
+- The `rag-synthesize` helper is now a reference under `plugins/axon/references/rag-synthesize/SKILL.md`, not a user-facing skill.
+- Axon does not currently expose every Firecrawl capability as a one-command equivalent; the shipped skills describe only supported Axon workflows.
+- The CI Android workflow pins Aurora at `8748eb6434b3bbe4c75f25bfff71950b7efc051b`, so the final Android code had to match that API rather than the newer local Aurora checkout.
+
+## Technical Decisions
+
+- Kept an honest `download` skill based on Axon `scrape`, `crawl --output-dir`, and `screenshot`, while documenting that Axon does not yet have a single first-class offline-site download command.
+- Removed unsupported or misleading skills instead of forcing Firecrawl-only capabilities onto Axon.
+- Added `.cargo/config.toml` with `AXON_ALLOW_FALLBACK_WEB_ASSETS=1` so local Cargo tests understand the repo's web-asset fallback behavior without manually exporting the variable each time.
+- Used a clean integration PR rather than merging the older stale worktree branch.
+- Deleted only the merged integration branch/worktree during maintenance; left `codex/pull-agent-skills` because `git merge-base --is-ancestor codex/pull-agent-skills main` returned nonzero.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+| --- | --- | --- | --- | --- |
+| modified | `.cargo/config.toml` | - | Set local Cargo env fallback for web assets. | `git diff 228dc609..7b351dbc` |
+| modified | `CHANGELOG.md` | - | Record CLI release changes. | `git diff 228dc609..7b351dbc` |
+| modified | `CLAUDE.md` | - | Update Axon agent memory/docs for skills. | `git diff 228dc609..7b351dbc` |
+| modified | `Cargo.lock` | - | Version sync for CLI release. | `git diff 228dc609..7b351dbc` |
+| modified | `Cargo.toml` | - | Bump workspace/product version. | `git diff 228dc609..7b351dbc` |
+| modified | `README.md` | - | Version/doc sync. | `git diff 228dc609..7b351dbc` |
+| modified | `apps/android/CHANGELOG.md` | - | Record Android release bump. | `git diff 228dc609..7b351dbc` |
+| modified | `apps/android/app/build.gradle.kts` | - | Bump Android version code/name. | `git diff 228dc609..7b351dbc` |
+| modified | `apps/android/gradle/verification-metadata.xml` | - | Add dependency verification checksums required by CI. | `git diff 228dc609..7b351dbc` |
+| modified | `apps/web/openapi/axon.json` | - | Version sync. | `git diff 228dc609..7b351dbc` |
+| modified | `apps/web/package-lock.json` | - | Version sync. | `git diff 228dc609..7b351dbc` |
+| modified | `apps/web/package.json` | - | Version sync. | `git diff 228dc609..7b351dbc` |
+| modified | `crates/axon-core/src/llm/headless/gemini.rs` | - | Align Gemini/headless references with updated skill naming. | `git diff 228dc609..7b351dbc` |
+| modified | `crates/axon-core/src/llm/headless/gemini/home.rs` | - | Align Gemini/headless references with updated skill naming. | `git diff 228dc609..7b351dbc` |
+| modified | `crates/axon-core/src/llm/headless/gemini/stream.rs` | - | Align Gemini/headless references with updated skill naming. | `git diff 228dc609..7b351dbc` |
+| modified | `crates/axon-core/src/llm/headless/gemini_tests.rs` | - | Update tests for renamed references. | `git diff 228dc609..7b351dbc` |
+| modified | `crates/axon-vector/src/ops/commands/ask/synthesis_prompt.rs` | - | Point synthesis prompt at moved reference skill. | `git diff 228dc609..7b351dbc` |
+| modified | `crates/axon-vector/src/ops/commands/ask/synthesis_prompt_tests.rs` | - | Update prompt tests for moved reference skill. | `git diff 228dc609..7b351dbc` |
+| modified | `crates/axon-vector/src/ops/commands/streaming_tests.rs` | - | Update tests for renamed/moved skill references. | `git diff 228dc609..7b351dbc` |
+| modified | `plugins/axon/README.md` | - | Document Axon plugin skill layout. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/examples/workflow-output-templates.md` | - | Shared workflow skill output examples. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/references/capture-recipes.md` | - | Shared capture guidance for skills. | `git diff 228dc609..7b351dbc` |
+| renamed | `plugins/axon/references/rag-synthesize/SKILL.md` | `plugins/axon/skills/axon-rag-synthesize/SKILL.md` | Move internal RAG synthesis helper out of user-facing skills. | `R099` in diff |
+| renamed | `plugins/axon/references/rag-synthesize/example-response.md` | `plugins/axon/skills/axon-rag-synthesize/references/example-response.md` | Preserve RAG synthesis reference example. | `R096` in diff |
+| created | `plugins/axon/references/workflow-authoring.md` | - | Shared workflow authoring guidance. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/cli/SKILL.md` | - | Axon CLI skill. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/cli/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/cli/rules/install.md` | - | CLI install rule reference. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/cli/rules/security.md` | - | CLI security rule reference. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/company-directories/SKILL.md` | - | Company directory research workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/company-directories/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/competitive-intel/SKILL.md` | - | Competitive intelligence workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/competitive-intel/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/crawl/SKILL.md` | - | Crawl workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/crawl/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/dashboard-reporting/SKILL.md` | - | Dashboard/reporting workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/dashboard-reporting/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/deep-research/SKILL.md` | - | Deep research workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/deep-research/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/demo-walkthrough/SKILL.md` | - | Demo walkthrough workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/demo-walkthrough/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/download/SKILL.md` | - | Download/capture workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/download/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/extract/SKILL.md` | - | Structured extraction workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/extract/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/knowledge-base/SKILL.md` | - | Knowledge-base query workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/knowledge-base/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/knowledge-ingest/SKILL.md` | - | Knowledge ingest workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/knowledge-ingest/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/lead-gen/SKILL.md` | - | Lead generation workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/lead-gen/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/lead-research/SKILL.md` | - | Lead research workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/lead-research/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/map/SKILL.md` | - | URL mapping workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/map/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/market-research/SKILL.md` | - | Market research workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/market-research/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/monitor/SKILL.md` | - | Monitoring workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/monitor/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/qa/SKILL.md` | - | QA workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/qa/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/research-papers/SKILL.md` | - | Research paper workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/research-papers/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/scrape/SKILL.md` | - | Scrape workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/scrape/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/search/SKILL.md` | - | Search workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/search/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/seo-audit/SKILL.md` | - | SEO audit workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/seo-audit/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/shop/SKILL.md` | - | Shopping/product research workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/shop/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| modified | `plugins/axon/skills/using-axon/SKILL.md` | - | Update core Axon skill after rebrand. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/using-axon/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/website-design-clone/SKILL.md` | - | Website design capture/clone workflow. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/website-design-clone/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/workflows/SKILL.md` | - | Workflow authoring skill. | `git diff 228dc609..7b351dbc` |
+| created | `plugins/axon/skills/workflows/agents/openai.yaml` | - | OpenAI skill metadata. | `git diff 228dc609..7b351dbc` |
+| created | `tests/agent_skills_hygiene.rs` | - | Guard skill layout and metadata. | `git diff 228dc609..7b351dbc` |
+| modified | `tests/ci_changed_paths.rs` | - | Cover path gate behavior. | `git diff 228dc609..7b351dbc` |
+
+## Beads Activity
+
+No bead activity was performed for this session. Evidence: `bd list --all --sort updated --reverse --limit 100 --json` returned historical issues, and `.beads/interactions.jsonl` showed recent historical tracker changes through June 27 but no action tied to PR #286 or this session-log branch.
+
+## Repository Maintenance
+
+### Plans
+
+Checked `docs/plans/` and `docs/plans/complete/`. No plan file was clearly tied to the Axon skills rebrand/PR #286 session, so no plan was moved.
+
+### Beads
+
+Read recent beads and interactions. No directly relevant open bead was identified for the completed PR #286 work, and no follow-up bead was created because the remaining items are documented below as optional future product work rather than session-blocking defects.
+
+### Worktrees and branches
+
+- Removed `/home/jmagar/workspace/axon/.worktrees/merge-agent-skills` after `git merge-base --is-ancestor codex/merge-agent-skills main` returned `0`.
+- Deleted local branch `codex/merge-agent-skills` and remote branch `origin/codex/merge-agent-skills`.
+- Left `/home/jmagar/workspace/axon/.worktrees/pull-agent-skills` and branch `codex/pull-agent-skills` because `git merge-base --is-ancestor codex/pull-agent-skills main` returned `1`.
+- Left `/home/jmagar/workspace/_no_mcp_worktrees/axon` because `marketplace-no-mcp` is a documented long-lived branch.
+- Left `/home/jmagar/.codex/worktrees/f3ccd619-f8cd-4611-91d2-26facf66e9e7/axon` because it is detached and ownership was unclear.
+
+### Stale docs
+
+The PR updated plugin docs and `CLAUDE.md`. No additional stale docs were proven during this save-session pass. The available Claude transcript was inspected, but it was an older 15-line session with a cut-off prompt and was not authoritative for this Codex work.
+
+### Dirty worktree
+
+The main checkout had pre-existing dirty files before and after the merge/pull. They were preserved and not staged for this session artifact.
+
+## Tools and Skills Used
+
+- **Skills.** Used `vibin:save-to-md` for this session artifact workflow.
+- **Shell commands.** Used `git`, `gh`, `cargo`, Gradle, and inspection commands to manage branches, verify CI, and collect evidence.
+- **GitHub CLI.** Used `gh pr view`, `gh pr merge`, `gh pr checks`, `gh run view`, `gh run watch`, and `gh run rerun`.
+- **Subagents/parallel reviewers.** Earlier in the session, reviewer agents were dispatched to inspect skills and surface issues; the final branch addressed the findings captured in the conversation.
+- **External CLIs.** Used Axon/cargo/Gradle workflows for verification; no browser automation was used in this closeout pass.
+- **MCP/tools.** No Labby/Axon MCP tool call was required during the final merge and save-session closeout.
+
+## Commands Executed
+
+| command | result |
+| --- | --- |
+| `cargo test --test agent_skills_hygiene` | Passed locally before merge. |
+| `cargo test --test ci_changed_paths` | Passed locally before merge. |
+| `cargo test -p axon-vector synthesis_prompt` | Passed locally with Cargo env fallback. |
+| `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr` | Passed after CLI and Android version bumps. |
+| `AXON_AURORA_ANDROID_PATH=/home/jmagar/workspace/aurora-design-system/.worktrees/ci-8748eb6/android apps/android/gradlew -p apps/android :app:compileDebugKotlin --no-daemon --stacktrace` | Passed against the CI-pinned Aurora API. |
+| `AXON_AURORA_ANDROID_PATH=/home/jmagar/workspace/aurora-design-system/.worktrees/ci-8748eb6/android apps/android/gradlew -p apps/android :app:verifyOpenApiGeneratedClient --no-daemon --stacktrace` | Passed against the CI-pinned Aurora API. |
+| `gh run rerun 28306268322 --failed` | Reran failed compose smoke after external Docker Hub timeout. |
+| `gh run view 28306268310 --json status,conclusion,url` | Reported `completed` and `success`. |
+| `gh pr merge 286 --merge` | Merged PR #286. |
+| `git pull --ff-only` | Fast-forwarded main from `228dc609` to `7b351dbc`. |
+| `git worktree remove /home/jmagar/workspace/axon/.worktrees/merge-agent-skills` | Removed merged clean integration worktree. |
+| `git branch -d codex/merge-agent-skills` | Deleted merged local branch. |
+| `git push origin --delete codex/merge-agent-skills` | Deleted merged remote branch; pre-push hook skipped due no matching pushed files. |
+
+## Errors Encountered
+
+- Direct push to protected `main` failed earlier in the session, so the feature work was routed through PR #286.
+- Auto-merge was unavailable for the repository, so the PR was merged manually after checks completed.
+- CI initially failed on version-sync and Android checks; fixes were committed as `65e9cccc`, `169f5fe1`, and `2e409476`.
+- Compose smoke failed once due an external Docker Hub timeout while starting BuildKit; rerunning failed jobs succeeded.
+- Local Android verification initially used a newer Aurora checkout than CI; the final fix was verified against the pinned Aurora SHA.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+| --- | --- | --- |
+| Axon plugin skills | Mixed/Firecrawl-derived naming and unsupported skill assumptions. | Axon-local skills under `plugins/axon/skills/` with capability-honest content. |
+| Skill metadata | Not every skill had OpenAI metadata. | Every shipped skill has `agents/openai.yaml`, guarded by tests. |
+| RAG synth helper | Exposed as a skill-like path. | Moved under `plugins/axon/references/rag-synthesize/`. |
+| Cargo test env | `AXON_ALLOW_FALLBACK_WEB_ASSETS=1` often had to be exported manually. | Local Cargo config supplies it for Cargo commands. |
+| Release checks | Version-sync failed after shipping component changes. | CLI version is `6.1.3`; Android version is `1.4.4` / versionCode `13`. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+| --- | --- | --- | --- |
+| `cargo test --test agent_skills_hygiene` | Skill layout and metadata pass. | Passed. | pass |
+| `cargo test --test ci_changed_paths` | CI classifier tests pass. | Passed. | pass |
+| `cargo test -p axon-vector synthesis_prompt` | Prompt tests pass without manual env export. | Passed. | pass |
+| `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr` | Shipping component versions are bumped. | Passed. | pass |
+| Pinned Aurora `:app:compileDebugKotlin` | Android code compiles against CI-pinned Aurora. | Passed. | pass |
+| Pinned Aurora `:app:verifyOpenApiGeneratedClient` | Generated Android OpenAPI client is current. | Passed. | pass |
+| GitHub Actions run `28306268310` | CI completes successfully. | `completed success`. | pass |
+| PR #286 state | PR is merged. | `MERGED` at `2026-06-28T00:43:09Z`. | pass |
+| `git pull --ff-only` in main checkout | Main fast-forwards without overwriting dirty files. | Fast-forwarded to `7b351dbc`. | pass |
+
+## Risks and Rollback
+
+- Risk: The `download` skill still describes a composed workflow rather than a first-class offline-site mirroring command. Rollback is to delete or narrow `plugins/axon/skills/download/SKILL.md`.
+- Risk: `AXON_ALLOW_FALLBACK_WEB_ASSETS=1` in `.cargo/config.toml` affects Cargo commands run from this repo. Rollback is to remove that env entry and require explicit env setup again.
+- Rollback for the feature merge is `git revert -m 1 7b351dbc4d7b29a74f91efba376b808107eca9e9`, followed by a PR.
+
+## Decisions Not Taken
+
+- Did not keep Firecrawl skills that Axon cannot honestly support.
+- Did not keep `axon-` prefixes after moving skills into the Axon plugin namespace.
+- Did not delete `codex/pull-agent-skills`, because it was not proven ancestry-merged into `main`.
+- Did not clean unrelated dirty files in the main checkout.
+
+## References
+
+- PR #286: https://github.com/jmagar/axon/pull/286
+- CI run: https://github.com/jmagar/axon/actions/runs/28306268310
+- Compose smoke retry run: https://github.com/jmagar/axon/actions/runs/28306268322
+- Firecrawl CLI skills source: https://github.com/firecrawl/cli/tree/main/skills
+- Firecrawl workflows skills source: https://github.com/firecrawl/firecrawl-workflows/tree/main/skills
+- OpenAI skills metadata docs: https://developers.openai.com/codex/skills#optional-metadata
+
+## Open Questions
+
+- Whether Axon should add a first-class offline-site download/mirror command that saves HTML, assets, rewritten URLs, preserved directory structure, and offline browsing support.
+- Whether the stale `codex/pull-agent-skills` branch should be deleted after a human confirms its remaining commit is obsolete.
+- Whether `marketplace-no-mcp` should be synced after the main merge; it was observed behind `origin/marketplace-no-mcp`.
+
+## Next Steps
+
+- If offline mirroring matters, design and implement a first-class Axon download/mirror command rather than stretching the skill around `scrape` and `crawl --output-dir`.
+- Review and retire `codex/pull-agent-skills` if no one needs the old stale worktree.
+- Consider syncing the long-lived `marketplace-no-mcp` branch from current `main` using its established generated-branch workflow.


### PR DESCRIPTION
## Summary\n- save the session log for the Axon skills rebrand and PR #286 closeout\n- document CI/merge evidence and repository maintenance decisions\n\n## Verification\n- committed with path-limited docs-only commit\n- pre-push router reported docs-only plan with no checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a session log at docs/sessions/2026-06-27-axon-skills-rebrand-pr286.md documenting the Axon skills rebrand and the closeout of PR #286. Includes CI/merge evidence and repo maintenance decisions for a clear audit trail.

<sup>Written for commit 6bd13b9b2eeba6314474c91c9354742e9ac4d58a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed session log for the Axon skills rebrand work, including timeline, key decisions, verification notes, risks, and next steps.
  * Documented the changes made during the integration process, along with the files touched and outcomes of validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->