### PR TITLE
Polish palette command bar interactions

### DIFF
--- a/apps/palette-tauri/CHANGELOG.md
+++ b/apps/palette-tauri/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.12.1] - 2026-06-28
+
 ## [5.12.0] - 2026-06-26
 
 ### Added

--- a/apps/palette-tauri/package.json
+++ b/apps/palette-tauri/package.json
@@ -54,5 +54,5 @@
     "vite:dev": "vite --host 127.0.0.1"
   },
   "type": "module",
-  "version": "5.12.0"
+  "version": "5.12.1"
 }

--- a/apps/palette-tauri/src-tauri/Cargo.lock
+++ b/apps/palette-tauri/src-tauri/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axon-palette-tauri"
-version = "5.12.0"
+version = "5.12.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/apps/palette-tauri/src-tauri/Cargo.toml
+++ b/apps/palette-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axon-palette-tauri"
-version = "5.12.0"
+version = "5.12.1"
 description = "Tauri command palette for the Axon REST API"
 edition = "2024"
 rust-version = "1.94.0"

--- a/apps/palette-tauri/src-tauri/tauri.conf.json
+++ b/apps/palette-tauri/src-tauri/tauri.conf.json
@@ -59,5 +59,5 @@
   },
   "identifier": "tv.tootie.axon.palette",
   "productName": "Axon Palette",
-  "version": "5.12.0"
+  "version": "5.12.1"
 }

--- a/apps/palette-tauri/src/App.test.tsx
+++ b/apps/palette-tauri/src/App.test.tsx
@@ -81,11 +81,8 @@ describe("App local help", () => {
 
   it("opens selected action help from the command bar and replays it from history as local help", async () => {
     await renderAndType("scrape");
-    const commandHelp = (await screen.findAllByLabelText("Help for Scrape URL")).find((button) =>
-      button.classList.contains("command-help"),
-    );
-    expect(commandHelp).toBeDefined();
-    fireEvent.click(commandHelp!);
+    fireEvent.click(await screen.findByRole("button", { name: "Menu" }));
+    fireEvent.click(await screen.findByText("Help"));
 
     expect((await screen.findAllByText("Scrape URL")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("POST /v1/scrape").length).toBeGreaterThan(0);
@@ -99,13 +96,13 @@ describe("App local help", () => {
     expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("axon_http_request", expect.anything());
   });
 
-  it("shows unknown-query help from the command-bar question mark without REST", async () => {
+  it("shows Ask help for free text from the command menu without REST", async () => {
     await renderAndType("nope");
 
-    fireEvent.click(await screen.findByRole("button", { name: "Help" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Menu" }));
+    fireEvent.click(await screen.findByText("Help"));
 
-    expect(await screen.findByText("No matching action:")).toBeTruthy();
-    expect(screen.getByText("nope")).toBeTruthy();
+    expect((await screen.findAllByText("POST /v1/ask")).length).toBeGreaterThan(0);
     expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("axon_http_request", expect.anything());
   });
 });

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -96,8 +96,13 @@ export default function App() {
     if (looksLikeUrl(parsed.search)) {
       return sortActionsForDisplay(ACTIONS).slice(0, 12);
     }
+    const matches = ACTIONS.filter((action) => actionMatches(action, parsed.search));
+    if (parsed.search.trim().length > 0 && matches.length === 0) {
+      const ask = ACTIONS.find((action) => action.subcommand === "ask");
+      return ask ? [ask] : [];
+    }
     return sortActionsByRelevance(
-      ACTIONS.filter((action) => actionMatches(action, parsed.search)),
+      matches,
       parsed.search,
     ).slice(0, 12);
   }, [parsed.invoked, parsed.search]);
@@ -113,7 +118,8 @@ export default function App() {
   selectedIndex = Math.min(selectedIndex, Math.max(filtered.length - 1, 0));
   const suggestedAction = filtered[selectedIndex];
   const active = modeAction ?? suggestedAction;
-  const activeArgument = active ? argumentFor(active, modeAction, parsed, query) : "";
+  const askFallback = active?.subcommand === "ask" && !modeAction && !parsed.invoked && parsed.search.trim().length > 0 && !actionMatches(active, parsed.search);
+  const activeArgument = active ? (askFallback ? parsed.search : argumentFor(active, modeAction, parsed, query)) : "";
   const validation = active ? validationMessage(active, activeArgument) : "No matching action";
   const confirmationArmed =
     active && !validation ? actionConfirmationArmed(pendingConfirmation, active, activeArgument) : false;
@@ -357,7 +363,7 @@ export default function App() {
       if (!modeAction && !parsed.invoked && active.argMode !== "none" && !looksLikeUrl(parsed.search)) {
         enterActionMode(active);
       } else {
-        requestSubmit(active);
+        requestSubmit(active, askFallback ? parsed.search : undefined);
       }
     } else if (event.key === "Tab") {
       event.preventDefault();

--- a/apps/palette-tauri/src/components/palette/ActionList.test.tsx
+++ b/apps/palette-tauri/src/components/palette/ActionList.test.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { ActionList } from "@/components/palette/ActionList";
-import { ACTIONS } from "@/lib/actions";
+import { ACTIONS, type PaletteAction } from "@/lib/actions";
 import { parseCommand } from "@/lib/paletteView";
 
 const onSubmit = vi.fn();
@@ -94,4 +94,33 @@ it("enters argument mode on row click for an action that needs input", async () 
   expect(onEnterMode).toHaveBeenCalledTimes(1);
   expect(onEnterMode.mock.calls[0][0].subcommand).toBe("scrape");
   expect(onSubmit).not.toHaveBeenCalled();
+});
+
+it("submits free text through Ask instead of entering argument mode", async () => {
+  const user = userEvent.setup();
+  const [ask] = ACTIONS.filter((action): action is PaletteAction => action.subcommand === "ask");
+  if (!ask) throw new Error("missing ask action");
+
+  function AskHarness() {
+    const [selected, setSelected] = useState(0);
+    return (
+      <ActionList
+        filtered={[ask]}
+        selected={selected}
+        setSelected={setSelected}
+        parsed={parseCommand("why is qdrant slow today")}
+        onSubmit={onSubmit}
+        onEnterMode={onEnterMode}
+        onHelp={onHelp}
+      />
+    );
+  }
+
+  render(<AskHarness />);
+  await user.click(screen.getByRole("option", { name: /Ask/ }));
+
+  expect(onSubmit).toHaveBeenCalledTimes(1);
+  expect(onSubmit.mock.calls[0][0].subcommand).toBe("ask");
+  expect(onSubmit.mock.calls[0][1]).toBe("why is qdrant slow today");
+  expect(onEnterMode).not.toHaveBeenCalled();
 });

--- a/apps/palette-tauri/src/components/palette/ActionList.tsx
+++ b/apps/palette-tauri/src/components/palette/ActionList.tsx
@@ -4,7 +4,7 @@ import { ActionIcon } from "@/components/palette/ActionIcon";
 import { Button } from "@/components/ui/aurora/button";
 import { Kbd } from "@/components/ui/aurora/kbd";
 import { ScrollArea } from "@/components/ui/aurora/scroll-area";
-import { acceptsDirectUrl, type PaletteAction } from "@/lib/actions";
+import { acceptsDirectUrl, actionMatches, type PaletteAction } from "@/lib/actions";
 import { isAsyncAction } from "@/lib/actionHelp";
 import { actionDisplayMeta } from "@/lib/actionMeta";
 import { looksLikeUrl, type ParsedCommand } from "@/lib/paletteView";
@@ -14,7 +14,7 @@ interface ActionListProps {
   selected: number;
   setSelected: Dispatch<SetStateAction<number>>;
   parsed: ParsedCommand;
-  onSubmit: (action: PaletteAction) => void;
+  onSubmit: (action: PaletteAction, argumentOverride?: string) => void;
   onEnterMode: (action: PaletteAction) => void;
   onHelp: (action: PaletteAction) => void;
 }
@@ -116,6 +116,13 @@ export function ActionList({ filtered, selected, setSelected, parsed, onSubmit, 
                             } else if (action.argMode === "none") {
                               // No-input actions run immediately — no empty argument prompt.
                               onSubmit(action);
+                            } else if (
+                              action.subcommand === "ask" &&
+                              parsed.search.trim().length > 0 &&
+                              !actionMatches(action, parsed.search)
+                            ) {
+                              // Free text in the empty command field is an Ask prompt.
+                              onSubmit(action, parsed.search);
                             } else if (acceptsDirectUrl(action) && looksLikeUrl(parsed.search)) {
                               onSubmit(action);
                             } else {

--- a/apps/palette-tauri/src/components/palette/PaletteCommandBar.test.tsx
+++ b/apps/palette-tauri/src/components/palette/PaletteCommandBar.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { PaletteCommandBar } from "@/components/palette/PaletteCommandBar";
 import { ACTIONS, type PaletteAction } from "@/lib/actions";
+import { actionDisplayMeta } from "@/lib/actionMeta";
 
 const config = {
   serverUrl: "http://127.0.0.1:9999",
@@ -112,9 +113,9 @@ describe("PaletteCommandBar action switcher disclosure (A11Y-H1 / T-M4)", () => 
 
     const askButton = screen
       .getAllByRole("button")
-      .find((b) => b.textContent?.includes(ask.subcommand));
-    expect(askButton).toBeDefined();
-    await user.click(askButton!);
+      .find((b) => b.textContent?.includes(actionDisplayMeta(ask).label));
+    if (!askButton) throw new Error("missing Ask switcher button");
+    await user.click(askButton);
     expect(onSwitchAction).toHaveBeenCalledTimes(1);
     expect(onSwitchAction.mock.calls[0][0].subcommand).toBe("ask");
   });
@@ -128,18 +129,32 @@ describe("PaletteCommandBar action switcher disclosure (A11Y-H1 / T-M4)", () => 
     expect(screen.getByText("Question to answer")).toBeInTheDocument();
   });
 
-  it("renders a pinned switcher footer with current action context and hints", async () => {
+  it("renders grouped switcher sections with compact action metadata", async () => {
     const user = userEvent.setup();
     renderBar({ modeAction: scrape });
 
     await user.click(screen.getByRole("button", { name: /Switch from/ }));
 
-    const footer = screen.getByText("One URL to content").closest(".command-action-footer");
-    expect(footer).toBeTruthy();
-    expect(within(footer as HTMLElement).getByText("Scrape")).toBeInTheDocument();
-    expect(within(footer as HTMLElement).getByText("navigate")).toBeInTheDocument();
-    expect(within(footer as HTMLElement).getByText("switch")).toBeInTheDocument();
-    expect(within(footer as HTMLElement).getByText("close")).toBeInTheDocument();
+    expect(screen.getByText("Fetch & read")).toBeInTheDocument();
+    expect(screen.getByText("Reason")).toBeInTheDocument();
+    expect(screen.getByText("Question to answer")).toBeInTheDocument();
+    expect(screen.queryByText("navigate")).not.toBeInTheDocument();
+  });
+
+  it("opens the utility menu and routes help through the menu", async () => {
+    const user = userEvent.setup();
+    const onHelp = vi.fn();
+    renderBar({ onHelp });
+
+    await user.click(screen.getByRole("button", { name: "Menu" }));
+
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Config")).toBeInTheDocument();
+    expect(screen.getByText("Environment")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Help"));
+    expect(onHelp).toHaveBeenCalledTimes(1);
+    expect(onHelp.mock.calls[0][0].subcommand).toBe("scrape");
   });
 
   it("closes the disclosure on Escape and keeps focus on the trigger", async () => {

--- a/apps/palette-tauri/src/components/palette/PaletteCommandBar.tsx
+++ b/apps/palette-tauri/src/components/palette/PaletteCommandBar.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, ChevronDown, HelpCircle, Search, Send, Settings } from "lucide-react";
+import { ArrowLeft, ChevronDown, CircleHelp, Menu, Search, Send, Settings, SlidersHorizontal, TerminalSquare } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { actionIcon } from "@/components/palette/ActionIcon";
@@ -53,6 +53,8 @@ function sentenceCase(value: string): string {
   return value ? value[0].toUpperCase() + value.slice(1) : value;
 }
 
+const SWITCHER_GROUPS = ["Fetch & read", "Crawl & ingest", "Search & discover", "Reason", "System", "Jobs"] as const;
+
 export function PaletteCommandBar({
   active,
   activeDescendantId,
@@ -81,26 +83,43 @@ export function PaletteCommandBar({
   const ModeIcon = modeAction ? actionIcon(modeAction.subcommand) : null;
   const switcherRef = useRef<HTMLDivElement | null>(null);
   const switcherTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const menuTriggerRef = useRef<HTMLButtonElement | null>(null);
   const [switcherOpen, setSwitcherOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const switcherActions = useMemo(
     () => sortActionsForDisplay(ACTIONS).filter((action) => action.subcommand !== modeAction?.subcommand),
     [modeAction?.subcommand],
   );
-  const modeMeta = modeAction ? actionDisplayMeta(modeAction) : null;
-  const modeDescriptor = modeMeta ? sentenceCase(`${modeMeta.input} to ${modeMeta.output}`) : "";
+  const groupedSwitcherActions = useMemo(() => {
+    const groups = new Map<string, PaletteAction[]>();
+    for (const action of switcherActions) {
+      const category = actionDisplayMeta(action).category;
+      groups.set(category, [...(groups.get(category) ?? []), action]);
+    }
+    return [
+      ...SWITCHER_GROUPS.map((category) => ({ category, actions: groups.get(category) ?? [] })),
+      ...[...groups.entries()]
+        .filter(([category]) => !SWITCHER_GROUPS.includes(category as (typeof SWITCHER_GROUPS)[number]))
+        .map(([category, actions]) => ({ category, actions })),
+    ].filter((group) => group.actions.length > 0);
+  }, [switcherActions]);
 
   useEffect(() => {
-    if (!switcherOpen) return;
+    if (!switcherOpen && !menuOpen) return;
     const onPointerDown = (event: PointerEvent) => {
       if (switcherRef.current?.contains(event.target as Node)) return;
+      if (menuRef.current?.contains(event.target as Node)) return;
       setSwitcherOpen(false);
+      setMenuOpen(false);
     };
     window.addEventListener("pointerdown", onPointerDown);
     return () => window.removeEventListener("pointerdown", onPointerDown);
-  }, [switcherOpen]);
+  }, [switcherOpen, menuOpen]);
 
   useEffect(() => {
     setSwitcherOpen(false);
+    setMenuOpen(false);
   }, []);
 
   // A11Y-M2 — surface submit validation as text tied to the input via
@@ -139,6 +158,7 @@ export function PaletteCommandBar({
       </Button>
       <span className="axon-divider" aria-hidden="true" />
       {/* biome-ignore lint/a11y/noStaticElementInteractions: click-to-focus convenience; the real control is the command input within */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard users focus the input directly; this wrapper only expands the pointer target */}
       <div className="command-input-wrap" onClick={() => focusInput()}>
         {modeAction && ModeIcon ? (
           // A11Y-H1 — the action switcher is an `aria-expanded` disclosure of plain
@@ -154,6 +174,7 @@ export function PaletteCommandBar({
               type="button"
               onClick={(event) => {
                 event.stopPropagation();
+                setMenuOpen(false);
                 setSwitcherOpen((open) => !open);
               }}
               onKeyDown={(event) => {
@@ -177,8 +198,6 @@ export function PaletteCommandBar({
               <div
                 id="command-action-disclosure"
                 className="command-action-menu"
-                role="group"
-                aria-label="Switch action"
                 onKeyDown={(event) => {
                   if (event.key === "Escape") {
                     event.stopPropagation();
@@ -188,46 +207,38 @@ export function PaletteCommandBar({
                 }}
               >
                 <div className="command-action-options">
-                  {switcherActions.map((action) => {
-                    const Icon = actionIcon(action.subcommand);
-                    const meta = actionDisplayMeta(action);
-                    const descriptor = sentenceCase(`${meta.input} to ${meta.output}`);
-                    return (
-                      <Button
-                        variant="plain"
-                        size="unstyled"
-                        key={action.subcommand}
-                        className={`command-action-option command-action-option-${action.tone}`}
-                        type="button"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          setSwitcherOpen(false);
-                          onSwitchAction(action);
-                        }}
-                      >
-                        <Icon size={15} strokeWidth={1.85} aria-hidden="true" />
-                        <span>
-                          <strong>{meta.label}</strong>
-                          <small>{descriptor}</small>
-                        </span>
-                        <Kbd unstyled>{action.subcommand}</Kbd>
-                      </Button>
-                    );
-                  })}
+                  {groupedSwitcherActions.map((group) => (
+                    <div className="command-action-group" key={group.category}>
+                      <div className="command-action-group-heading">{group.category}</div>
+                      {group.actions.map((action) => {
+                        const Icon = actionIcon(action.subcommand);
+                        const meta = actionDisplayMeta(action);
+                        const descriptor = sentenceCase(`${meta.input} to ${meta.output}`);
+                        return (
+                          <Button
+                            variant="plain"
+                            size="unstyled"
+                            key={action.subcommand}
+                            className={`command-action-option command-action-option-${action.tone}`}
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setSwitcherOpen(false);
+                              onSwitchAction(action);
+                            }}
+                          >
+                            <Icon size={15} strokeWidth={1.85} aria-hidden="true" />
+                            <span>
+                              <strong>{meta.label}</strong>
+                              <small>{descriptor}</small>
+                            </span>
+                            <Kbd unstyled>{actionDisplayMeta(action).method}</Kbd>
+                          </Button>
+                        );
+                      })}
+                    </div>
+                  ))}
                 </div>
-                {modeAction && modeMeta && (
-                  <div className="command-action-footer">
-                    <span className="command-action-footer-current">
-                      <strong>{modeMeta.label}</strong>
-                      <span>{modeDescriptor}</span>
-                    </span>
-                    <span className="command-action-footer-hints">
-                      <span><Kbd unstyled>↑</Kbd><Kbd unstyled>↓</Kbd> navigate</span>
-                      <span><Kbd unstyled>↵</Kbd> switch</span>
-                      <span><Kbd unstyled>esc</Kbd> close</span>
-                    </span>
-                  </div>
-                )}
               </div>
             )}
           </div>
@@ -258,23 +269,9 @@ export function PaletteCommandBar({
       <Button
         variant="plain"
         size="unstyled"
-        // `.command-help:disabled` owns the disabled look (no opacity change);
-        // neutralize the primitive base's disabled:opacity-45 to stay pixel-identical.
-        className="command-help disabled:opacity-100"
-        type="button"
-        onClick={() => onHelp(active, active ? undefined : query.trim())}
-        disabled={running}
-        aria-label={active ? `Help for ${active.label}` : "Help"}
-        title={active ? `Help for ${active.label}` : "Help"}
-      >
-        <HelpCircle size={15} />
-      </Button>
-      <Button
-        variant="plain"
-        size="unstyled"
         // `.command-submit:disabled` owns the disabled look (no opacity change);
         // neutralize the primitive base's disabled:opacity-45 to stay pixel-identical.
-        className={`${active && !validation ? `command-submit command-submit-${active.tone}` : "command-submit"} disabled:opacity-100`}
+        className={`${active && !validation ? "command-submit command-submit-armed" : "command-submit"} disabled:opacity-100`}
         type="button"
         onClick={() => active && onSubmit(active)}
         disabled={submitDisabled}
@@ -283,17 +280,91 @@ export function PaletteCommandBar({
       >
         <Send size={15} />
       </Button>
-      <Button
-        variant="plain"
-        size="unstyled"
-        className={settingsOpen ? "command-settings command-settings-active" : "command-settings"}
-        type="button"
-        onClick={onToggleSettings}
-        aria-label="Settings"
-        title="Settings"
-      >
-        <Settings size={15} />
-      </Button>
+      <div className="command-menu-wrap" ref={menuRef}>
+        <Button
+          variant="plain"
+          size="unstyled"
+          ref={menuTriggerRef}
+          className={settingsOpen || menuOpen ? "command-settings command-settings-active" : "command-settings"}
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            setSwitcherOpen(false);
+            setMenuOpen((open) => !open);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape" && menuOpen) {
+              event.stopPropagation();
+              setMenuOpen(false);
+              menuTriggerRef.current?.focus();
+            }
+          }}
+          aria-haspopup="true"
+          aria-expanded={menuOpen}
+          aria-controls="command-menu"
+          aria-label="Menu"
+          title="Menu"
+        >
+          <Menu size={15} />
+        </Button>
+        {menuOpen && (
+          <div id="command-menu" className="command-menu">
+            <Button
+              variant="plain"
+              size="unstyled"
+              className="command-menu-item"
+              type="button"
+              onClick={() => {
+                setMenuOpen(false);
+                onToggleSettings();
+              }}
+            >
+              <Settings size={15} strokeWidth={1.7} aria-hidden="true" />
+              <span><strong>Settings</strong><small>Palette preferences</small></span>
+            </Button>
+            <Button
+              variant="plain"
+              size="unstyled"
+              className="command-menu-item"
+              type="button"
+              onClick={() => {
+                setMenuOpen(false);
+                onToggleSettings();
+              }}
+            >
+              <SlidersHorizontal size={15} strokeWidth={1.7} aria-hidden="true" />
+              <span><strong>Config</strong><small>config.toml tuning</small></span>
+            </Button>
+            <Button
+              variant="plain"
+              size="unstyled"
+              className="command-menu-item"
+              type="button"
+              onClick={() => {
+                setMenuOpen(false);
+                onToggleSettings();
+              }}
+            >
+              <TerminalSquare size={15} strokeWidth={1.7} aria-hidden="true" />
+              <span><strong>Environment</strong><small>.env secrets & URLs</small></span>
+            </Button>
+            <Button
+              variant="plain"
+              size="unstyled"
+              className="command-menu-item command-menu-item-separated"
+              type="button"
+              onClick={() => {
+                setMenuOpen(false);
+                onHelp(active, active ? undefined : query.trim());
+              }}
+              disabled={running}
+            >
+              <CircleHelp size={15} strokeWidth={1.7} aria-hidden="true" />
+              <span><strong>Help</strong><small>Shortcuts & action docs</small></span>
+            </Button>
+          </div>
+        )}
+      </div>
     </section>
   );
 }

--- a/apps/palette-tauri/src/lib/actionMeta.ts
+++ b/apps/palette-tauri/src/lib/actionMeta.ts
@@ -37,13 +37,13 @@ const ACTION_META: Partial<Record<PaletteSubcommand, ActionDisplayDetails>> = {
   status: { category: "System", input: "none", output: "jobs", label: "Status" },
   stats: { category: "System", input: "none", output: "stats", label: "Stats" },
   doctor: { category: "System", input: "none", output: "health", label: "Doctor" },
-  endpoints: { category: "Inspect", input: "URL", output: "endpoints", label: "Endpoints" },
-  brand: { category: "Inspect", input: "URL", output: "brand", label: "Brand" },
+  endpoints: { category: "Fetch & read", input: "URL", output: "endpoints", label: "Endpoints" },
+  brand: { category: "Fetch & read", input: "URL", output: "brand", label: "Brand" },
   dedupe: { category: "System", input: "settings", output: "report", label: "Dedupe" },
   purge: { category: "System", input: "url", output: "report", label: "Purge" },
-  "watch-list": { category: "Watch", input: "none", output: "watches", label: "Watch list" },
-  "watch-create": { category: "Watch", input: "URL", output: "watch", label: "Watch create" },
-  "watch-run": { category: "Watch", input: "watch id", output: "run", label: "Watch run" },
+  "watch-list": { category: "System", input: "none", output: "watches", label: "Watch list" },
+  "watch-create": { category: "System", input: "URL", output: "watch", label: "Watch create" },
+  "watch-run": { category: "System", input: "watch id", output: "run", label: "Watch run" },
 };
 
 export function actionDisplayMeta(action: PaletteAction): ActionDisplayMeta {
@@ -77,14 +77,14 @@ export function actionKindLabel(action: PaletteAction): string {
   }
 }
 
-export function actionKindTone(action: PaletteAction): "info" | "success" | "warn" | "neutral" | "rose" | "violet" {
+export function actionKindTone(action: PaletteAction): "info" | "success" | "warn" | "neutral" | "rose" | "orange" {
   switch (action.kind) {
     case "admin":
       return "warn";
     case "discovery":
       return "neutral";
     case "job":
-      return "violet";
+      return "orange";
     case "local":
       return "info";
     default:

--- a/apps/palette-tauri/src/lib/actions.ts
+++ b/apps/palette-tauri/src/lib/actions.ts
@@ -1,6 +1,6 @@
 export type ArgMode = "none" | "optionalSingle" | "single" | "split";
 type RemoteActionKind = "operation" | "job" | "admin" | "discovery";
-type ActionTone = "info" | "success" | "warn" | "neutral" | "rose" | "violet";
+type ActionTone = "info" | "success" | "warn" | "neutral" | "rose" | "orange";
 export const JOB_FAMILIES = ["crawl", "embed", "extract", "ingest"] as const;
 export type JobFamily = (typeof JOB_FAMILIES)[number];
 export const JOB_OPERATIONS = ["list", "status", "cancel", "cleanup", "clear", "recover"] as const;
@@ -130,7 +130,7 @@ const STATIC_ACTIONS = [
     aliases: ["chat", "llm", "talk"],
     description: "Chat directly with the configured LLM without RAG retrieval.",
     example: "chat explain this error simply",
-    tone: "violet",
+    tone: "rose",
   },
   {
     label: "Query knowledge base",
@@ -160,7 +160,7 @@ const STATIC_ACTIONS = [
     aliases: ["suggest", "recommend", "discover-more"],
     description: "Suggest additional documentation URLs worth crawling.",
     example: "suggest tauri",
-    tone: "violet",
+    tone: "rose",
   },
   {
     label: "Evaluate answer",
@@ -170,7 +170,7 @@ const STATIC_ACTIONS = [
     aliases: ["evaluate", "eval", "judge"],
     description: "Compare RAG and baseline answers with an independent LLM judge.",
     example: "evaluate how does Tauri v2 HTTP work?",
-    tone: "violet",
+    tone: "rose",
   },
   {
     label: "Search the web",
@@ -200,7 +200,7 @@ const STATIC_ACTIONS = [
     aliases: ["embed", "index", "vectorize"],
     description: "Embed a URL, file, directory, or text input into the collection.",
     example: "embed https://docs.rs/serde",
-    tone: "violet",
+    tone: "orange",
   },
   {
     label: "Extract data",
@@ -210,7 +210,7 @@ const STATIC_ACTIONS = [
     aliases: ["extract", "structured", "parse"],
     description: "Queue structured extraction for one or more URLs.",
     example: "extract https://example.com/pricing",
-    tone: "violet",
+    tone: "orange",
   },
   {
     label: "Ingest target",
@@ -220,7 +220,7 @@ const STATIC_ACTIONS = [
     aliases: ["ingest", "import", "repo", "youtube", "reddit"],
     description: "Ingest GitHub, Reddit, or YouTube targets into the collection.",
     example: "ingest https://github.com/zed-industries/zed",
-    tone: "warn",
+    tone: "orange",
   },
   {
     label: "Job status",
@@ -285,7 +285,7 @@ const STATIC_ACTIONS = [
     aliases: ["endpoints", "api", "routes", "discover-endpoints"],
     description: "Scan a page for API endpoints, scripts, and optional probes.",
     example: "endpoints https://example.com/app",
-    tone: "violet",
+    tone: "info",
   },
   {
     label: "Extract brand",
@@ -315,7 +315,7 @@ const STATIC_ACTIONS = [
     aliases: ["screenshot", "capture", "shot", "png"],
     description: "Render a URL in Chrome and capture a full-page screenshot using the default viewport.",
     example: "screenshot https://example.com",
-    tone: "violet",
+    tone: "info",
   },
   {
     label: "Dedupe collection",
@@ -356,7 +356,7 @@ const STATIC_ACTIONS = [
     aliases: ["watch-create", "watch-url", "monitor-url"],
     description: "Create a URL change detector. Optional second argument is seconds.",
     example: "watch-create https://example.com/docs 3600",
-    tone: "violet",
+    tone: "orange",
   },
   {
     label: "Run watch now",
@@ -376,7 +376,7 @@ const STATIC_ACTIONS = [
     aliases: ["sessions-prepared", "ingest-sessions-prepared", "prepared-sessions"],
     description: "Submit a prepared AI-session ingest request as JSON.",
     example: "ingest-sessions-prepared {\"sessions\":[]}",
-    tone: "violet",
+    tone: "orange",
   },
 ] as const satisfies readonly PaletteAction[];
 
@@ -422,7 +422,7 @@ function jobLifecycleActions(family: JobFamily): PaletteAction[] {
       aliases: [`${family}-cancel`, `cancel-${family}`],
       description: `Cancel one pending or running ${family} job by UUID.`,
       example: `${family}-cancel 00000000-0000-4000-8000-000000000000`,
-      tone: "warn",
+      tone: "orange",
     },
     {
       label: `Cleanup ${family} jobs`,
@@ -432,7 +432,7 @@ function jobLifecycleActions(family: JobFamily): PaletteAction[] {
       aliases: [`${family}-cleanup`, `cleanup-${family}`],
       description: `Clean completed ${family} job records.`,
       example: `${family}-cleanup`,
-      tone: "warn",
+      tone: "orange",
     },
     {
       label: `Clear ${family} jobs`,

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -130,6 +130,9 @@
   --axon-launcher-glow:
     0 4px 16px rgba(0, 0, 0, 0.34),
     0 1px 3px rgba(0, 0, 0, 0.30);
+  --axon-orange: #ff9645;
+  --axon-orange-strong: #ffb474;
+  --axon-orange-deep: #c96a1c;
 }
 
 * {
@@ -168,6 +171,50 @@ body {
 body[data-fixture] {
   min-width: 0;
   overflow: auto;
+}
+
+@media (max-width: 559px) {
+  body:not(.tauri-runtime) {
+    min-width: 0;
+  }
+
+  #app {
+    place-items: start center;
+    padding-top: 136px;
+  }
+
+  .palette-shell,
+  .palette-shell-results,
+  .palette-shell-compact {
+    width: min(100vw - 16px, 720px);
+  }
+
+  .palette-shell-compact {
+    --axon-launcher-inset: 8px;
+  }
+
+  .palette-shell-compact .command-bar {
+    gap: 6px;
+    padding: 0 6px 0 8px;
+  }
+
+  .axon-word {
+    display: none;
+  }
+
+  .palette-footer {
+    padding: 0 10px;
+  }
+
+  .palette-footer-hints {
+    justify-content: flex-start;
+    gap: 8px;
+    overflow: hidden;
+  }
+
+  .palette-footer-hints .palette-hint-group {
+    display: none;
+  }
 }
 
 .fixture-shell {
@@ -1321,21 +1368,35 @@ textarea {
   min-width: 0;
   align-items: center;
   gap: 10px;
-  height: 100%;
+  height: 44px;
+  padding: 0 8px 0 12px;
   color: var(--aurora-text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 11px;
   cursor: text;
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease;
 }
 
 .command-input-wrap:focus-within {
   color: var(--aurora-text-muted);
+  background: color-mix(in srgb, var(--aurora-accent-primary) 6%, var(--aurora-control-surface));
+  border-color: color-mix(in srgb, var(--aurora-accent-primary) 62%, var(--aurora-border-strong));
+  box-shadow:
+    0 0 22px 4px color-mix(in srgb, var(--aurora-accent-primary) 34%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--aurora-text-primary) 5%, transparent);
 }
 
 /* A11Y-M1 — visible keyboard-focus ring for the command input. The <input>
    itself has outline:0; surface focus on its wrapper so AT/keyboard users get
    a WCAG 2.4.7 indicator. :focus-visible avoids a ring on pointer clicks. */
 .command-input-wrap:has(.command-input:focus-visible) {
-  border-radius: 9px;
-  box-shadow: inset 0 0 0 1px var(--aurora-focus-ring-strong);
+  box-shadow:
+    0 0 24px 5px color-mix(in srgb, var(--aurora-accent-primary) 38%, transparent),
+    inset 0 0 0 1px var(--aurora-focus-ring-strong);
 }
 
 /* Active-mode switcher: the selected action sits inside the input and opens a
@@ -1396,8 +1457,8 @@ textarea {
   color: var(--aurora-accent-pink-strong);
 }
 
-.command-mode-icon-violet {
-  color: var(--aurora-accent-violet-strong);
+.command-mode-icon-orange {
+  color: var(--axon-orange-strong);
 }
 
 .command-action-menu {
@@ -1426,6 +1487,27 @@ textarea {
   overflow-y: auto;
   flex-direction: column;
   gap: 2px;
+}
+
+.command-action-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.command-action-group + .command-action-group {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid color-mix(in srgb, var(--aurora-border-default) 54%, transparent);
+}
+
+.command-action-group-heading {
+  padding: 2px 7px 3px;
+  color: var(--aurora-text-muted);
+  font-size: 10px;
+  font-weight: 780;
+  letter-spacing: var(--aurora-letter-eyebrow);
+  text-transform: uppercase;
 }
 
 .command-action-search {
@@ -1580,6 +1662,25 @@ textarea {
   letter-spacing: 0;
 }
 
+.command-submit-armed,
+.command-submit-armed:hover:not(:disabled),
+.palette-shell-compact .command-submit-armed,
+.palette-shell-compact .command-submit-armed:hover:not(:disabled) {
+  color: #2a0f18;
+  background: var(--aurora-accent-pink);
+  border-color: var(--aurora-accent-pink-deep);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--aurora-accent-pink-deep) 48%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22);
+}
+
+.command-submit-armed:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--aurora-focus-ring-strong),
+    0 0 0 1px color-mix(in srgb, var(--aurora-accent-pink-deep) 48%, transparent);
+}
+
 .command-action-option-warn {
   color: var(--aurora-warn-foreground);
 }
@@ -1588,8 +1689,97 @@ textarea {
   color: var(--aurora-accent-pink-strong);
 }
 
-.command-action-option-violet {
-  color: var(--aurora-accent-violet-strong);
+.command-action-option-orange {
+  color: var(--axon-orange-strong);
+}
+
+.command-menu-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.command-settings-active {
+  color: var(--aurora-text-primary);
+  background: var(--aurora-hover-bg);
+  border-color: var(--aurora-border-strong);
+}
+
+.command-menu {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 8px);
+  right: 0;
+  display: flex;
+  min-width: 230px;
+  padding: 6px;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--aurora-text-primary);
+  background: color-mix(in srgb, var(--aurora-panel-strong) 98%, transparent);
+  border: 1px solid color-mix(in srgb, var(--aurora-border-strong) 68%, transparent);
+  border-radius: 10px;
+  box-shadow:
+    0 16px 36px rgba(0, 0, 0, 0.44),
+    inset 0 1px 0 rgba(255, 255, 255, 0.055);
+}
+
+.command-menu-item {
+  all: unset;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 5px 7px;
+  color: var(--aurora-accent-strong);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.command-menu-item:hover:not(:disabled),
+.command-menu-item:focus-visible {
+  color: var(--aurora-text-primary);
+  background: color-mix(in srgb, var(--aurora-accent-primary) 7%, var(--aurora-panel-strong));
+  border-color: color-mix(in srgb, var(--aurora-accent-primary) 26%, var(--aurora-border-default));
+  outline: none;
+}
+
+.command-menu-item:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.command-menu-item-separated {
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top-color: color-mix(in srgb, var(--aurora-border-default) 58%, transparent);
+}
+
+.command-menu-item span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.command-menu-item strong,
+.command-menu-item small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-menu-item strong {
+  color: var(--aurora-text-primary);
+  font-size: 12px;
+  font-weight: 720;
+}
+
+.command-menu-item small {
+  color: var(--aurora-text-muted);
+  font-size: 10.5px;
+  font-weight: 520;
 }
 
 .palette-grid {
@@ -1850,7 +2040,7 @@ textarea {
 }
 
 .running-stat-accent strong {
-  color: var(--aurora-warn-foreground);
+  color: var(--aurora-accent-strong);
 }
 
 .running-progress-head {
@@ -1865,15 +2055,15 @@ textarea {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--aurora-warn-foreground);
+  color: var(--aurora-accent-pink-strong);
 }
 
 .running-progress-head i {
   width: 5px;
   height: 5px;
   border-radius: 999px;
-  background: var(--aurora-warn);
-  box-shadow: 0 0 6px var(--aurora-warn);
+  background: var(--aurora-success);
+  box-shadow: 0 0 6px var(--aurora-success);
   animation: crawl-pulse 1.6s ease-in-out infinite;
 }
 
@@ -1889,7 +2079,7 @@ textarea {
   display: block;
   width: 17%;
   height: 100%;
-  background: linear-gradient(90deg, var(--aurora-warn-border), var(--aurora-warn));
+  background: linear-gradient(90deg, var(--aurora-success), var(--aurora-accent-primary));
   border-radius: inherit;
 }
 
@@ -2064,7 +2254,7 @@ textarea {
 
 .ask-activity-row svg {
   margin-top: 1px;
-  color: var(--aurora-accent-violet-strong);
+  color: var(--aurora-accent-pink-strong);
 }
 
 .ask-activity-tool svg {
@@ -2377,9 +2567,9 @@ textarea {
 
 .output-tone-warn .output-op-tile,
 .output-running .output-op-tile {
-  color: var(--aurora-warn-foreground);
-  background: color-mix(in srgb, var(--aurora-warn) 14%, var(--aurora-control-surface));
-  border-color: color-mix(in srgb, var(--aurora-warn) 30%, transparent);
+  color: var(--axon-orange-strong);
+  background: color-mix(in srgb, var(--axon-orange) 14%, var(--aurora-control-surface));
+  border-color: color-mix(in srgb, var(--axon-orange) 30%, transparent);
 }
 
 .output-tone-rose .output-op-tile {
@@ -2388,10 +2578,10 @@ textarea {
   border-color: color-mix(in srgb, var(--aurora-accent-pink) 30%, transparent);
 }
 
-.output-tone-violet .output-op-tile {
-  color: var(--aurora-accent-violet-strong);
-  background: color-mix(in srgb, var(--aurora-accent-violet) 13%, var(--aurora-control-surface));
-  border-color: color-mix(in srgb, var(--aurora-accent-violet) 30%, transparent);
+.output-tone-orange .output-op-tile {
+  color: var(--axon-orange-strong);
+  background: color-mix(in srgb, var(--axon-orange) 13%, var(--aurora-control-surface));
+  border-color: color-mix(in srgb, var(--axon-orange) 30%, transparent);
 }
 
 .output-status {
@@ -2652,10 +2842,10 @@ textarea {
   border-color: color-mix(in srgb, var(--aurora-accent-pink) 28%, transparent);
 }
 
-.action-icon-violet {
-  color: var(--aurora-accent-violet-strong);
-  background: color-mix(in srgb, var(--aurora-accent-violet) 13%, var(--aurora-control-surface));
-  border-color: color-mix(in srgb, var(--aurora-accent-violet) 28%, transparent);
+.action-icon-orange {
+  color: var(--axon-orange-strong);
+  background: color-mix(in srgb, var(--axon-orange) 13%, var(--aurora-control-surface));
+  border-color: color-mix(in srgb, var(--axon-orange) 28%, transparent);
 }
 
 .action-main {
@@ -3632,8 +3822,8 @@ textarea {
   border-color: var(--aurora-accent-pink-border);
 }
 
-.operation-hero-violet {
-  border-color: var(--aurora-accent-violet-border);
+.operation-hero-orange {
+  border-color: color-mix(in srgb, var(--axon-orange) 34%, transparent);
 }
 
 .operation-hero-icon {
@@ -3654,10 +3844,10 @@ textarea {
   border-color: var(--aurora-accent-pink-border);
 }
 
-.operation-hero-violet .operation-hero-icon {
-  color: var(--aurora-accent-violet-strong);
-  background: var(--aurora-accent-violet-surface);
-  border-color: var(--aurora-accent-violet-border);
+.operation-hero-orange .operation-hero-icon {
+  color: var(--axon-orange-strong);
+  background: color-mix(in srgb, var(--axon-orange) 12%, var(--aurora-panel-medium));
+  border-color: color-mix(in srgb, var(--axon-orange) 30%, transparent);
 }
 
 .operation-hero-success .operation-hero-icon {


### PR DESCRIPTION
## Summary
- port the detached palette command-bar interaction polish onto current main
- add ask fallback behavior for unmatched free-text input
- group the action switcher and consolidate help/settings into a command menu
- bump palette app version to 5.12.1

## Verification
- npm test -- --run (apps/palette-tauri)
- npm run build (apps/palette-tauri)
- cargo xtask check-release-versions --base origin/main --head HEAD --mode pr
- pre-push hook: version-sync + openapi-drift

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Palette command bar with a grouped action switcher and a new utility menu, and added Ask fallback for unmatched free‑text input. Improves accessibility, mobile layout, and visual tones; bumps Palette app to 5.12.1.

- **New Features**
  - Ask fallback: if search has no matches, show and submit via `ask` with the typed text.
  - Grouped action switcher by category with compact labels and method hints; closes on Escape.
  - Replaced help/settings buttons with a Menu (Settings, Config, Environment, Help).
  - “Armed” submit styling and clearer input focus ring.
  - Mobile polish under 560px: tighter bar, compact footer hints.
  - Action metadata/tones: jobs use orange; `endpoints`/`brand` moved to “Fetch & read”; watch tools to “System”.

- **Dependencies**
  - Bumped `apps/palette-tauri` to 5.12.1 (`package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`).

<sup>Written for commit a5fdbe130e3152f60c52ac40ac4dbf0dcf05683a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command menu with quick access to Settings, Config, Environment, and Help.
  * Grouped action switcher items into clearer categories for easier browsing.
  * Improved “Ask” handling so free-text queries can be submitted directly when no action matches.

* **Bug Fixes**
  * Help actions and command-bar interactions now follow the updated menu flow.
  * Refined responsive behavior and visual states on smaller screens.

* **Style**
  * Refreshed the palette with a new orange accent theme across command, action, and status UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->