### PR TITLE
feat(axon-error): error taxonomy + wire axon-api (Phase 1 completion)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ version = "6.2.1"
 name = "axon-api"
 version = "6.2.1"
 dependencies = [
+ "axon-error",
  "chrono",
  "percent-encoding",
  "schemars",
@@ -582,6 +583,15 @@ version = "6.2.1"
 [[package]]
 name = "axon-error"
 version = "6.2.1"
+dependencies = [
+ "chrono",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "utoipa",
+ "uuid",
+]
 
 [[package]]
 name = "axon-extract"

--- a/crates/axon-api/Cargo.toml
+++ b/crates/axon-api/Cargo.toml
@@ -7,6 +7,7 @@ description = "Axon transport-neutral API contract and result DTOs shared across
 license = "MIT"
 
 [dependencies]
+axon-error = { path = "../axon-error" }
 serde = { version = "1", features = ["derive"] }
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
 percent-encoding = "2"

--- a/crates/axon-api/src/source.rs
+++ b/crates/axon-api/src/source.rs
@@ -49,3 +49,7 @@ mod vector_tests;
 #[cfg(test)]
 #[path = "source_graph_tests.rs"]
 mod graph_tests;
+
+#[cfg(test)]
+#[path = "source_stage_fixture_tests.rs"]
+mod stage_fixture_tests;

--- a/crates/axon-api/src/source/status.rs
+++ b/crates/axon-api/src/source/status.rs
@@ -54,26 +54,11 @@ pub struct PageInfo {
     pub total: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
-#[serde(deny_unknown_fields)]
-pub struct ApiError {
-    pub code: String,
-    pub message: String,
-    pub stage: PipelinePhase,
-    pub retryable: bool,
-    pub severity: Severity,
-    pub details: MetadataMap,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub job_id: Option<JobId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_id: Option<SourceId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_id: Option<ProviderId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub retry_after_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cooldown_until: Option<Timestamp>,
-}
+// `ApiError` and its error enums are owned by `axon-error`, the lowest shared
+// error boundary. `axon-api` re-exports them so the surrounding envelopes
+// (`ErrorEnvelope`, `StreamEvent::Error`, `SourceStatus.last_error`,
+// `SourceProgressEvent.error`, `capability.rs`) embed the one shared shape.
+pub use axon_error::{ApiError, ErrorSeverity, ErrorStage, ErrorVisibility};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]

--- a/crates/axon-api/src/source_stage_fixture_tests.rs
+++ b/crates/axon-api/src/source_stage_fixture_tests.rs
@@ -1,0 +1,330 @@
+//! Phase-1 stage-result fixtures: a success, degraded, and failed variant for
+//! every stage-result DTO, each round-tripped through serde.
+//!
+//! The failed variant of each stage result carries an error on its
+//! `StageResultHeader` (a `SourceError`), and every failed fixture is paired
+//! with a shared `axon_error::ApiError` value that is asserted to round-trip —
+//! proving the shared error shape embeds cleanly alongside the stage results.
+
+use chrono::Utc;
+
+use super::*;
+
+fn job_id() -> JobId {
+    JobId(uuid::Uuid::nil())
+}
+
+fn stage_id() -> StageId {
+    StageId(uuid::Uuid::nil())
+}
+
+fn now() -> Timestamp {
+    Timestamp::from(Utc::now())
+}
+
+fn counts() -> StageCounts {
+    StageCounts {
+        items_total: Some(2),
+        items_done: 2,
+        documents_total: Some(2),
+        documents_done: 2,
+        chunks_total: Some(8),
+        chunks_done: 8,
+        bytes_total: Some(100),
+        bytes_done: 100,
+    }
+}
+
+fn source_error() -> SourceError {
+    SourceError {
+        code: "source.acquire.fetch_failed".to_string(),
+        severity: Severity::Failed,
+        message: "fetch failed".to_string(),
+        source_item_key: Some(SourceItemKey::from("src/lib.rs")),
+        retryable: true,
+        provider_id: Some(ProviderId::from("tei")),
+        cause: None,
+    }
+}
+
+/// A `StageResultHeader` at the given phase/status, with an error when failed.
+fn header(phase: PipelinePhase, status: LifecycleStatus, failed: bool) -> StageResultHeader {
+    StageResultHeader {
+        job_id: job_id(),
+        stage_id: stage_id(),
+        phase,
+        status,
+        started_at: now(),
+        completed_at: Some(now()),
+        counts: counts(),
+        warnings: Vec::new(),
+        error: if failed { Some(source_error()) } else { None },
+    }
+}
+
+/// The three lifecycle variants exercised by every fixture.
+fn variants(phase: PipelinePhase) -> [(StageResultHeader, bool); 3] {
+    [
+        (header(phase, LifecycleStatus::Completed, false), false),
+        (
+            header(phase, LifecycleStatus::CompletedDegraded, false),
+            false,
+        ),
+        (header(phase, LifecycleStatus::Failed, true), true),
+    ]
+}
+
+/// Assert a stage-result value round-trips through serde.
+fn round_trip<T>(value: &T)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+{
+    let json = serde_json::to_value(value).expect("serialize");
+    let back: T = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(&back, value);
+}
+
+/// The shared error shape paired with every failed stage fixture.
+fn shared_api_error() -> ApiError {
+    ApiError::new(
+        "source.acquire.fetch_failed",
+        ErrorStage::Fetching,
+        "fetch failed",
+    )
+    .with_source_id("src_local")
+    .with_job_id("job_1")
+}
+
+fn adapter() -> AdapterRef {
+    AdapterRef {
+        name: "local".to_string(),
+        version: "0.1.0".to_string(),
+    }
+}
+
+fn manifest() -> SourceManifest {
+    SourceManifest {
+        source_id: SourceId::from("src_local"),
+        generation: SourceGenerationId::from("gen_1"),
+        adapter: adapter(),
+        scope: SourceScope::Directory,
+        items: Vec::new(),
+        created_at: now(),
+        metadata: MetadataMap::default(),
+    }
+}
+
+#[test]
+fn failed_stage_fixtures_pair_with_shared_api_error() {
+    // The shared ApiError embedded alongside a failed stage result round-trips.
+    round_trip(&shared_api_error());
+}
+
+#[test]
+fn stage_execution_result_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Fetching) {
+        let value = StageExecutionResult {
+            header,
+            data: counts(),
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn authorization_result_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Authorizing) {
+        let value = AuthorizationResult {
+            header,
+            source_id: Some(SourceId::from("src_local")),
+            decision: SecurityDecision {
+                allowed: true,
+                scope: "docs".to_string(),
+                reason: "policy allows".to_string(),
+                redactions: Vec::new(),
+                warnings: Vec::new(),
+            },
+            caller: CallerContext {
+                actor: Some("cli".to_string()),
+                transport: TransportKind::Cli,
+                scopes: vec!["axon:read".to_string()],
+                visibility_ceiling: Visibility::Internal,
+            },
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn lease_result_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Leasing) {
+        let value = LeaseResult {
+            header,
+            lease_key: "lease_1".to_string(),
+            acquired: true,
+            owner: "worker_1".to_string(),
+            expires_at: now(),
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn source_acquisition_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Fetching) {
+        let value = SourceAcquisition {
+            header,
+            source_id: SourceId::from("src_local"),
+            generation: SourceGenerationId::from("gen_1"),
+            adapter: adapter(),
+            scope: SourceScope::Directory,
+            manifest: manifest(),
+            fetched_items: Vec::new(),
+            artifacts: Vec::new(),
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn source_manifest_diff_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Diffing) {
+        let value = SourceManifestDiff {
+            header,
+            source_id: SourceId::from("src_local"),
+            previous_generation: Some(SourceGenerationId::from("gen_0")),
+            next_generation: SourceGenerationId::from("gen_1"),
+            added: Vec::new(),
+            modified: Vec::new(),
+            removed: Vec::new(),
+            unchanged: Vec::new(),
+            skipped: Vec::new(),
+            failed: Vec::new(),
+            counts: DiffCounts {
+                added: 0,
+                modified: 0,
+                removed: 0,
+                unchanged: 0,
+                skipped: 0,
+                failed: 0,
+            },
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn source_enrichment_fixtures_round_trip() {
+    let statuses = [
+        (LifecycleStatus::Completed, EnrichmentStatus::Completed),
+        (
+            LifecycleStatus::CompletedDegraded,
+            EnrichmentStatus::Degraded,
+        ),
+        (LifecycleStatus::Failed, EnrichmentStatus::Failed),
+    ];
+    for (idx, (header, _failed)) in variants(PipelinePhase::Enriching).into_iter().enumerate() {
+        let value = SourceEnrichment {
+            header,
+            source_id: SourceId::from("src_local"),
+            source_item_key: SourceItemKey::from("src/lib.rs"),
+            enrichment_kind: EnrichmentKind::Metadata,
+            status: statuses[idx].1,
+            metadata: MetadataMap::default(),
+            parse_hints: Vec::new(),
+            chunk_hints: Vec::new(),
+            graph_candidates: Vec::new(),
+            artifacts: Vec::new(),
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn parse_result_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Parsing) {
+        let value = ParseResult {
+            header,
+            document_id: DocumentId::from("doc_1"),
+            facts: Vec::new(),
+            graph_candidates: Vec::new(),
+            parser_id: "markdown".to_string(),
+            parser_version: "1.0.0".to_string(),
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn graph_write_result_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Graphing) {
+        let value = GraphWriteResult {
+            header,
+            source_id: SourceId::from("src_local"),
+            candidates_seen: 4,
+            nodes_upserted: 3,
+            edges_upserted: 2,
+            evidence_records: 5,
+            warnings: Vec::new(),
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn vector_store_write_result_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Upserting) {
+        let value = VectorStoreWriteResult {
+            header,
+            collection: "axon".to_string(),
+            points_attempted: 8,
+            points_written: 8,
+            payload_indexes_created: vec!["seed_url".to_string()],
+            usage: ProviderUsage {
+                input_tokens: None,
+                output_tokens: None,
+                requests: 1,
+                duration_ms: 42,
+            },
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn publish_generation_result_fixtures_round_trip() {
+    for (header, _failed) in variants(PipelinePhase::Publishing) {
+        let value = PublishGenerationResult {
+            header,
+            source_id: SourceId::from("src_local"),
+            generation: SourceGenerationId::from("gen_1"),
+            published_at: now(),
+            document_count: 2,
+            chunk_count: 8,
+            vector_point_count: 8,
+            cleanup_debt: Vec::new(),
+        };
+        round_trip(&value);
+    }
+}
+
+#[test]
+fn cleanup_debt_result_fixtures_round_trip() {
+    let statuses = [
+        LifecycleStatus::Completed,
+        LifecycleStatus::CompletedDegraded,
+        LifecycleStatus::Failed,
+    ];
+    for (idx, (header, _failed)) in variants(PipelinePhase::Cleaning).into_iter().enumerate() {
+        let value = CleanupDebtResult {
+            header,
+            debt_id: CleanupDebtId::from("debt_1"),
+            kind: CleanupDebtKind::VectorDelete,
+            status: statuses[idx],
+            items_attempted: 3,
+            items_cleaned: if idx == 2 { 1 } else { 3 },
+            next_retry_at: if idx == 2 { Some(now()) } else { None },
+        };
+        round_trip(&value);
+    }
+}

--- a/crates/axon-error/Cargo.toml
+++ b/crates/axon-error/Cargo.toml
@@ -5,5 +5,13 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Axon shared error taxonomy: ApiError, error codes, stages, severity, retry/cooling/degradation classifications, and redaction-aware context"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+schemars = { version = "1", features = ["chrono04", "uuid1"] }
+utoipa = { version = "5", features = ["chrono", "uuid"] }

--- a/crates/axon-error/src/api_error.rs
+++ b/crates/axon-error/src/api_error.rs
@@ -1,3 +1,207 @@
-//! Marker module for the target `axon-error::api_error` boundary.
+//! `ApiError` — the shared error type for the unified pipeline.
+//!
+//! Field shape follows the "Error Shape" section of
+//! `docs/pipeline-unification/runtime/error-handling.md`. Correlation ids are
+//! plain strings here because `axon-error` sits below `axon-api` and cannot see
+//! its typed id newtypes.
 
-pub const MODULE_NAME: &str = "api_error";
+use std::collections::BTreeMap;
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::code::ErrorCode;
+use crate::context::ErrorVisibility;
+use crate::cooling::ProviderCooling;
+use crate::degradation::DegradationPolicy;
+use crate::retry::{RetryPolicy, RetryScope};
+use crate::severity::ErrorSeverity;
+use crate::stage::ErrorStage;
+
+/// The shared, transport-neutral error shape.
+///
+/// Every crate reports failures as an `ApiError` so CLI, REST, MCP, jobs, logs,
+/// and progress streams render one consistent structure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct ApiError {
+    /// Stable machine code (e.g. `provider.unavailable`).
+    pub code: ErrorCode,
+    /// Redacted human-readable message.
+    pub message: String,
+    /// Pipeline/transport stage.
+    pub stage: ErrorStage,
+    /// Whether retry may succeed.
+    pub retryable: bool,
+    /// Severity classification.
+    pub severity: ErrorSeverity,
+    /// Where this error may be surfaced.
+    pub visibility: ErrorVisibility,
+    /// Redacted structured context (safe key/value pairs only).
+    pub details: BTreeMap<String, String>,
+
+    /// Job correlation id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    /// Source id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    /// Item/file/page key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_item_key: Option<String>,
+    /// Document id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document_id: Option<String>,
+    /// Chunk id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunk_id: Option<String>,
+    /// Provider that failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    /// Suggested retry delay, in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_ms: Option<u64>,
+    /// Provider/job cooling timestamp.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_until: Option<DateTime<Utc>>,
+}
+
+impl ApiError {
+    /// Construct a new error from a code, stage, and message.
+    ///
+    /// `retryable` and `severity` are derived from the code's classification;
+    /// `visibility` defaults to `Public`. Adjust with the builder methods or by
+    /// mutating the fields directly.
+    pub fn new(code: impl Into<ErrorCode>, stage: ErrorStage, message: impl Into<String>) -> Self {
+        let code = code.into();
+        let (severity, retryable) = code.classify();
+        Self {
+            code,
+            message: message.into(),
+            stage,
+            retryable,
+            severity,
+            visibility: ErrorVisibility::Public,
+            details: BTreeMap::new(),
+            job_id: None,
+            source_id: None,
+            source_item_key: None,
+            document_id: None,
+            chunk_id: None,
+            provider_id: None,
+            retry_after_ms: None,
+            cooldown_until: None,
+        }
+    }
+
+    /// Attach a redacted context detail.
+    pub fn with_context(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.details.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set the source id.
+    pub fn with_source_id(mut self, source_id: impl Into<String>) -> Self {
+        self.source_id = Some(source_id.into());
+        self
+    }
+
+    /// Set the job id.
+    pub fn with_job_id(mut self, job_id: impl Into<String>) -> Self {
+        self.job_id = Some(job_id.into());
+        self
+    }
+
+    /// Set the provider id.
+    pub fn with_provider_id(mut self, provider_id: impl Into<String>) -> Self {
+        self.provider_id = Some(provider_id.into());
+        self
+    }
+
+    /// Override the visibility of this error.
+    pub fn with_visibility(mut self, visibility: ErrorVisibility) -> Self {
+        self.visibility = visibility;
+        self
+    }
+
+    /// Set the severity explicitly (overrides the code-derived default).
+    pub fn with_severity(mut self, severity: ErrorSeverity) -> Self {
+        self.severity = severity;
+        self
+    }
+
+    /// Set a provider/job cooling window.
+    pub fn with_cooldown_until(mut self, cooldown_until: DateTime<Utc>) -> Self {
+        self.cooldown_until = Some(cooldown_until);
+        self
+    }
+
+    /// Machine-readable retry policy for this error.
+    ///
+    /// Retry scope is inferred from the correlation ids present: a provider id
+    /// yields `Provider`, otherwise a chunk/document/item/job id narrows the
+    /// scope, defaulting to `Job`.
+    pub fn retry_policy(&self) -> RetryPolicy {
+        let retry_scope = if self.provider_id.is_some() {
+            RetryScope::Provider
+        } else if self.chunk_id.is_some() || self.document_id.is_some() {
+            RetryScope::Document
+        } else if self.source_item_key.is_some() {
+            RetryScope::Item
+        } else {
+            RetryScope::Job
+        };
+        RetryPolicy {
+            retryable: self.retryable,
+            retry_after_ms: self.retry_after_ms,
+            attempt: 0,
+            max_attempts: None,
+            backoff_ms: None,
+            cooldown_until: self.cooldown_until,
+            retry_scope,
+        }
+    }
+
+    /// Graceful-degradation decision for this error.
+    ///
+    /// A `Degraded` severity is degradable; anything terminal is not.
+    pub fn degradation_policy(&self) -> DegradationPolicy {
+        if self.severity == ErrorSeverity::Degraded {
+            DegradationPolicy::degradable(self.message.clone())
+        } else {
+            DegradationPolicy::not_degradable()
+        }
+    }
+
+    /// Provider cooling window, when a cooldown is active.
+    pub fn provider_cooling(&self) -> Option<ProviderCooling> {
+        self.cooldown_until.map(|cooldown_until| ProviderCooling {
+            provider_id: self.provider_id.clone(),
+            cooldown_until,
+            reason: None,
+        })
+    }
+}
+
+impl fmt::Display for ApiError {
+    /// Redaction-safe rendering: emits only `code`, `stage`, and `message`.
+    ///
+    /// `details` and correlation ids are never written here — they may carry
+    /// context marked non-public, and redaction is a renderer concern.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{code}] ({stage:?}) {message}",
+            code = self.code,
+            stage = self.stage,
+            message = self.message
+        )
+    }
+}
+
+impl std::error::Error for ApiError {}
+
+#[cfg(test)]
+#[path = "api_error_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/api_error_tests.rs
+++ b/crates/axon-error/src/api_error_tests.rs
@@ -1,0 +1,101 @@
+use super::*;
+use crate::context::ErrorVisibility;
+use crate::retry::RetryScope;
+use crate::severity::ErrorSeverity;
+use crate::stage::ErrorStage;
+
+#[test]
+fn new_derives_severity_and_retryable_from_code() {
+    let err = ApiError::new(
+        "provider.unavailable",
+        ErrorStage::Embedding,
+        "provider down",
+    );
+    assert_eq!(err.severity, ErrorSeverity::Failed);
+    assert!(err.retryable);
+    assert_eq!(err.visibility, ErrorVisibility::Public);
+}
+
+#[test]
+fn builder_sets_correlation_ids_as_strings() {
+    let err = ApiError::new("ledger.transaction", ErrorStage::Leasing, "boom")
+        .with_source_id("src_1")
+        .with_job_id("job_1")
+        .with_provider_id("tei")
+        .with_context("provider", "tei");
+    assert_eq!(err.source_id.as_deref(), Some("src_1"));
+    assert_eq!(err.job_id.as_deref(), Some("job_1"));
+    assert_eq!(err.provider_id.as_deref(), Some("tei"));
+    assert_eq!(err.details.get("provider").map(String::as_str), Some("tei"));
+}
+
+#[test]
+fn api_error_round_trips_serde_and_omits_none() {
+    let err = ApiError::new("command.unknown", ErrorStage::Parsing, "nope");
+    let value = serde_json::to_value(&err).unwrap();
+    assert_eq!(value["code"], "command.unknown");
+    assert_eq!(value["stage"], "parsing");
+    assert_eq!(value["severity"], "failed");
+    assert_eq!(value["visibility"], "public");
+    assert!(value.get("job_id").is_none(), "None ids are skipped");
+
+    let back: ApiError = serde_json::from_value(value).unwrap();
+    assert_eq!(back, err);
+}
+
+#[test]
+fn retry_policy_infers_scope_from_ids() {
+    let provider =
+        ApiError::new("provider.unavailable", ErrorStage::Embedding, "x").with_provider_id("tei");
+    assert_eq!(provider.retry_policy().retry_scope, RetryScope::Provider);
+
+    let job = ApiError::new("ledger.transaction", ErrorStage::Leasing, "x");
+    assert_eq!(job.retry_policy().retry_scope, RetryScope::Job);
+}
+
+#[test]
+fn degradation_policy_follows_severity() {
+    let degraded = ApiError::new("parser.fallback", ErrorStage::ParsingContent, "x")
+        .with_severity(ErrorSeverity::Degraded);
+    assert!(degraded.degradation_policy().degradable);
+
+    let failed = ApiError::new("vector.upsert_failed", ErrorStage::Upserting, "x");
+    assert!(!failed.degradation_policy().degradable);
+}
+
+#[test]
+fn display_never_leaks_details_or_ids() {
+    let err = ApiError::new(
+        "provider.unavailable",
+        ErrorStage::Embedding,
+        "provider down",
+    )
+    .with_visibility(ErrorVisibility::Sensitive)
+    .with_source_id("src_secret_local_path")
+    .with_context("secret_token", "hunter2");
+    let shown = err.to_string();
+    assert!(shown.contains("provider.unavailable"));
+    assert!(shown.contains("provider down"));
+    assert!(
+        !shown.contains("hunter2"),
+        "details value must not leak via Display: {shown}"
+    );
+    assert!(
+        !shown.contains("src_secret_local_path"),
+        "correlation ids must not leak via Display: {shown}"
+    );
+}
+
+#[test]
+fn provider_cooling_present_only_when_cooldown_set() {
+    let no_cool = ApiError::new("provider.unavailable", ErrorStage::Embedding, "x");
+    assert!(no_cool.provider_cooling().is_none());
+
+    let until = chrono::Utc::now();
+    let cooling = ApiError::new("provider.unavailable", ErrorStage::Embedding, "x")
+        .with_provider_id("tei")
+        .with_cooldown_until(until);
+    let cooling = cooling.provider_cooling().unwrap();
+    assert_eq!(cooling.provider_id.as_deref(), Some("tei"));
+    assert_eq!(cooling.cooldown_until, until);
+}

--- a/crates/axon-error/src/code.rs
+++ b/crates/axon-error/src/code.rs
@@ -1,3 +1,109 @@
-//! Marker module for the target `axon-error::code` boundary.
+//! Stable machine error codes.
+//!
+//! An [`ErrorCode`] is a dotted string like `provider.unavailable`. The prefix
+//! before the first `.` is its category. Classification (severity + retryable)
+//! follows the "Error Categories" table in
+//! `docs/pipeline-unification/runtime/error-handling.md`.
 
-pub const MODULE_NAME: &str = "code";
+use std::fmt;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::severity::ErrorSeverity;
+
+/// A stable, machine-readable error code (e.g. `provider.unavailable`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+#[serde(transparent)]
+#[schema(value_type = String)]
+pub struct ErrorCode(pub String);
+
+impl ErrorCode {
+    /// Construct a code from anything string-like.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// The category — the prefix before the first `.` (or the whole code).
+    pub fn category(&self) -> &str {
+        self.0.split('.').next().unwrap_or(&self.0)
+    }
+
+    /// The dotted family — everything before the final `.` segment.
+    ///
+    /// Used for prefix matching like `source.acquire`.
+    fn family(&self) -> &str {
+        match self.0.rfind('.') {
+            Some(idx) => &self.0[..idx],
+            None => &self.0,
+        }
+    }
+
+    /// Classify this code into `(severity, retryable)` per the error-handling
+    /// contract's "Error Categories" table.
+    ///
+    /// Mapping (retry column of the table):
+    /// - `command.*` / `action.*` / `route.*` / `source.scope.*` → not retryable
+    /// - `redaction.*` → fatal, not retryable
+    /// - `source.acquire.*` / `ledger.*` / `embedding.*` / `vector.*` /
+    ///   `artifact.*` / `provider.*` / `prune.*` → retryable
+    /// - `parser.*` / `graph.*` → degrade/depends → not retryable, degraded
+    /// - `auth.*` / `source.resolve.*` / `output.*` → depends → not retryable
+    /// - unknown categories default to a non-retryable failure
+    pub fn classify(&self) -> (ErrorSeverity, bool) {
+        let family = self.family();
+        let category = self.category();
+
+        // Longest-prefix families first.
+        if family == "source.acquire" {
+            return (ErrorSeverity::Failed, true);
+        }
+        if family == "source.scope" {
+            return (ErrorSeverity::Failed, false);
+        }
+        if family == "source.resolve" {
+            return (ErrorSeverity::Failed, false);
+        }
+
+        match category {
+            // Parse/validation of a command/action/route: fail fast, no retry.
+            "command" | "action" | "route" => (ErrorSeverity::Failed, false),
+            // Auth failures: depends; conservatively not retryable here.
+            "auth" => (ErrorSeverity::Failed, false),
+            // Transient acquire/store/provider failures: retryable.
+            "ledger" | "embedding" | "vector" | "artifact" | "provider" | "prune" => {
+                (ErrorSeverity::Failed, true)
+            }
+            // Parser/graph: degrade with a fallback, so not a hard retry.
+            "parser" | "graph" => (ErrorSeverity::Degraded, false),
+            // Redaction: safety boundary — fatal, never retryable.
+            "redaction" => (ErrorSeverity::Fatal, false),
+            // Output too large / write failure: depends; not retryable.
+            "output" => (ErrorSeverity::Failed, false),
+            // Anything unrecognized: safe default is a non-retryable failure.
+            _ => (ErrorSeverity::Failed, false),
+        }
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for ErrorCode {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<String> for ErrorCode {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(test)]
+#[path = "code_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/code_tests.rs
+++ b/crates/axon-error/src/code_tests.rs
@@ -1,0 +1,74 @@
+use super::*;
+use crate::severity::ErrorSeverity;
+
+#[test]
+fn category_is_prefix_before_first_dot() {
+    assert_eq!(
+        ErrorCode::from("provider.unavailable").category(),
+        "provider"
+    );
+    assert_eq!(
+        ErrorCode::from("source.acquire.fetch_failed").category(),
+        "source"
+    );
+    assert_eq!(ErrorCode::from("standalone").category(), "standalone");
+}
+
+#[test]
+fn code_serializes_transparently() {
+    let code = ErrorCode::from("provider.unavailable");
+    assert_eq!(serde_json::to_value(&code).unwrap(), "provider.unavailable");
+    let back: ErrorCode = serde_json::from_value(serde_json::json!("x.y")).unwrap();
+    assert_eq!(back, ErrorCode::from("x.y"));
+}
+
+#[test]
+fn classify_maps_codes_to_severity_and_retry() {
+    // Not retryable: command/action/route parse/validation.
+    for code in ["command.unknown", "action.removed", "route.not_found"] {
+        assert_eq!(
+            ErrorCode::from(code).classify(),
+            (ErrorSeverity::Failed, false),
+            "{code}"
+        );
+    }
+
+    // Retryable transient families.
+    for code in [
+        "source.acquire.fetch_failed",
+        "ledger.transaction",
+        "embedding.batch_failed",
+        "vector.upsert_failed",
+        "artifact.write_failed",
+        "provider.unavailable",
+        "prune.cleanup_failed",
+    ] {
+        assert_eq!(
+            ErrorCode::from(code).classify(),
+            (ErrorSeverity::Failed, true),
+            "{code}"
+        );
+    }
+
+    // Unsupported scope: not retryable.
+    assert_eq!(
+        ErrorCode::from("source.scope.unsupported").classify(),
+        (ErrorSeverity::Failed, false)
+    );
+
+    // Parser/graph degrade, not retryable.
+    assert_eq!(
+        ErrorCode::from("parser.fallback").classify(),
+        (ErrorSeverity::Degraded, false)
+    );
+    assert_eq!(
+        ErrorCode::from("graph.merge_conflict").classify(),
+        (ErrorSeverity::Degraded, false)
+    );
+
+    // Redaction: fatal, not retryable.
+    assert_eq!(
+        ErrorCode::from("redaction.leak_detected").classify(),
+        (ErrorSeverity::Fatal, false)
+    );
+}

--- a/crates/axon-error/src/context.rs
+++ b/crates/axon-error/src/context.rs
@@ -1,3 +1,122 @@
-//! Marker module for the target `axon-error::context` boundary.
+//! Redaction-aware structured error context.
+//!
+//! `axon-error` carries redaction **hints** only — the actual secret detection
+//! and redaction implementation live in `axon-core` or the renderer boundary
+//! (see `docs/pipeline-unification/crates/axon-error/README.md`). An
+//! [`ErrorContext`] entry marked non-public must never be exposed by `Display`.
 
-pub const MODULE_NAME: &str = "context";
+use std::collections::BTreeMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Where a context entry (or error) may be surfaced.
+///
+/// From the "visibility" field in the error shape: `public`, `internal`,
+/// `sensitive`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorVisibility {
+    /// Safe to render to any caller, including remote/unauthenticated.
+    Public,
+    /// Internal diagnostics; render only to internal/admin surfaces.
+    Internal,
+    /// Sensitive/secret-adjacent; never render raw, redaction required.
+    Sensitive,
+}
+
+impl ErrorVisibility {
+    /// Whether a value at this visibility may be surfaced in public output.
+    pub fn is_public(&self) -> bool {
+        matches!(self, ErrorVisibility::Public)
+    }
+}
+
+/// A single redaction-aware context detail.
+///
+/// The `value` is a redaction *hint*, not necessarily a redacted value — the
+/// renderer decides what to emit based on `visibility` and `secret_class`. When
+/// `visibility` is not `Public`, callers must not surface `value` to public
+/// output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct ErrorContextEntry {
+    /// Detail value (a redaction hint; may be a placeholder for sensitive data).
+    pub value: String,
+    /// Where this entry may be surfaced.
+    pub visibility: ErrorVisibility,
+    /// Optional secret-class hint (e.g. `api_key`, `local_path`, `token`).
+    ///
+    /// A hint only — `axon-error` does not classify or redact; downstream
+    /// crates use it to pick the correct redaction policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_class: Option<String>,
+}
+
+impl ErrorContextEntry {
+    /// A public, non-secret entry.
+    pub fn public(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            visibility: ErrorVisibility::Public,
+            secret_class: None,
+        }
+    }
+
+    /// A sensitive entry carrying an optional secret-class hint.
+    pub fn sensitive(value: impl Into<String>, secret_class: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            visibility: ErrorVisibility::Sensitive,
+            secret_class: Some(secret_class.into()),
+        }
+    }
+
+    /// Whether this entry is safe to surface in public output.
+    pub fn is_public(&self) -> bool {
+        self.visibility.is_public()
+    }
+}
+
+/// Redacted key/value error details with per-entry visibility + secret hints.
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema,
+)]
+#[serde(transparent)]
+pub struct ErrorContext {
+    /// Ordered detail map, keyed by a stable field name.
+    pub entries: BTreeMap<String, ErrorContextEntry>,
+}
+
+impl ErrorContext {
+    /// An empty context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the context has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Insert or replace an entry, returning `self` for chaining.
+    pub fn insert(mut self, key: impl Into<String>, entry: ErrorContextEntry) -> Self {
+        self.entries.insert(key.into(), entry);
+        self
+    }
+
+    /// Insert a public, non-secret detail.
+    pub fn public(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.insert(key, ErrorContextEntry::public(value))
+    }
+
+    /// Iterate only the entries safe to surface publicly.
+    pub fn public_entries(&self) -> impl Iterator<Item = (&String, &ErrorContextEntry)> {
+        self.entries.iter().filter(|(_, entry)| entry.is_public())
+    }
+}
+
+#[cfg(test)]
+#[path = "context_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/context_tests.rs
+++ b/crates/axon-error/src/context_tests.rs
@@ -1,0 +1,42 @@
+use super::*;
+
+#[test]
+fn visibility_json_names_are_snake_case() {
+    assert_eq!(
+        serde_json::to_value(ErrorVisibility::Public).unwrap(),
+        "public"
+    );
+    assert_eq!(
+        serde_json::to_value(ErrorVisibility::Internal).unwrap(),
+        "internal"
+    );
+    assert_eq!(
+        serde_json::to_value(ErrorVisibility::Sensitive).unwrap(),
+        "sensitive"
+    );
+}
+
+#[test]
+fn public_entries_exclude_sensitive() {
+    let ctx = ErrorContext::new()
+        .public("provider", "tei")
+        .insert("token", ErrorContextEntry::sensitive("REDACTED", "api_key"));
+
+    let public: Vec<_> = ctx.public_entries().map(|(k, _)| k.clone()).collect();
+    assert_eq!(public, vec!["provider".to_string()]);
+    assert!(!ctx.entries["token"].is_public());
+    assert_eq!(
+        ctx.entries["token"].secret_class.as_deref(),
+        Some("api_key")
+    );
+}
+
+#[test]
+fn context_round_trips_serde() {
+    let ctx = ErrorContext::new()
+        .public("provider", "tei")
+        .insert("token", ErrorContextEntry::sensitive("REDACTED", "api_key"));
+    let value = serde_json::to_value(&ctx).unwrap();
+    let back: ErrorContext = serde_json::from_value(value).unwrap();
+    assert_eq!(back, ctx);
+}

--- a/crates/axon-error/src/conversion.rs
+++ b/crates/axon-error/src/conversion.rs
@@ -1,3 +1,50 @@
-//! Marker module for the target `axon-error::conversion` boundary.
+//! The error-projection boundary.
+//!
+//! [`IntoApiError`] is the single conversion trait every domain/provider/store
+//! error implements so it can be projected into the shared [`ApiError`] shape
+//! without exposing provider internals. Concrete provider/store specifics live
+//! in their own crates — `axon-error` only provides the trait and generic
+//! helpers.
 
-pub const MODULE_NAME: &str = "conversion";
+use crate::api_error::ApiError;
+use crate::code::ErrorCode;
+use crate::stage::ErrorStage;
+
+/// Project a domain/provider/store error into the shared [`ApiError`].
+///
+/// This is the "ErrorProjection" boundary: implementers map their root-cause
+/// class into a stable code + stage + redacted message, never leaking raw
+/// provider internals into `message` or `details`.
+pub trait IntoApiError {
+    /// Convert `self` into the shared error shape.
+    fn into_api_error(self) -> ApiError;
+}
+
+impl IntoApiError for ApiError {
+    fn into_api_error(self) -> ApiError {
+        self
+    }
+}
+
+/// Build an [`ApiError`] from parts, deriving severity/retryable from the code.
+///
+/// A generic helper for conversions that only have a code, stage, and a
+/// redacted message.
+pub fn api_error_from_parts(
+    code: impl Into<ErrorCode>,
+    stage: ErrorStage,
+    message: impl Into<String>,
+) -> ApiError {
+    ApiError::new(code, stage, message)
+}
+
+/// Project any `IntoApiError` value.
+///
+/// Convenience wrapper so call sites can write `project(err)` uniformly.
+pub fn project(error: impl IntoApiError) -> ApiError {
+    error.into_api_error()
+}
+
+#[cfg(test)]
+#[path = "conversion_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/conversion_tests.rs
+++ b/crates/axon-error/src/conversion_tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+use crate::stage::ErrorStage;
+
+struct FakeProviderError {
+    detail: String,
+}
+
+impl IntoApiError for FakeProviderError {
+    fn into_api_error(self) -> ApiError {
+        // Projects a root-cause class to a stable code without leaking the raw
+        // provider detail into the public message.
+        ApiError::new(
+            "provider.unavailable",
+            ErrorStage::Embedding,
+            "Embedding provider is unavailable.",
+        )
+        .with_context("root_cause_class", "network")
+        .with_context("detail_len", self.detail.len().to_string())
+    }
+}
+
+#[test]
+fn into_api_error_projects_without_exposing_internals() {
+    let err = FakeProviderError {
+        detail: "tcp connect timeout to 10.0.0.5:443".to_string(),
+    };
+    let api = project(err);
+    assert_eq!(
+        api.code,
+        crate::code::ErrorCode::from("provider.unavailable")
+    );
+    assert!(api.retryable);
+    assert!(!api.message.contains("10.0.0.5"));
+}
+
+#[test]
+fn api_error_into_api_error_is_identity() {
+    let err = ApiError::new("vector.upsert_failed", ErrorStage::Upserting, "boom");
+    assert_eq!(err.clone().into_api_error(), err);
+}
+
+#[test]
+fn from_parts_derives_classification() {
+    let err = api_error_from_parts("provider.unavailable", ErrorStage::Embedding, "down");
+    assert!(err.retryable);
+}

--- a/crates/axon-error/src/cooling.rs
+++ b/crates/axon-error/src/cooling.rs
@@ -1,3 +1,48 @@
-//! Marker module for the target `axon-error::cooling` boundary.
+//! Provider saturation / cool-down classification.
+//!
+//! See "Provider cooling" in
+//! `docs/pipeline-unification/runtime/error-handling.md`.
 
-pub const MODULE_NAME: &str = "cooling";
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// A provider cooling window that prevents tight retry loops.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct ProviderCooling {
+    /// The provider that is cooling, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    /// When the cooling window ends.
+    pub cooldown_until: DateTime<Utc>,
+    /// Human-readable reason for the cooling window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl ProviderCooling {
+    /// Construct a cooling window ending at `cooldown_until`.
+    pub fn new(cooldown_until: DateTime<Utc>) -> Self {
+        Self {
+            provider_id: None,
+            cooldown_until,
+            reason: None,
+        }
+    }
+
+    /// Attach the cooling provider id.
+    pub fn with_provider(mut self, provider_id: impl Into<String>) -> Self {
+        self.provider_id = Some(provider_id.into());
+        self
+    }
+
+    /// Attach a reason.
+    pub fn with_reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason = Some(reason.into());
+        self
+    }
+}
+
+#[cfg(test)]
+#[path = "cooling_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/cooling_tests.rs
+++ b/crates/axon-error/src/cooling_tests.rs
@@ -1,0 +1,22 @@
+use super::*;
+use chrono::{TimeZone, Utc};
+
+#[test]
+fn cooling_builder_sets_fields() {
+    let until = Utc.with_ymd_and_hms(2026, 6, 30, 20, 25, 0).unwrap();
+    let cooling = ProviderCooling::new(until)
+        .with_provider("tei")
+        .with_reason("rate limited");
+    assert_eq!(cooling.provider_id.as_deref(), Some("tei"));
+    assert_eq!(cooling.cooldown_until, until);
+    assert_eq!(cooling.reason.as_deref(), Some("rate limited"));
+}
+
+#[test]
+fn round_trips_serde() {
+    let until = Utc.with_ymd_and_hms(2026, 6, 30, 20, 25, 0).unwrap();
+    let cooling = ProviderCooling::new(until).with_provider("tei");
+    let value = serde_json::to_value(&cooling).unwrap();
+    let back: ProviderCooling = serde_json::from_value(value).unwrap();
+    assert_eq!(back, cooling);
+}

--- a/crates/axon-error/src/degradation.rs
+++ b/crates/axon-error/src/degradation.rs
@@ -1,3 +1,41 @@
-//! Marker module for the target `axon-error::degradation` boundary.
+//! Graceful-degradation decisions.
+//!
+//! See "Degraded vs Failed" in
+//! `docs/pipeline-unification/runtime/error-handling.md`.
 
-pub const MODULE_NAME: &str = "degradation";
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Whether an error path can degrade rather than fail, and why.
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema,
+)]
+pub struct DegradationPolicy {
+    /// Whether the pipeline may degrade (continue with reduced behavior).
+    pub degradable: bool,
+    /// Human-readable reason for the degradation decision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl DegradationPolicy {
+    /// A policy that permits degradation with a reason.
+    pub fn degradable(reason: impl Into<String>) -> Self {
+        Self {
+            degradable: true,
+            reason: Some(reason.into()),
+        }
+    }
+
+    /// A policy that forbids degradation (required work must fail hard).
+    pub fn not_degradable() -> Self {
+        Self {
+            degradable: false,
+            reason: None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "degradation_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/degradation_tests.rs
+++ b/crates/axon-error/src/degradation_tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[test]
+fn degradable_carries_reason() {
+    let policy = DegradationPolicy::degradable("optional graph extraction failed");
+    assert!(policy.degradable);
+    assert_eq!(
+        policy.reason.as_deref(),
+        Some("optional graph extraction failed")
+    );
+}
+
+#[test]
+fn not_degradable_has_no_reason() {
+    let policy = DegradationPolicy::not_degradable();
+    assert!(!policy.degradable);
+    assert!(policy.reason.is_none());
+}
+
+#[test]
+fn round_trips_serde() {
+    let policy = DegradationPolicy::degradable("fallback used");
+    let value = serde_json::to_value(&policy).unwrap();
+    let back: DegradationPolicy = serde_json::from_value(value).unwrap();
+    assert_eq!(back, policy);
+}

--- a/crates/axon-error/src/lib.rs
+++ b/crates/axon-error/src/lib.rs
@@ -1,7 +1,13 @@
-//! Target pipeline crate skeleton for `axon-error`.
+//! Shared error taxonomy for the unified Axon pipeline.
 //!
-//! This crate is intentionally marker-only in PR0. Runtime behavior moves here
-//! in issue #298 implementation PRs after contract tests exist.
+//! `axon-error` is the lowest shared error boundary: it owns the typed error
+//! taxonomy ([`ApiError`], [`ErrorCode`], [`ErrorStage`], [`ErrorSeverity`],
+//! [`ErrorVisibility`]) plus retry / cooling / degradation classifications and
+//! redaction-aware context. It depends on no other Axon crate, so every crate
+//! can report failures through it without forming a cycle.
+//!
+//! Contract: `docs/pipeline-unification/crates/axon-error/README.md`; behavior
+//! spec: `docs/pipeline-unification/runtime/error-handling.md`.
 
 pub mod api_error;
 pub mod code;
@@ -13,5 +19,15 @@ pub mod retry;
 pub mod severity;
 pub mod stage;
 pub mod testing;
+
+pub use api_error::ApiError;
+pub use code::ErrorCode;
+pub use context::{ErrorContext, ErrorContextEntry, ErrorVisibility};
+pub use conversion::{IntoApiError, api_error_from_parts, project};
+pub use cooling::ProviderCooling;
+pub use degradation::DegradationPolicy;
+pub use retry::{RetryPolicy, RetryScope};
+pub use severity::ErrorSeverity;
+pub use stage::ErrorStage;
 
 pub const CRATE_NAME: &str = "axon-error";

--- a/crates/axon-error/src/retry.rs
+++ b/crates/axon-error/src/retry.rs
@@ -1,3 +1,87 @@
-//! Marker module for the target `axon-error::retry` boundary.
+//! Machine-readable retry / fail-fast classification.
+//!
+//! Fields come from the "Retry and Cooling" section of
+//! `docs/pipeline-unification/runtime/error-handling.md`.
 
-pub const MODULE_NAME: &str = "retry";
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// The scope a retry decision applies to.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryScope {
+    /// A single source item.
+    Item,
+    /// A single document.
+    Document,
+    /// A pipeline phase.
+    Phase,
+    /// The whole job.
+    Job,
+    /// A provider (cooling window applies).
+    Provider,
+}
+
+/// Machine-readable retry policy for an error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct RetryPolicy {
+    /// Whether retry may succeed.
+    pub retryable: bool,
+    /// Minimum delay before a retry, in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_ms: Option<u64>,
+    /// Current attempt number.
+    pub attempt: u32,
+    /// Configured max attempts, if bounded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_attempts: Option<u32>,
+    /// Next backoff duration, in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backoff_ms: Option<u64>,
+    /// Provider/source cooling window, if active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_until: Option<DateTime<Utc>>,
+    /// The scope this retry decision applies to.
+    pub retry_scope: RetryScope,
+}
+
+impl RetryPolicy {
+    /// A non-retryable, fail-fast policy scoped to a single item.
+    pub fn fail_fast() -> Self {
+        Self {
+            retryable: false,
+            retry_after_ms: None,
+            attempt: 0,
+            max_attempts: None,
+            backoff_ms: None,
+            cooldown_until: None,
+            retry_scope: RetryScope::Item,
+        }
+    }
+
+    /// A retryable policy for a transient failure at the given scope.
+    pub fn retryable(retry_scope: RetryScope) -> Self {
+        Self {
+            retryable: true,
+            retry_after_ms: None,
+            attempt: 0,
+            max_attempts: None,
+            backoff_ms: None,
+            cooldown_until: None,
+            retry_scope,
+        }
+    }
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self::fail_fast()
+    }
+}
+
+#[cfg(test)]
+#[path = "retry_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/retry_tests.rs
+++ b/crates/axon-error/src/retry_tests.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+#[test]
+fn retry_scope_json_names_are_snake_case() {
+    let cases = [
+        (RetryScope::Item, "item"),
+        (RetryScope::Document, "document"),
+        (RetryScope::Phase, "phase"),
+        (RetryScope::Job, "job"),
+        (RetryScope::Provider, "provider"),
+    ];
+    for (scope, name) in cases {
+        assert_eq!(serde_json::to_value(scope).unwrap(), name);
+    }
+}
+
+#[test]
+fn fail_fast_is_not_retryable() {
+    let policy = RetryPolicy::fail_fast();
+    assert!(!policy.retryable);
+    assert_eq!(policy.retry_scope, RetryScope::Item);
+}
+
+#[test]
+fn retry_policy_round_trips_serde() {
+    let policy = RetryPolicy::retryable(RetryScope::Provider);
+    let value = serde_json::to_value(&policy).unwrap();
+    let back: RetryPolicy = serde_json::from_value(value).unwrap();
+    assert_eq!(back, policy);
+}

--- a/crates/axon-error/src/severity.rs
+++ b/crates/axon-error/src/severity.rs
@@ -1,3 +1,39 @@
-//! Marker module for the target `axon-error::severity` boundary.
+//! Error severity classification.
+//!
+//! Semantics come from the "Severity Semantics" table in
+//! `docs/pipeline-unification/runtime/error-handling.md`.
 
-pub const MODULE_NAME: &str = "severity";
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// How severe an error is and whether it terminates the item/job.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorSeverity {
+    /// Informational event; not terminal.
+    Info,
+    /// Non-fatal issue, full behavior preserved; not terminal.
+    Warning,
+    /// Behavior reduced but acceptable by policy; may or may not be terminal.
+    Degraded,
+    /// Required work failed; terminal for the affected item/job.
+    Failed,
+    /// Cannot continue safely; terminal.
+    Fatal,
+}
+
+impl ErrorSeverity {
+    /// Whether this severity terminates the affected item/job.
+    ///
+    /// `Failed` and `Fatal` are terminal; `Info`, `Warning`, and `Degraded`
+    /// are not.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, ErrorSeverity::Failed | ErrorSeverity::Fatal)
+    }
+}
+
+#[cfg(test)]
+#[path = "severity_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/severity_tests.rs
+++ b/crates/axon-error/src/severity_tests.rs
@@ -1,0 +1,24 @@
+use super::*;
+
+#[test]
+fn severity_json_names_are_snake_case() {
+    let cases = [
+        (ErrorSeverity::Info, "info"),
+        (ErrorSeverity::Warning, "warning"),
+        (ErrorSeverity::Degraded, "degraded"),
+        (ErrorSeverity::Failed, "failed"),
+        (ErrorSeverity::Fatal, "fatal"),
+    ];
+    for (severity, name) in cases {
+        assert_eq!(serde_json::to_value(severity).unwrap(), name);
+    }
+}
+
+#[test]
+fn is_terminal_matches_contract() {
+    assert!(!ErrorSeverity::Info.is_terminal());
+    assert!(!ErrorSeverity::Warning.is_terminal());
+    assert!(!ErrorSeverity::Degraded.is_terminal());
+    assert!(ErrorSeverity::Failed.is_terminal());
+    assert!(ErrorSeverity::Fatal.is_terminal());
+}

--- a/crates/axon-error/src/stage.rs
+++ b/crates/axon-error/src/stage.rs
@@ -1,3 +1,64 @@
-//! Marker module for the target `axon-error::stage` boundary.
+//! Pipeline/transport stage each error is attributed to.
+//!
+//! Stage values come from the "Stage Values" table in
+//! `docs/pipeline-unification/runtime/error-handling.md`. Serialized JSON names
+//! are stable snake_case and must not change without a schema revision.
 
-pub const MODULE_NAME: &str = "stage";
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Pipeline/transport stage an error is attributed to.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorStage {
+    /// CLI/MCP/REST request parse, removed command/action.
+    Parsing,
+    /// Missing fields, bad types, unsupported flags.
+    Validation,
+    /// Source resolution, canonical URI, authority.
+    Resolving,
+    /// Adapter/scope/provider selection.
+    Routing,
+    /// Auth, credentials, execution policy.
+    Authorizing,
+    /// Source plan, prune plan.
+    Planning,
+    /// Job/watch/source lease.
+    Leasing,
+    /// Manifest/map discovery.
+    Discovering,
+    /// Manifest diff.
+    Diffing,
+    /// HTTP/git/package/local/MCP/CLI fetch.
+    Fetching,
+    /// Browser/CDP/render provider.
+    Rendering,
+    /// SourceDocument creation.
+    Normalizing,
+    /// Parser facts/chunk parser (serialized as `parsing_content`).
+    ParsingContent,
+    /// Graph writes/merge/conflict.
+    Graphing,
+    /// Chunking/PreparedDocument.
+    Preparing,
+    /// Embedding provider/batch.
+    Embedding,
+    /// VectorStore writes.
+    Upserting,
+    /// Generation publish.
+    Publishing,
+    /// Cleanup/prune/dedupe.
+    Cleaning,
+    /// Query/retrieve context.
+    Retrieving,
+    /// LLM synthesis.
+    Synthesizing,
+    /// Progress/log/status emit.
+    Observing,
+}
+
+#[cfg(test)]
+#[path = "stage_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/stage_tests.rs
+++ b/crates/axon-error/src/stage_tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn stage_json_names_are_snake_case_and_stable() {
+    let cases = [
+        (ErrorStage::Parsing, "parsing"),
+        (ErrorStage::Validation, "validation"),
+        (ErrorStage::Resolving, "resolving"),
+        (ErrorStage::Routing, "routing"),
+        (ErrorStage::Authorizing, "authorizing"),
+        (ErrorStage::Planning, "planning"),
+        (ErrorStage::Leasing, "leasing"),
+        (ErrorStage::Discovering, "discovering"),
+        (ErrorStage::Diffing, "diffing"),
+        (ErrorStage::Fetching, "fetching"),
+        (ErrorStage::Rendering, "rendering"),
+        (ErrorStage::Normalizing, "normalizing"),
+        (ErrorStage::ParsingContent, "parsing_content"),
+        (ErrorStage::Graphing, "graphing"),
+        (ErrorStage::Preparing, "preparing"),
+        (ErrorStage::Embedding, "embedding"),
+        (ErrorStage::Upserting, "upserting"),
+        (ErrorStage::Publishing, "publishing"),
+        (ErrorStage::Cleaning, "cleaning"),
+        (ErrorStage::Retrieving, "retrieving"),
+        (ErrorStage::Synthesizing, "synthesizing"),
+        (ErrorStage::Observing, "observing"),
+    ];
+    assert_eq!(cases.len(), 22, "expected 22 stage variants covered");
+    for (stage, name) in cases {
+        assert_eq!(serde_json::to_value(stage).unwrap(), name);
+        let back: ErrorStage = serde_json::from_value(serde_json::json!(name)).unwrap();
+        assert_eq!(back, stage);
+    }
+}

--- a/crates/axon-error/src/testing.rs
+++ b/crates/axon-error/src/testing.rs
@@ -1,3 +1,59 @@
-//! Marker module for the target `axon-error::testing` boundary.
+//! Fixture errors and fakes for tests and schema snapshots.
+//!
+//! These builders produce stable, deterministic [`ApiError`] values so tests
+//! and generated schema snapshots stay reproducible.
 
-pub const MODULE_NAME: &str = "testing";
+use chrono::{DateTime, TimeZone, Utc};
+
+use crate::api_error::ApiError;
+use crate::context::ErrorVisibility;
+use crate::severity::ErrorSeverity;
+use crate::stage::ErrorStage;
+
+/// A fixed timestamp used by fixtures for reproducible snapshots.
+fn fixture_cooldown() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 30, 20, 25, 0)
+        .single()
+        .expect("fixture cooldown timestamp is a valid, unambiguous UTC instant")
+}
+
+/// Construct a minimal test error from a code string and stage.
+pub fn test_error(code: &str, stage: ErrorStage) -> ApiError {
+    ApiError::new(code, stage, format!("test error: {code}"))
+}
+
+/// A retryable provider-outage error (embedding provider unavailable, cooling).
+pub fn retryable_provider_outage() -> ApiError {
+    ApiError::new(
+        "provider.unavailable",
+        ErrorStage::Embedding,
+        "Embedding provider is unavailable.",
+    )
+    .with_provider_id("tei")
+    .with_context("provider", "tei")
+    .with_cooldown_until(fixture_cooldown())
+}
+
+/// A fatal config-failure error (redaction/config safety boundary).
+pub fn fatal_config_failure() -> ApiError {
+    ApiError::new(
+        "redaction.config_invalid",
+        ErrorStage::Validation,
+        "Content could not be safely processed.",
+    )
+    .with_visibility(ErrorVisibility::Internal)
+}
+
+/// A degraded parser error (parser fell back but chunks remain citable).
+pub fn degraded_parser() -> ApiError {
+    ApiError::new(
+        "parser.fallback",
+        ErrorStage::ParsingContent,
+        "Parser fell back to a generic strategy.",
+    )
+    .with_severity(ErrorSeverity::Degraded)
+}
+
+#[cfg(test)]
+#[path = "testing_tests.rs"]
+mod tests;

--- a/crates/axon-error/src/testing_tests.rs
+++ b/crates/axon-error/src/testing_tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+use crate::context::ErrorVisibility;
+use crate::severity::ErrorSeverity;
+
+#[test]
+fn test_error_uses_code_and_stage() {
+    let err = test_error("vector.upsert_failed", ErrorStage::Upserting);
+    assert_eq!(err.stage, ErrorStage::Upserting);
+    assert_eq!(err.code.to_string(), "vector.upsert_failed");
+}
+
+#[test]
+fn retryable_provider_outage_is_retryable_and_cooling() {
+    let err = retryable_provider_outage();
+    assert!(err.retryable);
+    assert_eq!(err.provider_id.as_deref(), Some("tei"));
+    assert!(err.provider_cooling().is_some());
+}
+
+#[test]
+fn fatal_config_failure_is_fatal_internal() {
+    let err = fatal_config_failure();
+    assert_eq!(err.severity, ErrorSeverity::Fatal);
+    assert!(!err.retryable);
+    assert_eq!(err.visibility, ErrorVisibility::Internal);
+}
+
+#[test]
+fn degraded_parser_is_degraded() {
+    let err = degraded_parser();
+    assert_eq!(err.severity, ErrorSeverity::Degraded);
+    assert!(err.degradation_policy().degradable);
+}
+
+#[test]
+fn fixtures_round_trip_serde() {
+    for err in [
+        retryable_provider_outage(),
+        fatal_config_failure(),
+        degraded_parser(),
+    ] {
+        let value = serde_json::to_value(&err).unwrap();
+        let back: ApiError = serde_json::from_value(value).unwrap();
+        assert_eq!(back, err);
+    }
+}

--- a/xtask/src/checks/repo_structure_spec.rs
+++ b/xtask/src/checks/repo_structure_spec.rs
@@ -1,5 +1,9 @@
 pub const REQUIRED_WORKSPACE_MEMBERS: &[&str] = &[
     "xtask",
+    // axon-error graduated from the PR0 skeleton in Phase 1 (issue #298): it now
+    // carries real dependencies and sidecar tests, so it is a required member
+    // rather than a `TARGET_CRATES` skeleton entry.
+    "crates/axon-error",
     "crates/axon-api",
     "crates/axon-authz",
     "crates/axon-core",
@@ -21,22 +25,11 @@ pub struct TargetCrate {
     pub modules: &'static [&'static str],
 }
 
+// NOTE: `axon-error` is intentionally NOT listed here. It was filled in during
+// Phase 1 (issue #298) — real dependencies, sidecar tests, and public API — so
+// it is no longer an empty PR0 skeleton and is instead a required workspace
+// member (see `REQUIRED_WORKSPACE_MEMBERS`).
 pub const TARGET_CRATES: &[TargetCrate] = &[
-    TargetCrate {
-        name: "axon-error",
-        modules: &[
-            "api_error",
-            "code",
-            "stage",
-            "severity",
-            "retry",
-            "degradation",
-            "cooling",
-            "context",
-            "conversion",
-            "testing",
-        ],
-    },
     TargetCrate {
         name: "axon-observe",
         modules: &[

--- a/xtask/src/checks/repo_structure_tests.rs
+++ b/xtask/src/checks/repo_structure_tests.rs
@@ -184,13 +184,13 @@ fn unexpected_target_module_file_fails() {
 fn target_dependency_fails() {
     let fixture = complete_fixture();
     write(
-        &fixture.root.join("crates/axon-error/Cargo.toml"),
-        "[package]\nname = \"axon-error\"\nrust-version.workspace = true\n\n[dependencies]\naxon-services = { path = \"../axon-services\" }\n",
+        &fixture.root.join("crates/axon-observe/Cargo.toml"),
+        "[package]\nname = \"axon-observe\"\nrust-version.workspace = true\n\n[dependencies]\naxon-services = { path = \"../axon-services\" }\n",
     );
 
     let err = check_root(&fixture.root).unwrap_err();
     assert!(
-        err.contains("PR0 target crate axon-error must keep [dependencies] empty"),
+        err.contains("PR0 target crate axon-observe must keep [dependencies] empty"),
         "{err}"
     );
 }
@@ -199,13 +199,15 @@ fn target_dependency_fails() {
 fn target_specific_dependency_fails() {
     let fixture = complete_fixture();
     write(
-        &fixture.root.join("crates/axon-error/Cargo.toml"),
-        "[package]\nname = \"axon-error\"\nrust-version.workspace = true\n\n[target.'cfg(unix)'.dependencies]\naxon-services = { path = \"../axon-services\" }\n",
+        &fixture.root.join("crates/axon-observe/Cargo.toml"),
+        "[package]\nname = \"axon-observe\"\nrust-version.workspace = true\n\n[target.'cfg(unix)'.dependencies]\naxon-services = { path = \"../axon-services\" }\n",
     );
 
     let err = check_root(&fixture.root).unwrap_err();
     assert!(
-        err.contains("PR0 target crate axon-error must keep [target.cfg(unix).dependencies] empty"),
+        err.contains(
+            "PR0 target crate axon-observe must keep [target.cfg(unix).dependencies] empty"
+        ),
         "{err}"
     );
 }
@@ -214,8 +216,8 @@ fn target_specific_dependency_fails() {
 fn package_metadata_dependencies_are_allowed() {
     let fixture = complete_fixture();
     write(
-        &fixture.root.join("crates/axon-error/Cargo.toml"),
-        "[package]\nname = \"axon-error\"\nrust-version.workspace = true\n\n[package.metadata.dependencies]\nnotes = \"not a Cargo dependency table\"\n\n[dependencies]\n",
+        &fixture.root.join("crates/axon-observe/Cargo.toml"),
+        "[package]\nname = \"axon-observe\"\nrust-version.workspace = true\n\n[package.metadata.dependencies]\nnotes = \"not a Cargo dependency table\"\n\n[dependencies]\n",
     );
 
     check_root(&fixture.root).unwrap();


### PR DESCRIPTION
Completes the Phase-1 error-taxonomy items of #298 that #303 (DTO spine) merged without.

## What
- **axon-error** filled in (dependency-free, lowest crate): `ErrorStage` (22), `ErrorSeverity`, `ErrorVisibility`, `ErrorCode`+classify, `ApiError` (correlation ids as strings), `RetryPolicy`/`DegradationPolicy`/`ProviderCooling`, `ErrorContext`, conversion trait, testing fixtures + sidecar tests.
- **axon-api** depends on axon-error and re-exports `ApiError` instead of defining it locally (was in `source/status.rs`).
- **stage-result fixtures**: success/degraded/failed for all stage-result types.
- **xtask**: graduated `axon-error` out of the PR0 skeleton guard (other skeletons still guarded).

## Verified
cargo check ✓ · cargo test (148) ✓ · cargo fmt ✓ · clippy ✓ (1 pre-existing `large_enum_variant` on baseline) · `cargo xtask check` **All checks passed**.

## Out of scope
Removed-field rejection tests (blocked on PR 3 schema generator).

Unblocks codex's Phase 3 (stores/providers return `Result<_, ApiError>`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a shared error taxonomy in `axon-error` and wire `axon-api` to use and re-export it. This completes Phase 1 of #298 and standardizes error shape, classification, and retry/cooling across the pipeline.

- **New Features**
  - `axon-error`: adds `ApiError` (code, stage, severity, visibility, retry/cooling/degradation, redaction-aware context; string correlation IDs), `ErrorCode::classify`, `ErrorStage` (22), `ErrorSeverity`, `ErrorVisibility`, `RetryPolicy`, `DegradationPolicy`, `ProviderCooling`, and `IntoApiError` + helpers and fixtures with sidecar tests.
  - `axon-api`: now depends on `axon-error` and re-exports `ApiError`/enums; removes the local `ApiError`. Adds success/degraded/failed stage-result fixtures with serde round-trip tests, asserting the shared `ApiError` embeds cleanly. `xtask` updated to graduate `axon-error` from the PR0 skeleton.

- **Migration**
  - Use `axon_api::source::status::ApiError` (re-exported from `axon-error`) and update any stage/severity/visibility enum references.
  - Providers/stores should return `Result<_, ApiError>` and, where needed, implement `IntoApiError` to project local errors into the shared shape.

<sup>Written for commit 063b9bbe578cc955457d80158121a2b73866d7c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

