### PR TITLE
Improve code search watcher indexing UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.5] - 2026-06-28
+
 ## [6.1.4] - 2026-06-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "async-trait",
  "axon-cli",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "axon-api"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "chrono",
  "percent-encoding",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "axon-authz"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "axum",
  "lab-auth",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "axon-cli"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "axon-code-index"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "anyhow",
  "axon-core",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "axon-core"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "axon-crawl"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "axon-core",
  "base64",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "axon-extract"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "axon-api",
  "axon-core",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "axon-ingest"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "axon-jobs"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "axon-mcp"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "axon-api",
  "axon-authz",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "axon-services"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "axon-vector"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "axon-web"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "async-trait",
  "axon-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 # `axon` package keeps an explicit `version` too (the release checker reads it as
 # a string); `cargo xtask bump-version cli` moves both in lockstep.
 [workspace.package]
-version = "6.1.4"
+version = "6.1.5"
 
 # Override lab-auth from the git source with a local vendored copy that uses
 # rusqlite 0.32 (libsqlite3-sys 0.30) instead of rusqlite 0.39 (libsqlite3-sys
@@ -22,7 +22,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "6.1.4"
+version = "6.1.5"
 edition = "2024"
 rust-version = "1.94.0"
 description = "Web crawl, scrape, embed, and query CLI backed by a self-hosted RAG stack"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon
 
-Version: 6.1.4
+Version: 6.1.5
 
 Axon is a self-hosted RAG stack for crawling, scraping, ingesting, embedding, searching, and asking questions over indexed content. The production release is Docker Compose first: one Axon server container, Qdrant, Hugging Face TEI with `Qwen/Qwen3-Embedding-0.6B`, and Chrome for JS-heavy pages.
 

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "6.1.4"
+    "version": "6.1.5"
   },
   "paths": {
     "/healthz": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -18,7 +18,7 @@
         "vitest": "^4.1.9"
       },
       "name": "@axon/admin-panel",
-      "version": "6.1.4"
+      "version": "6.1.5"
     },
     "node_modules/@asamuzakjp/css-color": {
       "dependencies": {
@@ -2701,5 +2701,5 @@
     }
   },
   "requires": true,
-  "version": "6.1.4"
+  "version": "6.1.5"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,5 +28,5 @@
     "openapi:types": "node scripts/generate-openapi-types.mjs openapi/axon.json lib/generated/axon-api.ts",
     "test": "vitest run"
   },
-  "version": "6.1.4"
+  "version": "6.1.5"
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -339,7 +339,7 @@
 
 # Number of changed files processed per foreground refresh batch.
 # Env: AXON_CODE_SEARCH_CHANGED_FILE_BATCH_SIZE
-# changed-file-batch-size = 5
+# changed-file-batch-size = 64
 
 [watch]
 # Recurring watch scheduler sweep interval and lease TTL.

--- a/crates/axon-cli/src/commands/code_search.rs
+++ b/crates/axon-cli/src/commands/code_search.rs
@@ -1,9 +1,12 @@
 use crate::commands::resolve_input_text;
 use axon_core::config::Config;
 use axon_core::logging::log_info;
-use axon_core::ui::{accent, muted, primary};
+use axon_core::ui::{
+    accent, error, metric, muted, primary, status_text, success, symbol_for_status, warning,
+};
 use axon_services::code_search_watch::{
-    StdoutCodeSearchWatchEventSink, run_code_search_watch as run_code_search_watch_service,
+    CodeSearchWatchDryRunPlan, CodeSearchWatchEvent, CodeSearchWatchEventSink, ReindexProgress,
+    run_code_search_watch as run_code_search_watch_service,
 };
 use axon_services::context::ServiceContext;
 use axon_services::query as query_svc;
@@ -91,8 +94,248 @@ pub async fn run_code_search_watch(
         .code_search_watch
         .clone()
         .ok_or("code-search-watch requires watcher options")?;
-    let sink = StdoutCodeSearchWatchEventSink { json: options.json };
+    let sink = CliCodeSearchWatchEventSink { json: options.json };
     run_code_search_watch_service(service_context, options, &sink)
         .await
         .map_err(|err| -> Box<dyn Error> { err.to_string().into() })
+}
+
+struct CliCodeSearchWatchEventSink {
+    json: bool,
+}
+
+impl CodeSearchWatchEventSink for CliCodeSearchWatchEventSink {
+    fn emit(&self, event: CodeSearchWatchEvent) {
+        if self.json {
+            emit_code_search_watch_json(event);
+        } else {
+            render_code_search_watch_event(event);
+        }
+    }
+}
+
+fn emit_code_search_watch_json(event: CodeSearchWatchEvent) {
+    match serde_json::to_string(&event) {
+        Ok(line) => println!("{line}"),
+        Err(error) => println!(
+            "{{\"event\":\"serialization_failed\",\"error\":{}}}",
+            serde_json::json!(error.to_string())
+        ),
+    }
+}
+
+fn render_code_search_watch_event(event: CodeSearchWatchEvent) {
+    match event {
+        CodeSearchWatchEvent::Started {
+            watch_dirs,
+            roots,
+            initial_refresh,
+        } => {
+            println!("{}", primary("Code Search Watcher"));
+            println!(
+                "  {} {} {}",
+                symbol_for_status("running"),
+                metric(roots.len(), if roots.len() == 1 { "repo" } else { "repos" }),
+                muted(&format!("watching {} dir(s)", watch_dirs.len())),
+            );
+            if initial_refresh {
+                println!("  {} {}", muted("Mode:"), accent("initial refresh"));
+            }
+        }
+        CodeSearchWatchEvent::Pending { root, paths } => {
+            println!(
+                "  {} {} {}",
+                symbol_for_status("pending"),
+                accent("Queued changes"),
+                muted(&format!("{} · {paths} path(s)", root.display())),
+            );
+        }
+        CodeSearchWatchEvent::RefreshStarted { root, reason } => {
+            println!();
+            println!("{}", primary("Refresh"));
+            println!(
+                "  {} {} {}",
+                symbol_for_status("running"),
+                accent(root.to_string_lossy().as_ref()),
+                muted(reason),
+            );
+        }
+        CodeSearchWatchEvent::RefreshProgress { progress } => {
+            render_code_search_refresh_progress(progress);
+        }
+        CodeSearchWatchEvent::RefreshFinished {
+            root,
+            status,
+            warning: freshness_warning,
+            indexed_files,
+            removed_files,
+            generation,
+        } => {
+            let outcome = if freshness_warning.is_some() {
+                "warning"
+            } else {
+                "completed"
+            };
+            let generation = generation
+                .map(|generation| generation.to_string())
+                .unwrap_or_else(|| "none".to_string());
+            println!(
+                "  {} {} {}",
+                symbol_for_status(outcome),
+                status_text(outcome),
+                muted(&format!(
+                    "{} · status={status} · indexed={indexed_files} · removed={removed_files} · generation={generation}",
+                    root.display()
+                )),
+            );
+            if let Some(message) = freshness_warning {
+                println!("    {} {}", warning("warning:"), muted(&message));
+            }
+        }
+        CodeSearchWatchEvent::RefreshFailed { root, error: err } => {
+            println!(
+                "  {} {} {}",
+                symbol_for_status("failed"),
+                error("Refresh failed"),
+                muted(&format!("{} · {err}", root.display())),
+            );
+        }
+        CodeSearchWatchEvent::DryRun { plan } => render_code_search_watch_dry_run(plan),
+        CodeSearchWatchEvent::Enabled {
+            unit_path,
+            env_path,
+            roots,
+        } => {
+            println!("{}", success("✓ Code search watcher enabled"));
+            println!(
+                "  {} {}",
+                metric(roots.len(), if roots.len() == 1 { "repo" } else { "repos" }),
+                muted("configured"),
+            );
+            println!(
+                "  {} {}",
+                muted("Unit:"),
+                accent(&unit_path.display().to_string())
+            );
+            println!(
+                "  {} {}",
+                muted("Env:"),
+                accent(&env_path.display().to_string())
+            );
+        }
+        CodeSearchWatchEvent::Stopped => {
+            println!(
+                "  {} {}",
+                symbol_for_status("completed"),
+                muted("Watcher stopped")
+            );
+        }
+    }
+}
+
+fn render_code_search_refresh_progress(progress: ReindexProgress) {
+    match progress {
+        ReindexProgress::Started {
+            generation,
+            total_files,
+            added_files,
+            modified_files,
+            removed_files,
+            total_batches,
+        } => {
+            println!("  {}", primary("Plan"));
+            println!(
+                "    {} {}",
+                muted("Generation:"),
+                accent(&generation.to_string())
+            );
+            println!(
+                "    {} {}",
+                muted("Files:"),
+                accent(&format!(
+                    "{total_files} total · {added_files} added · {modified_files} modified · {removed_files} removed"
+                )),
+            );
+            println!(
+                "    {} {}",
+                muted("Batches:"),
+                accent(&total_batches.to_string())
+            );
+        }
+        ReindexProgress::BatchFinished {
+            generation: _,
+            batch_number,
+            total_batches,
+            processed_files,
+            total_files,
+            batch_files,
+            embedded_docs,
+        } => {
+            let pct = progress_percent(processed_files, total_files);
+            let previous_files = processed_files.saturating_sub(batch_files);
+            let previous_pct = progress_percent(previous_files, total_files);
+            let crossed_five_percent = pct != previous_pct && pct.is_multiple_of(5);
+            if batch_number != 1 && batch_number != total_batches && !crossed_five_percent {
+                return;
+            }
+            println!(
+                "  {} {} {}",
+                symbol_for_status("running"),
+                accent(&format!("{processed_files}/{total_files} files")),
+                muted(&format!(
+                    "{pct}% · batch {batch_number}/{total_batches} · {embedded_docs} docs"
+                )),
+            );
+        }
+        ReindexProgress::CleanupStarted {
+            generation: _,
+            cleanup_paths,
+        } => {
+            println!(
+                "  {} {}",
+                muted("Cleanup:"),
+                accent(&format!("{cleanup_paths} path(s)")),
+            );
+        }
+        ReindexProgress::CommitStarted { generation } => {
+            println!(
+                "  {} {}",
+                muted("Commit:"),
+                accent(&format!("generation {generation}"))
+            );
+        }
+        ReindexProgress::Finished { generation } => {
+            println!(
+                "  {} {}",
+                success("✓ Indexed"),
+                muted(&format!("generation {generation}"))
+            );
+        }
+    }
+}
+
+fn progress_percent(done: usize, total: usize) -> usize {
+    done.saturating_mul(100).checked_div(total).unwrap_or(100)
+}
+
+fn render_code_search_watch_dry_run(plan: CodeSearchWatchDryRunPlan) {
+    println!("{}", primary("Code Search Dry Run"));
+    println!(
+        "  {} {}",
+        metric(
+            plan.roots.len(),
+            if plan.roots.len() == 1 {
+                "repo"
+            } else {
+                "repos"
+            }
+        ),
+        muted(&format!("{} file(s)", plan.total_files)),
+    );
+    for root in plan.roots {
+        println!("  {}", accent(&root.root.display().to_string()));
+        for file in root.files {
+            println!("    {} {}", muted("•"), muted(&file));
+        }
+    }
 }

--- a/crates/axon-cli/src/commands/setup.rs
+++ b/crates/axon-cli/src/commands/setup.rs
@@ -259,8 +259,6 @@ async fn run_plugin_hook_setup_command(cfg: &Config) -> Result<(), Box<dyn Error
     // `apply_plugin_options()` in `run()`. Re-applying here is harmless and
     // covers any direct caller that bypasses the early path.
     apply_plugin_options();
-    // Keep the user's terminal copy in ~/.local/bin fresh each session.
-    let _ = install_self();
 
     // The SessionStart hook NEVER deploys — provisioning is the `/axon-deploy`
     // slash command. The hook only probes whether the stack is already serving:

--- a/crates/axon-code-index/Cargo.toml
+++ b/crates/axon-code-index/Cargo.toml
@@ -43,7 +43,7 @@ unused_qualifications = "warn"
 all = { level = "warn", priority = -1 }
 module_inception = "allow"              # src/crawl.rs: acceptable module name
 [features]
-test-util = []
+test-util = ["axon-vector/test-util"]
 
 [dev-dependencies]
 axon-core = { path = "../axon-core", features = ["test-util"] }

--- a/crates/axon-code-index/src/code_index_tests.rs
+++ b/crates/axon-code-index/src/code_index_tests.rs
@@ -404,6 +404,7 @@ async fn changed_refresh_cleans_previous_generation_for_complete_snapshot() {
 }
 
 #[tokio::test]
+#[cfg(feature = "test-util")]
 async fn concurrent_refresh_cannot_delete_newer_generation() {
     let body = axon_vector::ops::qdrant::local_code_batch_delete_body_for_test(
         "project-1",

--- a/crates/axon-code-index/src/ensure.rs
+++ b/crates/axon-code-index/src/ensure.rs
@@ -6,11 +6,11 @@ use dashmap::DashMap;
 use tokio::sync::Mutex;
 
 use crate::config::{CodeIndexIdentity, freshness_ttl, reindex_timeout};
-use crate::indexer::{
-    ReindexSummary, finish_completed_generation, reindex_changed_files, retry_cleanup_debt,
-};
+use crate::indexer::{finish_completed_generation, reindex_changed_files, retry_cleanup_debt};
 use crate::manifest::{ManifestOptions, build_manifest};
+use crate::progress::ReindexProgressSink;
 use crate::store::CodeIndexStore;
+use crate::summary::ReindexSummary;
 use axon_core::config::Config;
 
 static FRESH_UNTIL: LazyLock<DashMap<String, Instant>> = LazyLock::new(DashMap::new);
@@ -53,6 +53,16 @@ pub async fn ensure_fresh(
     pool: sqlx::SqlitePool,
     identity: &CodeIndexIdentity,
     options: EnsureFreshOptions,
+) -> anyhow::Result<EnsureFreshOutcome> {
+    ensure_fresh_with_progress(cfg, pool, identity, options, None).await
+}
+
+pub async fn ensure_fresh_with_progress(
+    cfg: &Config,
+    pool: sqlx::SqlitePool,
+    identity: &CodeIndexIdentity,
+    options: EnsureFreshOptions,
+    progress: Option<&dyn ReindexProgressSink>,
 ) -> anyhow::Result<EnsureFreshOutcome> {
     if FRESH_UNTIL
         .get(&identity.project_key)
@@ -97,7 +107,7 @@ pub async fn ensure_fresh(
         });
     }
 
-    let result = refresh_under_lease(cfg, &store, identity, &options).await;
+    let result = refresh_under_lease(cfg, &store, identity, &options, progress).await;
     let release_result = store.release_lease(identity, &owner).await;
     if let Err(err) = release_result {
         tracing::warn!(error = %err, "code-search freshness lease release failed");
@@ -141,10 +151,11 @@ async fn refresh_under_lease(
     store: &CodeIndexStore,
     identity: &CodeIndexIdentity,
     options: &EnsureFreshOptions,
+    progress: Option<&dyn ReindexProgressSink>,
 ) -> Result<ReindexSummary, RefreshError> {
     tokio::time::timeout(
         options.reindex_timeout,
-        refresh_under_lease_inner(cfg, store, identity, options),
+        refresh_under_lease_inner(cfg, store, identity, options, progress),
     )
     .await
     .map_err(|_| RefreshError::TimedOut)?
@@ -155,6 +166,7 @@ async fn refresh_under_lease_inner(
     store: &CodeIndexStore,
     identity: &CodeIndexIdentity,
     options: &EnsureFreshOptions,
+    progress: Option<&dyn ReindexProgressSink>,
 ) -> Result<ReindexSummary, RefreshError> {
     let manifest = build_manifest(store, identity, options.manifest_options)
         .await
@@ -164,7 +176,7 @@ async fn refresh_under_lease_inner(
         .await
         .map_err(|err| RefreshError::Failed(err.to_string()))?
     {
-        return finish_completed_generation(cfg, store, identity, &manifest, generation)
+        return finish_completed_generation(cfg, store, identity, &manifest, generation, progress)
             .await
             .map_err(|err| RefreshError::Failed(err.to_string()));
     }
@@ -183,7 +195,7 @@ async fn refresh_under_lease_inner(
         return Ok(ReindexSummary::default());
     }
 
-    reindex_changed_files(cfg, store, identity, &manifest, &diff)
+    reindex_changed_files(cfg, store, identity, &manifest, &diff, progress)
         .await
         .map_err(|err| RefreshError::Failed(err.to_string()))
 }

--- a/crates/axon-code-index/src/indexer.rs
+++ b/crates/axon-code-index/src/indexer.rs
@@ -3,17 +3,14 @@ use std::sync::{Arc, Mutex};
 
 use crate::config::{CodeIndexIdentity, max_indexed_file_bytes};
 use crate::manifest::{FileDiff, FileManifestEntry, ManifestSnapshot};
+use crate::paths::code_path_prefixes;
+use crate::progress::{ReindexProgress, ReindexProgressSink, ReindexRunOptions, emit_progress};
 use crate::store::CodeIndexStore;
+use crate::summary::ReindexSummary;
 use axon_core::config::Config;
 use axon_vector::ops::{
     SourceDocument, SourceOrigin, embed_prepared_docs, prepare_source_document,
 };
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct ReindexSummary {
-    pub indexed_files: usize,
-    pub removed_files: usize,
-}
 
 pub(crate) async fn reindex_changed_files(
     cfg: &Config,
@@ -21,9 +18,22 @@ pub(crate) async fn reindex_changed_files(
     identity: &CodeIndexIdentity,
     manifest: &ManifestSnapshot,
     diff: &FileDiff,
+    progress: Option<&dyn ReindexProgressSink>,
 ) -> anyhow::Result<ReindexSummary> {
     let generation = store.next_generation(identity).await?;
-    reindex_changed_files_inner(Some(cfg), store, identity, manifest, diff, generation, None).await
+    reindex_changed_files_inner(
+        Some(cfg),
+        store,
+        identity,
+        manifest,
+        diff,
+        ReindexRunOptions {
+            generation,
+            progress,
+            test_deletes: None,
+        },
+    )
+    .await
 }
 
 pub(crate) async fn retry_cleanup_debt(
@@ -40,8 +50,18 @@ pub(crate) async fn finish_completed_generation(
     identity: &CodeIndexIdentity,
     manifest: &ManifestSnapshot,
     generation: i64,
+    progress: Option<&dyn ReindexProgressSink>,
 ) -> anyhow::Result<ReindexSummary> {
-    finish_completed_generation_inner(Some(cfg), store, identity, manifest, generation, None).await
+    finish_completed_generation_inner(
+        Some(cfg),
+        store,
+        identity,
+        manifest,
+        generation,
+        progress,
+        None,
+    )
+    .await
 }
 
 async fn reindex_changed_files_inner(
@@ -50,12 +70,26 @@ async fn reindex_changed_files_inner(
     identity: &CodeIndexIdentity,
     manifest: &ManifestSnapshot,
     diff: &FileDiff,
-    generation: i64,
-    test_deletes: Option<Arc<Mutex<Vec<String>>>>,
+    options: ReindexRunOptions<'_>,
 ) -> anyhow::Result<ReindexSummary> {
     let mut summary = ReindexSummary::default();
+    let generation = options.generation;
+    let progress = options.progress;
     let previous_generation = generation.saturating_sub(1);
     let mut cleanup_paths = diff.removed.clone();
+    let batch_size = axon_core::config::parse::tuning::code_search_changed_file_batch_size();
+    let total_batches = manifest.files.len().div_ceil(batch_size);
+    emit_progress(
+        progress,
+        ReindexProgress::Started {
+            generation,
+            total_files: manifest.files.len(),
+            added_files: diff.added.len(),
+            modified_files: diff.modified.len(),
+            removed_files: diff.removed.len(),
+            total_batches,
+        },
+    );
     tracing::info!(
         project_key = %identity.project_key,
         generation,
@@ -77,6 +111,7 @@ async fn reindex_changed_files_inner(
         identity,
         manifest,
         generation,
+        progress,
         &mut cleanup_paths,
     )
     .await?;
@@ -91,6 +126,13 @@ async fn reindex_changed_files_inner(
         previous_generation,
         "code-search reindex cleanup debt start"
     );
+    emit_progress(
+        progress,
+        ReindexProgress::CleanupStarted {
+            generation,
+            cleanup_paths: cleanup_paths.len(),
+        },
+    );
     store
         .add_cleanup_debt(identity, previous_generation, &cleanup_paths)
         .await?;
@@ -99,18 +141,20 @@ async fn reindex_changed_files_inner(
         generation,
         "code-search reindex commit start"
     );
+    emit_progress(progress, ReindexProgress::CommitStarted { generation });
     store.commit_generation(identity, generation).await?;
     tracing::info!(
         project_key = %identity.project_key,
         generation,
         "code-search reindex commit done"
     );
-    cleanup_debt(cfg, store, identity, test_deletes).await?;
+    cleanup_debt(cfg, store, identity, options.test_deletes).await?;
     tracing::info!(
         project_key = %identity.project_key,
         generation,
         "code-search reindex cleanup done"
     );
+    emit_progress(progress, ReindexProgress::Finished { generation });
     Ok(summary)
 }
 
@@ -120,15 +164,17 @@ async fn reindex_manifest_batches(
     identity: &CodeIndexIdentity,
     manifest: &ManifestSnapshot,
     generation: i64,
+    progress: Option<&dyn ReindexProgressSink>,
     cleanup_paths: &mut Vec<String>,
 ) -> anyhow::Result<()> {
-    let batch_size = changed_file_batch_size();
+    let batch_size = axon_core::config::parse::tuning::code_search_changed_file_batch_size();
     let total_batches = manifest.files.len().div_ceil(batch_size);
     for (batch_index, batch) in manifest.files.chunks(batch_size).enumerate() {
         let batch_number = batch_index + 1;
         log_reindex_batch_start(identity, generation, batch_number, total_batches, batch);
         let prepared =
             prepare_reindex_batch(store, identity, generation, cleanup_paths, batch).await?;
+        let embedded_docs = prepared.len();
         embed_reindex_batch(
             cfg,
             identity,
@@ -147,6 +193,19 @@ async fn reindex_manifest_batches(
             batch,
         )
         .await?;
+        let processed_files = (batch_number * batch_size).min(manifest.files.len());
+        emit_progress(
+            progress,
+            ReindexProgress::BatchFinished {
+                generation,
+                batch_number,
+                total_batches,
+                processed_files,
+                total_files: manifest.files.len(),
+                batch_files: batch.len(),
+                embedded_docs,
+            },
+        );
     }
     Ok(())
 }
@@ -315,21 +374,6 @@ async fn prepare_local_code_doc(
         .map_err(|err| anyhow::anyhow!("prepare local code source document failed: {err}"))
 }
 
-pub(crate) fn code_path_prefixes(relative_path: &str) -> Vec<String> {
-    let mut prefixes = Vec::new();
-    let mut current = String::new();
-    let parts = relative_path.split('/').collect::<Vec<_>>();
-    for part in parts.iter().take(parts.len().saturating_sub(1)) {
-        if part.is_empty() {
-            continue;
-        }
-        current.push_str(part);
-        current.push('/');
-        prefixes.push(current.clone());
-    }
-    prefixes
-}
-
 async fn cleanup_debt(
     cfg: Option<&Config>,
     store: &CodeIndexStore,
@@ -372,6 +416,7 @@ async fn finish_completed_generation_inner(
     identity: &CodeIndexIdentity,
     manifest: &ManifestSnapshot,
     generation: i64,
+    progress: Option<&dyn ReindexProgressSink>,
     test_deletes: Option<Arc<Mutex<Vec<String>>>>,
 ) -> anyhow::Result<ReindexSummary> {
     let previous_generation = generation.saturating_sub(1);
@@ -387,16 +432,21 @@ async fn finish_completed_generation_inner(
         previous_generation,
         "code-search finish completed generation"
     );
+    emit_progress(
+        progress,
+        ReindexProgress::CleanupStarted {
+            generation,
+            cleanup_paths: cleanup_paths.len(),
+        },
+    );
     store
         .add_cleanup_debt(identity, previous_generation, &cleanup_paths)
         .await?;
+    emit_progress(progress, ReindexProgress::CommitStarted { generation });
     store.commit_generation(identity, generation).await?;
     cleanup_debt(cfg, store, identity, test_deletes).await?;
+    emit_progress(progress, ReindexProgress::Finished { generation });
     Ok(ReindexSummary::default())
-}
-
-fn changed_file_batch_size() -> usize {
-    axon_core::config::parse::tuning::code_search_changed_file_batch_size()
 }
 
 #[cfg(test)]
@@ -414,8 +464,11 @@ pub(crate) async fn reindex_changed_files_for_test(
         identity,
         manifest,
         diff,
-        generation,
-        Some(deletes),
+        ReindexRunOptions {
+            generation,
+            progress: None,
+            test_deletes: Some(deletes),
+        },
     )
     .await
 }
@@ -428,6 +481,14 @@ pub(crate) async fn finish_completed_generation_for_test(
     generation: i64,
     deletes: Arc<Mutex<Vec<String>>>,
 ) -> anyhow::Result<ReindexSummary> {
-    finish_completed_generation_inner(None, store, identity, manifest, generation, Some(deletes))
-        .await
+    finish_completed_generation_inner(
+        None,
+        store,
+        identity,
+        manifest,
+        generation,
+        None,
+        Some(deletes),
+    )
+    .await
 }

--- a/crates/axon-code-index/src/lib.rs
+++ b/crates/axon-code-index/src/lib.rs
@@ -2,11 +2,15 @@ pub mod config;
 pub mod ensure;
 pub mod indexer;
 pub mod manifest;
+mod paths;
+pub mod progress;
 pub mod store;
 mod store_schema;
+mod summary;
 
 pub use config::{CodeIndexIdentity, CodeSearchAllowedRoots};
 pub use ensure::{FreshnessWarning, ensure_fresh};
+pub use progress::{ReindexProgress, ReindexProgressSink};
 
 #[cfg(test)]
 #[path = "code_index_tests.rs"]

--- a/crates/axon-code-index/src/paths.rs
+++ b/crates/axon-code-index/src/paths.rs
@@ -1,0 +1,14 @@
+pub(crate) fn code_path_prefixes(relative_path: &str) -> Vec<String> {
+    let mut prefixes = Vec::new();
+    let mut current = String::new();
+    let parts = relative_path.split('/').collect::<Vec<_>>();
+    for part in parts.iter().take(parts.len().saturating_sub(1)) {
+        if part.is_empty() {
+            continue;
+        }
+        current.push_str(part);
+        current.push('/');
+        prefixes.push(current.clone());
+    }
+    prefixes
+}

--- a/crates/axon-code-index/src/progress.rs
+++ b/crates/axon-code-index/src/progress.rs
@@ -1,0 +1,49 @@
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum ReindexProgress {
+    Started {
+        generation: i64,
+        total_files: usize,
+        added_files: usize,
+        modified_files: usize,
+        removed_files: usize,
+        total_batches: usize,
+    },
+    BatchFinished {
+        generation: i64,
+        batch_number: usize,
+        total_batches: usize,
+        processed_files: usize,
+        total_files: usize,
+        batch_files: usize,
+        embedded_docs: usize,
+    },
+    CleanupStarted {
+        generation: i64,
+        cleanup_paths: usize,
+    },
+    CommitStarted {
+        generation: i64,
+    },
+    Finished {
+        generation: i64,
+    },
+}
+
+pub trait ReindexProgressSink: Sync {
+    fn emit(&self, progress: ReindexProgress);
+}
+
+pub(crate) struct ReindexRunOptions<'a> {
+    pub generation: i64,
+    pub progress: Option<&'a dyn ReindexProgressSink>,
+    pub test_deletes: Option<Arc<Mutex<Vec<String>>>>,
+}
+
+pub(crate) fn emit_progress(progress: Option<&dyn ReindexProgressSink>, event: ReindexProgress) {
+    if let Some(progress) = progress {
+        progress.emit(event);
+    }
+}

--- a/crates/axon-code-index/src/summary.rs
+++ b/crates/axon-code-index/src/summary.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ReindexSummary {
+    pub indexed_files: usize,
+    pub removed_files: usize,
+}

--- a/crates/axon-core/src/config/parse/toml_config_tests.rs
+++ b/crates/axon-core/src/config/parse/toml_config_tests.rs
@@ -415,7 +415,7 @@ quantization-always-ram = true
 freshness-ttl-secs = 30
 reindex-timeout-secs = 300
 max-file-bytes = 10485760
-changed-file-batch-size = 5
+changed-file-batch-size = 64
 
 [watch]
 tick-secs = 15

--- a/crates/axon-core/src/config/parse/tuning.rs
+++ b/crates/axon-core/src/config/parse/tuning.rs
@@ -604,7 +604,7 @@ pub fn code_search_changed_file_batch_size() -> usize {
     resolve_clamped_usize(
         "AXON_CODE_SEARCH_CHANGED_FILE_BATCH_SIZE",
         toml.code_search.changed_file_batch_size,
-        5,
+        64,
         1,
         1000,
     )

--- a/crates/axon-services/src/code_search_watch.rs
+++ b/crates/axon-services/src/code_search_watch.rs
@@ -6,6 +6,7 @@ use crate::context::ServiceContext;
 use crate::query;
 use crate::types::CodeSearchCaller;
 use anyhow::Result;
+use axon_code_index::ReindexProgressSink;
 use axon_core::config::CodeSearchWatchConfig;
 use notify::Watcher;
 use std::collections::BTreeMap;
@@ -14,9 +15,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
+pub use axon_code_index::ReindexProgress;
 pub use event::{
     CodeSearchWatchDryRunPlan, CodeSearchWatchDryRunRoot, CodeSearchWatchEvent,
-    CodeSearchWatchEventSink, StdoutCodeSearchWatchEventSink,
+    CodeSearchWatchEventSink,
 };
 use roots::{
     build_code_search_watch_dry_run_plan, code_search_watch_dirs, code_search_watch_dirty_roots,
@@ -140,10 +142,12 @@ fn queue_dirty_roots(
         });
         entry.since = Instant::now();
         entry.paths = entry.paths.saturating_add(1);
-        events.emit(CodeSearchWatchEvent::Pending {
-            root,
-            paths: entry.paths,
-        });
+        if entry.paths == 1 || entry.paths.is_multiple_of(100) {
+            events.emit(CodeSearchWatchEvent::Pending {
+                root,
+                paths: entry.paths,
+            });
+        }
     }
 }
 
@@ -192,7 +196,15 @@ async fn refresh_code_search_watch_root(
         root: root.to_path_buf(),
         reason,
     });
-    match query::refresh_code_search_index(ctx, Some(root), CodeSearchCaller::Cli).await {
+    let progress = WatchProgressSink { events };
+    match query::refresh_code_search_index_with_progress(
+        ctx,
+        Some(root),
+        CodeSearchCaller::Cli,
+        Some(&progress),
+    )
+    .await
+    {
         Ok(result) => events.emit(CodeSearchWatchEvent::RefreshFinished {
             root: root.to_path_buf(),
             status: result.freshness.status,
@@ -205,6 +217,17 @@ async fn refresh_code_search_watch_root(
             root: root.to_path_buf(),
             error: error.to_string(),
         }),
+    }
+}
+
+struct WatchProgressSink<'a> {
+    events: &'a dyn CodeSearchWatchEventSink,
+}
+
+impl ReindexProgressSink for WatchProgressSink<'_> {
+    fn emit(&self, progress: ReindexProgress) {
+        self.events
+            .emit(CodeSearchWatchEvent::RefreshProgress { progress });
     }
 }
 

--- a/crates/axon-services/src/code_search_watch/event.rs
+++ b/crates/axon-services/src/code_search_watch/event.rs
@@ -1,3 +1,4 @@
+use axon_code_index::ReindexProgress;
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -20,6 +21,9 @@ pub enum CodeSearchWatchEvent {
         indexed_files: usize,
         removed_files: usize,
         generation: Option<i64>,
+    },
+    RefreshProgress {
+        progress: ReindexProgress,
     },
     RefreshFailed {
         root: PathBuf,
@@ -54,123 +58,4 @@ pub struct CodeSearchWatchDryRunRoot {
 
 pub trait CodeSearchWatchEventSink: Sync {
     fn emit(&self, event: CodeSearchWatchEvent);
-}
-
-pub struct StdoutCodeSearchWatchEventSink {
-    pub json: bool,
-}
-
-impl CodeSearchWatchEventSink for StdoutCodeSearchWatchEventSink {
-    fn emit(&self, event: CodeSearchWatchEvent) {
-        if self.json {
-            emit_json(event);
-        } else {
-            emit_text(event);
-        }
-    }
-}
-
-fn emit_json(event: CodeSearchWatchEvent) {
-    match serde_json::to_string(&event) {
-        Ok(line) => println!("{line}"),
-        Err(error) => println!(
-            "{{\"event\":\"serialization_failed\",\"error\":{}}}",
-            serde_json::json!(error.to_string())
-        ),
-    }
-}
-
-fn emit_text(event: CodeSearchWatchEvent) {
-    match event {
-        CodeSearchWatchEvent::Started {
-            watch_dirs,
-            roots,
-            initial_refresh,
-        } => println!(
-            "code-search watcher started: {} watch dir(s), {} repo{}{}",
-            watch_dirs.len(),
-            roots.len(),
-            if roots.len() == 1 { "" } else { "s" },
-            if initial_refresh {
-                " (initial refresh enabled)"
-            } else {
-                ""
-            }
-        ),
-        CodeSearchWatchEvent::RefreshStarted { root, reason } => {
-            println!("code-search refresh started: {} {reason}", root.display());
-        }
-        CodeSearchWatchEvent::RefreshFinished {
-            root,
-            status,
-            warning,
-            indexed_files,
-            removed_files,
-            generation,
-        } => emit_refresh_finished(
-            root,
-            status,
-            warning,
-            indexed_files,
-            removed_files,
-            generation,
-        ),
-        CodeSearchWatchEvent::RefreshFailed { root, error } => {
-            println!("code-search refresh failed: {} {error}", root.display());
-        }
-        CodeSearchWatchEvent::Pending { root, paths } => {
-            println!(
-                "code-search watcher queued changes: {} {paths} path(s)",
-                root.display()
-            );
-        }
-        CodeSearchWatchEvent::DryRun { plan } => emit_dry_run(plan),
-        CodeSearchWatchEvent::Enabled {
-            unit_path,
-            env_path,
-            roots,
-        } => {
-            println!(
-                "code-search watcher enabled: {} repo root(s), unit={}, env={}",
-                roots.len(),
-                unit_path.display(),
-                env_path.display()
-            );
-        }
-        CodeSearchWatchEvent::Stopped => println!("code-search watcher stopped"),
-    }
-}
-
-fn emit_refresh_finished(
-    root: PathBuf,
-    status: String,
-    warning: Option<String>,
-    indexed_files: usize,
-    removed_files: usize,
-    generation: Option<i64>,
-) {
-    let generation = generation
-        .map(|generation| generation.to_string())
-        .unwrap_or_else(|| "none".to_string());
-    println!(
-        "code-search refresh finished: {} status={status} indexed={indexed_files} removed={removed_files} generation={generation}",
-        root.display()
-    );
-    if let Some(warning) = warning {
-        println!("code-search refresh warning: {warning}");
-    }
-}
-
-fn emit_dry_run(plan: CodeSearchWatchDryRunPlan) {
-    println!(
-        "code-search dry-run: {} repo(s), {} file(s)",
-        plan.roots.len(),
-        plan.total_files
-    );
-    for root in plan.roots {
-        println!("{}", root.root.display());
-        for file in root.files {
-            println!("  {file}");
-        }
-    }
 }

--- a/crates/axon-services/src/query.rs
+++ b/crates/axon-services/src/query.rs
@@ -10,9 +10,11 @@ use crate::types::{
     RetrieveResult, ServiceRetrieveVariantError, SuggestResult, Suggestion,
 };
 use axon_code_index::config::validate_path_prefix;
-use axon_code_index::ensure::EnsureFreshOptions;
+use axon_code_index::ensure::{EnsureFreshOptions, ensure_fresh_with_progress};
 use axon_code_index::store::CodeIndexStore;
-use axon_code_index::{CodeIndexIdentity, CodeSearchAllowedRoots, FreshnessWarning, ensure_fresh};
+use axon_code_index::{
+    CodeIndexIdentity, CodeSearchAllowedRoots, FreshnessWarning, ReindexProgressSink,
+};
 use axon_core::config::{Config, ConfigOverrides, ScrapeFormat};
 use axon_core::error::{ServiceError, diagnostics_from_error};
 use axon_vector::ops::commands::ask::{ask_result, ask_result_with_deltas};
@@ -272,9 +274,20 @@ pub async fn refresh_code_search_index(
     cwd: Option<&Path>,
     caller: CodeSearchCaller,
 ) -> Result<CodeSearchRefreshResult, Box<dyn Error + Send + Sync>> {
+    refresh_code_search_index_with_progress(ctx, cwd, caller, None).await
+}
+
+#[must_use = "refresh_code_search_index_with_progress returns a Result that should be handled"]
+pub async fn refresh_code_search_index_with_progress(
+    ctx: &ServiceContext,
+    cwd: Option<&Path>,
+    caller: CodeSearchCaller,
+    progress: Option<&dyn ReindexProgressSink>,
+) -> Result<CodeSearchRefreshResult, Box<dyn Error + Send + Sync>> {
     let root = resolve_code_search_root(cwd, caller).await?;
     let identity = code_search_identity(ctx.cfg(), root).await;
-    let freshness = resolve_code_search_freshness(ctx, &identity, true).await;
+    let freshness =
+        resolve_code_search_freshness_with_progress(ctx, &identity, true, progress).await;
     let generation = code_search_committed_generation(ctx, &identity).await?;
     Ok(CodeSearchRefreshResult {
         project_root: identity.project_root.clone(),
@@ -288,6 +301,15 @@ async fn resolve_code_search_freshness(
     ctx: &ServiceContext,
     identity: &CodeIndexIdentity,
     ensure: bool,
+) -> CodeSearchFreshness {
+    resolve_code_search_freshness_with_progress(ctx, identity, ensure, None).await
+}
+
+async fn resolve_code_search_freshness_with_progress(
+    ctx: &ServiceContext,
+    identity: &CodeIndexIdentity,
+    ensure: bool,
+    progress: Option<&dyn ReindexProgressSink>,
 ) -> CodeSearchFreshness {
     if !ensure {
         return code_search_freshness("skipped", None, 0, 0);
@@ -307,7 +329,15 @@ async fn resolve_code_search_freshness(
         }
     };
 
-    match ensure_fresh(ctx.cfg(), pool, identity, EnsureFreshOptions::default()).await {
+    match ensure_fresh_with_progress(
+        ctx.cfg(),
+        pool,
+        identity,
+        EnsureFreshOptions::default(),
+        progress,
+    )
+    .await
+    {
         Ok(outcome) => code_search_freshness(
             "fresh",
             outcome.warning,

--- a/crates/axon-vector/src/ops/input/code.rs
+++ b/crates/axon-vector/src/ops/input/code.rs
@@ -1,6 +1,6 @@
 // AST-aware code chunking via tree-sitter.
 
-use axon_core::logging::log_warn;
+use axon_core::logging::log_debug;
 
 use super::chunk_text_with_offsets;
 
@@ -67,10 +67,12 @@ pub fn chunk_code_chunks(content: &str, file_extension: &str) -> Option<Vec<Code
 
     if symbols.is_empty() {
         // A non-trivial supported file with zero symbols is suspected grammar
-        // drift (node-kind names changed upstream) — surface it before degrading
-        // the whole file to prose.
+        // drift (node-kind names changed upstream). Keep it available for
+        // debug diagnostics, but do not warn during normal indexing because
+        // the prose fallback below is loss-tolerant and expected for many
+        // script/config-shaped files.
         if content.len() > GRAMMAR_DRIFT_WARN_MIN_BYTES {
-            log_warn(&format!(
+            log_debug(&format!(
                 "command=chunk_code grammar_drift_zero_symbols ext={file_extension} bytes={}",
                 content.len()
             ));

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -220,7 +220,7 @@ The CLI may search the current Git checkout directly.
 | `code-search.freshness-ttl-secs` / `AXON_CODE_SEARCH_FRESHNESS_TTL_SECS` | `30` | Process-local freshness cache TTL before a new manifest check is required. |
 | `code-search.reindex-timeout-secs` / `AXON_CODE_SEARCH_REINDEX_TIMEOUT_SECS` | `300` | Foreground refresh timeout. On timeout, stale vectors are returned with a freshness warning; no background refresh continues in v1. |
 | `code-search.max-file-bytes` / `AXON_CODE_SEARCH_MAX_FILE_BYTES` | `10485760` | Max local source file size considered by the manifest and embed pass. Larger files are skipped. |
-| `code-search.changed-file-batch-size` / `AXON_CODE_SEARCH_CHANGED_FILE_BATCH_SIZE` | `5` | Changed-file batch size for local-code embedding. |
+| `code-search.changed-file-batch-size` / `AXON_CODE_SEARCH_CHANGED_FILE_BATCH_SIZE` | `64` | Changed-file batch size for local-code embedding. |
 
 ### TEI embedding
 

--- a/plugins/axon/CHANGELOG.md
+++ b/plugins/axon/CHANGELOG.md
@@ -3,8 +3,20 @@
 ## Unreleased
 
 ### Added
+- Rebuilt the plugin skill surface around 25 plain-name Axon skills under `skills/`: one `using-axon` guide, eight core command/action skills, and sixteen outcome-focused workflow skills.
+- Added OpenAI skill metadata at `agents/openai.yaml` for every shipped skill.
+- Added shared workflow references under `references/`, including capture recipes, workflow authoring guidance, and output templates.
 - Documented the `memory.remember`, `memory.search`, `memory.show`, `memory.link`, `memory.supersede`, and `memory.context` agent-memory actions in the `using-axon` skill.
 - Added a defensive SessionStart hook that recalls compact `memory.context` for the current git project when Axon memory is available.
+
+### Changed
+- Rebranded the imported Firecrawl-style skills as Axon-native workflows, removing the `axon-` folder prefix now that the skills live inside the Axon plugin namespace.
+- Moved the runtime RAG synthesis prompt from a user-facing skill path to `references/rag-synthesize/` so it can be embedded by Axon without appearing as an invocable plugin skill.
+- Updated the plugin README to describe the current HTTP MCP configuration, minimal user config, skills layout, and reference files.
+
+### Fixed
+- Added skill hygiene coverage so missing `SKILL.md`, missing `agents/openai.yaml`, stale `axon-` folder prefixes, or misplaced reference-only skills fail in tests.
+- Clarified that Axon download/offline-capture guidance is a composed `scrape`/`crawl --output-dir`/`screenshot` workflow, not a single first-class offline-site mirroring command.
 
 ## [1.5.4] - 2026-05-06
 

--- a/plugins/axon/README.md
+++ b/plugins/axon/README.md
@@ -10,7 +10,15 @@ Backed by Qdrant (hybrid dense + BM42 sparse + RRF), TEI for embeddings, optiona
 claude plugin install <path>
 ```
 
-The plugin manifest declares a minimal `userConfig` block. Claude Code prompts for the shared Axon server URL, bearer token, optional Tavily/GitHub/Reddit credentials, and optional OAuth settings. Qdrant, TEI, Chrome, Qwen3 embedding, and LLM backend settings are configured by the shared Docker setup path, not by plugin prompts.
+The plugin manifest declares a minimal `userConfig` block. Claude Code prompts
+only for connection details for an already-running Axon server.
+
+The current plugin prompt surface is intentionally small:
+
+- `server_url` — base URL for a running `axon serve` instance, defaulting to `http://localhost:8080`.
+- `api_token` — bearer token sent to `${server_url}/mcp`; leave empty only for loopback/unauthenticated development instances.
+
+Search providers, ingest credentials, Qdrant, TEI, Chrome, embedding, and LLM backend settings live in the shared Axon host configuration (`~/.axon/.env` and `~/.axon/config.toml`), not in plugin prompts.
 
 The plugin includes two narrow Claude hooks:
 
@@ -21,7 +29,7 @@ The hooks are intentionally non-blocking. They do not deploy Docker services; st
 
 To provision the stack for the first time, run `/axon-deploy` (or `axon setup` / `axon compose up` on the host directly).
 
-No systemd unit is created. Docker Compose is the only production deployment target. The `.mcp.json` connects Claude Code to `${user_config.server_url}/mcp` with the configured bearer token.
+No systemd unit is created. Docker Compose is the only production deployment target. The `.mcp.json` uses HTTP transport and connects Claude Code to `${user_config.server_url}/mcp` with the configured bearer token.
 
 ### Session Memory and Auto-Ingest
 
@@ -66,15 +74,23 @@ Default `response_mode: "path"` writes large outputs under the configured Axon a
 
 ## Skills
 
-The plugin ships plain-name Axon skills under `skills/`. Action skills cover the
-core CLI/MCP surfaces; workflow skills cover outcome-focused research,
-monitoring, QA, shopping, and design deliverables.
+The plugin ships 25 plain-name Axon skills under `skills/`. Because these
+skills already live inside the Axon plugin namespace, folder names do not carry
+an `axon-` prefix. Every skill includes `agents/openai.yaml` metadata.
+
+Action skills cover the core CLI/MCP surfaces; workflow skills cover
+outcome-focused research, monitoring, QA, shopping, and design deliverables.
 
 | Skill | Purpose |
 |-------|---------|
 | `using-axon` | Unified usage guide for the single `axon` MCP/CLI surface. |
 | `cli`, `crawl`, `download`, `extract`, `map`, `scrape`, `search`, `monitor` | Core Axon command and action workflows. |
 | `company-directories`, `competitive-intel`, `dashboard-reporting`, `deep-research`, `demo-walkthrough`, `knowledge-base`, `knowledge-ingest`, `lead-gen`, `lead-research`, `market-research`, `qa`, `research-papers`, `seo-audit`, `shop`, `website-design-clone`, `workflows` | Outcome-focused Axon workflow skills. |
+
+The `download` skill documents Axon's current composed capture workflow:
+`scrape`, `crawl --output-dir`, and `screenshot`. It is not a promise that Axon
+already has a single offline-site mirroring command that rewrites linked assets
+for fully browsable local copies.
 
 The runtime RAG synthesis prompt is stored under
 `references/rag-synthesize/SKILL.md` and embedded into `ask` synthesis at compile
@@ -90,16 +106,30 @@ time. It is intentionally not exposed as a user-invocable plugin skill.
 plugins/axon/
 ├── README.md                  — this file
 ├── CHANGELOG.md
-├── .mcp.json                  — MCP server config (stdio, ${user_config.*})
+├── .claude-plugin/
+│   └── plugin.json            — plugin manifest and userConfig
+├── .mcp.json                  — MCP server config (HTTP, ${user_config.*})
 ├── agents/
 │   └── researcher.md
+├── commands/
+│   └── axon-deploy.md
+├── examples/
+│   └── workflow-output-templates.md
+├── hooks/
+│   └── hooks.json
 ├── references/
 │   ├── capture-recipes.md
+│   ├── workflow-authoring.md
 │   └── rag-synthesize/
 │       ├── SKILL.md          — runtime RAG synthesis prompt
 │       └── example-response.md
+├── scripts/
+│   ├── plugin-setup.sh
+│   └── session-start-memory-context.sh
 └── skills/
-    ├── using-axon/SKILL.md   — meta-skill
+    ├── using-axon/
+    │   ├── SKILL.md          — meta-skill
+    │   └── agents/openai.yaml
     ├── cli/SKILL.md
     ├── crawl/SKILL.md
     ├── download/SKILL.md


### PR DESCRIPTION
## Summary
- add structured code-search reindex progress events through the shared service layer and CLI renderer
- quiet harmless zero-symbol parser drift warnings to debug output
- increase code-search changed-file batching defaults and document the knob
- stop plugin hook setup from self-installing over the active axon binary

## Verification
- cargo test -p axon-core toml_config --lib
- cargo test -p axon-code-index --features test-util
- cargo check -p axon-services -p axon-cli
- cargo clippy -p axon-code-index --all-targets --locked -- -D warnings
- cargo clippy -p axon-services --all-targets --locked -- -D warnings
- AXON_ALLOW_FALLBACK_WEB_ASSETS=1 cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo xtask check-openapi-drift
- pre-commit hook: monolith, rustfmt, xtask-check
- pre-push-router passed locally; direct main push was rejected by branch protection as expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the code-search watcher UX with streaming reindex progress and a clearer CLI renderer, and raises the changed-file batch size to 64 for faster indexing. Also refreshes the Axon plugin skills and docs.

- New Features
  - Added structured reindex progress in `axon-code-index` (`ReindexProgress`), emitted by `axon-services` as `RefreshProgress`, and rendered by `axon-cli` (text and `--json`); introduced `refresh_code_search_index_with_progress` and `ensure_fresh_with_progress`.
  - CLI shows the plan, batch milestones (first/last and 5%), cleanup, commit, finish; throttles “pending changes” logs (first and every 100th); includes dry-run file listings and watcher enable details.
  - Increased default `code-search.changed-file-batch-size` to `64`.
  - Overhauled `plugins/axon`: 25 plain-name skills with OpenAI metadata, new references, and an updated README.

- Bug Fixes
  - Downgraded zero-symbol parser drift messages to debug logs in `axon-vector`.
  - Stopped plugin hook setup from self-installing over the active Axon binary in `axon-cli` setup.

<sup>Written for commit bbc27d54f62bb2d8e8d32ede16210a6b0c9ef7a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code search refreshes and watch mode now show live progress updates, including batch completion and completion status.
  * CLI output for code search watch has been improved for both human-readable and JSON formats.

* **Bug Fixes**
  * Pending watch events are now throttled to reduce noisy updates.
  * The default changed-file batch size has been increased for local code search.

* **Documentation**
  * Updated version references and release notes to **6.1.5** across project docs and API metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->