### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-06-28-palette-code-search-cleanup-closeout.md
+++ b/docs/sessions/2026-06-28-palette-code-search-cleanup-closeout.md
@@ -1,0 +1,173 @@
+---
+date: 2026-06-28 16:11:20 EST
+repo: git@github.com:jmagar/axon.git
+branch: main
+head: 1bba9138
+session id: 34fb82ca-bbd6-4c0c-9a6a-2a467ee97e15
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-axon/34fb82ca-bbd6-4c0c-9a6a-2a467ee97e15.jsonl
+working directory: /home/jmagar/workspace/axon
+worktree: /home/jmagar/workspace/axon  1bba9138 [main]
+---
+
+# Palette, code-search, and repo cleanup closeout
+
+## User Request
+
+The session began with requests to review and merge Axon PRs, split palette code, resolve code-search watcher/runtime issues, clean stale branches and worktrees, and finish by saving a session log.
+
+## Session Overview
+
+The session closed multiple Axon work streams: PR cleanup and merges, code-search watcher UX/runtime fixes, stale binary/plugin-cache investigation, palette command bar polish, release/version validation, branch/worktree cleanup, and final repo-status verification. The current repository ended clean on `main` with only the protected `marketplace-no-mcp` variant remaining.
+
+## Sequence of Events
+
+1. Reviewed and resolved PR work around `278` and `279`, including merging `278`, rebasing/unblocking `279`, merging it to `main`, and cleaning up.
+2. Investigated Axon binary drift where an older `axon 6.0.2` binary caused config TOML parse errors for `[freshness]`; removed stale plugin-cache binaries and verified the newer binary path.
+3. Investigated code-search ingestion and watcher behavior, including warnings from zero-symbol grammar extraction, progress/logging expectations, SQLite corruption symptoms, output style, and embedding throughput settings.
+4. Implemented and merged code-search watcher indexing UX improvements via PR #289, then verified `main` release state and branch cleanup.
+5. Audited stale branches/worktrees, removed safe stale refs, kept `marketplace-no-mcp` protected, and synced its worktree.
+6. Ported a detached palette command-bar WIP onto `codex/palette-command-bar-finish`, verified it locally, bumped palette version to `5.12.1`, opened PR #291, waited for CI, merged it, synced `main`, and cleaned the now-stale detached worktree.
+7. Ran final repo-status evidence collection and saved this session note.
+
+## Key Findings
+
+- `main` is clean and synced with `origin/main` at `1bba9138`.
+- Only remote heads observed are `main` and `marketplace-no-mcp`; `marketplace-no-mcp` is protected by repo policy as the no-MCP marketplace variant.
+- The final open PR list was empty.
+- The detached worktree `/home/jmagar/.codex/worktrees/b4f4/axon` was clean, detached, and at `origin/main`, so it was safe to remove.
+- Lumen semantic search was available, but the first search failed with an embedding-service HTTP 429 overload.
+- The newest Claude transcript path existed, but it was an older June 23 cut-off prompt and not this Codex session; current session details came from visible Codex context and live repo evidence.
+
+## Technical Decisions
+
+- Kept CLI/MCP/API behavior in shared service/domain layers where applicable, rather than direct transport-only fixes.
+- Treated `marketplace-no-mcp` as protected long-lived infrastructure and excluded it from stale cleanup or merge-order recommendations.
+- Used targeted palette verification because the changed surface was `apps/palette-tauri`, then relied on CI gates for the broader PR merge decision.
+- Removed only clean, detached, already-merged worktrees whose content matched current `main`.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `apps/palette-tauri/CHANGELOG.md` | - | Record palette `5.12.1` release entry | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/package.json` | - | Bump palette package version to `5.12.1` | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src-tauri/Cargo.lock` | - | Sync Tauri package version | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src-tauri/Cargo.toml` | - | Sync Tauri package version | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src-tauri/tauri.conf.json` | - | Sync application version | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/App.test.tsx` | - | Cover palette command-bar behavior | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/App.tsx` | - | Wire command-bar interaction polish | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/components/palette/ActionList.test.tsx` | - | Add/adjust action-list behavior coverage | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/components/palette/ActionList.tsx` | - | Polish action-list integration | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/components/palette/PaletteCommandBar.test.tsx` | - | Add command-bar regression coverage | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/components/palette/PaletteCommandBar.tsx` | - | Implement command-bar interaction polish | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/lib/actionMeta.ts` | - | Adjust action metadata used by palette UI | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/lib/actions.ts` | - | Adjust palette action definitions | commit `1bba9138` / PR #291 |
+| modified | `apps/palette-tauri/src/styles.css` | - | Polish command-bar/action-list styling | commit `1bba9138` / PR #291 |
+| modified | `crates/axon-cli/src/commands/code_search.rs` and code-search related crates/docs | - | Improve code-search watcher indexing UX and output | commit `a38e52d8` / PR #289 |
+| created | `docs/sessions/2026-06-28-palette-code-search-cleanup-closeout.md` | - | Save this session log | this commit |
+
+## Beads Activity
+
+No bead changes were made by this Codex save-session step. Observed recent bead activity includes `axon_rust-27img` closed with reason `done` on 2026-06-28, plus prior June 27 freshness/code-search related bead closures. No new follow-up bead was created because the final repo status showed no known unfinished branch, PR, or cleanup work.
+
+## Repository Maintenance
+
+### Plans
+
+Checked `docs/plans` and found many existing completed plans already under `docs/plans/complete/`. The top-level plans remaining under `docs/plans/` were not moved because this session did not prove each plan was completed. A stray `/home/jmagar/workspace/axon_rust/docs/plans/2026-05-27-android-phase2-stubbed-modes.md` appeared in one command because `docs/plans` contains a symlink or external path reference; it was not modified.
+
+### Beads
+
+Ran `bd list --all --sort updated --reverse --limit 100 --json` and `tail -200 .beads/interactions.jsonl`. No bead was changed during the save-session closeout.
+
+### Worktrees and branches
+
+Observed worktrees before cleanup: `main`, protected `marketplace-no-mcp`, and detached `/home/jmagar/.codex/worktrees/b4f4/axon`. The detached worktree was clean and exactly at `origin/main`, so it was removed with `git worktree remove --force` and metadata was pruned. Final worktrees are only `main` and `marketplace-no-mcp`.
+
+### Stale docs
+
+Reviewed session-touched docs at the level required for this closeout. No stale user-facing doc was identified that contradicted the final implementation; this artifact records the session.
+
+### Transparency
+
+No dirty worktree or unknown branch was deleted. `marketplace-no-mcp` was left in place by explicit repo policy. The Lumen semantic-search failure was recorded rather than hidden.
+
+## Tools and Skills Used
+
+- **Skills.** `vibin:repo-status` for branch/worktree/PR audit; `vibin:save-to-md` for this artifact; prior session context included `lavra:lavra-review`, `superpowers:systematic-debugging`, and parallel-agent investigation.
+- **Shell commands.** Used Git, GitHub CLI, npm, cargo xtask, and Beads commands for verification, merge, cleanup, and evidence.
+- **MCP tools.** Tried `mcp__lumen.semantic_search` first for code discovery per instruction; it failed with HTTP 429 from the embedding service.
+- **External CLIs.** `gh` for PR/CI/merge evidence; `bd` for tracker evidence.
+- **File tools.** Used patch/write operations to create this session artifact.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `npm test -- --run` in `apps/palette-tauri` | Passed: 40 test files, 298 tests |
+| `npm run build` in `apps/palette-tauri` | Passed; Tauri release build produced artifacts under `bin` |
+| `cargo xtask bump-version palette patch` | Bumped palette from `5.12.0` to `5.12.1` |
+| `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr` | Passed for palette version bump |
+| `git push -u origin codex/palette-command-bar-finish` | Passed; pre-push version/openapi checks passed |
+| `gh pr checks 291 --watch --interval 20` | CI completed with required gates passing |
+| `gh pr merge 291 --squash --delete-branch` | Merged PR #291 and deleted remote branch |
+| `git fetch --prune origin` | Pruned merged palette branch; observed `marketplace-no-mcp` advanced |
+| `git -C /home/jmagar/workspace/_no_mcp_worktrees/axon pull --ff-only origin marketplace-no-mcp` | Fast-forwarded protected no-MCP worktree |
+| `git worktree remove --force /home/jmagar/.codex/worktrees/b4f4/axon` | Removed clean detached worktree at `origin/main` |
+| `git worktree prune` | Pruned stale worktree metadata |
+
+## Errors Encountered
+
+- `axon code-search-watch` initially failed earlier in the session because the PATH binary was `axon 6.0.2`, whose config schema did not know `[freshness]`. The stale older binary source was traced to plugin/cache binaries and removed.
+- Code-search watcher output showed many `grammar_drift_zero_symbols` warnings. These meant tree-sitter chunking found no symbol nodes for those files; they were noisy and not useful foreground progress.
+- Code-search refresh reported SQLite corruption with `database disk image is malformed`; the session investigated logging/output shape and safer stale-index fallback behavior.
+- `mcp__lumen.semantic_search` failed during save-session with an embedding HTTP 429 overload, so exact Git/CLI evidence was used for the maintenance pass.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Palette command bar | Detached WIP existed outside a mergeable branch | WIP was ported, versioned, tested, merged via PR #291, and released as `palette-v5.12.1` |
+| Code-search watcher | Foreground output was dominated by low-value warnings and weak progress visibility | PR #289 improved code-search watcher indexing UX and related docs/config |
+| Repo state | Multiple stale/superseded branches and detached worktrees existed during the session | Final repo has only `main` plus protected `marketplace-no-mcp` |
+| Axon binary drift | Older plugin-cache binary could shadow current schema support | Stale binary sources were removed and current binary path was restored |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `npm test -- --run` | Palette tests pass | 40 files / 298 tests passed | pass |
+| `npm run build` | Palette build succeeds | Build completed and produced release artifacts | pass |
+| `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr` | Palette version bump accepted | Passed with palette changed and `5.12.1` | pass |
+| `gh pr checks 291 --watch --interval 20` | Required PR checks pass | CI gate, palette-tauri, version-sync, rest-api-parity, CodeQL, GitGuardian passed | pass |
+| `gh pr list --state open --json ...` | No open PRs after merge | `[]` | pass |
+| `git ls-remote --heads origin` | Only intended remote heads remain | `main` and `marketplace-no-mcp` | pass |
+| `git status --short --branch` | Main clean and synced | `## main...origin/main` | pass |
+| `git -C /home/jmagar/workspace/_no_mcp_worktrees/axon status --short --branch` | No-MCP worktree clean and synced | `## marketplace-no-mcp...origin/marketplace-no-mcp` | pass |
+
+## Risks and Rollback
+
+The main risk from this session is palette UI regression from command-bar interaction/style changes. Rollback path is to revert merge commit `1bba9138` or restore PR #291 changes selectively. Code-search UX changes can be rolled back by reverting `a38e52d8` if watcher output or indexing behavior regresses.
+
+## Decisions Not Taken
+
+- Did not merge or delete `marketplace-no-mcp`; it is a protected long-lived variant.
+- Did not move top-level plans into `docs/plans/complete/` without direct evidence that each plan was finished.
+- Did not create follow-up beads because no concrete unfinished work remained after final repo-status verification.
+- Did not wait on CodeRabbit when GitHub Actions and required gates were green and GitHub allowed merge.
+
+## References
+
+- PR #289: `Improve code search watcher indexing UX`
+- PR #291: `Polish palette command bar interactions`
+- Session transcript path observed: `/home/jmagar/.claude/projects/-home-jmagar-workspace-axon/34fb82ca-bbd6-4c0c-9a6a-2a467ee97e15.jsonl`
+- Repo policy in `CLAUDE.md`: `marketplace-no-mcp` is a protected long-lived no-MCP marketplace variant.
+
+## Open Questions
+
+- The save-session transcript discovered under `~/.claude/projects` is not the active Codex session, so the saved note relies on current Codex context plus live Git/GitHub evidence.
+- Lumen semantic search was unavailable due to embedding overload during this save-session pass.
+
+## Next Steps
+
+No immediate repo action is required. Current expected state is `main` clean and synced, `marketplace-no-mcp` clean and synced, no open PRs, and no stale cleanup candidates.


### PR DESCRIPTION
## Summary
- Save the June 28 Axon closeout session log.
- Document palette/code-search merge work, repo cleanup, and verification evidence.

## Verification
- pre-commit hook passed for the session artifact commit
- pre-push docs-only router passed

Generated by the save-to-md workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the June 28 closeout session log, documenting the palette command bar release (v5.12.1), code-search watcher UX updates, repo cleanup, and verification evidence. This preserves an audit trail and the final repo state (main clean, `marketplace-no-mcp` protected).

<sup>Written for commit dccf6f3b238f8bd3d96beb61199564cfc0dea18b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

