### PR TITLE
Spike local source ledger preparation

### DIFF
--- a/crates/axon-services/src/lib.rs
+++ b/crates/axon-services/src/lib.rs
@@ -30,6 +30,8 @@ pub mod search;
 pub mod search_crawl;
 pub mod sessions;
 pub mod setup;
+#[allow(dead_code)]
+pub(crate) mod source_spike;
 pub mod summarize;
 pub mod sync;
 pub mod system;

--- a/crates/axon-services/src/source_spike.rs
+++ b/crates/axon-services/src/source_spike.rs
@@ -1,0 +1,340 @@
+use axon_source_ledger::{
+    ManifestItem, SourceIdentity, SourceKind, SourceLedgerStore, SourceStatus,
+};
+use axon_vector::ops::file_ingest::{SelectionPolicy, collect_files};
+use axon_vector::ops::input::classify::path_extension;
+use axon_vector::ops::{
+    LedgerPayload, PreparedDoc, SourceDocument, SourceOrigin, prepare_source_document,
+};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+use url::Url;
+
+const LOCAL_SOURCE_SPIKE_INDEX_VERSION: i64 = 1;
+const LOCAL_SOURCE_SPIKE_LEASE_TTL_MS: i64 = 30 * 60 * 1000;
+
+#[derive(Debug, Clone)]
+pub(crate) struct LocalSourceSpikeInput {
+    pub(crate) root: PathBuf,
+    pub(crate) collection: String,
+    pub(crate) owner: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct LocalSourceSpikeOutput {
+    pub(crate) source_id: String,
+    pub(crate) source_kind: SourceKind,
+    pub(crate) collection: String,
+    pub(crate) generation: i64,
+    pub(crate) manifest_items: Vec<LocalSourceSpikeManifestItem>,
+    pub(crate) prepared_docs: Vec<PreparedDoc>,
+    pub(crate) cleanup_placeholders: Vec<LocalSourceCleanupPlaceholder>,
+    pub(crate) status: SourceStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocalSourceSpikeManifestItem {
+    pub(crate) item_key: String,
+    pub(crate) content_hash: String,
+    pub(crate) size_bytes: i64,
+    pub(crate) modified_at_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocalSourceCleanupPlaceholder {
+    pub(crate) source_id: String,
+    pub(crate) generation: i64,
+    pub(crate) executed: bool,
+}
+
+#[derive(Debug, Clone)]
+struct LocalSourceItem {
+    path: PathBuf,
+    item_key: String,
+    manifest_item: ManifestItem,
+    output_item: LocalSourceSpikeManifestItem,
+    extension: String,
+    file_url: String,
+    text: String,
+}
+
+pub(crate) async fn prepare_local_source_spike(
+    input: LocalSourceSpikeInput,
+    store: &SourceLedgerStore,
+) -> anyhow::Result<LocalSourceSpikeOutput> {
+    let root = canonicalize_existing_path(&input.root).await?;
+    let source = SourceIdentity::new(
+        local_source_id(&root)?,
+        SourceKind::LocalCode,
+        input.collection.clone(),
+        LOCAL_SOURCE_SPIKE_INDEX_VERSION,
+    );
+    if !store
+        .acquire_lease(&source, &input.owner, LOCAL_SOURCE_SPIKE_LEASE_TTL_MS)
+        .await?
+    {
+        anyhow::bail!(
+            "source ledger refresh already running for {}",
+            source.source_id
+        );
+    }
+
+    let mut active_generation = None;
+    let result: anyhow::Result<LocalSourceSpikeOutput> = async {
+        store.ensure_source(&source).await?;
+        let items = discover_local_items(&root).await?;
+        let ledger_manifest_items = items
+            .iter()
+            .map(|item| item.manifest_item.clone())
+            .collect::<Vec<_>>();
+        let manifest_items = items
+            .iter()
+            .map(|item| item.output_item.clone())
+            .collect::<Vec<_>>();
+        let _diff = store
+            .diff_manifest(&source.source_id, &ledger_manifest_items)
+            .await?;
+        let generation = store
+            .begin_generation_for_owner(&source, &input.owner)
+            .await?;
+        active_generation = Some(generation);
+
+        for item in &ledger_manifest_items {
+            store
+                .record_manifest_item(&source.source_id, generation, item.clone())
+                .await?;
+        }
+
+        let mut prepared_docs = Vec::with_capacity(items.len());
+        for item in items {
+            let source_doc = source_document_for_item(&source, generation, &item)?;
+            let prepared = prepare_source_document(source_doc)
+                .await
+                .map_err(|err| anyhow::anyhow!("failed to prepare {}: {err}", item.item_key))?;
+            prepared_docs.push(prepared);
+        }
+
+        let status = store.source_status(&source.source_id).await?;
+        store.release_lease(&source.source_id, &input.owner).await?;
+        Ok(LocalSourceSpikeOutput {
+            source_id: source.source_id.clone(),
+            source_kind: source.source_kind.clone(),
+            collection: source.collection.clone(),
+            generation,
+            manifest_items,
+            prepared_docs,
+            cleanup_placeholders: vec![LocalSourceCleanupPlaceholder {
+                source_id: source.source_id.clone(),
+                generation,
+                executed: false,
+            }],
+            status,
+        })
+    }
+    .await;
+
+    match result {
+        Ok(output) => Ok(output),
+        Err(err) => {
+            if let Some(generation) = active_generation {
+                let abort_result = store
+                    .abort_generation_for_owner(&source.source_id, generation, &input.owner)
+                    .await;
+                let release_result = store.release_lease(&source.source_id, &input.owner).await;
+                match (abort_result, release_result) {
+                    (Ok(()), Ok(())) => Err(err),
+                    (Err(abort_err), Ok(())) => Err(err.context(format!(
+                        "additionally failed to abort source generation: {abort_err}"
+                    ))),
+                    (Ok(()), Err(release_err)) => Err(err.context(format!(
+                        "additionally failed to release source lease: {release_err}"
+                    ))),
+                    (Err(abort_err), Err(release_err)) => Err(err.context(format!(
+                        "additionally failed to abort source generation: {abort_err}; \
+                         additionally failed to release source lease: {release_err}"
+                    ))),
+                }
+            } else {
+                let release_result = store.release_lease(&source.source_id, &input.owner).await;
+                match release_result {
+                    Ok(()) => Err(err),
+                    Err(release_err) => Err(err.context(format!(
+                        "additionally failed to release source lease: {release_err}"
+                    ))),
+                }
+            }
+        }
+    }
+}
+
+async fn canonicalize_existing_path(path: &Path) -> anyhow::Result<PathBuf> {
+    tokio::fs::canonicalize(path)
+        .await
+        .map_err(|err| anyhow::anyhow!("invalid local source root {}: {err}", path.display()))
+}
+
+async fn discover_local_items(root: &Path) -> anyhow::Result<Vec<LocalSourceItem>> {
+    let metadata = tokio::fs::metadata(root).await.map_err(|err| {
+        anyhow::anyhow!("failed to stat local source root {}: {err}", root.display())
+    })?;
+    let paths = if metadata.is_file() {
+        vec![root.to_path_buf()]
+    } else if metadata.is_dir() {
+        collect_files(root, SelectionPolicy::Permissive).await?
+    } else {
+        anyhow::bail!(
+            "local source root {} is not a file or directory",
+            root.display()
+        );
+    };
+    let mut items = Vec::with_capacity(paths.len());
+    for path in paths {
+        items.push(local_source_item(root, &path, metadata.is_file()).await?);
+    }
+    items.sort_by(|a, b| a.item_key.cmp(&b.item_key));
+    Ok(items)
+}
+
+async fn local_source_item(
+    root: &Path,
+    path: &Path,
+    root_is_file: bool,
+) -> anyhow::Result<LocalSourceItem> {
+    let metadata = tokio::fs::metadata(path).await.map_err(|err| {
+        anyhow::anyhow!("failed to stat local source file {}: {err}", path.display())
+    })?;
+    let bytes = tokio::fs::read(path).await.map_err(|err| {
+        anyhow::anyhow!("failed to read local source file {}: {err}", path.display())
+    })?;
+    let item_key = item_key_for_path(root, path, root_is_file)?;
+    let content_hash = content_hash(&bytes);
+    let size_bytes = i64::try_from(bytes.len())
+        .map_err(|_| anyhow::anyhow!("file {} is too large for source ledger", path.display()))?;
+    let text = String::from_utf8(bytes).map_err(|err| {
+        anyhow::anyhow!(
+            "local source file {} is not valid UTF-8: {err}",
+            path.display()
+        )
+    })?;
+    let extension = path_extension(&item_key).to_ascii_lowercase();
+    let file_url = file_url_for_path(path)?;
+    let modified_at_ms = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+    Ok(LocalSourceItem {
+        path: path.to_path_buf(),
+        item_key: item_key.clone(),
+        manifest_item: ManifestItem::new(item_key.clone(), content_hash.clone(), size_bytes),
+        output_item: LocalSourceSpikeManifestItem {
+            item_key,
+            content_hash,
+            size_bytes,
+            modified_at_ms,
+        },
+        extension,
+        file_url,
+        text,
+    })
+}
+
+fn source_document_for_item(
+    source: &SourceIdentity,
+    generation: i64,
+    item: &LocalSourceItem,
+) -> anyhow::Result<SourceDocument> {
+    let title = Some(item.item_key.clone());
+    let extra = Some(serde_json::json!({
+        "local_file_path": item.item_key,
+        "local_file_extension": item.extension,
+        "local_file_hash": item.output_item.content_hash,
+        "local_file_size_bytes": item.output_item.size_bytes,
+        "local_file_modified_at_ms": item.output_item.modified_at_ms,
+        "local_content_kind": local_content_kind(&item.extension),
+    }));
+    let payload = LedgerPayload::try_new(
+        source.source_id.clone(),
+        source.source_kind.as_str(),
+        generation,
+        item.item_key.clone(),
+        source.index_version,
+    )
+    .map_err(|err| anyhow::anyhow!("invalid local ledger payload: {err}"))?;
+    let doc = SourceDocument::try_new_file(
+        SourceOrigin::LocalFile,
+        item.file_url.clone(),
+        item.item_key.clone(),
+        item.extension.clone(),
+        item.text.clone(),
+        source.source_kind.as_str(),
+        title,
+        extra,
+    )
+    .map_err(|err| anyhow::anyhow!("invalid local file source document: {err}"))?;
+    Ok(doc.with_ledger_payload(payload))
+}
+
+fn local_source_id(root: &Path) -> anyhow::Result<String> {
+    Ok(format!("local:{}", file_url_for_path(root)?))
+}
+
+fn file_url_for_path(path: &Path) -> anyhow::Result<String> {
+    Url::from_file_path(path)
+        .map(|url| url.to_string())
+        .map_err(|()| anyhow::anyhow!("failed to build file URL for {}", path.display()))
+}
+
+fn item_key_for_path(root: &Path, path: &Path, root_is_file: bool) -> anyhow::Result<String> {
+    let relative = if root_is_file {
+        path.file_name()
+            .map(PathBuf::from)
+            .ok_or_else(|| anyhow::anyhow!("file path {} has no file name", path.display()))?
+    } else {
+        path.strip_prefix(root)
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "failed to relativize {} under {}: {err}",
+                    path.display(),
+                    root.display()
+                )
+            })?
+            .to_path_buf()
+    };
+    let key = relative
+        .to_str()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "local source item key must be valid UTF-8 for {}",
+                path.display()
+            )
+        })?
+        .replace('\\', "/");
+    if key.is_empty() {
+        anyhow::bail!(
+            "local source item key cannot be empty for {}",
+            path.display()
+        );
+    }
+    Ok(key)
+}
+
+fn content_hash(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn local_content_kind(extension: &str) -> &'static str {
+    match extension {
+        "md" | "mdx" | "rst" => "markdown",
+        "txt" | "text" => "plain_text",
+        _ => "code_or_config",
+    }
+}
+
+#[cfg(test)]
+#[path = "source_spike_tests.rs"]
+mod tests;

--- a/crates/axon-services/src/source_spike_tests.rs
+++ b/crates/axon-services/src/source_spike_tests.rs
@@ -1,0 +1,213 @@
+use super::*;
+use axon_source_ledger::{SourceIdentity, SourceKind, SourceLedgerStore};
+use sha2::{Digest, Sha256};
+use std::error::Error;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+async fn test_store() -> Result<SourceLedgerStore, Box<dyn Error + Send + Sync>> {
+    Ok(SourceLedgerStore::new(
+        axon_jobs::store::open_sqlite_pool(":memory:").await?,
+    ))
+}
+
+fn sha256_hex(text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn spike_input(root: PathBuf) -> LocalSourceSpikeInput {
+    LocalSourceSpikeInput {
+        root,
+        collection: "axon-test".to_string(),
+        owner: "source-spike-test".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn markdown_fixture_creates_uncommitted_local_source_generation()
+-> Result<(), Box<dyn Error + Send + Sync>> {
+    let temp = TempDir::new()?;
+    let root = temp.path().join("docs");
+    tokio::fs::create_dir_all(&root).await?;
+    let body = "# Ledger Spike\n\nA markdown source document for the local ledger spike.\n";
+    tokio::fs::write(root.join("README.md"), body).await?;
+    let store = test_store().await?;
+
+    let output = prepare_local_source_spike(spike_input(root.clone()), &store).await?;
+
+    assert_eq!(output.source_kind, SourceKind::LocalCode);
+    assert_eq!(output.source_kind.as_str(), "local_code");
+    assert_eq!(output.collection, "axon-test");
+    assert_eq!(output.generation, 1);
+    assert_eq!(output.status.source_id, output.source_id);
+    assert_eq!(output.status.source_kind, SourceKind::LocalCode);
+    assert_eq!(output.status.committed_generation, 0);
+    assert_eq!(output.status.active_generation, Some(output.generation));
+    assert_eq!(output.status.cleanup_debt_count, 0);
+
+    assert_eq!(output.manifest_items.len(), 1);
+    let item = &output.manifest_items[0];
+    assert_eq!(item.item_key, "README.md");
+    assert_eq!(item.content_hash, sha256_hex(body));
+    assert_eq!(item.size_bytes, body.len() as i64);
+    assert!(item.modified_at_ms > 0);
+
+    assert_eq!(output.prepared_docs.len(), 1);
+    let prepared = &output.prepared_docs[0];
+    assert!(prepared.url().starts_with("file://"));
+    assert_eq!(prepared.domain(), "local");
+    assert_eq!(prepared.source_type(), "local_code");
+    assert_eq!(prepared.content_type(), "text");
+    assert_eq!(prepared.title(), Some("README.md"));
+    assert!(!prepared.chunks().is_empty());
+    let payload = prepared.ledger_payload().expect("ledger payload");
+    assert_eq!(payload.source_id(), output.source_id);
+    assert_eq!(payload.source_kind(), "local_code");
+    assert_eq!(payload.generation(), output.generation);
+    assert_eq!(payload.item_key(), "README.md");
+    assert_eq!(payload.index_version(), 1);
+    let doc_extra = prepared.extra().expect("doc extra");
+    assert_eq!(doc_extra["local_file_path"], "README.md");
+    assert_eq!(doc_extra["local_file_hash"], sha256_hex(body));
+    assert_eq!(doc_extra["local_file_size_bytes"], body.len() as i64);
+    assert!(doc_extra["local_file_modified_at_ms"].as_i64().unwrap() > 0);
+    assert_eq!(doc_extra["local_content_kind"], "markdown");
+    let chunk_extra = prepared.chunk_extra().first().expect("chunk metadata");
+    assert_eq!(chunk_extra["chunk_content_kind"], "markdown");
+    assert!(
+        chunk_extra["chunk_locator"]
+            .as_str()
+            .unwrap()
+            .contains("README.md#L")
+    );
+    assert!(chunk_extra["source_range"]["byte_start"].as_u64().is_some());
+    assert!(chunk_extra["source_range"]["line_start"].as_u64().is_some());
+
+    assert_eq!(output.cleanup_placeholders.len(), 1);
+    let placeholder = &output.cleanup_placeholders[0];
+    assert_eq!(placeholder.source_id, output.source_id);
+    assert_eq!(placeholder.generation, output.generation);
+    assert!(!placeholder.executed);
+
+    let status = store.source_status(&output.source_id).await?;
+    assert_eq!(status.committed_generation, 0);
+    assert_eq!(status.active_generation, Some(output.generation));
+    Ok(())
+}
+
+#[tokio::test]
+async fn rust_fixture_uses_code_chunk_metadata_and_relative_keys()
+-> Result<(), Box<dyn Error + Send + Sync>> {
+    let temp = TempDir::new()?;
+    let root = temp.path().join("repo");
+    let src = root.join("src");
+    tokio::fs::create_dir_all(&src).await?;
+    let body = format!(
+        "pub struct Spike;\n\nimpl Spike {{\n    pub fn run(&self) -> usize {{\n{}\n    }}\n}}\n",
+        (0..90)
+            .map(|i| format!("        let value_{i} = {i};"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    tokio::fs::write(src.join("lib.rs"), &body).await?;
+    let store = test_store().await?;
+
+    let output = prepare_local_source_spike(spike_input(root), &store).await?;
+
+    assert_eq!(output.source_kind, SourceKind::LocalCode);
+    assert_eq!(output.collection, "axon-test");
+    assert_eq!(output.status.committed_generation, 0);
+    assert_eq!(output.status.active_generation, Some(output.generation));
+    assert_eq!(output.manifest_items.len(), 1);
+    let item = &output.manifest_items[0];
+    assert_eq!(item.item_key, "src/lib.rs");
+    assert_eq!(item.content_hash, sha256_hex(&body));
+    assert_eq!(item.size_bytes, body.len() as i64);
+    assert!(item.modified_at_ms > 0);
+
+    let prepared = output.prepared_docs.first().expect("prepared rust doc");
+    assert_eq!(prepared.source_type(), "local_code");
+    assert_eq!(prepared.content_type(), "text");
+    assert_eq!(prepared.title(), Some("src/lib.rs"));
+    assert!(!prepared.chunks().is_empty());
+    let payload = prepared.ledger_payload().expect("ledger payload");
+    assert_eq!(payload.source_id(), output.source_id);
+    assert_eq!(payload.source_kind(), "local_code");
+    assert_eq!(payload.generation(), output.generation);
+    assert_eq!(payload.item_key(), "src/lib.rs");
+    assert_eq!(payload.index_version(), 1);
+    let doc_extra = prepared.extra().expect("doc extra");
+    assert_eq!(doc_extra["code_file_path"], "src/lib.rs");
+    assert_eq!(doc_extra["code_language"], "rust");
+    assert_eq!(doc_extra["code_is_test"], false);
+    assert_eq!(doc_extra["local_file_path"], "src/lib.rs");
+    assert_eq!(doc_extra["local_file_hash"], sha256_hex(&body));
+    assert_eq!(doc_extra["local_file_size_bytes"], body.len() as i64);
+    assert!(doc_extra["local_file_modified_at_ms"].as_i64().unwrap() > 0);
+    assert_eq!(doc_extra["local_content_kind"], "code_or_config");
+
+    let chunk_extra = prepared
+        .chunk_extra()
+        .iter()
+        .find(|extra| extra["chunk_content_kind"] == "code")
+        .expect("code chunk metadata");
+    assert_eq!(chunk_extra["code_chunk_source"], "tree_sitter");
+    assert!(
+        chunk_extra["chunk_locator"]
+            .as_str()
+            .unwrap()
+            .contains("src/lib.rs#L")
+    );
+    assert!(chunk_extra["code_line_start"].as_u64().is_some());
+    assert!(chunk_extra["code_line_end"].as_u64().is_some());
+    assert!(chunk_extra["source_range"]["line_start"].as_u64().is_some());
+    assert!(
+        chunk_extra
+            .get("symbol_name")
+            .and_then(|value| value.as_str())
+            .is_some()
+    );
+
+    assert_eq!(output.cleanup_placeholders.len(), 1);
+    assert_eq!(output.cleanup_placeholders[0].source_id, output.source_id);
+    assert_eq!(output.cleanup_placeholders[0].generation, output.generation);
+    assert!(!output.cleanup_placeholders[0].executed);
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_utf8_releases_lease_without_allocating_generation()
+-> Result<(), Box<dyn Error + Send + Sync>> {
+    let temp = TempDir::new()?;
+    let root = temp.path().join("repo");
+    tokio::fs::create_dir_all(&root).await?;
+    tokio::fs::write(root.join("bad.rs"), [0xff, 0xfe, 0xfd]).await?;
+    let canonical_root = tokio::fs::canonicalize(&root).await?;
+    let source_id = local_source_id(&canonical_root)?;
+    let store = test_store().await?;
+
+    let err = prepare_local_source_spike(spike_input(root), &store)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("not valid UTF-8"),
+        "expected UTF-8 failure, got: {err}"
+    );
+    assert_eq!(store.max_generation(&source_id).await?, 0);
+    assert_eq!(
+        store.source_status(&source_id).await?.active_generation,
+        None
+    );
+    assert!(
+        store
+            .acquire_lease(
+                &SourceIdentity::new(&source_id, SourceKind::LocalCode, "axon-test", 1),
+                "next-owner",
+                60_000,
+            )
+            .await?
+    );
+    Ok(())
+}

--- a/crates/axon-vector/src/ops/source_doc/ledger.rs
+++ b/crates/axon-vector/src/ops/source_doc/ledger.rs
@@ -70,6 +70,26 @@ impl LedgerPayload {
         payload["source_committed"] = Value::Bool(false);
     }
 
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    pub fn source_kind(&self) -> &str {
+        &self.source_kind
+    }
+
+    pub fn generation(&self) -> i64 {
+        self.generation
+    }
+
+    pub fn item_key(&self) -> &str {
+        &self.item_key
+    }
+
+    pub fn index_version(&self) -> i64 {
+        self.index_version
+    }
+
     pub(in crate::ops) fn point_id_seed(&self, url: &str, chunk_index: usize) -> String {
         format!(
             "ledger:{}:{}:{}:{}",

--- a/crates/axon-vector/src/ops/tei.rs
+++ b/crates/axon-vector/src/ops/tei.rs
@@ -168,6 +168,11 @@ impl PreparedDoc {
         self.extra.as_ref()
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn ledger_payload(&self) -> Option<&crate::ops::source_doc::LedgerPayload> {
+        self.ledger_payload.as_ref()
+    }
+
     pub fn chunks(&self) -> &[String] {
         &self.chunks
     }

--- a/docs/pipeline-unification/delivery/local-source-ledger-spike-notes.md
+++ b/docs/pipeline-unification/delivery/local-source-ledger-spike-notes.md
@@ -1,0 +1,67 @@
+# Local Source Ledger Spike Notes
+
+Issue: [#298](https://github.com/jmagar/axon/issues/298)
+
+Plan: [2026-07-01-local-source-ledger-spike.md](../plans/2026-07-01-local-source-ledger-spike.md)
+
+## Purpose
+
+This spike proves the local source path can enter the target pipeline shape before
+the public CLI, MCP, REST, watch, and job surfaces are rewritten.
+
+The proof target is:
+
+```text
+local path
+  -> local adapter prototype
+  -> SourceLedger draft generation
+  -> SourceDocument with LedgerPayload
+  -> prepare_source_document
+  -> PreparedDoc
+```
+
+The spike intentionally stops before embedding, Qdrant upsert, generation
+publish, committed-generation search gating, and cleanup execution. Cleanup
+placeholders in this PR are returned by the spike output only; they are not
+persisted to ledger cleanup debt until the later ledger-owned lifecycle PR.
+
+## Move Mostly As-Is
+
+These pieces already have the right shape and should be moved behind the new
+source pipeline rather than rewritten:
+
+- Local file walking and pruning from `axon-vector::ops::file_ingest`.
+- Path normalization into slash-separated source item keys.
+- Runtime `SourceDocument` constructors for local files and local markdown.
+- Code-aware preparation through `prepare_source_document`.
+- Tree-sitter/code chunk metadata, including file path, language, line ranges,
+  chunk locator, chunking method, and symbol extraction status.
+- Markdown chunk preparation and per-chunk source ranges.
+- Typed `LedgerPayload` stamping for source id, source kind, generation, item
+  key, index version, and uncommitted status.
+- TEI batching and throughput knobs after prepared documents exist.
+
+## Rewrite Or Replace Later
+
+These pieces should not be carried forward as-is:
+
+- Public `axon embed` and `code-search-watch` command split. The target surface
+  routes local paths through `axon <source>` / source actions with watch options.
+- Code-search-specific lifecycle names in user-facing progress, status, logs,
+  jobs, and docs. The target name is source/local-source, not code-search.
+- Any path that allocates generations without first passing provider preflight.
+- Any path that relies on Qdrant scrolls as the source of truth for mutable
+  source state.
+- Custom stale cleanup paths outside ledger cleanup debt.
+- Watch status models that are separate from the unified source job model.
+- Progress events that cannot be joined by one `job_id` across logs, ledger,
+  traces, status, and vector payloads.
+
+## Follow-Up PR Boundaries
+
+- PR3 should promote the spike shape into real local-source service boundaries.
+- PR4 should introduce committed-generation publish and source-owned cleanup debt
+  execution.
+- PR5 should cut CLI/MCP/REST to the unified source command/action/route model.
+- PR6 should move the proven code into the target crates once behavior is stable
+  enough to relocate without guessing.

--- a/docs/pipeline-unification/plans/2026-07-01-local-source-ledger-spike.md
+++ b/docs/pipeline-unification/plans/2026-07-01-local-source-ledger-spike.md
@@ -1,6 +1,6 @@
 # Local Source Ledger Spike Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Create PR2 for issue #298 by proving one local source can flow through the target pipeline shape far enough to expose the real friction before public CLI/MCP/REST rewiring.
 
@@ -18,6 +18,7 @@
 - Do not write Qdrant points through the new path.
 - Do not rewrite the job runtime.
 - Do not migrate, tombstone, or preserve existing local data.
+- Do not persist cleanup debt in the spike; persistent cleanup debt belongs to the later ledger-owned lifecycle PR.
 - Do not touch any `CLAUDE.md` files.
 - Keep files under 500 lines.
 - Add sibling test files; do not add inline tests in implementation modules.
@@ -32,7 +33,8 @@ This PR includes:
 - A small local-source adapter prototype that discovers local files and emits manifest/source-document inputs.
 - A source-ledger draft generation for the local source before preparation.
 - Markdown and Rust fixture tests proving prepared docs carry canonical local source and draft generation metadata.
-- Ledger assertions for source id, source kind, collection, generation, item keys, content hashes, and cleanup placeholders.
+- Ledger assertions for source id, source kind, collection, generation, item keys, and content hashes.
+- Output-only cleanup placeholders proving the shape that later PRs will persist as ledger cleanup debt.
 - Spike notes recording which current local embed/watch pieces should move versus be rewritten in later PRs.
 
 This PR excludes:
@@ -43,7 +45,7 @@ This PR excludes:
 - Watch scheduler changes.
 - Background job runtime changes.
 - Qdrant collection or payload writes.
-- Cleanup execution.
+- Cleanup debt persistence or execution.
 - Public config changes.
 
 ## Implementation Shape
@@ -81,8 +83,8 @@ Use concrete field types from the existing crates where ergonomic. The spike out
 
 ## Task 1: Add Failing Spike Tests
 
-- [ ] Create `crates/axon-services/src/source_spike_tests.rs`.
-- [ ] Add a Markdown fixture test:
+- [x] Create `crates/axon-services/src/source_spike_tests.rs`.
+- [x] Add a Markdown fixture test:
   - create a temp local source root with `README.md`
   - create an isolated SQLite source-ledger store
   - run the spike
@@ -91,21 +93,21 @@ Use concrete field types from the existing crates where ergonomic. The spike out
   - assert the manifest item has a stable content hash and nonzero size
   - assert at least one prepared doc/chunk is produced
   - assert prepared metadata contains the local source id and draft generation
-- [ ] Add a Rust fixture test:
+- [x] Add a Rust fixture test:
   - create a temp local source root with `src/lib.rs`
   - run the spike
   - assert the item key is `src/lib.rs`
   - assert prepared output uses the code-aware preparation path
   - assert prepared metadata contains the local source id and draft generation
-- [ ] Add a ledger status assertion:
+- [x] Add a ledger status assertion:
   - source kind is local path/local filesystem
   - collection is the requested collection
   - committed generation is still unset/zero
   - active or max generation matches the spike generation
-- [ ] Add cleanup placeholder assertions:
+- [x] Add cleanup placeholder assertions:
   - placeholders identify the source and generation
   - placeholders are not executed
-  - placeholders make clear later PRs will move cleanup into ledger cleanup debt
+  - placeholders make clear later PRs will persist cleanup into ledger cleanup debt
 
 Run and confirm the new tests fail for missing implementation:
 
@@ -115,79 +117,79 @@ cargo test -p axon-services source_spike --locked
 
 ## Task 2: Implement Local Source Manifest Discovery
 
-- [ ] Add `crates/axon-services/src/source_spike.rs`.
-- [ ] Resolve `LocalSourceSpikeInput.root` to a canonical local root where possible.
-- [ ] Support a single file or directory.
-- [ ] Walk directories deterministically.
-- [ ] Ignore directories/files already ignored by the existing local embed path where a reusable helper exists.
-- [ ] Produce stable relative item keys using slash separators.
-- [ ] Compute content hash, size, and modified timestamp for each file.
-- [ ] Infer content kind/language using the existing source-document or input-classification helpers where possible.
-- [ ] Keep acquisition local-only and synchronous; no network or browser behavior.
+- [x] Add `crates/axon-services/src/source_spike.rs`.
+- [x] Resolve `LocalSourceSpikeInput.root` to a canonical local root where possible.
+- [x] Support a single file or directory.
+- [x] Walk directories deterministically.
+- [x] Ignore directories/files already ignored by the existing local embed path where a reusable helper exists.
+- [x] Produce stable relative item keys using slash separators.
+- [x] Compute content hash, size, and modified timestamp for each file.
+- [x] Infer content kind/language using the existing source-document or input-classification helpers where possible.
+- [x] Keep acquisition local-only and synchronous; no network or browser behavior.
 
 ## Task 3: Create Ledger Draft Generation Before Preparation
 
-- [ ] Build a `SourceIdentity` for the local root.
-- [ ] Ensure the source exists in `SourceLedgerStore`.
-- [ ] Begin a new generation owned by the spike owner.
-- [ ] Diff or record the discovered manifest through existing ledger APIs.
-- [ ] Do not commit the generation.
-- [ ] Do not publish the generation.
-- [ ] Abort or release any lease/generation cleanly on test failure paths if the store API requires it.
-- [ ] Return ledger-derived source id, source kind, collection, generation, and manifest details in `LocalSourceSpikeOutput`.
+- [x] Build a `SourceIdentity` for the local root.
+- [x] Ensure the source exists in `SourceLedgerStore`.
+- [x] Begin a new generation owned by the spike owner.
+- [x] Diff or record the discovered manifest through existing ledger APIs.
+- [x] Do not commit the generation.
+- [x] Do not publish the generation.
+- [x] Abort or release any lease/generation cleanly on test failure paths if the store API requires it.
+- [x] Return ledger-derived source id, source kind, collection, generation, and manifest details in `LocalSourceSpikeOutput`.
 
 ## Task 4: Convert Local Items To SourceDocument And PreparedDoc
 
-- [ ] Convert each manifest item into the existing runtime `axon_vector::ops::source_doc::SourceDocument`.
-- [ ] Attach ledger metadata using the sanctioned ledger payload path, not spoofable raw extras.
-- [ ] Include source id, source kind, collection, generation, item key, canonical URI, file path, content hash, size, and content kind in metadata.
-- [ ] Call the existing `prepare_source_document` path for each document.
-- [ ] Keep `prepare_embed_docs` unchanged.
-- [ ] Keep `PreparedDoc` shape unchanged unless the tests prove a minimal metadata hook is missing.
+- [x] Convert each manifest item into the existing runtime `axon_vector::ops::source_doc::SourceDocument`.
+- [x] Attach ledger metadata using the sanctioned ledger payload path, not spoofable raw extras.
+- [x] Include source id, source kind, collection, generation, item key, canonical URI, file path, content hash, size, and content kind in metadata.
+- [x] Call the existing `prepare_source_document` path for each document.
+- [x] Keep `prepare_embed_docs` unchanged.
+- [x] Keep `PreparedDoc` shape unchanged unless the tests prove a minimal metadata hook is missing.
 
 ## Task 5: Record Move-Versus-Rewrite Notes
 
-- [ ] Add `docs/pipeline-unification/delivery/local-source-ledger-spike-notes.md`.
-- [ ] Document which current local embed/watch pieces can move mostly as-is:
+- [x] Add `docs/pipeline-unification/delivery/local-source-ledger-spike-notes.md`.
+- [x] Document which current local embed/watch pieces can move mostly as-is:
   - file discovery/exclusion
   - source-document construction
   - code/markdown preparation
   - TEI batching knobs
-- [ ] Document which pieces should be rewritten in later PRs:
+- [x] Document which pieces should be rewritten in later PRs:
   - public command surface
   - watch ownership/status naming
   - generation publish
   - cleanup debt execution
   - progress/heartbeat model
-- [ ] Link the notes back to issue #298 and this PR2 plan.
+- [x] Link the notes back to issue #298 and this PR2 plan.
 
 ## Task 6: Verify
 
-- [ ] Run targeted services tests:
+- [x] Run targeted services tests:
 
 ```bash
 cargo test -p axon-services source_spike --locked
 ```
 
-- [ ] Run source-ledger tests if ledger APIs were touched:
+- [x] Run source-ledger tests if ledger APIs were touched:
 
 ```bash
 cargo test -p axon-source-ledger --locked
 ```
 
-- [ ] Run vector source-doc tests if source-document metadata handling was touched:
+- [x] Run vector source-doc tests if source-document metadata handling was touched:
 
 ```bash
 cargo test -p axon-vector source_doc --locked
 ```
 
-- [ ] Run formatting:
+- [x] Run formatting:
 
 ```bash
 cargo fmt -- --check
 ```
 
-- [ ] Run the lightweight repo structure check:
+- [x] Run the lightweight repo structure check:
 
 ```bash
 cargo xtask check-repo-structure

--- a/docs/pipeline-unification/plans/2026-07-01-local-source-ledger-spike.md
+++ b/docs/pipeline-unification/plans/2026-07-01-local-source-ledger-spike.md
@@ -1,0 +1,203 @@
+# Local Source Ledger Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create PR2 for issue #298 by proving one local source can flow through the target pipeline shape far enough to expose the real friction before public CLI/MCP/REST rewiring.
+
+**Target flow:** `SourceRequest(local path) -> local adapter prototype -> SourceLedger draft/generation -> SourceDocument -> prepare_source_document -> PreparedDoc`
+
+**Architecture:** This PR is a spike, not a public cutover. It keeps the current `embed`, `code-search`, watch, Qdrant, TEI, CLI, MCP, and REST behavior unchanged. The spike lives behind an internal services module and tests so we can prove ledger ownership enters before document preparation.
+
+**Tech Stack:** Rust 2024, `axon-services`, `axon-source-ledger`, `axon-vector`, SQLite source-ledger store, existing `SourceDocument` and `PreparedDoc` runtime types.
+
+## Global Constraints
+
+- Do not wire this path to public CLI, MCP, REST, or watch commands.
+- Do not remove, rename, or alias existing commands in this PR.
+- Do not publish generations through the new path.
+- Do not write Qdrant points through the new path.
+- Do not rewrite the job runtime.
+- Do not migrate, tombstone, or preserve existing local data.
+- Do not touch any `CLAUDE.md` files.
+- Keep files under 500 lines.
+- Add sibling test files; do not add inline tests in implementation modules.
+- Prefer existing source-ledger and vector preparation APIs over inventing parallel abstractions.
+- Commit the plan before implementation; commit implementation after the targeted tests pass.
+
+## Target PR Scope
+
+This PR includes:
+
+- An internal local-source spike module in `axon-services`.
+- A small local-source adapter prototype that discovers local files and emits manifest/source-document inputs.
+- A source-ledger draft generation for the local source before preparation.
+- Markdown and Rust fixture tests proving prepared docs carry canonical local source and draft generation metadata.
+- Ledger assertions for source id, source kind, collection, generation, item keys, content hashes, and cleanup placeholders.
+- Spike notes recording which current local embed/watch pieces should move versus be rewritten in later PRs.
+
+This PR excludes:
+
+- CLI command changes.
+- MCP tool schema changes.
+- REST route changes.
+- Watch scheduler changes.
+- Background job runtime changes.
+- Qdrant collection or payload writes.
+- Cleanup execution.
+- Public config changes.
+
+## Implementation Shape
+
+Add an internal services module:
+
+```text
+crates/axon-services/src/source_spike.rs
+crates/axon-services/src/source_spike_tests.rs
+```
+
+Expose the module only from `crates/axon-services/src/lib.rs` for crate tests or as a clearly experimental internal API. It must not be called by CLI/MCP/REST.
+
+Core structs:
+
+```rust
+pub(crate) struct LocalSourceSpikeInput {
+    pub root: PathBuf,
+    pub collection: String,
+    pub owner: String,
+}
+
+pub(crate) struct LocalSourceSpikeOutput {
+    pub source_id: String,
+    pub source_kind: String,
+    pub collection: String,
+    pub generation: i64,
+    pub manifest_items: Vec<LocalSourceSpikeManifestItem>,
+    pub prepared_docs: Vec<PreparedDoc>,
+    pub cleanup_placeholders: Vec<LocalSourceSpikeCleanupPlaceholder>,
+}
+```
+
+Use concrete field types from the existing crates where ergonomic. The spike output may stay small, but it must expose enough state for tests to prove the lifecycle.
+
+## Task 1: Add Failing Spike Tests
+
+- [ ] Create `crates/axon-services/src/source_spike_tests.rs`.
+- [ ] Add a Markdown fixture test:
+  - create a temp local source root with `README.md`
+  - create an isolated SQLite source-ledger store
+  - run the spike
+  - assert one draft generation exists
+  - assert the manifest contains `README.md`
+  - assert the manifest item has a stable content hash and nonzero size
+  - assert at least one prepared doc/chunk is produced
+  - assert prepared metadata contains the local source id and draft generation
+- [ ] Add a Rust fixture test:
+  - create a temp local source root with `src/lib.rs`
+  - run the spike
+  - assert the item key is `src/lib.rs`
+  - assert prepared output uses the code-aware preparation path
+  - assert prepared metadata contains the local source id and draft generation
+- [ ] Add a ledger status assertion:
+  - source kind is local path/local filesystem
+  - collection is the requested collection
+  - committed generation is still unset/zero
+  - active or max generation matches the spike generation
+- [ ] Add cleanup placeholder assertions:
+  - placeholders identify the source and generation
+  - placeholders are not executed
+  - placeholders make clear later PRs will move cleanup into ledger cleanup debt
+
+Run and confirm the new tests fail for missing implementation:
+
+```bash
+cargo test -p axon-services source_spike --locked
+```
+
+## Task 2: Implement Local Source Manifest Discovery
+
+- [ ] Add `crates/axon-services/src/source_spike.rs`.
+- [ ] Resolve `LocalSourceSpikeInput.root` to a canonical local root where possible.
+- [ ] Support a single file or directory.
+- [ ] Walk directories deterministically.
+- [ ] Ignore directories/files already ignored by the existing local embed path where a reusable helper exists.
+- [ ] Produce stable relative item keys using slash separators.
+- [ ] Compute content hash, size, and modified timestamp for each file.
+- [ ] Infer content kind/language using the existing source-document or input-classification helpers where possible.
+- [ ] Keep acquisition local-only and synchronous; no network or browser behavior.
+
+## Task 3: Create Ledger Draft Generation Before Preparation
+
+- [ ] Build a `SourceIdentity` for the local root.
+- [ ] Ensure the source exists in `SourceLedgerStore`.
+- [ ] Begin a new generation owned by the spike owner.
+- [ ] Diff or record the discovered manifest through existing ledger APIs.
+- [ ] Do not commit the generation.
+- [ ] Do not publish the generation.
+- [ ] Abort or release any lease/generation cleanly on test failure paths if the store API requires it.
+- [ ] Return ledger-derived source id, source kind, collection, generation, and manifest details in `LocalSourceSpikeOutput`.
+
+## Task 4: Convert Local Items To SourceDocument And PreparedDoc
+
+- [ ] Convert each manifest item into the existing runtime `axon_vector::ops::source_doc::SourceDocument`.
+- [ ] Attach ledger metadata using the sanctioned ledger payload path, not spoofable raw extras.
+- [ ] Include source id, source kind, collection, generation, item key, canonical URI, file path, content hash, size, and content kind in metadata.
+- [ ] Call the existing `prepare_source_document` path for each document.
+- [ ] Keep `prepare_embed_docs` unchanged.
+- [ ] Keep `PreparedDoc` shape unchanged unless the tests prove a minimal metadata hook is missing.
+
+## Task 5: Record Move-Versus-Rewrite Notes
+
+- [ ] Add `docs/pipeline-unification/delivery/local-source-ledger-spike-notes.md`.
+- [ ] Document which current local embed/watch pieces can move mostly as-is:
+  - file discovery/exclusion
+  - source-document construction
+  - code/markdown preparation
+  - TEI batching knobs
+- [ ] Document which pieces should be rewritten in later PRs:
+  - public command surface
+  - watch ownership/status naming
+  - generation publish
+  - cleanup debt execution
+  - progress/heartbeat model
+- [ ] Link the notes back to issue #298 and this PR2 plan.
+
+## Task 6: Verify
+
+- [ ] Run targeted services tests:
+
+```bash
+cargo test -p axon-services source_spike --locked
+```
+
+- [ ] Run source-ledger tests if ledger APIs were touched:
+
+```bash
+cargo test -p axon-source-ledger --locked
+```
+
+- [ ] Run vector source-doc tests if source-document metadata handling was touched:
+
+```bash
+cargo test -p axon-vector source_doc --locked
+```
+
+- [ ] Run formatting:
+
+```bash
+cargo fmt -- --check
+```
+
+- [ ] Run the lightweight repo structure check:
+
+```bash
+cargo xtask check-repo-structure
+```
+
+## Done Criteria
+
+- Local Markdown fixture reaches `PreparedDoc` through a ledger draft generation.
+- Local Rust fixture reaches `PreparedDoc` through a ledger draft generation.
+- Tests prove the ledger draft exists before preparation.
+- Tests prove generation is not committed/published by the spike.
+- Current public `embed`, `code-search`, watch, CLI, MCP, and REST behavior is unchanged.
+- Move-versus-rewrite notes exist for the later full implementation.


### PR DESCRIPTION
## Summary

PR2 for #298. This proves the local source vertical can flow through the target shape without wiring public CLI/MCP/REST yet:

```text
local path
  -> local adapter prototype
  -> SourceLedger draft generation
  -> SourceDocument with LedgerPayload
  -> prepare_source_document
  -> PreparedDoc
```

## What Changed

- Added an internal `axon-services` local-source spike module.
- Discovers local file/directory inputs deterministically using the existing local file selection path.
- Creates a source-ledger draft generation before preparing documents.
- Records pending manifest items with source id, source kind, collection, generation, item keys, content hashes, sizes, and modified timestamps.
- Carries local content through a single read so manifest hash/size and prepared content cannot diverge.
- Stamps prepared docs through typed `LedgerPayload`, not spoofable raw extras.
- Adds Markdown, Rust, and invalid-UTF8 failure-path tests.
- Adds read-only `PreparedDoc::ledger_payload()` and `LedgerPayload` accessors for test/proof visibility.
- Adds local-source spike delivery notes and marks the PR2 plan tasks complete.

## Explicit Non-Goals

- No CLI/MCP/REST wiring.
- No Qdrant writes.
- No generation publish/commit.
- No cleanup debt persistence or execution.
- No job runtime rewrite.

Cleanup placeholders are output-only in this spike; durable cleanup debt is deferred to the later ledger-owned lifecycle PR.

## Issue #298 Gate

A read-only gate review compared the current diff against issue #298 and found the PR2 local-source ledger-shaped spike fully implemented for this slice. Later PR work remains for schema drift, durable cleanup debt, generation publish, CLI/MCP/REST cutover, unified jobs/observability, provider/store fakes, resolver/router registry, and source-family ports.

## Verification

- `cargo test -p axon-services source_spike --locked`
- `cargo test -p axon-source-ledger --locked`
- `cargo test -p axon-vector source_doc --locked`
- `cargo fmt -- --check`
- `cargo xtask check-repo-structure`
- pre-commit: `monolith`, `xtask-check`, `rustfmt`
- pre-push: `structural-checks`

Note: pre-commit emitted a monolith warning that `prepare_local_source_spike` is 103 lines, under the hard limit but above the warning threshold. This is acceptable for the spike and should be split before promotion to the real service boundary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal spike that runs a local path through the ledger-shaped pipeline into prepared docs, satisfying the local-source slice for #298. No CLI/MCP/REST wiring or publishing yet.

- **New Features**
  - Introduces an internal `axon-services` `source_spike` that discovers local files deterministically and builds stable item keys.
  - Starts a draft generation via `axon-source-ledger` (`SourceIdentity`, lease, begin generation), records manifest items, and does not commit/publish.
  - Converts files to `SourceDocument`s, stamps typed `LedgerPayload`, and prepares docs via existing `axon-vector` paths.
  - Ensures manifest hash/size match prepared content by reading each file once; includes modified timestamp in outputs.
  - Adds read-only accessors in `axon-vector`: `PreparedDoc::ledger_payload()` and getters on `LedgerPayload`.
  - Includes tests for Markdown, Rust (code-aware chunks), and invalid UTF‑8 failure path; adds spike notes and plan docs.
  - Returns cleanup placeholders only; no persistent cleanup debt or Qdrant writes.

<sup>Written for commit 900c45fba0091625f82d2c71602dd36b5a1787a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

