### PR TITLE
Implement source resolver router registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,13 @@ version = "6.2.1"
 [[package]]
 name = "axon-route"
 version = "6.2.1"
+dependencies = [
+ "axon-api",
+ "axon-error",
+ "hex",
+ "sha2 0.11.0",
+ "url",
+]
 
 [[package]]
 name = "axon-services"

--- a/crates/axon-route/Cargo.toml
+++ b/crates/axon-route/Cargo.toml
@@ -7,3 +7,8 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+axon-api = { path = "../axon-api" }
+axon-error = { path = "../axon-error" }
+hex = "0.4"
+sha2 = "0.11"
+url = "2"

--- a/crates/axon-route/src/alias.rs
+++ b/crates/axon-route/src/alias.rs
@@ -1,3 +1,22 @@
-//! Marker module for the target `axon-route::alias` boundary.
+//! Alias records used by authority resolution.
 
-pub const MODULE_NAME: &str = "alias";
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AliasRecord {
+    pub alias: String,
+    pub authority_id: String,
+    pub reason: String,
+}
+
+impl AliasRecord {
+    pub fn new(
+        alias: impl Into<String>,
+        authority_id: impl Into<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            alias: alias.into(),
+            authority_id: authority_id.into(),
+            reason: reason.into(),
+        }
+    }
+}

--- a/crates/axon-route/src/authority.rs
+++ b/crates/axon-route/src/authority.rs
@@ -1,6 +1,7 @@
 //! Authority and alias records used during source resolution.
 
 use axon_api::{AuthorityLevel, SourceKind, SourceScope};
+use url::Url;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AuthorityRecord {
@@ -24,7 +25,7 @@ impl AuthorityRecord {
         let canonical_uri = canonical_uri.into();
         Self {
             authority_id: authority_id.into(),
-            adapter_hint: adapter_hint_for_uri(&canonical_uri),
+            adapter_hint: adapter_hint_for_uri(&canonical_uri, source_kind),
             canonical_uri,
             source_kind,
             authority,
@@ -60,7 +61,7 @@ pub struct InMemoryAuthorityRegistry {
     records: Vec<AuthorityRecord>,
 }
 
-fn adapter_hint_for_uri(uri: &str) -> Option<String> {
+fn adapter_hint_for_uri(uri: &str, source_kind: SourceKind) -> Option<String> {
     let hint = if uri.starts_with("github://") {
         "github"
     } else if uri.starts_with("gitlab://") {
@@ -89,6 +90,10 @@ fn adapter_hint_for_uri(uri: &str) -> Option<String> {
         "cli"
     } else if uri.starts_with("mcp://") {
         "mcp"
+    } else if source_kind == SourceKind::Git
+        && (uri.starts_with("http://") || uri.starts_with("https://"))
+    {
+        adapter_hint_for_http_uri(uri)?
     } else if uri.starts_with("http://") || uri.starts_with("https://") {
         "web"
     } else {
@@ -119,10 +124,35 @@ impl InMemoryAuthorityRegistry {
 }
 
 fn normalize_alias(value: &str) -> String {
-    value
-        .trim()
+    let lower = value.trim().to_ascii_lowercase();
+    lower
+        .as_str()
         .trim_start_matches("https://")
         .trim_start_matches("http://")
         .trim_end_matches('/')
-        .to_ascii_lowercase()
+        .to_string()
+}
+
+fn adapter_hint_for_http_uri(uri: &str) -> Option<&'static str> {
+    let url = Url::parse(uri).ok()?;
+    let host = url.host_str()?.trim_start_matches("www.");
+    if host == "github.com" || host.ends_with(".github.com") {
+        Some("github")
+    } else if host == "gitlab.com" || host.ends_with(".gitlab.com") || host.starts_with("gitlab.") {
+        Some("gitlab")
+    } else if host == "codeberg.org"
+        || host.ends_with(".codeberg.org")
+        || host == "gitea.com"
+        || host.ends_with(".gitea.com")
+        || host == "forgejo.org"
+        || host.ends_with(".forgejo.org")
+        || host.starts_with("gitea.")
+        || host.starts_with("forgejo.")
+    {
+        Some("gitea")
+    } else if url.path().trim_end_matches('/').ends_with(".git") {
+        Some("git")
+    } else {
+        Some("web")
+    }
 }

--- a/crates/axon-route/src/authority.rs
+++ b/crates/axon-route/src/authority.rs
@@ -1,3 +1,71 @@
-//! Marker module for the target `axon-route::authority` boundary.
+//! Authority and alias records used during source resolution.
 
-pub const MODULE_NAME: &str = "authority";
+use axon_api::{AuthorityLevel, SourceKind, SourceScope};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuthorityRecord {
+    pub authority_id: String,
+    pub canonical_uri: String,
+    pub source_kind: SourceKind,
+    pub authority: AuthorityLevel,
+    pub aliases: Vec<String>,
+    pub entrypoints: Vec<(SourceScope, String)>,
+    pub confidence: f32,
+}
+
+impl AuthorityRecord {
+    pub fn new(
+        authority_id: impl Into<String>,
+        canonical_uri: impl Into<String>,
+        source_kind: SourceKind,
+        authority: AuthorityLevel,
+    ) -> Self {
+        Self {
+            authority_id: authority_id.into(),
+            canonical_uri: canonical_uri.into(),
+            source_kind,
+            authority,
+            aliases: Vec::new(),
+            entrypoints: Vec::new(),
+            confidence: 1.0,
+        }
+    }
+
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.aliases.push(normalize_alias(&alias.into()));
+        self
+    }
+
+    pub fn with_entrypoint(mut self, scope: SourceScope, uri: impl Into<String>) -> Self {
+        self.entrypoints.push((scope, uri.into()));
+        self
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryAuthorityRegistry {
+    records: Vec<AuthorityRecord>,
+}
+
+impl InMemoryAuthorityRegistry {
+    pub fn from_records(records: Vec<AuthorityRecord>) -> Self {
+        Self { records }
+    }
+
+    pub fn find(&self, raw_source: &str) -> Option<&AuthorityRecord> {
+        let alias = normalize_alias(raw_source);
+        self.records.iter().find(|record| {
+            normalize_alias(&record.canonical_uri) == alias
+                || record.aliases.iter().any(|candidate| candidate == &alias)
+        })
+    }
+}
+
+fn normalize_alias(value: &str) -> String {
+    value
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}

--- a/crates/axon-route/src/authority.rs
+++ b/crates/axon-route/src/authority.rs
@@ -48,6 +48,11 @@ impl AuthorityRecord {
         self.adapter_hint = Some(adapter.into());
         self
     }
+
+    pub fn with_confidence(mut self, confidence: f32) -> Self {
+        self.confidence = confidence.clamp(0.0, 1.0);
+        self
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -98,11 +103,18 @@ impl InMemoryAuthorityRegistry {
     }
 
     pub fn find(&self, raw_source: &str) -> Option<&AuthorityRecord> {
+        self.matches(raw_source).into_iter().next()
+    }
+
+    pub fn matches(&self, raw_source: &str) -> Vec<&AuthorityRecord> {
         let alias = normalize_alias(raw_source);
-        self.records.iter().find(|record| {
-            normalize_alias(&record.canonical_uri) == alias
-                || record.aliases.iter().any(|candidate| candidate == &alias)
-        })
+        self.records
+            .iter()
+            .filter(|record| {
+                normalize_alias(&record.canonical_uri) == alias
+                    || record.aliases.iter().any(|candidate| candidate == &alias)
+            })
+            .collect()
     }
 }
 

--- a/crates/axon-route/src/authority.rs
+++ b/crates/axon-route/src/authority.rs
@@ -10,6 +10,7 @@ pub struct AuthorityRecord {
     pub authority: AuthorityLevel,
     pub aliases: Vec<String>,
     pub entrypoints: Vec<(SourceScope, String)>,
+    pub adapter_hint: Option<String>,
     pub confidence: f32,
 }
 
@@ -20,9 +21,11 @@ impl AuthorityRecord {
         source_kind: SourceKind,
         authority: AuthorityLevel,
     ) -> Self {
+        let canonical_uri = canonical_uri.into();
         Self {
             authority_id: authority_id.into(),
-            canonical_uri: canonical_uri.into(),
+            adapter_hint: adapter_hint_for_uri(&canonical_uri),
+            canonical_uri,
             source_kind,
             authority,
             aliases: Vec::new(),
@@ -40,11 +43,53 @@ impl AuthorityRecord {
         self.entrypoints.push((scope, uri.into()));
         self
     }
+
+    pub fn with_adapter_hint(mut self, adapter: impl Into<String>) -> Self {
+        self.adapter_hint = Some(adapter.into());
+        self
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct InMemoryAuthorityRegistry {
     records: Vec<AuthorityRecord>,
+}
+
+fn adapter_hint_for_uri(uri: &str) -> Option<String> {
+    let hint = if uri.starts_with("github://") {
+        "github"
+    } else if uri.starts_with("gitlab://") {
+        "gitlab"
+    } else if uri.starts_with("gitea://") {
+        "gitea"
+    } else if uri.starts_with("git+https://") {
+        "git"
+    } else if let Some(rest) = uri.strip_prefix("pkg://") {
+        rest.split('/').next()?
+    } else if uri.starts_with("docker://") {
+        "docker"
+    } else if uri.starts_with("reddit://") {
+        "reddit"
+    } else if uri.starts_with("youtube://") {
+        "youtube"
+    } else if uri.starts_with("feed://") {
+        "feed"
+    } else if uri.starts_with("session://") {
+        "session"
+    } else if uri.starts_with("local://") {
+        "local"
+    } else if uri.starts_with("upload://") {
+        "upload"
+    } else if uri.starts_with("cli://") {
+        "cli"
+    } else if uri.starts_with("mcp://") {
+        "mcp"
+    } else if uri.starts_with("http://") || uri.starts_with("https://") {
+        "web"
+    } else {
+        return None;
+    };
+    Some(hint.to_string())
 }
 
 impl InMemoryAuthorityRegistry {

--- a/crates/axon-route/src/canonical.rs
+++ b/crates/axon-route/src/canonical.rs
@@ -23,7 +23,10 @@ pub fn canonicalize(raw: &str, requested_scope: Option<SourceScope>) -> Option<C
         .or_else(|| canonical_reddit(source))
         .or_else(|| canonical_youtube(source))
         .or_else(|| canonical_registry(source))
+        .or_else(|| canonical_gitlab(source))
+        .or_else(|| canonical_gitea(source))
         .or_else(|| canonical_github(source))
+        .or_else(|| canonical_generic_git(source))
         .or_else(|| canonical_web(source))
 }
 
@@ -196,6 +199,56 @@ fn canonical_github(raw: &str) -> Option<CanonicalSource> {
     ))
 }
 
+fn canonical_gitlab(raw: &str) -> Option<CanonicalSource> {
+    let url = normalized_url(raw)?;
+    let host = url.host_str()?;
+    if !host.contains("gitlab") {
+        return None;
+    }
+    let path = repo_path(&url)?;
+    Some(basic(
+        format!("gitlab://{host}/{path}"),
+        SourceKind::Git,
+        SourceScope::Repo,
+        "gitlab",
+        path.rsplit('/').next().unwrap_or(&path),
+        "resolved as GitLab repository source",
+    ))
+}
+
+fn canonical_gitea(raw: &str) -> Option<CanonicalSource> {
+    let url = normalized_url(raw)?;
+    let host = url.host_str()?;
+    if !(host.contains("gitea") || host.contains("forgejo") || host == "codeberg.org") {
+        return None;
+    }
+    let path = repo_path(&url)?;
+    Some(basic(
+        format!("gitea://{host}/{path}"),
+        SourceKind::Git,
+        SourceScope::Repo,
+        "gitea",
+        path.rsplit('/').next().unwrap_or(&path),
+        "resolved as Gitea/Forgejo repository source",
+    ))
+}
+
+fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
+    let url = normalized_url(raw)?;
+    let path = repo_path(&url)?;
+    if !path.ends_with(".git") {
+        return None;
+    }
+    Some(basic(
+        format!("git+https://{}{}", url.host_str()?, clean_path(&url)),
+        SourceKind::Git,
+        SourceScope::Repo,
+        "git",
+        path.rsplit('/').next().unwrap_or(&path),
+        "resolved as generic Git repository source",
+    ))
+}
+
 fn canonical_web(raw: &str) -> Option<CanonicalSource> {
     let url = normalized_url(raw)?;
     Some(basic(
@@ -227,11 +280,39 @@ fn clean_path(url: &Url) -> String {
     } else {
         url.path()
     };
+    let path = collapse_duplicate_slashes(path);
     if path == "/" {
-        "/".to_string()
+        path
     } else {
         path.trim_end_matches('/').to_string()
     }
+}
+
+fn repo_path(url: &Url) -> Option<String> {
+    let path = clean_path(url).trim_start_matches('/').to_string();
+    let path = path.split("/-/").next().unwrap_or(&path);
+    if path.split('/').count() < 2 {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+fn collapse_duplicate_slashes(path: &str) -> String {
+    let mut collapsed = String::with_capacity(path.len());
+    let mut previous_slash = false;
+    for ch in path.chars() {
+        if ch == '/' {
+            if !previous_slash {
+                collapsed.push(ch);
+            }
+            previous_slash = true;
+        } else {
+            collapsed.push(ch);
+            previous_slash = false;
+        }
+    }
+    collapsed
 }
 
 fn trim_git_suffix(value: &str) -> &str {

--- a/crates/axon-route/src/canonical.rs
+++ b/crates/axon-route/src/canonical.rs
@@ -1,7 +1,6 @@
 //! Lexical source normalization and source-family detection.
 
 use axon_api::{Severity, SourceKind, SourceScope, SourceWarning};
-use std::path::{Component, Path, PathBuf};
 use url::{Url, form_urlencoded};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -41,7 +40,7 @@ fn canonical_local(raw: &str, requested_scope: Option<SourceScope>) -> Option<Ca
     {
         return None;
     }
-    let normalized = normalize_local_path(raw);
+    let normalized = crate::local_path::normalize_local_path(raw);
     let key = crate::source_id::local_project_key(&normalized);
     let display_name = normalized
         .trim_end_matches('/')
@@ -122,7 +121,7 @@ fn canonical_feed(raw: &str) -> Option<CanonicalSource> {
         .or_else(|| raw.strip_prefix("atom:"))?;
     let url = normalized_url(feed_url)?;
     Some(basic(
-        format!("feed://{}{}", url.host_str()?, clean_path(&url)),
+        format!("feed://{}{}", host_port(&url)?, clean_path(&url)),
         SourceKind::Feed,
         SourceScope::Feed,
         "feed",
@@ -155,7 +154,7 @@ fn canonical_youtube(raw: &str) -> Option<CanonicalSource> {
         let id = url.path().trim_start_matches('/');
         return Some(youtube_video(id));
     }
-    if host.ends_with("youtube.com") && url.path() == "/watch" {
+    if is_youtube_host(host) && url.path() == "/watch" {
         let id = url.query_pairs().find(|(key, _)| key == "v")?.1;
         return Some(youtube_video(&id));
     }
@@ -229,12 +228,12 @@ fn canonical_github(raw: &str) -> Option<CanonicalSource> {
 fn canonical_gitlab(raw: &str) -> Option<CanonicalSource> {
     let url = normalized_url(raw)?;
     let host = url.host_str()?;
-    if !host.contains("gitlab") {
+    if !is_gitlab_host(host) {
         return None;
     }
     let path = repo_path(&url)?;
     Some(basic(
-        format!("gitlab://{host}/{path}"),
+        format!("gitlab://{}/{path}", host_port(&url)?),
         SourceKind::Git,
         SourceScope::Repo,
         "gitlab",
@@ -246,12 +245,12 @@ fn canonical_gitlab(raw: &str) -> Option<CanonicalSource> {
 fn canonical_gitea(raw: &str) -> Option<CanonicalSource> {
     let url = normalized_url(raw)?;
     let host = url.host_str()?;
-    if !(host.contains("gitea") || host.contains("forgejo") || host == "codeberg.org") {
+    if !is_gitea_host(host) {
         return None;
     }
     let path = repo_path(&url)?;
     Some(basic(
-        format!("gitea://{host}/{path}"),
+        format!("gitea://{}/{path}", host_port(&url)?),
         SourceKind::Git,
         SourceScope::Repo,
         "gitea",
@@ -267,7 +266,7 @@ fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
         return None;
     }
     Some(basic(
-        format!("git+https://{}{}", url.host_str()?, clean_path(&url)),
+        format!("git+https://{}{}", host_port(&url)?, clean_path(&url)),
         SourceKind::Git,
         SourceScope::Repo,
         "git",
@@ -282,7 +281,7 @@ fn canonical_web(raw: &str) -> Option<CanonicalSource> {
     let mut source = basic(
         format!(
             "https://{}{}{}",
-            url.host_str()?,
+            host_port(&url)?,
             clean_path(&url),
             query.query
         ),
@@ -327,6 +326,14 @@ fn clean_path(url: &Url) -> String {
     } else {
         path.trim_end_matches('/').to_string()
     }
+}
+
+fn host_port(url: &Url) -> Option<String> {
+    let host = url.host_str()?;
+    Some(match url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    })
 }
 
 struct QueryNormalization {
@@ -388,52 +395,15 @@ fn is_sensitive_param(key: &str) -> bool {
     key.contains("token")
         || key.contains("secret")
         || key.contains("password")
+        || key.contains("signature")
+        || key.contains("credential")
+        || key == "sig"
+        || key == "jwt"
         || key == "key"
         || key == "api_key"
         || key == "apikey"
         || key == "auth"
         || key == "authorization"
-}
-
-fn normalize_local_path(raw: &str) -> String {
-    let expanded = expand_home(raw.trim());
-    match std::fs::canonicalize(&expanded) {
-        Ok(path) => path.to_string_lossy().into_owned(),
-        Err(_) => normalize_path_components(&expanded),
-    }
-}
-
-fn expand_home(raw: &str) -> PathBuf {
-    if raw == "~" {
-        return home_dir();
-    }
-    if let Some(rest) = raw.strip_prefix("~/") {
-        return home_dir().join(rest);
-    }
-    PathBuf::from(raw)
-}
-
-fn home_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("~"))
-}
-
-fn normalize_path_components(path: &Path) -> String {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
-        .to_string_lossy()
-        .trim_end_matches('/')
-        .to_string()
 }
 
 fn repo_path(url: &Url) -> Option<String> {
@@ -465,6 +435,23 @@ fn collapse_duplicate_slashes(path: &str) -> String {
 
 fn trim_git_suffix(value: &str) -> &str {
     value.strip_suffix(".git").unwrap_or(value)
+}
+
+fn is_youtube_host(host: &str) -> bool {
+    host == "youtube.com" || host.ends_with(".youtube.com")
+}
+
+fn is_gitlab_host(host: &str) -> bool {
+    host == "gitlab.com" || host.ends_with(".gitlab.com")
+}
+
+fn is_gitea_host(host: &str) -> bool {
+    host == "codeberg.org"
+        || host.ends_with(".codeberg.org")
+        || host == "gitea.com"
+        || host.ends_with(".gitea.com")
+        || host == "forgejo.org"
+        || host.ends_with(".forgejo.org")
 }
 
 fn basic(

--- a/crates/axon-route/src/canonical.rs
+++ b/crates/axon-route/src/canonical.rs
@@ -1,8 +1,9 @@
 //! Lexical source normalization and source-family detection.
 
-use crate::provider_host::{is_gitea_host, is_gitlab_host, is_youtube_host};
+use crate::provider_host::{is_gitea_host, is_github_host, is_gitlab_host, is_youtube_host};
+use crate::query::{normalized_query, sensitive_query_warnings};
 use axon_api::{Severity, SourceKind, SourceScope, SourceWarning};
-use url::{Url, form_urlencoded};
+use url::Url;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CanonicalSource {
@@ -127,6 +128,9 @@ fn canonical_feed(raw: &str) -> Option<CanonicalSource> {
         .or_else(|| raw.strip_prefix("feed:"))
         .or_else(|| raw.strip_prefix("atom:"))?;
     let url = normalized_url(feed_url)?;
+    if !is_http_url(&url) {
+        return None;
+    }
     let mut source = basic(
         format!("feed://{}{}", host_port(&url)?, clean_path(&url)),
         SourceKind::Feed,
@@ -260,8 +264,19 @@ fn canonical_gitea(raw: &str) -> Option<CanonicalSource> {
 
 fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
     let url = normalized_url(raw)?;
+    if !is_http_url(&url) {
+        return None;
+    }
     let path = repo_path(&url)?;
     if !path.ends_with(".git") {
+        return None;
+    }
+    let repo = path
+        .rsplit('/')
+        .next()
+        .and_then(|name| name.strip_suffix(".git"))
+        .unwrap_or_default();
+    if repo.is_empty() {
         return None;
     }
     let mut source = basic(
@@ -274,7 +289,7 @@ fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
         SourceKind::Git,
         SourceScope::Repo,
         "git",
-        path.rsplit('/').next().unwrap_or(&path),
+        repo,
         "resolved as generic Git repository source",
     );
     source.warnings.extend(sensitive_query_warnings(&url));
@@ -283,6 +298,9 @@ fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
 
 fn canonical_web(raw: &str) -> Option<CanonicalSource> {
     let url = normalized_url(raw)?;
+    if !is_http_url(&url) {
+        return None;
+    }
     if is_malformed_provider_url(&url) {
         return None;
     }
@@ -324,6 +342,10 @@ fn normalized_url(raw: &str) -> Option<Url> {
     Some(url)
 }
 
+fn is_http_url(url: &Url) -> bool {
+    matches!(url.scheme(), "http" | "https")
+}
+
 fn clean_path(url: &Url) -> String {
     let path = if url.path().is_empty() {
         "/"
@@ -344,90 +366,6 @@ fn host_port(url: &Url) -> Option<String> {
         Some(port) => format!("{host}:{port}"),
         None => host.to_string(),
     })
-}
-
-struct QueryNormalization {
-    query: String,
-    warnings: Vec<SourceWarning>,
-}
-
-fn normalized_query(url: &Url) -> QueryNormalization {
-    let mut kept = Vec::new();
-    let mut redacted = false;
-    for (key, value) in url.query_pairs() {
-        let key = key.to_string();
-        let value = value.to_string();
-        if is_tracking_param(&key) {
-            continue;
-        }
-        if is_sensitive_param(&key) {
-            redacted = true;
-            kept.push((key, "REDACTED".to_string()));
-        } else {
-            kept.push((key, value));
-        }
-    }
-    kept.sort();
-
-    let query = if kept.is_empty() {
-        String::new()
-    } else {
-        let mut serializer = form_urlencoded::Serializer::new(String::new());
-        for (key, value) in kept {
-            serializer.append_pair(&key, &value);
-        }
-        format!("?{}", serializer.finish())
-    };
-
-    let warnings = if redacted {
-        vec![warning(
-            "source.query.sensitive_redacted",
-            "sensitive query parameter values were redacted in canonical URI",
-        )]
-    } else {
-        Vec::new()
-    };
-
-    QueryNormalization { query, warnings }
-}
-
-fn is_tracking_param(key: &str) -> bool {
-    let key = key.to_ascii_lowercase();
-    key.starts_with("utm_")
-        || matches!(
-            key.as_str(),
-            "fbclid" | "gclid" | "msclkid" | "mc_cid" | "mc_eid" | "igshid"
-        )
-}
-
-pub(crate) fn sensitive_query_warnings(url: &Url) -> Vec<SourceWarning> {
-    if url.query_pairs().any(|(key, _)| is_sensitive_param(&key)) {
-        vec![warning(
-            "source.query.sensitive_redacted",
-            "sensitive query parameter values were redacted in canonical URI",
-        )]
-    } else {
-        Vec::new()
-    }
-}
-
-fn is_sensitive_param(key: &str) -> bool {
-    let key = key.to_ascii_lowercase();
-    key.contains("token")
-        || key.contains("secret")
-        || key.contains("password")
-        || key.contains("signature")
-        || key.contains("credential")
-        || key == "access_key"
-        || key == "awsaccesskeyid"
-        || key.starts_with("x-amz-")
-        || key == "sig"
-        || key == "jwt"
-        || key == "key"
-        || key == "api_key"
-        || key == "apikey"
-        || key == "auth"
-        || key == "authorization"
 }
 
 fn repo_path(url: &Url) -> Option<String> {
@@ -461,6 +399,10 @@ fn is_malformed_provider_url(url: &Url) -> bool {
     let Some(host) = url.host_str().map(|host| host.trim_start_matches("www.")) else {
         return false;
     };
+    malformed_youtube_url(host, url) || malformed_github_url(host, url)
+}
+
+fn malformed_youtube_url(host: &str, url: &Url) -> bool {
     (host == "youtu.be" && url.path().trim_start_matches('/').is_empty())
         || (is_youtube_host(host)
             && url.path() == "/watch"
@@ -468,6 +410,18 @@ fn is_malformed_provider_url(url: &Url) -> bool {
                 .query_pairs()
                 .find(|(key, _)| key == "v")
                 .is_some_and(|(_, value)| value.trim().is_empty()))
+}
+
+fn malformed_github_url(host: &str, url: &Url) -> bool {
+    if !is_github_host(host) {
+        return false;
+    }
+    let parts = url
+        .path()
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    parts.get(1).is_some_and(|repo| *repo == ".git")
 }
 
 fn basic(

--- a/crates/axon-route/src/canonical.rs
+++ b/crates/axon-route/src/canonical.rs
@@ -1,3 +1,257 @@
-//! Marker module for the target `axon-route::canonical` boundary.
+//! Lexical source normalization and source-family detection.
 
-pub const MODULE_NAME: &str = "canonical";
+use axon_api::{SourceKind, SourceScope};
+use url::Url;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CanonicalSource {
+    pub canonical_uri: String,
+    pub source_kind: SourceKind,
+    pub default_scope: SourceScope,
+    pub adapter_hint: Option<String>,
+    pub display_name: String,
+    pub reason: String,
+}
+
+pub fn canonicalize(raw: &str, requested_scope: Option<SourceScope>) -> Option<CanonicalSource> {
+    let source = raw.trim();
+    canonical_local(source, requested_scope)
+        .or_else(|| canonical_mcp(source))
+        .or_else(|| canonical_cli(source))
+        .or_else(|| canonical_session(source))
+        .or_else(|| canonical_feed(source))
+        .or_else(|| canonical_reddit(source))
+        .or_else(|| canonical_youtube(source))
+        .or_else(|| canonical_registry(source))
+        .or_else(|| canonical_github(source))
+        .or_else(|| canonical_web(source))
+}
+
+fn canonical_local(raw: &str, requested_scope: Option<SourceScope>) -> Option<CanonicalSource> {
+    if !(raw.starts_with('/')
+        || raw.starts_with("./")
+        || raw.starts_with("../")
+        || raw.starts_with('~'))
+    {
+        return None;
+    }
+    let key = crate::source_id::local_project_key(raw);
+    let display_name = raw
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("local")
+        .to_string();
+    Some(CanonicalSource {
+        canonical_uri: format!("local://{key}"),
+        source_kind: SourceKind::Local,
+        default_scope: requested_scope.unwrap_or(SourceScope::Directory),
+        adapter_hint: Some("local".to_string()),
+        display_name,
+        reason: "resolved as local filesystem source".to_string(),
+    })
+}
+
+fn canonical_mcp(raw: &str) -> Option<CanonicalSource> {
+    let rest = raw.strip_prefix("mcp:")?;
+    let (server, tool) = rest.split_once('/')?;
+    Some(basic(
+        format!("mcp://{server}/tools/{tool}"),
+        SourceKind::McpTool,
+        SourceScope::Tool,
+        "mcp",
+        tool,
+        "resolved as MCP tool source",
+    ))
+}
+
+fn canonical_cli(raw: &str) -> Option<CanonicalSource> {
+    let rest = raw.strip_prefix("cli:")?.trim();
+    let tool = rest.split_whitespace().next()?;
+    Some(basic(
+        format!("cli://{tool}"),
+        SourceKind::CliTool,
+        SourceScope::Tool,
+        "cli",
+        tool,
+        "resolved as CLI tool source",
+    ))
+}
+
+fn canonical_session(raw: &str) -> Option<CanonicalSource> {
+    let rest = raw.strip_prefix("session:")?;
+    let (provider, session_id) = rest.split_once(':')?;
+    Some(basic(
+        format!("session://{provider}/{session_id}"),
+        SourceKind::Session,
+        SourceScope::Thread,
+        "session",
+        session_id,
+        "resolved as AI session source",
+    ))
+}
+
+fn canonical_feed(raw: &str) -> Option<CanonicalSource> {
+    let feed_url = raw
+        .strip_prefix("rss:")
+        .or_else(|| raw.strip_prefix("feed:"))
+        .or_else(|| raw.strip_prefix("atom:"))?;
+    let url = normalized_url(feed_url)?;
+    Some(basic(
+        format!("feed://{}{}", url.host_str()?, clean_path(&url)),
+        SourceKind::Feed,
+        SourceScope::Feed,
+        "feed",
+        url.host_str()?,
+        "resolved as feed source",
+    ))
+}
+
+fn canonical_reddit(raw: &str) -> Option<CanonicalSource> {
+    let subreddit = raw
+        .strip_prefix("r/")
+        .or_else(|| raw.strip_prefix("reddit.com/r/"))
+        .or_else(|| raw.strip_prefix("https://reddit.com/r/"))
+        .or_else(|| raw.strip_prefix("https://www.reddit.com/r/"))?;
+    let name = subreddit.split('/').next()?.trim();
+    Some(basic(
+        format!("reddit://r/{name}"),
+        SourceKind::Reddit,
+        SourceScope::Subreddit,
+        "reddit",
+        name,
+        "resolved as Reddit source",
+    ))
+}
+
+fn canonical_youtube(raw: &str) -> Option<CanonicalSource> {
+    let url = normalized_url(raw)?;
+    let host = url.host_str()?.trim_start_matches("www.");
+    if host == "youtu.be" {
+        let id = url.path().trim_start_matches('/');
+        return Some(youtube_video(id));
+    }
+    if host.ends_with("youtube.com") && url.path() == "/watch" {
+        let id = url.query_pairs().find(|(key, _)| key == "v")?.1;
+        return Some(youtube_video(&id));
+    }
+    None
+}
+
+fn youtube_video(id: &str) -> CanonicalSource {
+    basic(
+        format!("youtube://video/{id}"),
+        SourceKind::Youtube,
+        SourceScope::Video,
+        "youtube",
+        id,
+        "resolved as YouTube video source",
+    )
+}
+
+fn canonical_registry(raw: &str) -> Option<CanonicalSource> {
+    let (registry, package) = raw.split_once(':')?;
+    let adapter = match registry {
+        "crates" | "npm" | "pypi" | "docker" => registry,
+        _ => return None,
+    };
+    let package = if adapter == "pypi" {
+        package.to_ascii_lowercase()
+    } else {
+        package.to_string()
+    };
+    let canonical_uri = if adapter == "docker" {
+        format!("docker://docker.io/{package}")
+    } else {
+        format!("pkg://{adapter}/{package}")
+    };
+    Some(basic(
+        canonical_uri,
+        SourceKind::Registry,
+        SourceScope::Package,
+        adapter,
+        &package,
+        "resolved as registry package source",
+    ))
+}
+
+fn canonical_github(raw: &str) -> Option<CanonicalSource> {
+    let path = raw
+        .strip_prefix("https://github.com/")
+        .or_else(|| raw.strip_prefix("http://github.com/"))
+        .or_else(|| raw.strip_prefix("github.com/"))
+        .unwrap_or(raw);
+    let parts = path.split('/').take(3).collect::<Vec<_>>();
+    if parts.len() < 2 || parts[0].contains('.') || parts[0].is_empty() || parts[1].is_empty() {
+        return None;
+    }
+    Some(basic(
+        format!("github://{}/{}", parts[0], trim_git_suffix(parts[1])),
+        SourceKind::Git,
+        SourceScope::Repo,
+        "github",
+        parts[1],
+        "resolved as GitHub repository source",
+    ))
+}
+
+fn canonical_web(raw: &str) -> Option<CanonicalSource> {
+    let url = normalized_url(raw)?;
+    Some(basic(
+        format!("https://{}{}", url.host_str()?, clean_path(&url)),
+        SourceKind::Web,
+        SourceScope::Site,
+        "web",
+        url.host_str()?,
+        "resolved as web source",
+    ))
+}
+
+fn normalized_url(raw: &str) -> Option<Url> {
+    let candidate = if raw.contains("://") {
+        raw.to_string()
+    } else if raw.contains('.') {
+        format!("https://{raw}")
+    } else {
+        return None;
+    };
+    let mut url = Url::parse(&candidate).ok()?;
+    url.set_scheme(&url.scheme().to_ascii_lowercase()).ok()?;
+    Some(url)
+}
+
+fn clean_path(url: &Url) -> String {
+    let path = if url.path().is_empty() {
+        "/"
+    } else {
+        url.path()
+    };
+    if path == "/" {
+        "/".to_string()
+    } else {
+        path.trim_end_matches('/').to_string()
+    }
+}
+
+fn trim_git_suffix(value: &str) -> &str {
+    value.strip_suffix(".git").unwrap_or(value)
+}
+
+fn basic(
+    canonical_uri: String,
+    source_kind: SourceKind,
+    default_scope: SourceScope,
+    adapter: &str,
+    display_name: &str,
+    reason: &str,
+) -> CanonicalSource {
+    CanonicalSource {
+        canonical_uri,
+        source_kind,
+        default_scope,
+        adapter_hint: Some(adapter.to_string()),
+        display_name: display_name.to_string(),
+        reason: reason.to_string(),
+    }
+}

--- a/crates/axon-route/src/canonical.rs
+++ b/crates/axon-route/src/canonical.rs
@@ -1,5 +1,6 @@
 //! Lexical source normalization and source-family detection.
 
+use crate::provider_host::{is_gitea_host, is_gitlab_host, is_youtube_host};
 use axon_api::{Severity, SourceKind, SourceScope, SourceWarning};
 use url::{Url, form_urlencoded};
 
@@ -63,6 +64,9 @@ fn canonical_local(raw: &str, requested_scope: Option<SourceScope>) -> Option<Ca
 fn canonical_mcp(raw: &str) -> Option<CanonicalSource> {
     let rest = raw.strip_prefix("mcp:")?;
     let (server, tool) = rest.split_once('/')?;
+    if server.trim().is_empty() || tool.trim().is_empty() {
+        return None;
+    }
     Some(basic(
         format!("mcp://{server}/tools/{tool}"),
         SourceKind::McpTool,
@@ -89,6 +93,9 @@ fn canonical_cli(raw: &str) -> Option<CanonicalSource> {
 fn canonical_session(raw: &str) -> Option<CanonicalSource> {
     let rest = raw.strip_prefix("session:")?;
     let (provider, session_id) = rest.split_once(':')?;
+    if provider.trim().is_empty() || session_id.trim().is_empty() {
+        return None;
+    }
     Some(basic(
         format!("session://{provider}/{session_id}"),
         SourceKind::Session,
@@ -120,14 +127,16 @@ fn canonical_feed(raw: &str) -> Option<CanonicalSource> {
         .or_else(|| raw.strip_prefix("feed:"))
         .or_else(|| raw.strip_prefix("atom:"))?;
     let url = normalized_url(feed_url)?;
-    Some(basic(
+    let mut source = basic(
         format!("feed://{}{}", host_port(&url)?, clean_path(&url)),
         SourceKind::Feed,
         SourceScope::Feed,
         "feed",
         url.host_str()?,
         "resolved as feed source",
-    ))
+    );
+    source.warnings.extend(sensitive_query_warnings(&url));
+    Some(source)
 }
 
 fn canonical_reddit(raw: &str) -> Option<CanonicalSource> {
@@ -137,6 +146,9 @@ fn canonical_reddit(raw: &str) -> Option<CanonicalSource> {
         .or_else(|| raw.strip_prefix("https://reddit.com/r/"))
         .or_else(|| raw.strip_prefix("https://www.reddit.com/r/"))?;
     let name = subreddit.split('/').next()?.trim();
+    if name.is_empty() {
+        return None;
+    }
     Some(basic(
         format!("reddit://r/{name}"),
         SourceKind::Reddit,
@@ -152,10 +164,16 @@ fn canonical_youtube(raw: &str) -> Option<CanonicalSource> {
     let host = url.host_str()?.trim_start_matches("www.");
     if host == "youtu.be" {
         let id = url.path().trim_start_matches('/');
+        if id.is_empty() {
+            return None;
+        }
         return Some(youtube_video(id));
     }
     if is_youtube_host(host) && url.path() == "/watch" {
         let id = url.query_pairs().find(|(key, _)| key == "v")?.1;
+        if id.trim().is_empty() {
+            return None;
+        }
         return Some(youtube_video(&id));
     }
     None
@@ -178,6 +196,10 @@ fn canonical_registry(raw: &str) -> Option<CanonicalSource> {
         "crates" | "npm" | "pypi" | "docker" => registry,
         _ => return None,
     };
+    let package = package.trim();
+    if package.is_empty() {
+        return None;
+    }
     let package = if adapter == "pypi" {
         package.to_ascii_lowercase()
     } else {
@@ -205,14 +227,16 @@ fn canonical_gitlab(raw: &str) -> Option<CanonicalSource> {
         return None;
     }
     let path = repo_path(&url)?;
-    Some(basic(
+    let mut source = basic(
         format!("gitlab://{}/{path}", host_port(&url)?),
         SourceKind::Git,
         SourceScope::Repo,
         "gitlab",
         path.rsplit('/').next().unwrap_or(&path),
         "resolved as GitLab repository source",
-    ))
+    );
+    source.warnings.extend(sensitive_query_warnings(&url));
+    Some(source)
 }
 
 fn canonical_gitea(raw: &str) -> Option<CanonicalSource> {
@@ -222,14 +246,16 @@ fn canonical_gitea(raw: &str) -> Option<CanonicalSource> {
         return None;
     }
     let path = repo_path(&url)?;
-    Some(basic(
+    let mut source = basic(
         format!("gitea://{}/{path}", host_port(&url)?),
         SourceKind::Git,
         SourceScope::Repo,
         "gitea",
         path.rsplit('/').next().unwrap_or(&path),
         "resolved as Gitea/Forgejo repository source",
-    ))
+    );
+    source.warnings.extend(sensitive_query_warnings(&url));
+    Some(source)
 }
 
 fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
@@ -238,7 +264,7 @@ fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
     if !path.ends_with(".git") {
         return None;
     }
-    Some(basic(
+    let mut source = basic(
         format!(
             "git+{}://{}{}",
             url.scheme(),
@@ -250,11 +276,16 @@ fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
         "git",
         path.rsplit('/').next().unwrap_or(&path),
         "resolved as generic Git repository source",
-    ))
+    );
+    source.warnings.extend(sensitive_query_warnings(&url));
+    Some(source)
 }
 
 fn canonical_web(raw: &str) -> Option<CanonicalSource> {
     let url = normalized_url(raw)?;
+    if is_malformed_provider_url(&url) {
+        return None;
+    }
     let query = normalized_query(&url);
     let mut source = basic(
         format!(
@@ -369,6 +400,17 @@ fn is_tracking_param(key: &str) -> bool {
         )
 }
 
+pub(crate) fn sensitive_query_warnings(url: &Url) -> Vec<SourceWarning> {
+    if url.query_pairs().any(|(key, _)| is_sensitive_param(&key)) {
+        vec![warning(
+            "source.query.sensitive_redacted",
+            "sensitive query parameter values were redacted in canonical URI",
+        )]
+    } else {
+        Vec::new()
+    }
+}
+
 fn is_sensitive_param(key: &str) -> bool {
     let key = key.to_ascii_lowercase();
     key.contains("token")
@@ -376,6 +418,9 @@ fn is_sensitive_param(key: &str) -> bool {
         || key.contains("password")
         || key.contains("signature")
         || key.contains("credential")
+        || key == "access_key"
+        || key == "awsaccesskeyid"
+        || key.starts_with("x-amz-")
         || key == "sig"
         || key == "jwt"
         || key == "key"
@@ -412,21 +457,17 @@ fn collapse_duplicate_slashes(path: &str) -> String {
     collapsed
 }
 
-fn is_youtube_host(host: &str) -> bool {
-    host == "youtube.com" || host.ends_with(".youtube.com")
-}
-
-fn is_gitlab_host(host: &str) -> bool {
-    host == "gitlab.com" || host.ends_with(".gitlab.com")
-}
-
-fn is_gitea_host(host: &str) -> bool {
-    host == "codeberg.org"
-        || host.ends_with(".codeberg.org")
-        || host == "gitea.com"
-        || host.ends_with(".gitea.com")
-        || host == "forgejo.org"
-        || host.ends_with(".forgejo.org")
+fn is_malformed_provider_url(url: &Url) -> bool {
+    let Some(host) = url.host_str().map(|host| host.trim_start_matches("www.")) else {
+        return false;
+    };
+    (host == "youtu.be" && url.path().trim_start_matches('/').is_empty())
+        || (is_youtube_host(host)
+            && url.path() == "/watch"
+            && url
+                .query_pairs()
+                .find(|(key, _)| key == "v")
+                .is_some_and(|(_, value)| value.trim().is_empty()))
 }
 
 fn basic(

--- a/crates/axon-route/src/canonical.rs
+++ b/crates/axon-route/src/canonical.rs
@@ -27,7 +27,7 @@ pub fn canonicalize(raw: &str, requested_scope: Option<SourceScope>) -> Option<C
         .or_else(|| canonical_registry(source))
         .or_else(|| canonical_gitlab(source))
         .or_else(|| canonical_gitea(source))
-        .or_else(|| canonical_github(source))
+        .or_else(|| crate::github::canonical_github(source))
         .or_else(|| canonical_generic_git(source))
         .or_else(|| canonical_web(source))
 }
@@ -198,33 +198,6 @@ fn canonical_registry(raw: &str) -> Option<CanonicalSource> {
     ))
 }
 
-fn canonical_github(raw: &str) -> Option<CanonicalSource> {
-    let path = raw
-        .strip_prefix("https://github.com/")
-        .or_else(|| raw.strip_prefix("http://github.com/"))
-        .or_else(|| raw.strip_prefix("github.com/"))
-        .unwrap_or(raw);
-    let parts = path.split('/').take(3).collect::<Vec<_>>();
-    if parts.len() < 2 || parts[0].contains('.') || parts[0].is_empty() || parts[1].is_empty() {
-        return None;
-    }
-    let mut source = basic(
-        format!("github://{}/{}", parts[0], trim_git_suffix(parts[1])),
-        SourceKind::Git,
-        SourceScope::Repo,
-        "github",
-        parts[1],
-        "resolved as GitHub repository source",
-    );
-    if path == raw {
-        source.warnings.push(warning(
-            "source.inferred.github_shorthand",
-            "source interpreted as GitHub owner/repo shorthand",
-        ));
-    }
-    Some(source)
-}
-
 fn canonical_gitlab(raw: &str) -> Option<CanonicalSource> {
     let url = normalized_url(raw)?;
     let host = url.host_str()?;
@@ -266,7 +239,12 @@ fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
         return None;
     }
     Some(basic(
-        format!("git+https://{}{}", host_port(&url)?, clean_path(&url)),
+        format!(
+            "git+{}://{}{}",
+            url.scheme(),
+            host_port(&url)?,
+            clean_path(&url)
+        ),
         SourceKind::Git,
         SourceScope::Repo,
         "git",
@@ -280,7 +258,8 @@ fn canonical_web(raw: &str) -> Option<CanonicalSource> {
     let query = normalized_query(&url);
     let mut source = basic(
         format!(
-            "https://{}{}{}",
+            "{}://{}{}{}",
+            url.scheme(),
             host_port(&url)?,
             clean_path(&url),
             query.query
@@ -431,10 +410,6 @@ fn collapse_duplicate_slashes(path: &str) -> String {
         }
     }
     collapsed
-}
-
-fn trim_git_suffix(value: &str) -> &str {
-    value.strip_suffix(".git").unwrap_or(value)
 }
 
 fn is_youtube_host(host: &str) -> bool {

--- a/crates/axon-route/src/canonical.rs
+++ b/crates/axon-route/src/canonical.rs
@@ -1,7 +1,8 @@
 //! Lexical source normalization and source-family detection.
 
-use axon_api::{SourceKind, SourceScope};
-use url::Url;
+use axon_api::{Severity, SourceKind, SourceScope, SourceWarning};
+use std::path::{Component, Path, PathBuf};
+use url::{Url, form_urlencoded};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CanonicalSource {
@@ -11,6 +12,7 @@ pub struct CanonicalSource {
     pub adapter_hint: Option<String>,
     pub display_name: String,
     pub reason: String,
+    pub warnings: Vec<SourceWarning>,
 }
 
 pub fn canonicalize(raw: &str, requested_scope: Option<SourceScope>) -> Option<CanonicalSource> {
@@ -19,6 +21,7 @@ pub fn canonicalize(raw: &str, requested_scope: Option<SourceScope>) -> Option<C
         .or_else(|| canonical_mcp(source))
         .or_else(|| canonical_cli(source))
         .or_else(|| canonical_session(source))
+        .or_else(|| canonical_upload(source))
         .or_else(|| canonical_feed(source))
         .or_else(|| canonical_reddit(source))
         .or_else(|| canonical_youtube(source))
@@ -38,8 +41,9 @@ fn canonical_local(raw: &str, requested_scope: Option<SourceScope>) -> Option<Ca
     {
         return None;
     }
-    let key = crate::source_id::local_project_key(raw);
-    let display_name = raw
+    let normalized = normalize_local_path(raw);
+    let key = crate::source_id::local_project_key(&normalized);
+    let display_name = normalized
         .trim_end_matches('/')
         .rsplit('/')
         .next()
@@ -53,6 +57,7 @@ fn canonical_local(raw: &str, requested_scope: Option<SourceScope>) -> Option<Ca
         adapter_hint: Some("local".to_string()),
         display_name,
         reason: "resolved as local filesystem source".to_string(),
+        warnings: Vec::new(),
     })
 }
 
@@ -92,6 +97,21 @@ fn canonical_session(raw: &str) -> Option<CanonicalSource> {
         "session",
         session_id,
         "resolved as AI session source",
+    ))
+}
+
+fn canonical_upload(raw: &str) -> Option<CanonicalSource> {
+    let artifact = raw.strip_prefix("upload:")?.trim();
+    if artifact.is_empty() {
+        return None;
+    }
+    Some(basic(
+        format!("upload://{artifact}"),
+        SourceKind::Upload,
+        SourceScope::File,
+        "upload",
+        artifact,
+        "resolved as upload/artifact source",
     ))
 }
 
@@ -189,14 +209,21 @@ fn canonical_github(raw: &str) -> Option<CanonicalSource> {
     if parts.len() < 2 || parts[0].contains('.') || parts[0].is_empty() || parts[1].is_empty() {
         return None;
     }
-    Some(basic(
+    let mut source = basic(
         format!("github://{}/{}", parts[0], trim_git_suffix(parts[1])),
         SourceKind::Git,
         SourceScope::Repo,
         "github",
         parts[1],
         "resolved as GitHub repository source",
-    ))
+    );
+    if path == raw {
+        source.warnings.push(warning(
+            "source.inferred.github_shorthand",
+            "source interpreted as GitHub owner/repo shorthand",
+        ));
+    }
+    Some(source)
 }
 
 fn canonical_gitlab(raw: &str) -> Option<CanonicalSource> {
@@ -251,14 +278,28 @@ fn canonical_generic_git(raw: &str) -> Option<CanonicalSource> {
 
 fn canonical_web(raw: &str) -> Option<CanonicalSource> {
     let url = normalized_url(raw)?;
-    Some(basic(
-        format!("https://{}{}", url.host_str()?, clean_path(&url)),
+    let query = normalized_query(&url);
+    let mut source = basic(
+        format!(
+            "https://{}{}{}",
+            url.host_str()?,
+            clean_path(&url),
+            query.query
+        ),
         SourceKind::Web,
         SourceScope::Site,
         "web",
         url.host_str()?,
         "resolved as web source",
-    ))
+    );
+    source.warnings.extend(query.warnings);
+    if !raw.contains("://") {
+        source.warnings.push(warning(
+            "source.inferred.scheme",
+            "source did not include a URL scheme; https was inferred",
+        ));
+    }
+    Some(source)
 }
 
 fn normalized_url(raw: &str) -> Option<Url> {
@@ -286,6 +327,113 @@ fn clean_path(url: &Url) -> String {
     } else {
         path.trim_end_matches('/').to_string()
     }
+}
+
+struct QueryNormalization {
+    query: String,
+    warnings: Vec<SourceWarning>,
+}
+
+fn normalized_query(url: &Url) -> QueryNormalization {
+    let mut kept = Vec::new();
+    let mut redacted = false;
+    for (key, value) in url.query_pairs() {
+        let key = key.to_string();
+        let value = value.to_string();
+        if is_tracking_param(&key) {
+            continue;
+        }
+        if is_sensitive_param(&key) {
+            redacted = true;
+            kept.push((key, "REDACTED".to_string()));
+        } else {
+            kept.push((key, value));
+        }
+    }
+    kept.sort();
+
+    let query = if kept.is_empty() {
+        String::new()
+    } else {
+        let mut serializer = form_urlencoded::Serializer::new(String::new());
+        for (key, value) in kept {
+            serializer.append_pair(&key, &value);
+        }
+        format!("?{}", serializer.finish())
+    };
+
+    let warnings = if redacted {
+        vec![warning(
+            "source.query.sensitive_redacted",
+            "sensitive query parameter values were redacted in canonical URI",
+        )]
+    } else {
+        Vec::new()
+    };
+
+    QueryNormalization { query, warnings }
+}
+
+fn is_tracking_param(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.starts_with("utm_")
+        || matches!(
+            key.as_str(),
+            "fbclid" | "gclid" | "msclkid" | "mc_cid" | "mc_eid" | "igshid"
+        )
+}
+
+fn is_sensitive_param(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+        || key == "key"
+        || key == "api_key"
+        || key == "apikey"
+        || key == "auth"
+        || key == "authorization"
+}
+
+fn normalize_local_path(raw: &str) -> String {
+    let expanded = expand_home(raw.trim());
+    match std::fs::canonicalize(&expanded) {
+        Ok(path) => path.to_string_lossy().into_owned(),
+        Err(_) => normalize_path_components(&expanded),
+    }
+}
+
+fn expand_home(raw: &str) -> PathBuf {
+    if raw == "~" {
+        return home_dir();
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        return home_dir().join(rest);
+    }
+    PathBuf::from(raw)
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("~"))
+}
+
+fn normalize_path_components(path: &Path) -> String {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+        .to_string_lossy()
+        .trim_end_matches('/')
+        .to_string()
 }
 
 fn repo_path(url: &Url) -> Option<String> {
@@ -334,5 +482,16 @@ fn basic(
         adapter_hint: Some(adapter.to_string()),
         display_name: display_name.to_string(),
         reason: reason.to_string(),
+        warnings: Vec::new(),
+    }
+}
+
+fn warning(code: &str, message: &str) -> SourceWarning {
+    SourceWarning {
+        code: code.to_string(),
+        severity: Severity::Info,
+        message: message.to_string(),
+        source_item_key: None,
+        retryable: false,
     }
 }

--- a/crates/axon-route/src/capability.rs
+++ b/crates/axon-route/src/capability.rs
@@ -1,3 +1,130 @@
-//! Marker module for the target `axon-route::capability` boundary.
+//! Adapter declarations consumed by the router.
 
-pub const MODULE_NAME: &str = "capability";
+use axon_api::{
+    AdapterRef, ChunkHint, CredentialRequirement, ExecutionAffinity, ParserHint,
+    ProviderRequirement, SafetyClass, SourceKind, SourceScope,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdapterDefinition {
+    pub adapter: AdapterRef,
+    pub source_kind: SourceKind,
+    pub default_scope: SourceScope,
+    pub supported_scopes: Vec<SourceScope>,
+    pub safety_class: SafetyClass,
+    pub execution_affinity: ExecutionAffinity,
+    pub provider_requirements: Vec<ProviderRequirement>,
+    pub credential_requirements: Vec<CredentialRequirement>,
+    pub chunking_hints: Vec<ChunkHint>,
+    pub parser_hints: Vec<ParserHint>,
+    pub watch_supported: bool,
+    pub refresh_supported: bool,
+}
+
+impl AdapterDefinition {
+    pub fn new(
+        name: impl Into<String>,
+        version: impl Into<String>,
+        source_kind: SourceKind,
+        default_scope: SourceScope,
+    ) -> Self {
+        Self {
+            adapter: AdapterRef {
+                name: name.into(),
+                version: version.into(),
+            },
+            source_kind,
+            default_scope,
+            supported_scopes: vec![default_scope],
+            safety_class: safety_class(source_kind),
+            execution_affinity: ExecutionAffinity::Worker,
+            provider_requirements: Vec::new(),
+            credential_requirements: Vec::new(),
+            chunking_hints: Vec::new(),
+            parser_hints: Vec::new(),
+            watch_supported: matches!(source_kind, SourceKind::Local | SourceKind::Web),
+            refresh_supported: true,
+        }
+    }
+
+    pub fn with_scope(mut self, scope: SourceScope) -> Self {
+        if !self.supported_scopes.contains(&scope) {
+            self.supported_scopes.push(scope);
+        }
+        self
+    }
+
+    pub fn with_safety_class(mut self, safety_class: SafetyClass) -> Self {
+        self.safety_class = safety_class;
+        self
+    }
+}
+
+fn safety_class(source_kind: SourceKind) -> SafetyClass {
+    match source_kind {
+        SourceKind::Local => SafetyClass::LocalFilesystem,
+        SourceKind::CliTool | SourceKind::McpTool => SafetyClass::ToolExecution,
+        _ => SafetyClass::PublicNetwork,
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AdapterRegistry {
+    adapters: Vec<AdapterDefinition>,
+}
+
+impl AdapterRegistry {
+    pub fn from_adapters(mut adapters: Vec<AdapterDefinition>) -> Self {
+        adapters.sort_by(|left, right| left.adapter.name.cmp(&right.adapter.name));
+        Self { adapters }
+    }
+
+    pub fn target_defaults() -> Self {
+        Self::from_adapters(vec![
+            AdapterDefinition::new("cli", "1", SourceKind::CliTool, SourceScope::Tool),
+            AdapterDefinition::new("crates", "1", SourceKind::Registry, SourceScope::Package)
+                .with_scope(SourceScope::Version),
+            AdapterDefinition::new("docker", "1", SourceKind::Registry, SourceScope::Package)
+                .with_scope(SourceScope::Version),
+            AdapterDefinition::new("feed", "1", SourceKind::Feed, SourceScope::Feed),
+            AdapterDefinition::new("github", "1", SourceKind::Git, SourceScope::Repo)
+                .with_scope(SourceScope::Branch)
+                .with_scope(SourceScope::Issue)
+                .with_scope(SourceScope::PullRequest)
+                .with_scope(SourceScope::Release),
+            AdapterDefinition::new("local", "1", SourceKind::Local, SourceScope::Directory)
+                .with_scope(SourceScope::File)
+                .with_scope(SourceScope::Workspace)
+                .with_safety_class(SafetyClass::LocalFilesystem),
+            AdapterDefinition::new("mcp", "1", SourceKind::McpTool, SourceScope::Tool),
+            AdapterDefinition::new("npm", "1", SourceKind::Registry, SourceScope::Package)
+                .with_scope(SourceScope::Version),
+            AdapterDefinition::new("pypi", "1", SourceKind::Registry, SourceScope::Package)
+                .with_scope(SourceScope::Version),
+            AdapterDefinition::new("reddit", "1", SourceKind::Reddit, SourceScope::Subreddit)
+                .with_scope(SourceScope::Thread)
+                .with_scope(SourceScope::Comment),
+            AdapterDefinition::new("session", "1", SourceKind::Session, SourceScope::Thread),
+            AdapterDefinition::new("web", "1", SourceKind::Web, SourceScope::Site)
+                .with_scope(SourceScope::Page)
+                .with_scope(SourceScope::Docs)
+                .with_scope(SourceScope::Map),
+            AdapterDefinition::new("youtube", "1", SourceKind::Youtube, SourceScope::Video)
+                .with_scope(SourceScope::Playlist)
+                .with_scope(SourceScope::Channel),
+        ])
+    }
+
+    pub fn adapters_for(&self, source_kind: SourceKind) -> Vec<&AdapterDefinition> {
+        self.adapters
+            .iter()
+            .filter(|adapter| adapter.source_kind == source_kind)
+            .collect()
+    }
+
+    pub fn find(&self, name: &str) -> Option<&AdapterDefinition> {
+        self.adapters
+            .iter()
+            .find(|adapter| adapter.adapter.name == name)
+    }
+}

--- a/crates/axon-route/src/capability.rs
+++ b/crates/axon-route/src/capability.rs
@@ -92,6 +92,18 @@ impl AdapterRegistry {
                 .with_scope(SourceScope::Issue)
                 .with_scope(SourceScope::PullRequest)
                 .with_scope(SourceScope::Release),
+            AdapterDefinition::new("git", "1", SourceKind::Git, SourceScope::Repo)
+                .with_scope(SourceScope::Branch),
+            AdapterDefinition::new("gitea", "1", SourceKind::Git, SourceScope::Repo)
+                .with_scope(SourceScope::Branch)
+                .with_scope(SourceScope::Issue)
+                .with_scope(SourceScope::PullRequest)
+                .with_scope(SourceScope::Release),
+            AdapterDefinition::new("gitlab", "1", SourceKind::Git, SourceScope::Repo)
+                .with_scope(SourceScope::Branch)
+                .with_scope(SourceScope::Issue)
+                .with_scope(SourceScope::MergeRequest)
+                .with_scope(SourceScope::Release),
             AdapterDefinition::new("local", "1", SourceKind::Local, SourceScope::Directory)
                 .with_scope(SourceScope::File)
                 .with_scope(SourceScope::Workspace)

--- a/crates/axon-route/src/capability.rs
+++ b/crates/axon-route/src/capability.rs
@@ -15,6 +15,8 @@ pub struct AdapterDefinition {
     pub execution_affinity: ExecutionAffinity,
     pub provider_requirements: Vec<ProviderRequirement>,
     pub credential_requirements: Vec<CredentialRequirement>,
+    pub option_schema_id: String,
+    pub allowed_option_keys: Vec<String>,
     pub chunking_hints: Vec<ChunkHint>,
     pub parser_hints: Vec<ParserHint>,
     pub watch_supported: bool,
@@ -28,9 +30,10 @@ impl AdapterDefinition {
         source_kind: SourceKind,
         default_scope: SourceScope,
     ) -> Self {
+        let name = name.into();
         Self {
             adapter: AdapterRef {
-                name: name.into(),
+                name: name.clone(),
                 version: version.into(),
             },
             source_kind,
@@ -40,6 +43,8 @@ impl AdapterDefinition {
             execution_affinity: ExecutionAffinity::Worker,
             provider_requirements: Vec::new(),
             credential_requirements: Vec::new(),
+            option_schema_id: format!("adapter:{name}:options:v1"),
+            allowed_option_keys: Vec::new(),
             chunking_hints: Vec::new(),
             parser_hints: Vec::new(),
             watch_supported: matches!(source_kind, SourceKind::Local | SourceKind::Web),

--- a/crates/axon-route/src/capability.rs
+++ b/crates/axon-route/src/capability.rs
@@ -141,6 +141,7 @@ impl AdapterRegistry {
             AdapterDefinition::new("reddit", "1", SourceKind::Reddit, SourceScope::Subreddit)
                 .with_scope(SourceScope::Thread)
                 .with_scope(SourceScope::Comment)
+                .with_safety_class(SafetyClass::AuthenticatedNetwork)
                 .with_credential(
                     CredentialKind::ApiKey,
                     "Reddit API credentials are required before acquisition",

--- a/crates/axon-route/src/capability.rs
+++ b/crates/axon-route/src/capability.rs
@@ -85,6 +85,14 @@ pub struct AdapterRegistry {
 
 impl AdapterRegistry {
     pub fn from_adapters(mut adapters: Vec<AdapterDefinition>) -> Self {
+        for adapter in &mut adapters {
+            if let Some(minimum) = minimum_safety_class(adapter.source_kind) {
+                adapter.safety_class = minimum;
+            }
+            if !adapter.supported_scopes.contains(&adapter.default_scope) {
+                adapter.supported_scopes.push(adapter.default_scope);
+            }
+        }
         adapters.sort_by(|left, right| left.adapter.name.cmp(&right.adapter.name));
         Self { adapters }
     }
@@ -155,5 +163,14 @@ impl AdapterRegistry {
         self.adapters
             .iter()
             .find(|adapter| adapter.adapter.name == name)
+    }
+}
+
+fn minimum_safety_class(source_kind: SourceKind) -> Option<SafetyClass> {
+    match source_kind {
+        SourceKind::Local | SourceKind::CliTool | SourceKind::McpTool => {
+            Some(safety_class(source_kind))
+        }
+        _ => None,
     }
 }

--- a/crates/axon-route/src/capability.rs
+++ b/crates/axon-route/src/capability.rs
@@ -1,7 +1,7 @@
 //! Adapter declarations consumed by the router.
 
 use axon_api::{
-    AdapterRef, ChunkHint, CredentialRequirement, ExecutionAffinity, ParserHint,
+    AdapterRef, ChunkHint, CredentialKind, CredentialRequirement, ExecutionAffinity, ParserHint,
     ProviderRequirement, SafetyClass, SourceKind, SourceScope,
 };
 
@@ -58,6 +58,16 @@ impl AdapterDefinition {
         self.safety_class = safety_class;
         self
     }
+
+    pub fn with_credential(mut self, credential_kind: CredentialKind, reason: &str) -> Self {
+        self.credential_requirements.push(CredentialRequirement {
+            credential_kind,
+            secret_ref: None,
+            required: true,
+            reason: reason.to_string(),
+        });
+        self
+    }
 }
 
 fn safety_class(source_kind: SourceKind) -> SafetyClass {
@@ -81,7 +91,8 @@ impl AdapterRegistry {
 
     pub fn target_defaults() -> Self {
         Self::from_adapters(vec![
-            AdapterDefinition::new("cli", "1", SourceKind::CliTool, SourceScope::Tool),
+            AdapterDefinition::new("cli", "1", SourceKind::CliTool, SourceScope::Tool)
+                .with_safety_class(SafetyClass::ToolExecution),
             AdapterDefinition::new("crates", "1", SourceKind::Registry, SourceScope::Package)
                 .with_scope(SourceScope::Version),
             AdapterDefinition::new("docker", "1", SourceKind::Registry, SourceScope::Package)
@@ -108,15 +119,21 @@ impl AdapterRegistry {
                 .with_scope(SourceScope::File)
                 .with_scope(SourceScope::Workspace)
                 .with_safety_class(SafetyClass::LocalFilesystem),
-            AdapterDefinition::new("mcp", "1", SourceKind::McpTool, SourceScope::Tool),
+            AdapterDefinition::new("mcp", "1", SourceKind::McpTool, SourceScope::Tool)
+                .with_safety_class(SafetyClass::ToolExecution),
             AdapterDefinition::new("npm", "1", SourceKind::Registry, SourceScope::Package)
                 .with_scope(SourceScope::Version),
             AdapterDefinition::new("pypi", "1", SourceKind::Registry, SourceScope::Package)
                 .with_scope(SourceScope::Version),
             AdapterDefinition::new("reddit", "1", SourceKind::Reddit, SourceScope::Subreddit)
                 .with_scope(SourceScope::Thread)
-                .with_scope(SourceScope::Comment),
+                .with_scope(SourceScope::Comment)
+                .with_credential(
+                    CredentialKind::ApiKey,
+                    "Reddit API credentials are required before acquisition",
+                ),
             AdapterDefinition::new("session", "1", SourceKind::Session, SourceScope::Thread),
+            AdapterDefinition::new("upload", "1", SourceKind::Upload, SourceScope::File),
             AdapterDefinition::new("web", "1", SourceKind::Web, SourceScope::Site)
                 .with_scope(SourceScope::Page)
                 .with_scope(SourceScope::Docs)

--- a/crates/axon-route/src/capability.rs
+++ b/crates/axon-route/src/capability.rs
@@ -92,7 +92,9 @@ impl AdapterRegistry {
     pub fn from_adapters(mut adapters: Vec<AdapterDefinition>) -> Self {
         for adapter in &mut adapters {
             if let Some(minimum) = minimum_safety_class(adapter.source_kind) {
-                adapter.safety_class = minimum;
+                if safety_rank(adapter.safety_class) < safety_rank(minimum) {
+                    adapter.safety_class = minimum;
+                }
             }
             if !adapter.supported_scopes.contains(&adapter.default_scope) {
                 adapter.supported_scopes.push(adapter.default_scope);
@@ -178,5 +180,14 @@ fn minimum_safety_class(source_kind: SourceKind) -> Option<SafetyClass> {
             Some(safety_class(source_kind))
         }
         _ => None,
+    }
+}
+
+fn safety_rank(safety_class: SafetyClass) -> u8 {
+    match safety_class {
+        SafetyClass::PublicNetwork => 0,
+        SafetyClass::AuthenticatedNetwork => 1,
+        SafetyClass::LocalFilesystem => 2,
+        SafetyClass::ToolExecution => 3,
     }
 }

--- a/crates/axon-route/src/github.rs
+++ b/crates/axon-route/src/github.rs
@@ -26,6 +26,9 @@ pub(crate) fn canonical_github(raw: &str) -> Option<CanonicalSource> {
     }
     let owner = parts[0];
     let repo = trim_git_suffix(parts[1]);
+    if repo.is_empty() {
+        return None;
+    }
     let repo_uri = format!("github://{owner}/{repo}");
     let (canonical_uri, scope, reason) = github_subpath(&repo_uri, &parts[2..]).unwrap_or((
         repo_uri,
@@ -50,7 +53,7 @@ pub(crate) fn canonical_github(raw: &str) -> Option<CanonicalSource> {
     if let Ok(url) = url::Url::parse(raw) {
         source
             .warnings
-            .extend(crate::canonical::sensitive_query_warnings(&url));
+            .extend(crate::query::sensitive_query_warnings(&url));
     }
     Some(source)
 }

--- a/crates/axon-route/src/github.rs
+++ b/crates/axon-route/src/github.rs
@@ -1,0 +1,90 @@
+//! GitHub source canonicalization.
+
+use axon_api::{Severity, SourceKind, SourceScope, SourceWarning};
+
+use crate::canonical::CanonicalSource;
+
+pub(crate) fn canonical_github(raw: &str) -> Option<CanonicalSource> {
+    let path = raw
+        .strip_prefix("https://github.com/")
+        .or_else(|| raw.strip_prefix("http://github.com/"))
+        .or_else(|| raw.strip_prefix("github.com/"))
+        .or_else(|| {
+            if raw.contains("://") || raw.contains('.') {
+                None
+            } else {
+                Some(raw)
+            }
+        })?;
+    let parts = path
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    if parts.len() < 2 || parts[0].contains('.') || parts[0].is_empty() || parts[1].is_empty() {
+        return None;
+    }
+    let owner = parts[0];
+    let repo = trim_git_suffix(parts[1]);
+    let repo_uri = format!("github://{owner}/{repo}");
+    let (canonical_uri, scope, reason) = github_subpath(&repo_uri, &parts[2..]).unwrap_or((
+        repo_uri,
+        SourceScope::Repo,
+        "resolved as GitHub repository source",
+    ));
+    let mut source = CanonicalSource {
+        canonical_uri,
+        source_kind: SourceKind::Git,
+        default_scope: scope,
+        adapter_hint: Some("github".to_string()),
+        display_name: repo.to_string(),
+        reason: reason.to_string(),
+        warnings: Vec::new(),
+    };
+    if path == raw {
+        source.warnings.push(warning(
+            "source.inferred.github_shorthand",
+            "source interpreted as GitHub owner/repo shorthand",
+        ));
+    }
+    Some(source)
+}
+
+fn github_subpath(repo_uri: &str, rest: &[&str]) -> Option<(String, SourceScope, &'static str)> {
+    match rest {
+        ["issues", id, ..] => Some((
+            format!("{repo_uri}/issues/{id}"),
+            SourceScope::Issue,
+            "resolved as GitHub issue source",
+        )),
+        ["pull", id, ..] | ["pulls", id, ..] => Some((
+            format!("{repo_uri}/pulls/{id}"),
+            SourceScope::PullRequest,
+            "resolved as GitHub pull request source",
+        )),
+        ["releases", "tag", tag, ..] => Some((
+            format!("{repo_uri}/releases/tag/{tag}"),
+            SourceScope::Release,
+            "resolved as GitHub release source",
+        )),
+        ["tree", branch @ ..] if !branch.is_empty() => Some((
+            format!("{repo_uri}/tree/{}", branch.join("/")),
+            SourceScope::Branch,
+            "resolved as GitHub branch source",
+        )),
+        _ => None,
+    }
+}
+
+fn trim_git_suffix(value: &str) -> &str {
+    value.strip_suffix(".git").unwrap_or(value)
+}
+
+fn warning(code: &str, message: &str) -> SourceWarning {
+    SourceWarning {
+        code: code.to_string(),
+        severity: Severity::Info,
+        message: message.to_string(),
+        source_item_key: None,
+        retryable: false,
+    }
+}

--- a/crates/axon-route/src/github.rs
+++ b/crates/axon-route/src/github.rs
@@ -10,12 +10,13 @@ pub(crate) fn canonical_github(raw: &str) -> Option<CanonicalSource> {
         .or_else(|| raw.strip_prefix("http://github.com/"))
         .or_else(|| raw.strip_prefix("github.com/"))
         .or_else(|| {
-            if raw.contains("://") || raw.contains('.') {
+            if raw.contains("://") || raw.contains('.') || raw.contains(':') {
                 None
             } else {
                 Some(raw)
             }
         })?;
+    let path = path.split(['?', '#']).next().unwrap_or(path);
     let parts = path
         .split('/')
         .filter(|part| !part.is_empty())
@@ -45,6 +46,11 @@ pub(crate) fn canonical_github(raw: &str) -> Option<CanonicalSource> {
             "source.inferred.github_shorthand",
             "source interpreted as GitHub owner/repo shorthand",
         ));
+    }
+    if let Ok(url) = url::Url::parse(raw) {
+        source
+            .warnings
+            .extend(crate::canonical::sensitive_query_warnings(&url));
     }
     Some(source)
 }

--- a/crates/axon-route/src/lib.rs
+++ b/crates/axon-route/src/lib.rs
@@ -6,6 +6,7 @@ pub mod canonical;
 pub mod capability;
 mod github;
 pub mod local_path;
+mod provider_host;
 pub mod resolver;
 pub mod router;
 pub mod scope;

--- a/crates/axon-route/src/lib.rs
+++ b/crates/axon-route/src/lib.rs
@@ -1,7 +1,4 @@
-//! Target pipeline crate skeleton for `axon-route`.
-//!
-//! This crate is intentionally marker-only in PR0. Runtime behavior moves here
-//! in issue #298 implementation PRs after contract tests exist.
+//! Source resolution and routing for the unified source pipeline.
 
 pub mod alias;
 pub mod authority;
@@ -13,12 +10,16 @@ pub mod scope;
 pub mod source_id;
 pub mod testing;
 
+pub use alias::AliasRecord;
 pub use authority::{AuthorityRecord, InMemoryAuthorityRegistry};
+pub use axon_api::{ResolvedSource, RoutePlan, SourceId, SourceScope};
 pub use capability::{AdapterDefinition, AdapterRegistry};
 pub use resolver::SourceResolver;
 pub use router::{RouteDecision, SourceRouter};
 
 pub const CRATE_NAME: &str = "axon-route";
+pub type AdapterMatch = AdapterDefinition;
+pub type CanonicalUri = String;
 
 #[cfg(test)]
 #[path = "route_tests.rs"]

--- a/crates/axon-route/src/lib.rs
+++ b/crates/axon-route/src/lib.rs
@@ -4,6 +4,7 @@ pub mod alias;
 pub mod authority;
 pub mod canonical;
 pub mod capability;
+pub mod local_path;
 pub mod resolver;
 pub mod router;
 pub mod scope;
@@ -15,7 +16,7 @@ pub use authority::{AuthorityRecord, InMemoryAuthorityRegistry};
 pub use axon_api::{ResolvedSource, RoutePlan, SourceId, SourceScope};
 pub use capability::{AdapterDefinition, AdapterRegistry};
 pub use resolver::SourceResolver;
-pub use router::{RouteDecision, SourceRouter};
+pub use router::{RouteDecision, RouteSecurityPolicy, SourceRouter};
 
 pub const CRATE_NAME: &str = "axon-route";
 pub type AdapterMatch = AdapterDefinition;
@@ -24,3 +25,11 @@ pub type CanonicalUri = String;
 #[cfg(test)]
 #[path = "route_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "route_normalization_tests.rs"]
+mod route_normalization_tests;
+
+#[cfg(test)]
+#[path = "route_validation_tests.rs"]
+mod route_validation_tests;

--- a/crates/axon-route/src/lib.rs
+++ b/crates/axon-route/src/lib.rs
@@ -13,4 +13,13 @@ pub mod scope;
 pub mod source_id;
 pub mod testing;
 
+pub use authority::{AuthorityRecord, InMemoryAuthorityRegistry};
+pub use capability::{AdapterDefinition, AdapterRegistry};
+pub use resolver::SourceResolver;
+pub use router::{RouteDecision, SourceRouter};
+
 pub const CRATE_NAME: &str = "axon-route";
+
+#[cfg(test)]
+#[path = "route_tests.rs"]
+mod tests;

--- a/crates/axon-route/src/lib.rs
+++ b/crates/axon-route/src/lib.rs
@@ -4,6 +4,7 @@ pub mod alias;
 pub mod authority;
 pub mod canonical;
 pub mod capability;
+mod github;
 pub mod local_path;
 pub mod resolver;
 pub mod router;

--- a/crates/axon-route/src/lib.rs
+++ b/crates/axon-route/src/lib.rs
@@ -7,6 +7,7 @@ pub mod capability;
 mod github;
 pub mod local_path;
 mod provider_host;
+mod query;
 pub mod resolver;
 pub mod router;
 pub mod scope;

--- a/crates/axon-route/src/local_path.rs
+++ b/crates/axon-route/src/local_path.rs
@@ -1,0 +1,40 @@
+//! Lexical local path normalization for route identity.
+
+use std::path::{Component, Path, PathBuf};
+
+pub fn normalize_local_path(raw: &str) -> String {
+    normalize_path_components(&expand_home(raw.trim()))
+}
+
+fn expand_home(raw: &str) -> PathBuf {
+    if raw == "~" {
+        return home_dir();
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        return home_dir().join(rest);
+    }
+    PathBuf::from(raw)
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("~"))
+}
+
+fn normalize_path_components(path: &Path) -> String {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+        .to_string_lossy()
+        .trim_end_matches('/')
+        .to_string()
+}

--- a/crates/axon-route/src/local_path.rs
+++ b/crates/axon-route/src/local_path.rs
@@ -37,10 +37,12 @@ fn normalize_path_components(path: &Path) -> String {
             other => normalized.push(other.as_os_str()),
         }
     }
-    normalized
-        .to_string_lossy()
-        .trim_end_matches('/')
-        .to_string()
+    let rendered = normalized.to_string_lossy().to_string();
+    if rendered == "/" {
+        rendered
+    } else {
+        rendered.trim_end_matches('/').to_string()
+    }
 }
 
 fn contains_only_parent_dirs(path: &Path) -> bool {

--- a/crates/axon-route/src/local_path.rs
+++ b/crates/axon-route/src/local_path.rs
@@ -28,7 +28,11 @@ fn normalize_path_components(path: &Path) -> String {
         match component {
             Component::CurDir => {}
             Component::ParentDir => {
-                normalized.pop();
+                if normalized.as_os_str().is_empty() || contains_only_parent_dirs(&normalized) {
+                    normalized.push("..");
+                } else {
+                    normalized.pop();
+                }
             }
             other => normalized.push(other.as_os_str()),
         }
@@ -37,4 +41,9 @@ fn normalize_path_components(path: &Path) -> String {
         .to_string_lossy()
         .trim_end_matches('/')
         .to_string()
+}
+
+fn contains_only_parent_dirs(path: &Path) -> bool {
+    path.components()
+        .all(|component| matches!(component, Component::ParentDir))
 }

--- a/crates/axon-route/src/provider_host.rs
+++ b/crates/axon-route/src/provider_host.rs
@@ -2,6 +2,10 @@ pub(crate) fn is_youtube_host(host: &str) -> bool {
     host == "youtube.com" || host.ends_with(".youtube.com")
 }
 
+pub(crate) fn is_github_host(host: &str) -> bool {
+    host == "github.com" || host.ends_with(".github.com")
+}
+
 pub(crate) fn is_gitlab_host(host: &str) -> bool {
     host == "gitlab.com" || host.ends_with(".gitlab.com") || host.starts_with("gitlab.")
 }

--- a/crates/axon-route/src/provider_host.rs
+++ b/crates/axon-route/src/provider_host.rs
@@ -1,0 +1,18 @@
+pub(crate) fn is_youtube_host(host: &str) -> bool {
+    host == "youtube.com" || host.ends_with(".youtube.com")
+}
+
+pub(crate) fn is_gitlab_host(host: &str) -> bool {
+    host == "gitlab.com" || host.ends_with(".gitlab.com") || host.starts_with("gitlab.")
+}
+
+pub(crate) fn is_gitea_host(host: &str) -> bool {
+    host == "codeberg.org"
+        || host.ends_with(".codeberg.org")
+        || host == "gitea.com"
+        || host.ends_with(".gitea.com")
+        || host == "forgejo.org"
+        || host.ends_with(".forgejo.org")
+        || host.starts_with("gitea.")
+        || host.starts_with("forgejo.")
+}

--- a/crates/axon-route/src/query.rs
+++ b/crates/axon-route/src/query.rs
@@ -1,0 +1,90 @@
+use axon_api::{Severity, SourceWarning};
+use url::{Url, form_urlencoded};
+
+pub(crate) struct QueryNormalization {
+    pub(crate) query: String,
+    pub(crate) warnings: Vec<SourceWarning>,
+}
+
+pub(crate) fn normalized_query(url: &Url) -> QueryNormalization {
+    let mut kept = Vec::new();
+    let mut redacted = false;
+    for (key, value) in url.query_pairs() {
+        let key = key.to_string();
+        let value = value.to_string();
+        if is_tracking_param(&key) {
+            continue;
+        }
+        if is_sensitive_param(&key) {
+            redacted = true;
+            kept.push((key, "REDACTED".to_string()));
+        } else {
+            kept.push((key, value));
+        }
+    }
+    kept.sort();
+
+    let query = if kept.is_empty() {
+        String::new()
+    } else {
+        let mut serializer = form_urlencoded::Serializer::new(String::new());
+        for (key, value) in kept {
+            serializer.append_pair(&key, &value);
+        }
+        format!("?{}", serializer.finish())
+    };
+
+    let warnings = if redacted {
+        vec![warning()]
+    } else {
+        Vec::new()
+    };
+
+    QueryNormalization { query, warnings }
+}
+
+pub(crate) fn sensitive_query_warnings(url: &Url) -> Vec<SourceWarning> {
+    if url.query_pairs().any(|(key, _)| is_sensitive_param(&key)) {
+        vec![warning()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn is_tracking_param(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.starts_with("utm_")
+        || matches!(
+            key.as_str(),
+            "fbclid" | "gclid" | "msclkid" | "mc_cid" | "mc_eid" | "igshid"
+        )
+}
+
+fn is_sensitive_param(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+        || key.contains("signature")
+        || key.contains("credential")
+        || key == "access_key"
+        || key == "awsaccesskeyid"
+        || key.starts_with("x-amz-")
+        || key == "sig"
+        || key == "jwt"
+        || key == "key"
+        || key == "api_key"
+        || key == "apikey"
+        || key == "auth"
+        || key == "authorization"
+}
+
+fn warning() -> SourceWarning {
+    SourceWarning {
+        code: "source.query.sensitive_redacted".to_string(),
+        severity: Severity::Info,
+        message: "sensitive query parameter values were redacted in canonical URI".to_string(),
+        source_item_key: None,
+        retryable: false,
+    }
+}

--- a/crates/axon-route/src/resolver.rs
+++ b/crates/axon-route/src/resolver.rs
@@ -27,67 +27,9 @@ impl SourceResolver {
 
     pub fn resolve(&self, request: &SourceRequest) -> Result<ResolvedSource, ApiError> {
         let mut warnings = Vec::new();
-        let canonical = match self.authorities.find(&request.source) {
-            Some(record) => {
-                let scope = request.scope.unwrap_or(SourceScope::Docs);
-                let canonical_uri = record
-                    .entrypoints
-                    .iter()
-                    .find(|(candidate_scope, _)| candidate_scope == &scope)
-                    .map(|(_, uri)| uri.clone())
-                    .unwrap_or_else(|| record.canonical_uri.clone());
-                warnings.push(warning(
-                    "authority.entrypoint_mapped",
-                    "source matched an authority entrypoint",
-                ));
-                canonical::CanonicalSource {
-                    canonical_uri,
-                    source_kind: record.source_kind,
-                    default_scope: scope,
-                    adapter_hint: None,
-                    display_name: request.source.clone(),
-                    reason: format!("matched authority {}", record.authority_id),
-                }
-            }
-            None => canonical::canonicalize(&request.source, request.scope).ok_or_else(|| {
-                ApiError::new(
-                    "source.resolve.unsupported",
-                    ErrorStage::Resolving,
-                    "unsupported source input",
-                )
-                .with_context("source", request.source.clone())
-            })?,
-        };
-
-        let mut candidates = self
-            .adapters
-            .adapters_for(canonical.source_kind)
-            .into_iter()
-            .map(|adapter| AdapterCandidate {
-                adapter: adapter.adapter.clone(),
-                supported_scopes: adapter.supported_scopes.clone(),
-                confidence: if Some(adapter.adapter.name.as_str())
-                    == canonical.adapter_hint.as_deref()
-                {
-                    1.0
-                } else {
-                    0.8
-                },
-                reason: format!("{} adapter supports source kind", adapter.adapter.name),
-            })
-            .collect::<Vec<_>>();
-        candidates.sort_by(|left, right| {
-            right
-                .confidence
-                .total_cmp(&left.confidence)
-                .then_with(|| left.adapter.name.cmp(&right.adapter.name))
-        });
-
-        let authority = self
-            .authorities
-            .find(&request.source)
-            .map(|record| record.authority)
-            .unwrap_or(AuthorityLevel::Inferred);
+        let canonical = self.resolve_canonical(request, &mut warnings)?;
+        let candidates = self.candidates_for(&canonical);
+        let authority = self.authority_for(&request.source);
         let confidence = if authority == AuthorityLevel::Official {
             0.95
         } else {
@@ -111,6 +53,78 @@ impl SourceResolver {
             reason: canonical.reason,
             warnings,
         })
+    }
+
+    fn resolve_canonical(
+        &self,
+        request: &SourceRequest,
+        warnings: &mut Vec<SourceWarning>,
+    ) -> Result<canonical::CanonicalSource, ApiError> {
+        match self.authorities.find(&request.source) {
+            Some(record) => {
+                let scope = request.scope.unwrap_or(SourceScope::Docs);
+                let canonical_uri = record
+                    .entrypoints
+                    .iter()
+                    .find(|(candidate_scope, _)| candidate_scope == &scope)
+                    .map(|(_, uri)| uri.clone())
+                    .unwrap_or_else(|| record.canonical_uri.clone());
+                warnings.push(warning(
+                    "authority.entrypoint_mapped",
+                    "source matched an authority entrypoint",
+                ));
+                Ok(canonical::CanonicalSource {
+                    canonical_uri,
+                    source_kind: record.source_kind,
+                    default_scope: scope,
+                    adapter_hint: None,
+                    display_name: request.source.clone(),
+                    reason: format!("matched authority {}", record.authority_id),
+                })
+            }
+            None => canonical::canonicalize(&request.source, request.scope).ok_or_else(|| {
+                ApiError::new(
+                    "source.resolve.unsupported",
+                    ErrorStage::Resolving,
+                    "unsupported source input",
+                )
+                .with_context("source", request.source.clone())
+            }),
+        }
+    }
+
+    fn candidates_for(&self, canonical: &canonical::CanonicalSource) -> Vec<AdapterCandidate> {
+        let mut candidates = self
+            .adapters
+            .adapters_for(canonical.source_kind)
+            .into_iter()
+            .map(|adapter| AdapterCandidate {
+                adapter: adapter.adapter.clone(),
+                supported_scopes: adapter.supported_scopes.clone(),
+                confidence: if Some(adapter.adapter.name.as_str())
+                    == canonical.adapter_hint.as_deref()
+                {
+                    1.0
+                } else {
+                    0.8
+                },
+                reason: format!("{} adapter supports source kind", adapter.adapter.name),
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by(|left, right| {
+            right
+                .confidence
+                .total_cmp(&left.confidence)
+                .then_with(|| left.adapter.name.cmp(&right.adapter.name))
+        });
+        candidates
+    }
+
+    fn authority_for(&self, source: &str) -> AuthorityLevel {
+        self.authorities
+            .find(source)
+            .map(|record| record.authority)
+            .unwrap_or(AuthorityLevel::Inferred)
     }
 }
 

--- a/crates/axon-route/src/resolver.rs
+++ b/crates/axon-route/src/resolver.rs
@@ -28,6 +28,7 @@ impl SourceResolver {
     pub fn resolve(&self, request: &SourceRequest) -> Result<ResolvedSource, ApiError> {
         let mut warnings = Vec::new();
         let canonical = self.resolve_canonical(request, &mut warnings)?;
+        warnings.extend(canonical.warnings.clone());
         let candidates = self.candidates_for(&canonical);
         let authority = self.authority_for(&request.source);
         let confidence = if authority == AuthorityLevel::Official {
@@ -80,6 +81,7 @@ impl SourceResolver {
                     adapter_hint: None,
                     display_name: request.source.clone(),
                     reason: format!("matched authority {}", record.authority_id),
+                    warnings: Vec::new(),
                 })
             }
             None => canonical::canonicalize(&request.source, request.scope).ok_or_else(|| {

--- a/crates/axon-route/src/resolver.rs
+++ b/crates/axon-route/src/resolver.rs
@@ -1,3 +1,125 @@
-//! Marker module for the target `axon-route::resolver` boundary.
+//! Source resolver boundary.
 
-pub const MODULE_NAME: &str = "resolver";
+use axon_api::{
+    AdapterCandidate, AuthorityLevel, ResolvedSource, Severity, SourceRequest, SourceScope,
+    SourceWarning,
+};
+use axon_error::{ApiError, ErrorStage};
+
+use crate::authority::InMemoryAuthorityRegistry;
+use crate::canonical;
+use crate::capability::AdapterRegistry;
+use crate::source_id::source_id;
+
+#[derive(Debug, Clone)]
+pub struct SourceResolver {
+    authorities: InMemoryAuthorityRegistry,
+    adapters: AdapterRegistry,
+}
+
+impl SourceResolver {
+    pub fn new(authorities: InMemoryAuthorityRegistry, adapters: AdapterRegistry) -> Self {
+        Self {
+            authorities,
+            adapters,
+        }
+    }
+
+    pub fn resolve(&self, request: &SourceRequest) -> Result<ResolvedSource, ApiError> {
+        let mut warnings = Vec::new();
+        let canonical = match self.authorities.find(&request.source) {
+            Some(record) => {
+                let scope = request.scope.unwrap_or(SourceScope::Docs);
+                let canonical_uri = record
+                    .entrypoints
+                    .iter()
+                    .find(|(candidate_scope, _)| candidate_scope == &scope)
+                    .map(|(_, uri)| uri.clone())
+                    .unwrap_or_else(|| record.canonical_uri.clone());
+                warnings.push(warning(
+                    "authority.entrypoint_mapped",
+                    "source matched an authority entrypoint",
+                ));
+                canonical::CanonicalSource {
+                    canonical_uri,
+                    source_kind: record.source_kind,
+                    default_scope: scope,
+                    adapter_hint: None,
+                    display_name: request.source.clone(),
+                    reason: format!("matched authority {}", record.authority_id),
+                }
+            }
+            None => canonical::canonicalize(&request.source, request.scope).ok_or_else(|| {
+                ApiError::new(
+                    "source.resolve.unsupported",
+                    ErrorStage::Resolving,
+                    "unsupported source input",
+                )
+                .with_context("source", request.source.clone())
+            })?,
+        };
+
+        let mut candidates = self
+            .adapters
+            .adapters_for(canonical.source_kind)
+            .into_iter()
+            .map(|adapter| AdapterCandidate {
+                adapter: adapter.adapter.clone(),
+                supported_scopes: adapter.supported_scopes.clone(),
+                confidence: if Some(adapter.adapter.name.as_str())
+                    == canonical.adapter_hint.as_deref()
+                {
+                    1.0
+                } else {
+                    0.8
+                },
+                reason: format!("{} adapter supports source kind", adapter.adapter.name),
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by(|left, right| {
+            right
+                .confidence
+                .total_cmp(&left.confidence)
+                .then_with(|| left.adapter.name.cmp(&right.adapter.name))
+        });
+
+        let authority = self
+            .authorities
+            .find(&request.source)
+            .map(|record| record.authority)
+            .unwrap_or(AuthorityLevel::Inferred);
+        let confidence = if authority == AuthorityLevel::Official {
+            0.95
+        } else {
+            0.75
+        };
+
+        Ok(ResolvedSource {
+            requested_uri: request.source.clone(),
+            canonical_uri: canonical.canonical_uri.clone(),
+            source_id: source_id(canonical.source_kind, &canonical.canonical_uri),
+            source_kind: canonical.source_kind,
+            display_name: canonical.display_name,
+            candidate_adapters: candidates.clone(),
+            default_scope: request.scope.unwrap_or(canonical.default_scope),
+            available_scopes: candidates
+                .first()
+                .map(|candidate| candidate.supported_scopes.clone())
+                .unwrap_or_default(),
+            authority,
+            confidence,
+            reason: canonical.reason,
+            warnings,
+        })
+    }
+}
+
+fn warning(code: &str, message: &str) -> SourceWarning {
+    SourceWarning {
+        code: code.to_string(),
+        severity: Severity::Info,
+        message: message.to_string(),
+        source_item_key: None,
+        retryable: false,
+    }
+}

--- a/crates/axon-route/src/resolver.rs
+++ b/crates/axon-route/src/resolver.rs
@@ -57,10 +57,7 @@ impl SourceResolver {
             display_name: canonical.display_name,
             candidate_adapters: candidates.clone(),
             default_scope: request.scope.unwrap_or(canonical.default_scope),
-            available_scopes: candidates
-                .first()
-                .map(|candidate| candidate.supported_scopes.clone())
-                .unwrap_or_default(),
+            available_scopes: union_available_scopes(&candidates),
             authority,
             confidence,
             reason: canonical.reason,
@@ -77,7 +74,9 @@ impl SourceResolver {
         match authority_record {
             Some(record) => {
                 self.validate_authority_record(record)?;
-                let scope = request.scope.unwrap_or(SourceScope::Docs);
+                let scope = request
+                    .scope
+                    .unwrap_or_else(|| default_scope_for_authority_record(record));
                 let canonical_uri = record
                     .entrypoints
                     .iter()
@@ -187,6 +186,7 @@ fn uri_matches_kind(uri: &str, kind: SourceKind) -> bool {
                 || uri.starts_with("gitea://")
                 || uri.starts_with("git+http://")
                 || uri.starts_with("git+https://")
+                || git_provider_url(uri)
         }
         SourceKind::Registry => uri.starts_with("pkg://") || uri.starts_with("docker://"),
         SourceKind::Feed => uri.starts_with("feed://"),
@@ -198,6 +198,65 @@ fn uri_matches_kind(uri: &str, kind: SourceKind) -> bool {
         SourceKind::Memory => uri.starts_with("memory://"),
         SourceKind::Upload => uri.starts_with("upload://"),
     }
+}
+
+fn union_available_scopes(candidates: &[AdapterCandidate]) -> Vec<SourceScope> {
+    let mut scopes = Vec::new();
+    for candidate in candidates {
+        for scope in &candidate.supported_scopes {
+            if !scopes.contains(scope) {
+                scopes.push(*scope);
+            }
+        }
+    }
+    scopes
+}
+
+fn default_scope_for_authority_record(record: &crate::authority::AuthorityRecord) -> SourceScope {
+    record
+        .entrypoints
+        .first()
+        .map(|(scope, _)| *scope)
+        .unwrap_or_else(|| default_scope_for_kind(record.source_kind))
+}
+
+fn default_scope_for_kind(source_kind: SourceKind) -> SourceScope {
+    match source_kind {
+        SourceKind::Web => SourceScope::Site,
+        SourceKind::Local => SourceScope::Directory,
+        SourceKind::Git => SourceScope::Repo,
+        SourceKind::Registry => SourceScope::Package,
+        SourceKind::Feed => SourceScope::Feed,
+        SourceKind::Reddit => SourceScope::Subreddit,
+        SourceKind::Youtube => SourceScope::Video,
+        SourceKind::Session => SourceScope::Thread,
+        SourceKind::CliTool | SourceKind::McpTool => SourceScope::Tool,
+        SourceKind::Memory => SourceScope::Thread,
+        SourceKind::Upload => SourceScope::File,
+    }
+}
+
+fn git_provider_url(uri: &str) -> bool {
+    let Ok(url) = url::Url::parse(uri) else {
+        return false;
+    };
+    let Some(host) = url.host_str().map(|host| host.trim_start_matches("www.")) else {
+        return false;
+    };
+    host == "github.com"
+        || host.ends_with(".github.com")
+        || host == "gitlab.com"
+        || host.ends_with(".gitlab.com")
+        || host.starts_with("gitlab.")
+        || host == "codeberg.org"
+        || host.ends_with(".codeberg.org")
+        || host == "gitea.com"
+        || host.ends_with(".gitea.com")
+        || host == "forgejo.org"
+        || host.ends_with(".forgejo.org")
+        || host.starts_with("gitea.")
+        || host.starts_with("forgejo.")
+        || url.path().trim_end_matches('/').ends_with(".git")
 }
 
 fn public_requested_uri(request: &SourceRequest, canonical: &canonical::CanonicalSource) -> String {

--- a/crates/axon-route/src/resolver.rs
+++ b/crates/axon-route/src/resolver.rs
@@ -27,23 +27,27 @@ impl SourceResolver {
 
     pub fn resolve(&self, request: &SourceRequest) -> Result<ResolvedSource, ApiError> {
         let mut warnings = Vec::new();
-        let authority_record = self.authorities.find(&request.source);
+        let authority_matches = self.authorities.matches(&request.source);
+        if authority_matches.len() > 1 {
+            return Err(ApiError::new(
+                "source.resolve.ambiguous",
+                ErrorStage::Resolving,
+                "source matched multiple authority records",
+            )
+            .with_context("source", request.source.clone())
+            .with_context("matches", authority_matches.len().to_string()));
+        }
+        let authority_record = authority_matches.first().copied();
         let canonical = self.resolve_canonical(request, authority_record, &mut warnings)?;
         warnings.extend(canonical.warnings.clone());
         let candidates = self.candidates_for(&canonical);
         let authority = authority_record
             .map(|record| record.authority)
             .unwrap_or(AuthorityLevel::Inferred);
-        let confidence = if authority == AuthorityLevel::Official {
-            0.95
-        } else {
-            0.75
-        };
-        let requested_uri = if canonical.source_kind == SourceKind::Local {
-            "local://redacted".to_string()
-        } else {
-            request.source.clone()
-        };
+        let confidence = authority_record
+            .map(|record| record.confidence.clamp(0.0, 1.0))
+            .unwrap_or(0.75);
+        let requested_uri = public_requested_uri(request, &canonical);
 
         Ok(ResolvedSource {
             requested_uri,
@@ -72,6 +76,7 @@ impl SourceResolver {
     ) -> Result<canonical::CanonicalSource, ApiError> {
         match authority_record {
             Some(record) => {
+                self.validate_authority_record(record)?;
                 let scope = request.scope.unwrap_or(SourceScope::Docs);
                 let canonical_uri = record
                     .entrypoints
@@ -130,6 +135,93 @@ impl SourceResolver {
         });
         candidates
     }
+
+    fn validate_authority_record(
+        &self,
+        record: &crate::authority::AuthorityRecord,
+    ) -> Result<(), ApiError> {
+        if !uri_matches_kind(&record.canonical_uri, record.source_kind)
+            || record
+                .entrypoints
+                .iter()
+                .any(|(_, uri)| !uri_matches_kind(uri, record.source_kind))
+        {
+            return Err(ApiError::new(
+                "source.authority.invalid",
+                ErrorStage::Resolving,
+                "authority record URI does not match declared source kind",
+            )
+            .with_context("authority_id", record.authority_id.clone()));
+        }
+        if let Some(adapter_hint) = record.adapter_hint.as_deref() {
+            let adapter = self.adapters.find(adapter_hint).ok_or_else(|| {
+                ApiError::new(
+                    "source.authority.invalid",
+                    ErrorStage::Resolving,
+                    "authority record references an unknown adapter",
+                )
+                .with_context("authority_id", record.authority_id.clone())
+                .with_context("adapter", adapter_hint.to_string())
+            })?;
+            if adapter.source_kind != record.source_kind {
+                return Err(ApiError::new(
+                    "source.authority.invalid",
+                    ErrorStage::Resolving,
+                    "authority adapter does not support declared source kind",
+                )
+                .with_context("authority_id", record.authority_id.clone())
+                .with_context("adapter", adapter_hint.to_string()));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn uri_matches_kind(uri: &str, kind: SourceKind) -> bool {
+    match kind {
+        SourceKind::Web => uri.starts_with("http://") || uri.starts_with("https://"),
+        SourceKind::Local => uri.starts_with("local://"),
+        SourceKind::Git => {
+            uri.starts_with("github://")
+                || uri.starts_with("gitlab://")
+                || uri.starts_with("gitea://")
+                || uri.starts_with("git+http://")
+                || uri.starts_with("git+https://")
+        }
+        SourceKind::Registry => uri.starts_with("pkg://") || uri.starts_with("docker://"),
+        SourceKind::Feed => uri.starts_with("feed://"),
+        SourceKind::Reddit => uri.starts_with("reddit://"),
+        SourceKind::Youtube => uri.starts_with("youtube://"),
+        SourceKind::Session => uri.starts_with("session://"),
+        SourceKind::CliTool => uri.starts_with("cli://"),
+        SourceKind::McpTool => uri.starts_with("mcp://"),
+        SourceKind::Memory => uri.starts_with("memory://"),
+        SourceKind::Upload => uri.starts_with("upload://"),
+    }
+}
+
+fn public_requested_uri(request: &SourceRequest, canonical: &canonical::CanonicalSource) -> String {
+    if canonical.source_kind == SourceKind::Local {
+        return "local://redacted".to_string();
+    }
+    let redacted_query = canonical
+        .warnings
+        .iter()
+        .any(|warning| warning.code == "source.query.sensitive_redacted");
+    if redacted_query || has_url_userinfo(&request.source) {
+        canonical.canonical_uri.clone()
+    } else {
+        request.source.clone()
+    }
+}
+
+fn has_url_userinfo(source: &str) -> bool {
+    let Some((_, rest)) = source.split_once("://") else {
+        return false;
+    };
+    rest.split('/')
+        .next()
+        .is_some_and(|host| host.contains('@'))
 }
 
 fn warning(code: &str, message: &str) -> SourceWarning {

--- a/crates/axon-route/src/resolver.rs
+++ b/crates/axon-route/src/resolver.rs
@@ -1,8 +1,8 @@
 //! Source resolver boundary.
 
 use axon_api::{
-    AdapterCandidate, AuthorityLevel, ResolvedSource, Severity, SourceRequest, SourceScope,
-    SourceWarning,
+    AdapterCandidate, AuthorityLevel, ResolvedSource, Severity, SourceKind, SourceRequest,
+    SourceScope, SourceWarning,
 };
 use axon_error::{ApiError, ErrorStage};
 
@@ -27,18 +27,26 @@ impl SourceResolver {
 
     pub fn resolve(&self, request: &SourceRequest) -> Result<ResolvedSource, ApiError> {
         let mut warnings = Vec::new();
-        let canonical = self.resolve_canonical(request, &mut warnings)?;
+        let authority_record = self.authorities.find(&request.source);
+        let canonical = self.resolve_canonical(request, authority_record, &mut warnings)?;
         warnings.extend(canonical.warnings.clone());
         let candidates = self.candidates_for(&canonical);
-        let authority = self.authority_for(&request.source);
+        let authority = authority_record
+            .map(|record| record.authority)
+            .unwrap_or(AuthorityLevel::Inferred);
         let confidence = if authority == AuthorityLevel::Official {
             0.95
         } else {
             0.75
         };
+        let requested_uri = if canonical.source_kind == SourceKind::Local {
+            "local://redacted".to_string()
+        } else {
+            request.source.clone()
+        };
 
         Ok(ResolvedSource {
-            requested_uri: request.source.clone(),
+            requested_uri,
             canonical_uri: canonical.canonical_uri.clone(),
             source_id: source_id(canonical.source_kind, &canonical.canonical_uri),
             source_kind: canonical.source_kind,
@@ -59,9 +67,10 @@ impl SourceResolver {
     fn resolve_canonical(
         &self,
         request: &SourceRequest,
+        authority_record: Option<&crate::authority::AuthorityRecord>,
         warnings: &mut Vec<SourceWarning>,
     ) -> Result<canonical::CanonicalSource, ApiError> {
-        match self.authorities.find(&request.source) {
+        match authority_record {
             Some(record) => {
                 let scope = request.scope.unwrap_or(SourceScope::Docs);
                 let canonical_uri = record
@@ -78,7 +87,7 @@ impl SourceResolver {
                     canonical_uri,
                     source_kind: record.source_kind,
                     default_scope: scope,
-                    adapter_hint: None,
+                    adapter_hint: record.adapter_hint.clone(),
                     display_name: request.source.clone(),
                     reason: format!("matched authority {}", record.authority_id),
                     warnings: Vec::new(),
@@ -120,13 +129,6 @@ impl SourceResolver {
                 .then_with(|| left.adapter.name.cmp(&right.adapter.name))
         });
         candidates
-    }
-
-    fn authority_for(&self, source: &str) -> AuthorityLevel {
-        self.authorities
-            .find(source)
-            .map(|record| record.authority)
-            .unwrap_or(AuthorityLevel::Inferred)
     }
 }
 

--- a/crates/axon-route/src/route_normalization_tests.rs
+++ b/crates/axon-route/src/route_normalization_tests.rs
@@ -171,6 +171,8 @@ fn resolver_rejects_empty_source_identifiers() {
         "crates:",
         "pypi:",
         "docker:",
+        "https://github.com/jmagar/.git",
+        "ftp://example.com/docs",
     ];
 
     for source in invalid {

--- a/crates/axon-route/src/route_normalization_tests.rs
+++ b/crates/axon-route/src/route_normalization_tests.rs
@@ -33,6 +33,25 @@ fn resolver_preserves_non_default_ports_in_canonical_sources() {
 }
 
 #[test]
+fn resolver_preserves_explicit_http_scheme() {
+    let resolver = resolver();
+    let web = resolver
+        .resolve(&SourceRequest::new("http://localhost:8080/docs"))
+        .expect("http web resolves");
+    let git = resolver
+        .resolve(&SourceRequest::new(
+            "http://git.example.com/org/project.git",
+        ))
+        .expect("http git resolves");
+
+    assert_eq!(web.canonical_uri, "http://localhost:8080/docs");
+    assert_eq!(
+        git.canonical_uri,
+        "git+http://git.example.com/org/project.git"
+    );
+}
+
+#[test]
 fn resolver_uses_lexical_local_path_identity_without_requiring_existing_paths() {
     let resolver = resolver();
     let first = resolver
@@ -50,6 +69,24 @@ fn resolver_uses_lexical_local_path_identity_without_requiring_existing_paths() 
 
     assert_eq!(first.canonical_uri, second.canonical_uri);
     assert_eq!(first.source_id, second.source_id);
+}
+
+#[test]
+fn resolver_preserves_leading_parent_components_in_relative_local_paths() {
+    let resolver = resolver();
+    let parent = resolver
+        .resolve(&SourceRequest::local_path("../repo", true))
+        .expect("parent relative path resolves");
+    let nested_parent = resolver
+        .resolve(&SourceRequest::local_path("../../repo", true))
+        .expect("nested parent relative path resolves");
+    let local = resolver
+        .resolve(&SourceRequest::local_path("./repo", true))
+        .expect("local relative path resolves");
+
+    assert_ne!(parent.canonical_uri, local.canonical_uri);
+    assert_ne!(nested_parent.canonical_uri, parent.canonical_uri);
+    assert_ne!(nested_parent.source_id, local.source_id);
 }
 
 #[test]
@@ -121,4 +158,96 @@ fn authority_aliases_preserve_provider_specific_adapter_hints() {
 
     assert_eq!(github.candidate_adapters[0].adapter.name, "github");
     assert_eq!(pypi.candidate_adapters[0].adapter.name, "pypi");
+}
+
+#[test]
+fn resolver_rejects_ambiguous_authority_aliases() {
+    let resolver = SourceResolver::new(
+        InMemoryAuthorityRegistry::from_records(vec![
+            AuthorityRecord::new(
+                "auth_fastapi_pkg",
+                "pkg://pypi/fastapi",
+                SourceKind::Registry,
+                AuthorityLevel::Official,
+            )
+            .with_alias("fastapi"),
+            AuthorityRecord::new(
+                "auth_fastapi_docs",
+                "https://fastapi.tiangolo.com/",
+                SourceKind::Web,
+                AuthorityLevel::Official,
+            )
+            .with_alias("fastapi"),
+        ]),
+        AdapterRegistry::target_defaults(),
+    );
+
+    let err = resolver
+        .resolve(&SourceRequest::new("fastapi"))
+        .expect_err("duplicate alias is ambiguous");
+
+    assert_eq!(err.code.0, "source.resolve.ambiguous");
+}
+
+#[test]
+fn resolver_redacts_requested_uri_when_input_contains_url_secrets() {
+    let resolved = resolver()
+        .resolve(&SourceRequest::new(
+            "https://example.com/file?token=abc&q=rust",
+        ))
+        .expect("secret URL resolves");
+
+    assert_eq!(
+        resolved.requested_uri,
+        "https://example.com/file?q=rust&token=REDACTED"
+    );
+    assert!(!resolved.requested_uri.contains("abc"));
+}
+
+#[test]
+fn resolver_preserves_github_subpath_identity_for_supported_scopes() {
+    let resolver = resolver();
+    let issue = resolver
+        .resolve(&SourceRequest::new(
+            "https://github.com/jmagar/axon/issues/308",
+        ))
+        .expect("issue resolves");
+    let pull = resolver
+        .resolve(&SourceRequest::new(
+            "https://github.com/jmagar/axon/pull/308",
+        ))
+        .expect("pull resolves");
+    let branch = resolver
+        .resolve(&SourceRequest::new(
+            "https://github.com/jmagar/axon/tree/main",
+        ))
+        .expect("branch resolves");
+
+    assert_eq!(issue.canonical_uri, "github://jmagar/axon/issues/308");
+    assert_eq!(pull.canonical_uri, "github://jmagar/axon/pulls/308");
+    assert_eq!(branch.canonical_uri, "github://jmagar/axon/tree/main");
+    assert_ne!(issue.source_id, pull.source_id);
+}
+
+#[test]
+fn resolver_uses_authority_record_confidence() {
+    let resolver = SourceResolver::new(
+        InMemoryAuthorityRegistry::from_records(vec![
+            AuthorityRecord::new(
+                "auth_low_confidence_docs",
+                "https://example.com/docs",
+                SourceKind::Web,
+                AuthorityLevel::Official,
+            )
+            .with_alias("low-docs")
+            .with_confidence(0.42),
+        ]),
+        AdapterRegistry::target_defaults(),
+    );
+
+    let resolved = resolver
+        .resolve(&SourceRequest::new("low-docs"))
+        .expect("authority resolves");
+
+    assert_eq!(resolved.confidence, 0.42);
 }

--- a/crates/axon-route/src/route_normalization_tests.rs
+++ b/crates/axon-route/src/route_normalization_tests.rs
@@ -1,4 +1,4 @@
-use axon_api::{AuthorityLevel, SourceKind, SourceRequest};
+use axon_api::{AuthorityLevel, SourceKind, SourceRequest, SourceScope};
 
 use crate::{AdapterRegistry, AuthorityRecord, InMemoryAuthorityRegistry, SourceResolver};
 
@@ -117,14 +117,105 @@ fn resolver_does_not_classify_spoofed_provider_hosts() {
 fn resolver_redacts_common_signed_url_query_params() {
     let resolved = resolver()
         .resolve(&SourceRequest::new(
-            "https://example.com/file?X-Amz-Signature=abc&sig=def&jwt=ghi&q=rust",
+            "https://example.com/file?X-Amz-Signature=abc&sig=def&jwt=ghi&q=rust&access_key=key&AWSAccessKeyId=id&X-Amz-Credential=cred",
         ))
         .expect("signed URL resolves");
 
     assert_eq!(
         resolved.canonical_uri,
-        "https://example.com/file?X-Amz-Signature=REDACTED&jwt=REDACTED&q=rust&sig=REDACTED"
+        "https://example.com/file?AWSAccessKeyId=REDACTED&X-Amz-Credential=REDACTED&X-Amz-Signature=REDACTED&access_key=REDACTED&jwt=REDACTED&q=rust&sig=REDACTED"
     );
+}
+
+#[test]
+fn resolver_suppresses_query_secrets_for_git_provider_urls() {
+    let resolved = resolver()
+        .resolve(&SourceRequest::new(
+            "https://gitlab.com/group/repo?AWSAccessKeyId=id&X-Amz-Credential=cred",
+        ))
+        .expect("gitlab URL resolves");
+
+    assert_eq!(resolved.canonical_uri, "gitlab://gitlab.com/group/repo");
+    assert_eq!(resolved.requested_uri, resolved.canonical_uri);
+    assert!(!resolved.requested_uri.contains("AWSAccessKeyId"));
+    assert!(
+        resolved
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "source.query.sensitive_redacted")
+    );
+}
+
+#[test]
+fn source_id_uses_stable_source_kind_spelling() {
+    let id = crate::source_id::source_id(SourceKind::CliTool, "cli://rg");
+    let expected = format!(
+        "src_{}",
+        &crate::source_id::stable_hash("cli_tool:cli://rg:v1")[..16]
+    );
+
+    assert_eq!(id.0, expected);
+}
+
+#[test]
+fn resolver_rejects_empty_source_identifiers() {
+    let resolver = resolver();
+    let invalid = [
+        "mcp:/tool",
+        "mcp:server/",
+        "session:claude:",
+        "r/",
+        "https://youtu.be/",
+        "https://youtube.com/watch?v=",
+        "npm:",
+        "crates:",
+        "pypi:",
+        "docker:",
+    ];
+
+    for source in invalid {
+        let err = match resolver.resolve(&SourceRequest::new(source)) {
+            Ok(resolved) => panic!("{source} should be rejected, got {resolved:?}"),
+            Err(err) => err,
+        };
+        assert_eq!(err.code.0, "source.resolve.unsupported", "{source}");
+    }
+}
+
+#[test]
+fn resolver_preserves_root_local_path_identity() {
+    assert_eq!(crate::local_path::normalize_local_path("/"), "/");
+
+    let root = resolver()
+        .resolve(&SourceRequest::local_path("/", true))
+        .expect("root path resolves");
+
+    assert!(root.canonical_uri.starts_with("local://lp_"));
+    assert_ne!(root.display_name, "");
+}
+
+#[test]
+fn resolver_classifies_prefixed_self_hosted_git_providers() {
+    let resolver = resolver();
+    let gitlab = resolver
+        .resolve(&SourceRequest::new("https://gitlab.example.com/org/repo"))
+        .expect("self-hosted gitlab resolves");
+    let gitea = resolver
+        .resolve(&SourceRequest::new("https://gitea.example.com/org/repo"))
+        .expect("self-hosted gitea resolves");
+    let forgejo = resolver
+        .resolve(&SourceRequest::new("https://forgejo.example.com/org/repo"))
+        .expect("self-hosted forgejo resolves");
+
+    assert_eq!(gitlab.canonical_uri, "gitlab://gitlab.example.com/org/repo");
+    assert_eq!(gitlab.candidate_adapters[0].adapter.name, "gitlab");
+    assert_eq!(gitea.canonical_uri, "gitea://gitea.example.com/org/repo");
+    assert_eq!(gitea.candidate_adapters[0].adapter.name, "gitea");
+    assert_eq!(
+        forgejo.canonical_uri,
+        "gitea://forgejo.example.com/org/repo"
+    );
+    assert_eq!(forgejo.candidate_adapters[0].adapter.name, "gitea");
 }
 
 #[test]
@@ -158,6 +249,71 @@ fn authority_aliases_preserve_provider_specific_adapter_hints() {
 
     assert_eq!(github.candidate_adapters[0].adapter.name, "github");
     assert_eq!(pypi.candidate_adapters[0].adapter.name, "pypi");
+}
+
+#[test]
+fn authority_alias_matching_is_scheme_case_insensitive() {
+    let resolver = SourceResolver::new(
+        InMemoryAuthorityRegistry::from_records(vec![
+            AuthorityRecord::new(
+                "auth_shadcn_docs",
+                "https://ui.shadcn.com/docs",
+                SourceKind::Web,
+                AuthorityLevel::Official,
+            )
+            .with_alias("https://ui.shadcn.com/docs"),
+        ]),
+        AdapterRegistry::target_defaults(),
+    );
+
+    let resolved = resolver
+        .resolve(&SourceRequest::new("HTTPS://UI.SHADCN.COM/DOCS/"))
+        .expect("uppercase scheme alias resolves");
+
+    assert_eq!(resolved.authority, AuthorityLevel::Official);
+    assert_eq!(resolved.canonical_uri, "https://ui.shadcn.com/docs");
+}
+
+#[test]
+fn authority_records_derive_default_scope_from_entrypoints() {
+    let resolver = SourceResolver::new(
+        InMemoryAuthorityRegistry::from_records(vec![
+            AuthorityRecord::new(
+                "auth_axon_repo",
+                "github://jmagar/axon",
+                SourceKind::Git,
+                AuthorityLevel::Official,
+            )
+            .with_alias("axon-source")
+            .with_entrypoint(SourceScope::Repo, "github://jmagar/axon"),
+        ]),
+        AdapterRegistry::target_defaults(),
+    );
+
+    let resolved = resolver
+        .resolve(&SourceRequest::new("axon-source"))
+        .expect("authority resolves");
+
+    assert_eq!(resolved.default_scope, SourceScope::Repo);
+    assert_eq!(resolved.canonical_uri, "github://jmagar/axon");
+}
+
+#[test]
+fn resolver_unions_available_scopes_from_all_candidate_adapters() {
+    let registry = AdapterRegistry::from_adapters(vec![
+        crate::AdapterDefinition::new("alpha-web", "1", SourceKind::Web, SourceScope::Site),
+        crate::AdapterDefinition::new("beta-web", "1", SourceKind::Web, SourceScope::Page)
+            .with_scope(SourceScope::Map),
+    ]);
+    let resolver = SourceResolver::new(InMemoryAuthorityRegistry::default(), registry);
+
+    let resolved = resolver
+        .resolve(&SourceRequest::new("example.com"))
+        .expect("web resolves");
+
+    assert!(resolved.available_scopes.contains(&SourceScope::Site));
+    assert!(resolved.available_scopes.contains(&SourceScope::Page));
+    assert!(resolved.available_scopes.contains(&SourceScope::Map));
 }
 
 #[test]

--- a/crates/axon-route/src/route_normalization_tests.rs
+++ b/crates/axon-route/src/route_normalization_tests.rs
@@ -251,3 +251,25 @@ fn resolver_uses_authority_record_confidence() {
 
     assert_eq!(resolved.confidence, 0.42);
 }
+
+#[test]
+fn resolver_rejects_inconsistent_authority_records() {
+    let resolver = SourceResolver::new(
+        InMemoryAuthorityRegistry::from_records(vec![
+            AuthorityRecord::new(
+                "auth_bad_docs",
+                "local://lp_bad",
+                SourceKind::Web,
+                AuthorityLevel::Official,
+            )
+            .with_alias("bad-docs"),
+        ]),
+        AdapterRegistry::target_defaults(),
+    );
+
+    let err = resolver
+        .resolve(&SourceRequest::new("bad-docs"))
+        .expect_err("inconsistent authority record fails");
+
+    assert_eq!(err.code.0, "source.authority.invalid");
+}

--- a/crates/axon-route/src/route_normalization_tests.rs
+++ b/crates/axon-route/src/route_normalization_tests.rs
@@ -1,0 +1,124 @@
+use axon_api::{AuthorityLevel, SourceKind, SourceRequest};
+
+use crate::{AdapterRegistry, AuthorityRecord, InMemoryAuthorityRegistry, SourceResolver};
+
+fn resolver() -> SourceResolver {
+    SourceResolver::new(
+        InMemoryAuthorityRegistry::default(),
+        AdapterRegistry::target_defaults(),
+    )
+}
+
+#[test]
+fn resolver_preserves_non_default_ports_in_canonical_sources() {
+    let resolver = resolver();
+    let web = resolver
+        .resolve(&SourceRequest::new("https://example.com:8443/docs"))
+        .expect("web resolves");
+    let feed = resolver
+        .resolve(&SourceRequest::new("rss:https://example.com:8443/feed.xml"))
+        .expect("feed resolves");
+    let git = resolver
+        .resolve(&SourceRequest::new(
+            "https://git.example.com:8443/org/project.git",
+        ))
+        .expect("git resolves");
+
+    assert_eq!(web.canonical_uri, "https://example.com:8443/docs");
+    assert_eq!(feed.canonical_uri, "feed://example.com:8443/feed.xml");
+    assert_eq!(
+        git.canonical_uri,
+        "git+https://git.example.com:8443/org/project.git"
+    );
+}
+
+#[test]
+fn resolver_uses_lexical_local_path_identity_without_requiring_existing_paths() {
+    let resolver = resolver();
+    let first = resolver
+        .resolve(&SourceRequest::local_path(
+            "/tmp/axon-route-missing/./nested/../repo",
+            true,
+        ))
+        .expect("first path resolves");
+    let second = resolver
+        .resolve(&SourceRequest::local_path(
+            "/tmp/axon-route-missing/repo/",
+            true,
+        ))
+        .expect("second path resolves");
+
+    assert_eq!(first.canonical_uri, second.canonical_uri);
+    assert_eq!(first.source_id, second.source_id);
+}
+
+#[test]
+fn resolver_does_not_classify_spoofed_provider_hosts() {
+    let resolver = resolver();
+    let youtube_spoof = resolver
+        .resolve(&SourceRequest::new("https://notyoutube.com/watch?v=abc"))
+        .expect("spoof host resolves as web");
+    let gitlab_spoof = resolver
+        .resolve(&SourceRequest::new(
+            "https://notgitlab.example.com/org/repo",
+        ))
+        .expect("spoof host resolves as web");
+
+    assert_eq!(youtube_spoof.source_kind, SourceKind::Web);
+    assert_eq!(
+        youtube_spoof.canonical_uri,
+        "https://notyoutube.com/watch?v=abc"
+    );
+    assert_eq!(gitlab_spoof.source_kind, SourceKind::Web);
+    assert_eq!(
+        gitlab_spoof.canonical_uri,
+        "https://notgitlab.example.com/org/repo"
+    );
+}
+
+#[test]
+fn resolver_redacts_common_signed_url_query_params() {
+    let resolved = resolver()
+        .resolve(&SourceRequest::new(
+            "https://example.com/file?X-Amz-Signature=abc&sig=def&jwt=ghi&q=rust",
+        ))
+        .expect("signed URL resolves");
+
+    assert_eq!(
+        resolved.canonical_uri,
+        "https://example.com/file?X-Amz-Signature=REDACTED&jwt=REDACTED&q=rust&sig=REDACTED"
+    );
+}
+
+#[test]
+fn authority_aliases_preserve_provider_specific_adapter_hints() {
+    let resolver = SourceResolver::new(
+        InMemoryAuthorityRegistry::from_records(vec![
+            AuthorityRecord::new(
+                "auth_axon_repo",
+                "github://jmagar/axon",
+                SourceKind::Git,
+                AuthorityLevel::Official,
+            )
+            .with_alias("axon-repo"),
+            AuthorityRecord::new(
+                "auth_fastapi_pkg",
+                "pkg://pypi/fastapi",
+                SourceKind::Registry,
+                AuthorityLevel::Official,
+            )
+            .with_alias("fastapi"),
+        ]),
+        AdapterRegistry::target_defaults(),
+    );
+
+    let github = resolver
+        .resolve(&SourceRequest::new("axon-repo"))
+        .expect("repo alias resolves");
+    let pypi = resolver
+        .resolve(&SourceRequest::new("fastapi"))
+        .expect("package alias resolves");
+
+    assert_eq!(github.candidate_adapters[0].adapter.name, "github");
+    assert_eq!(pypi.candidate_adapters[0].adapter.name, "pypi");
+}

--- a/crates/axon-route/src/route_tests.rs
+++ b/crates/axon-route/src/route_tests.rs
@@ -1,4 +1,4 @@
-use axon_api::{AuthorityLevel, SafetyClass, SourceKind, SourceRequest, SourceScope};
+use axon_api::{AuthorityLevel, SafetyClass, SourceIntent, SourceKind, SourceRequest, SourceScope};
 
 use crate::{
     AdapterRegistry, AuthorityRecord, InMemoryAuthorityRegistry, SourceResolver, SourceRouter,
@@ -245,6 +245,55 @@ fn router_rejects_unsupported_scope_before_acquisition() {
 
     assert_eq!(err.code.0, "source.scope.unsupported");
     assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_rejects_unknown_explicit_adapter() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("example.com");
+    request.adapter = Some("missing-adapter".to_string());
+    let resolved = resolver.resolve(&request).expect("source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("unknown adapter fails before acquisition");
+
+    assert_eq!(err.code.0, "route.adapter.unknown");
+    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_rejects_adapter_that_does_not_support_source_kind() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("example.com");
+    request.adapter = Some("github".to_string());
+    let resolved = resolver.resolve(&request).expect("source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("source-kind mismatch fails before acquisition");
+
+    assert_eq!(err.code.0, "route.adapter.unsupported_source");
+    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_routes_map_as_first_class_scope() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("example.com");
+    request.intent = SourceIntent::Map;
+    request.scope = Some(SourceScope::Map);
+    request.embed = false;
+    let resolved = resolver.resolve(&request).expect("source resolves");
+
+    let route = router.route(&request, resolved).expect("map routes");
+
+    assert_eq!(route.adapter.name, "web");
+    assert_eq!(route.scope, SourceScope::Map);
+    assert!(route.graph_fact_kinds.contains(&"source".to_string()));
 }
 
 #[test]

--- a/crates/axon-route/src/route_tests.rs
+++ b/crates/axon-route/src/route_tests.rs
@@ -1,0 +1,189 @@
+use axon_api::{AuthorityLevel, SafetyClass, SourceKind, SourceRequest, SourceScope};
+
+use crate::{
+    AdapterRegistry, AuthorityRecord, InMemoryAuthorityRegistry, SourceResolver, SourceRouter,
+};
+
+fn resolver_with_authority() -> SourceResolver {
+    SourceResolver::new(
+        InMemoryAuthorityRegistry::from_records(vec![
+            AuthorityRecord::new(
+                "auth_shadcn_docs",
+                "https://ui.shadcn.com/docs",
+                SourceKind::Web,
+                AuthorityLevel::Official,
+            )
+            .with_alias("shadcn.com")
+            .with_entrypoint(SourceScope::Docs, "https://ui.shadcn.com/docs"),
+        ]),
+        AdapterRegistry::target_defaults(),
+    )
+}
+
+#[test]
+fn resolver_maps_known_alias_to_official_docs_entrypoint() {
+    let resolver = resolver_with_authority();
+    let mut request = SourceRequest::new("shadcn.com");
+    request.scope = Some(SourceScope::Docs);
+
+    let resolved = resolver.resolve(&request).expect("alias resolves");
+
+    assert_eq!(resolved.requested_uri, "shadcn.com");
+    assert_eq!(resolved.canonical_uri, "https://ui.shadcn.com/docs");
+    assert_eq!(resolved.source_kind, SourceKind::Web);
+    assert_eq!(resolved.default_scope, SourceScope::Docs);
+    assert_eq!(resolved.authority, AuthorityLevel::Official);
+    assert!(resolved.confidence >= 0.9);
+    assert!(
+        resolved
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "authority.entrypoint_mapped")
+    );
+}
+
+#[test]
+fn resolver_normalizes_source_families_without_fetching_content() {
+    let resolver = resolver_with_authority();
+
+    let cases = [
+        (
+            SourceRequest::new("example.com"),
+            SourceKind::Web,
+            "https://example.com/",
+            SourceScope::Site,
+            "web",
+        ),
+        (
+            SourceRequest::new("https://github.com/jmagar/axon"),
+            SourceKind::Git,
+            "github://jmagar/axon",
+            SourceScope::Repo,
+            "github",
+        ),
+        (
+            SourceRequest::new("jmagar/axon"),
+            SourceKind::Git,
+            "github://jmagar/axon",
+            SourceScope::Repo,
+            "github",
+        ),
+        (
+            SourceRequest::new("crates:serde"),
+            SourceKind::Registry,
+            "pkg://crates/serde",
+            SourceScope::Package,
+            "crates",
+        ),
+        (
+            SourceRequest::new("npm:@modelcontextprotocol/sdk"),
+            SourceKind::Registry,
+            "pkg://npm/@modelcontextprotocol/sdk",
+            SourceScope::Package,
+            "npm",
+        ),
+        (
+            SourceRequest::new("r/rust"),
+            SourceKind::Reddit,
+            "reddit://r/rust",
+            SourceScope::Subreddit,
+            "reddit",
+        ),
+        (
+            SourceRequest::new("https://youtube.com/watch?v=dQw4w9WgXcQ"),
+            SourceKind::Youtube,
+            "youtube://video/dQw4w9WgXcQ",
+            SourceScope::Video,
+            "youtube",
+        ),
+        (
+            SourceRequest::new("rss:https://example.com/feed.xml"),
+            SourceKind::Feed,
+            "feed://example.com/feed.xml",
+            SourceScope::Feed,
+            "feed",
+        ),
+        (
+            SourceRequest::new("session:claude:abc123"),
+            SourceKind::Session,
+            "session://claude/abc123",
+            SourceScope::Thread,
+            "session",
+        ),
+        (
+            SourceRequest::new("cli:rg --help"),
+            SourceKind::CliTool,
+            "cli://rg",
+            SourceScope::Tool,
+            "cli",
+        ),
+        (
+            SourceRequest::new("mcp:context7/resolve-library-id"),
+            SourceKind::McpTool,
+            "mcp://context7/tools/resolve-library-id",
+            SourceScope::Tool,
+            "mcp",
+        ),
+    ];
+
+    for (request, source_kind, canonical_uri, default_scope, adapter) in cases {
+        let resolved = resolver
+            .resolve(&request)
+            .unwrap_or_else(|err| panic!("{} should resolve: {err}", request.source));
+        assert_eq!(resolved.source_kind, source_kind, "{}", request.source);
+        assert_eq!(resolved.canonical_uri, canonical_uri, "{}", request.source);
+        assert_eq!(resolved.default_scope, default_scope, "{}", request.source);
+        assert_eq!(resolved.candidate_adapters[0].adapter.name, adapter);
+    }
+}
+
+#[test]
+fn resolver_keeps_local_absolute_paths_out_of_public_identity() {
+    let resolver = resolver_with_authority();
+    let request = SourceRequest::local_path("/home/jmagar/workspace/axon/crates/axon-route", true);
+
+    let resolved = resolver.resolve(&request).expect("local path resolves");
+
+    assert_eq!(resolved.source_kind, SourceKind::Local);
+    assert_eq!(resolved.default_scope, SourceScope::Directory);
+    assert!(resolved.canonical_uri.starts_with("local://lp_"));
+    assert!(!resolved.canonical_uri.contains("/home/jmagar"));
+    assert!(resolved.display_name.contains("axon-route"));
+}
+
+#[test]
+fn router_rejects_unsupported_scope_before_acquisition() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("crates:serde");
+    request.scope = Some(SourceScope::Subreddit);
+    let resolved = resolver.resolve(&request).expect("source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("unsupported scope fails before acquisition");
+
+    assert_eq!(err.code.0, "source.scope.unsupported");
+    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_selects_adapters_deterministically() {
+    let registry = AdapterRegistry::from_adapters(vec![
+        crate::AdapterDefinition::new("zeta", "1", SourceKind::Web, SourceScope::Site)
+            .with_scope(SourceScope::Page),
+        crate::AdapterDefinition::new("alpha", "1", SourceKind::Web, SourceScope::Site)
+            .with_scope(SourceScope::Page),
+    ]);
+    let resolver = SourceResolver::new(InMemoryAuthorityRegistry::default(), registry.clone());
+    let router = SourceRouter::new(registry);
+    let request = SourceRequest::new("example.com");
+    let resolved = resolver.resolve(&request).expect("web source resolves");
+
+    let route = router.route(&request, resolved).expect("route resolves");
+
+    assert_eq!(route.adapter.name, "alpha");
+    assert_eq!(route.scope, SourceScope::Site);
+    assert_eq!(route.safety_class, SafetyClass::PublicNetwork);
+    assert!(route.refresh_supported);
+}

--- a/crates/axon-route/src/route_tests.rs
+++ b/crates/axon-route/src/route_tests.rs
@@ -1,4 +1,4 @@
-use axon_api::{AuthorityLevel, SafetyClass, SourceIntent, SourceKind, SourceRequest, SourceScope};
+use axon_api::{AuthorityLevel, SourceIntent, SourceKind, SourceRequest, SourceScope};
 
 use crate::{
     AdapterRegistry, AuthorityRecord, InMemoryAuthorityRegistry, SourceResolver, SourceRouter,
@@ -222,7 +222,9 @@ fn resolver_keeps_local_absolute_paths_out_of_public_identity() {
     assert_eq!(resolved.source_kind, SourceKind::Local);
     assert_eq!(resolved.default_scope, SourceScope::Directory);
     assert!(resolved.canonical_uri.starts_with("local://lp_"));
+    assert_eq!(resolved.requested_uri, "local://redacted");
     assert!(!resolved.canonical_uri.contains("/home/jmagar"));
+    assert!(!resolved.requested_uri.contains("/home/jmagar"));
     assert!(resolved.display_name.contains("axon-route"));
 }
 
@@ -372,77 +374,6 @@ fn router_rejects_adapter_that_does_not_support_source_kind() {
 }
 
 #[test]
-fn router_rejects_unknown_route_options() {
-    let resolver = resolver_with_authority();
-    let router = SourceRouter::new(AdapterRegistry::target_defaults());
-    let mut request = SourceRequest::new("example.com");
-    request
-        .options
-        .values
-        .insert("definitely_not_valid".to_string(), true.into());
-    let resolved = resolver.resolve(&request).expect("source resolves");
-
-    let err = router
-        .route(&request, resolved)
-        .expect_err("unknown route option fails");
-
-    assert_eq!(err.code.0, "route.options.unsupported");
-    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
-}
-
-#[test]
-fn router_requires_explicit_tool_execution_allowance() {
-    let resolver = resolver_with_authority();
-    let router = SourceRouter::new(AdapterRegistry::target_defaults());
-    let request = SourceRequest::new("mcp:context7/resolve-library-id");
-    let resolved = resolver.resolve(&request).expect("mcp source resolves");
-
-    let err = router
-        .route(&request, resolved)
-        .expect_err("tool execution needs explicit opt-in");
-
-    assert_eq!(err.code.0, "route.tool_execution.denied");
-    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
-}
-
-#[test]
-fn router_reports_credentials_required_by_adapter() {
-    let resolver = resolver_with_authority();
-    let router = SourceRouter::new(AdapterRegistry::target_defaults());
-    let request = SourceRequest::new("r/rust");
-    let resolved = resolver.resolve(&request).expect("reddit source resolves");
-
-    let route = router.route(&request, resolved).expect("reddit routes");
-
-    assert_eq!(route.adapter.name, "reddit");
-    assert!(
-        route
-            .credential_requirements
-            .iter()
-            .any(|requirement| requirement.required)
-    );
-}
-
-#[test]
-fn router_allows_tool_execution_with_explicit_option() {
-    let resolver = resolver_with_authority();
-    let router = SourceRouter::new(AdapterRegistry::target_defaults());
-    let mut request = SourceRequest::new("cli:repomix --help");
-    request
-        .options
-        .values
-        .insert("allow_tool_execution".to_string(), true.into());
-    let resolved = resolver.resolve(&request).expect("cli source resolves");
-
-    let route = router
-        .route(&request, resolved)
-        .expect("cli route resolves");
-
-    assert_eq!(route.adapter.name, "cli");
-    assert_eq!(route.safety_class, SafetyClass::ToolExecution);
-}
-
-#[test]
 fn router_routes_map_as_first_class_scope() {
     let resolver = resolver_with_authority();
     let router = SourceRouter::new(AdapterRegistry::target_defaults());
@@ -457,25 +388,4 @@ fn router_routes_map_as_first_class_scope() {
     assert_eq!(route.adapter.name, "web");
     assert_eq!(route.scope, SourceScope::Map);
     assert!(route.graph_fact_kinds.contains(&"source".to_string()));
-}
-
-#[test]
-fn router_selects_adapters_deterministically() {
-    let registry = AdapterRegistry::from_adapters(vec![
-        crate::AdapterDefinition::new("zeta", "1", SourceKind::Web, SourceScope::Site)
-            .with_scope(SourceScope::Page),
-        crate::AdapterDefinition::new("alpha", "1", SourceKind::Web, SourceScope::Site)
-            .with_scope(SourceScope::Page),
-    ]);
-    let resolver = SourceResolver::new(InMemoryAuthorityRegistry::default(), registry.clone());
-    let router = SourceRouter::new(registry);
-    let request = SourceRequest::new("example.com");
-    let resolved = resolver.resolve(&request).expect("web source resolves");
-
-    let route = router.route(&request, resolved).expect("route resolves");
-
-    assert_eq!(route.adapter.name, "alpha");
-    assert_eq!(route.scope, SourceScope::Site);
-    assert_eq!(route.safety_class, SafetyClass::PublicNetwork);
-    assert!(route.refresh_supported);
 }

--- a/crates/axon-route/src/route_tests.rs
+++ b/crates/axon-route/src/route_tests.rs
@@ -374,6 +374,22 @@ fn router_rejects_adapter_that_does_not_support_source_kind() {
 }
 
 #[test]
+fn router_rejects_explicit_adapter_outside_resolved_provider_family() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("https://github.com/jmagar/axon");
+    request.adapter = Some("git".to_string());
+    let resolved = resolver.resolve(&request).expect("github source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("generic git adapter is not the resolved github provider");
+
+    assert_eq!(err.code.0, "route.adapter.unsupported_source");
+    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
 fn router_routes_map_as_first_class_scope() {
     let resolver = resolver_with_authority();
     let router = SourceRouter::new(AdapterRegistry::target_defaults());

--- a/crates/axon-route/src/route_tests.rs
+++ b/crates/axon-route/src/route_tests.rs
@@ -83,6 +83,34 @@ fn resolver_normalizes_source_families_without_fetching_content() {
             "npm",
         ),
         (
+            SourceRequest::new("pypi:FastAPI"),
+            SourceKind::Registry,
+            "pkg://pypi/fastapi",
+            SourceScope::Package,
+            "pypi",
+        ),
+        (
+            SourceRequest::new("docker:library/postgres:16"),
+            SourceKind::Registry,
+            "docker://docker.io/library/postgres:16",
+            SourceScope::Package,
+            "docker",
+        ),
+        (
+            SourceRequest::new("https://gitlab.com/group/subgroup/project"),
+            SourceKind::Git,
+            "gitlab://gitlab.com/group/subgroup/project",
+            SourceScope::Repo,
+            "gitlab",
+        ),
+        (
+            SourceRequest::new("https://git.example.com/org/project.git"),
+            SourceKind::Git,
+            "git+https://git.example.com/org/project.git",
+            SourceScope::Repo,
+            "git",
+        ),
+        (
             SourceRequest::new("r/rust"),
             SourceKind::Reddit,
             "reddit://r/rust",
@@ -138,6 +166,23 @@ fn resolver_normalizes_source_families_without_fetching_content() {
 }
 
 #[test]
+fn resolver_uses_equivalent_canonical_uri_for_noisy_web_urls() {
+    let resolver = resolver_with_authority();
+    let clean = resolver
+        .resolve(&SourceRequest::new("https://example.com/docs"))
+        .expect("clean resolves");
+    let noisy = resolver
+        .resolve(&SourceRequest::new(
+            "HTTPS://Example.COM:443//docs/?utm_source=newsletter&fbclid=abc#install",
+        ))
+        .expect("noisy resolves");
+
+    assert_eq!(noisy.canonical_uri, "https://example.com/docs");
+    assert_eq!(clean.canonical_uri, noisy.canonical_uri);
+    assert_eq!(clean.source_id, noisy.source_id);
+}
+
+#[test]
 fn resolver_keeps_local_absolute_paths_out_of_public_identity() {
     let resolver = resolver_with_authority();
     let request = SourceRequest::local_path("/home/jmagar/workspace/axon/crates/axon-route", true);
@@ -149,6 +194,41 @@ fn resolver_keeps_local_absolute_paths_out_of_public_identity() {
     assert!(resolved.canonical_uri.starts_with("local://lp_"));
     assert!(!resolved.canonical_uri.contains("/home/jmagar"));
     assert!(resolved.display_name.contains("axon-route"));
+}
+
+#[test]
+fn target_registry_declares_expected_route_time_adapters() {
+    let registry = AdapterRegistry::target_defaults();
+    let expected = [
+        ("cli", SourceKind::CliTool, SourceScope::Tool),
+        ("crates", SourceKind::Registry, SourceScope::Package),
+        ("docker", SourceKind::Registry, SourceScope::Package),
+        ("feed", SourceKind::Feed, SourceScope::Feed),
+        ("git", SourceKind::Git, SourceScope::Repo),
+        ("github", SourceKind::Git, SourceScope::Repo),
+        ("gitlab", SourceKind::Git, SourceScope::Repo),
+        ("gitea", SourceKind::Git, SourceScope::Repo),
+        ("local", SourceKind::Local, SourceScope::Directory),
+        ("mcp", SourceKind::McpTool, SourceScope::Tool),
+        ("npm", SourceKind::Registry, SourceScope::Package),
+        ("pypi", SourceKind::Registry, SourceScope::Package),
+        ("reddit", SourceKind::Reddit, SourceScope::Subreddit),
+        ("session", SourceKind::Session, SourceScope::Thread),
+        ("web", SourceKind::Web, SourceScope::Site),
+        ("youtube", SourceKind::Youtube, SourceScope::Video),
+    ];
+
+    for (name, source_kind, default_scope) in expected {
+        let adapter = registry
+            .find(name)
+            .unwrap_or_else(|| panic!("{name} exists"));
+        assert_eq!(adapter.source_kind, source_kind, "{name}");
+        assert_eq!(adapter.default_scope, default_scope, "{name}");
+        assert!(
+            adapter.supported_scopes.contains(&default_scope),
+            "{name} supports its default scope"
+        );
+    }
 }
 
 #[test]

--- a/crates/axon-route/src/route_tests.rs
+++ b/crates/axon-route/src/route_tests.rs
@@ -183,6 +183,36 @@ fn resolver_uses_equivalent_canonical_uri_for_noisy_web_urls() {
 }
 
 #[test]
+fn resolver_preserves_meaningful_query_params_and_redacts_sensitive_params() {
+    let resolver = resolver_with_authority();
+    let search = resolver
+        .resolve(&SourceRequest::new(
+            "https://example.com/search?utm_source=newsletter&q=rust&page=2",
+        ))
+        .expect("search URL resolves");
+    let sensitive = resolver
+        .resolve(&SourceRequest::new(
+            "https://example.com/search?token=abc&q=rust&password=secret",
+        ))
+        .expect("sensitive URL resolves");
+
+    assert_eq!(
+        search.canonical_uri,
+        "https://example.com/search?page=2&q=rust"
+    );
+    assert_eq!(
+        sensitive.canonical_uri,
+        "https://example.com/search?password=REDACTED&q=rust&token=REDACTED"
+    );
+    assert!(
+        sensitive
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "source.query.sensitive_redacted")
+    );
+}
+
+#[test]
 fn resolver_keeps_local_absolute_paths_out_of_public_identity() {
     let resolver = resolver_with_authority();
     let request = SourceRequest::local_path("/home/jmagar/workspace/axon/crates/axon-route", true);
@@ -194,6 +224,67 @@ fn resolver_keeps_local_absolute_paths_out_of_public_identity() {
     assert!(resolved.canonical_uri.starts_with("local://lp_"));
     assert!(!resolved.canonical_uri.contains("/home/jmagar"));
     assert!(resolved.display_name.contains("axon-route"));
+}
+
+#[test]
+fn resolver_keys_equivalent_local_path_spellings_together() {
+    let resolver = resolver_with_authority();
+    let plain = resolver
+        .resolve(&SourceRequest::local_path(
+            "/home/jmagar/workspace/axon/crates/axon-route",
+            true,
+        ))
+        .expect("plain path resolves");
+    let trailing = resolver
+        .resolve(&SourceRequest::local_path(
+            "/home/jmagar/workspace/axon/crates/axon-route/",
+            true,
+        ))
+        .expect("trailing path resolves");
+
+    assert_eq!(plain.canonical_uri, trailing.canonical_uri);
+    assert_eq!(plain.source_id, trailing.source_id);
+}
+
+#[test]
+fn resolver_normalizes_upload_sources() {
+    let resolver = resolver_with_authority();
+    let resolved = resolver
+        .resolve(&SourceRequest::new("upload:artifact_123"))
+        .expect("upload source resolves");
+
+    assert_eq!(resolved.source_kind, SourceKind::Upload);
+    assert_eq!(resolved.canonical_uri, "upload://artifact_123");
+    assert_eq!(resolved.default_scope, SourceScope::File);
+    assert_eq!(resolved.candidate_adapters[0].adapter.name, "upload");
+}
+
+#[test]
+fn resolver_warns_when_source_shape_is_inferred() {
+    let resolver = resolver_with_authority();
+    let domain = resolver
+        .resolve(&SourceRequest::new("example.com/docs"))
+        .expect("scheme-less docs domain resolves");
+    let shorthand = resolver
+        .resolve(&SourceRequest::new("jmagar/axon"))
+        .expect("github shorthand resolves");
+
+    assert!(domain.confidence < 0.9);
+    assert!(shorthand.confidence < 0.9);
+    assert!(!domain.reason.is_empty());
+    assert!(!shorthand.reason.is_empty());
+    assert!(
+        domain
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "source.inferred.scheme")
+    );
+    assert!(
+        shorthand
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "source.inferred.github_shorthand")
+    );
 }
 
 #[test]
@@ -214,6 +305,7 @@ fn target_registry_declares_expected_route_time_adapters() {
         ("pypi", SourceKind::Registry, SourceScope::Package),
         ("reddit", SourceKind::Reddit, SourceScope::Subreddit),
         ("session", SourceKind::Session, SourceScope::Thread),
+        ("upload", SourceKind::Upload, SourceScope::File),
         ("web", SourceKind::Web, SourceScope::Site),
         ("youtube", SourceKind::Youtube, SourceScope::Video),
     ];
@@ -277,6 +369,77 @@ fn router_rejects_adapter_that_does_not_support_source_kind() {
 
     assert_eq!(err.code.0, "route.adapter.unsupported_source");
     assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_rejects_unknown_route_options() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("example.com");
+    request
+        .options
+        .values
+        .insert("definitely_not_valid".to_string(), true.into());
+    let resolved = resolver.resolve(&request).expect("source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("unknown route option fails");
+
+    assert_eq!(err.code.0, "route.options.unsupported");
+    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_requires_explicit_tool_execution_allowance() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let request = SourceRequest::new("mcp:context7/resolve-library-id");
+    let resolved = resolver.resolve(&request).expect("mcp source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("tool execution needs explicit opt-in");
+
+    assert_eq!(err.code.0, "route.tool_execution.denied");
+    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_reports_credentials_required_by_adapter() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let request = SourceRequest::new("r/rust");
+    let resolved = resolver.resolve(&request).expect("reddit source resolves");
+
+    let route = router.route(&request, resolved).expect("reddit routes");
+
+    assert_eq!(route.adapter.name, "reddit");
+    assert!(
+        route
+            .credential_requirements
+            .iter()
+            .any(|requirement| requirement.required)
+    );
+}
+
+#[test]
+fn router_allows_tool_execution_with_explicit_option() {
+    let resolver = resolver_with_authority();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("cli:repomix --help");
+    request
+        .options
+        .values
+        .insert("allow_tool_execution".to_string(), true.into());
+    let resolved = resolver.resolve(&request).expect("cli source resolves");
+
+    let route = router
+        .route(&request, resolved)
+        .expect("cli route resolves");
+
+    assert_eq!(route.adapter.name, "cli");
+    assert_eq!(route.safety_class, SafetyClass::ToolExecution);
 }
 
 #[test]

--- a/crates/axon-route/src/route_validation_tests.rs
+++ b/crates/axon-route/src/route_validation_tests.rs
@@ -92,14 +92,45 @@ fn router_allows_tool_execution_with_trusted_policy() {
         .route_with_policy(
             &request,
             resolved,
-            RouteSecurityPolicy {
-                allow_tool_execution: true,
-            },
+            RouteSecurityPolicy::trusted_tool_execution(),
         )
         .expect("trusted policy allows cli route");
 
     assert_eq!(route.adapter.name, "cli");
     assert_eq!(route.safety_class, SafetyClass::ToolExecution);
+}
+
+#[test]
+fn router_rejects_forged_resolved_source_identity() {
+    let resolver = resolver();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let request = SourceRequest::new("example.com");
+    let mut resolved = resolver.resolve(&request).expect("source resolves");
+    resolved.canonical_uri = "https://evil.example/".to_string();
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("forged source identity fails");
+
+    assert_eq!(err.code.0, "route.source.invalid");
+}
+
+#[test]
+fn router_enforces_minimum_tool_safety_class_from_registry() {
+    let registry = AdapterRegistry::from_adapters(vec![
+        crate::AdapterDefinition::new("cli", "1", SourceKind::CliTool, SourceScope::Tool)
+            .with_safety_class(SafetyClass::PublicNetwork),
+    ]);
+    let resolver = SourceResolver::new(InMemoryAuthorityRegistry::default(), registry.clone());
+    let router = SourceRouter::new(registry);
+    let request = SourceRequest::new("cli:repomix --help");
+    let resolved = resolver.resolve(&request).expect("cli resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("downgraded tool adapter is still denied");
+
+    assert_eq!(err.code.0, "route.tool_execution.denied");
 }
 
 #[test]

--- a/crates/axon-route/src/route_validation_tests.rs
+++ b/crates/axon-route/src/route_validation_tests.rs
@@ -154,6 +154,24 @@ fn router_enforces_minimum_tool_safety_class_from_registry() {
 }
 
 #[test]
+fn router_preserves_stricter_safety_class_than_source_minimum() {
+    let registry = AdapterRegistry::from_adapters(vec![
+        crate::AdapterDefinition::new("local", "1", SourceKind::Local, SourceScope::Directory)
+            .with_safety_class(SafetyClass::ToolExecution),
+    ]);
+    let resolver = SourceResolver::new(InMemoryAuthorityRegistry::default(), registry.clone());
+    let router = SourceRouter::new(registry);
+    let request = SourceRequest::local_path("/tmp/axon-route-local-tool", true);
+    let resolved = resolver.resolve(&request).expect("local resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("stricter local tool execution is still denied");
+
+    assert_eq!(err.code.0, "route.tool_execution.denied");
+}
+
+#[test]
 fn router_selects_adapters_deterministically() {
     let registry = AdapterRegistry::from_adapters(vec![
         crate::AdapterDefinition::new("zeta", "1", SourceKind::Web, SourceScope::Site)

--- a/crates/axon-route/src/route_validation_tests.rs
+++ b/crates/axon-route/src/route_validation_tests.rs
@@ -1,0 +1,124 @@
+use axon_api::{SafetyClass, SourceKind, SourceRequest, SourceScope};
+
+use crate::{
+    AdapterRegistry, InMemoryAuthorityRegistry, RouteSecurityPolicy, SourceResolver, SourceRouter,
+};
+
+fn resolver() -> SourceResolver {
+    SourceResolver::new(
+        InMemoryAuthorityRegistry::default(),
+        AdapterRegistry::target_defaults(),
+    )
+}
+
+#[test]
+fn router_rejects_unknown_route_options() {
+    let resolver = resolver();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("example.com");
+    request
+        .options
+        .values
+        .insert("definitely_not_valid".to_string(), true.into());
+    let resolved = resolver.resolve(&request).expect("source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("unknown route option fails");
+
+    assert_eq!(err.code.0, "route.options.unsupported");
+    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_requires_explicit_tool_execution_allowance() {
+    let resolver = resolver();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let request = SourceRequest::new("mcp:context7/resolve-library-id");
+    let resolved = resolver.resolve(&request).expect("mcp source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("tool execution needs explicit opt-in");
+
+    assert_eq!(err.code.0, "route.tool_execution.denied");
+    assert_eq!(err.stage, axon_error::ErrorStage::Routing);
+}
+
+#[test]
+fn router_reports_credentials_required_by_adapter() {
+    let resolver = resolver();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let request = SourceRequest::new("r/rust");
+    let resolved = resolver.resolve(&request).expect("reddit source resolves");
+
+    let route = router.route(&request, resolved).expect("reddit routes");
+
+    assert_eq!(route.adapter.name, "reddit");
+    assert!(
+        route
+            .credential_requirements
+            .iter()
+            .any(|requirement| requirement.required)
+    );
+}
+
+#[test]
+fn router_rejects_caller_controlled_tool_execution_option() {
+    let resolver = resolver();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let mut request = SourceRequest::new("cli:repomix --help");
+    request
+        .options
+        .values
+        .insert("allow_tool_execution".to_string(), true.into());
+    let resolved = resolver.resolve(&request).expect("cli source resolves");
+
+    let err = router
+        .route(&request, resolved)
+        .expect_err("public option does not authorize tool execution");
+
+    assert_eq!(err.code.0, "route.options.unsupported");
+}
+
+#[test]
+fn router_allows_tool_execution_with_trusted_policy() {
+    let resolver = resolver();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let request = SourceRequest::new("cli:repomix --help");
+    let resolved = resolver.resolve(&request).expect("cli source resolves");
+
+    let route = router
+        .route_with_policy(
+            &request,
+            resolved,
+            RouteSecurityPolicy {
+                allow_tool_execution: true,
+            },
+        )
+        .expect("trusted policy allows cli route");
+
+    assert_eq!(route.adapter.name, "cli");
+    assert_eq!(route.safety_class, SafetyClass::ToolExecution);
+}
+
+#[test]
+fn router_selects_adapters_deterministically() {
+    let registry = AdapterRegistry::from_adapters(vec![
+        crate::AdapterDefinition::new("zeta", "1", SourceKind::Web, SourceScope::Site)
+            .with_scope(SourceScope::Page),
+        crate::AdapterDefinition::new("alpha", "1", SourceKind::Web, SourceScope::Site)
+            .with_scope(SourceScope::Page),
+    ]);
+    let resolver = SourceResolver::new(InMemoryAuthorityRegistry::default(), registry.clone());
+    let router = SourceRouter::new(registry);
+    let request = SourceRequest::new("example.com");
+    let resolved = resolver.resolve(&request).expect("web source resolves");
+
+    let route = router.route(&request, resolved).expect("route resolves");
+
+    assert_eq!(route.adapter.name, "alpha");
+    assert_eq!(route.scope, SourceScope::Site);
+    assert_eq!(route.safety_class, SafetyClass::PublicNetwork);
+    assert!(route.refresh_supported);
+}

--- a/crates/axon-route/src/route_validation_tests.rs
+++ b/crates/axon-route/src/route_validation_tests.rs
@@ -61,6 +61,7 @@ fn router_reports_credentials_required_by_adapter() {
             .iter()
             .any(|requirement| requirement.required)
     );
+    assert_eq!(route.safety_class, SafetyClass::AuthenticatedNetwork);
 }
 
 #[test]
@@ -98,6 +99,25 @@ fn router_allows_tool_execution_with_trusted_policy() {
 
     assert_eq!(route.adapter.name, "cli");
     assert_eq!(route.safety_class, SafetyClass::ToolExecution);
+    assert_eq!(route.parser_hints[0].parser_id, "cli_tool");
+}
+
+#[test]
+fn router_uses_api_style_parser_ids_for_mcp_tools() {
+    let resolver = resolver();
+    let router = SourceRouter::new(AdapterRegistry::target_defaults());
+    let request = SourceRequest::new("mcp:context7/resolve-library-id");
+    let resolved = resolver.resolve(&request).expect("mcp source resolves");
+
+    let route = router
+        .route_with_policy(
+            &request,
+            resolved,
+            RouteSecurityPolicy::trusted_tool_execution(),
+        )
+        .expect("trusted policy allows mcp route");
+
+    assert_eq!(route.parser_hints[0].parser_id, "mcp_tool");
 }
 
 #[test]

--- a/crates/axon-route/src/router.rs
+++ b/crates/axon-route/src/router.rs
@@ -26,23 +26,7 @@ impl SourceRouter {
         source: ResolvedSource,
     ) -> Result<RoutePlan, ApiError> {
         let scope = request.scope.unwrap_or(source.default_scope);
-        let adapter = request
-            .adapter
-            .as_deref()
-            .and_then(|name| self.adapters.find(name))
-            .or_else(|| {
-                source
-                    .candidate_adapters
-                    .first()
-                    .and_then(|candidate| self.adapters.find(&candidate.adapter.name))
-            })
-            .ok_or_else(|| {
-                ApiError::new(
-                    "route.adapter.missing",
-                    ErrorStage::Routing,
-                    "no adapter supports resolved source",
-                )
-            })?;
+        let adapter = self.select_adapter(request, &source)?;
 
         if !adapter.supported_scopes.contains(&scope) {
             return Err(ApiError::new(
@@ -72,6 +56,45 @@ impl SourceRouter {
             watch_supported: adapter.watch_supported,
             refresh_supported: adapter.refresh_supported,
         })
+    }
+
+    fn select_adapter(
+        &self,
+        request: &SourceRequest,
+        source: &ResolvedSource,
+    ) -> Result<&AdapterDefinition, ApiError> {
+        if let Some(name) = request.adapter.as_deref() {
+            let adapter = self.adapters.find(name).ok_or_else(|| {
+                ApiError::new(
+                    "route.adapter.unknown",
+                    ErrorStage::Routing,
+                    "requested adapter is not registered",
+                )
+                .with_context("adapter", name.to_string())
+            })?;
+            if adapter.source_kind != source.source_kind {
+                return Err(ApiError::new(
+                    "route.adapter.unsupported_source",
+                    ErrorStage::Routing,
+                    "requested adapter does not support resolved source kind",
+                )
+                .with_context("adapter", name.to_string())
+                .with_context("source_kind", format!("{:?}", source.source_kind)));
+            }
+            return Ok(adapter);
+        }
+
+        source
+            .candidate_adapters
+            .first()
+            .and_then(|candidate| self.adapters.find(&candidate.adapter.name))
+            .ok_or_else(|| {
+                ApiError::new(
+                    "route.adapter.missing",
+                    ErrorStage::Routing,
+                    "no adapter supports resolved source",
+                )
+            })
     }
 }
 

--- a/crates/axon-route/src/router.rs
+++ b/crates/axon-route/src/router.rs
@@ -10,6 +10,11 @@ use crate::capability::{AdapterDefinition, AdapterRegistry};
 
 pub type RouteDecision = RoutePlan;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RouteSecurityPolicy {
+    pub allow_tool_execution: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct SourceRouter {
     adapters: AdapterRegistry,
@@ -25,6 +30,15 @@ impl SourceRouter {
         request: &SourceRequest,
         source: ResolvedSource,
     ) -> Result<RoutePlan, ApiError> {
+        self.route_with_policy(request, source, RouteSecurityPolicy::default())
+    }
+
+    pub fn route_with_policy(
+        &self,
+        request: &SourceRequest,
+        source: ResolvedSource,
+        policy: RouteSecurityPolicy,
+    ) -> Result<RoutePlan, ApiError> {
         let scope = request.scope.unwrap_or(source.default_scope);
         let adapter = self.select_adapter(request, &source)?;
 
@@ -37,7 +51,7 @@ impl SourceRouter {
             .with_context("adapter", adapter.adapter.name.clone())
             .with_context("scope", format!("{scope:?}")));
         }
-        self.validate_options(request, adapter)?;
+        self.validate_options(request, adapter, policy)?;
 
         Ok(RoutePlan {
             source,
@@ -102,34 +116,25 @@ impl SourceRouter {
         &self,
         request: &SourceRequest,
         adapter: &AdapterDefinition,
+        policy: RouteSecurityPolicy,
     ) -> Result<(), ApiError> {
         for key in request.options.values.keys() {
-            if key != "allow_tool_execution" {
-                return Err(ApiError::new(
-                    "route.options.unsupported",
-                    ErrorStage::Routing,
-                    "unsupported route option for selected adapter",
-                )
-                .with_context("adapter", adapter.adapter.name.clone())
-                .with_context("option", key.clone()));
-            }
+            return Err(ApiError::new(
+                "route.options.unsupported",
+                ErrorStage::Routing,
+                "unsupported route option for selected adapter",
+            )
+            .with_context("adapter", adapter.adapter.name.clone())
+            .with_context("option", key.clone()));
         }
 
-        if adapter.safety_class == SafetyClass::ToolExecution {
-            let allowed = request
-                .options
-                .values
-                .get("allow_tool_execution")
-                .and_then(|value| value.as_bool())
-                == Some(true);
-            if !allowed {
-                return Err(ApiError::new(
-                    "route.tool_execution.denied",
-                    ErrorStage::Routing,
-                    "tool execution sources require explicit allow_tool_execution=true",
-                )
-                .with_context("adapter", adapter.adapter.name.clone()));
-            }
+        if adapter.safety_class == SafetyClass::ToolExecution && !policy.allow_tool_execution {
+            return Err(ApiError::new(
+                "route.tool_execution.denied",
+                ErrorStage::Routing,
+                "tool execution sources require trusted execution policy",
+            )
+            .with_context("adapter", adapter.adapter.name.clone()));
         }
 
         Ok(())

--- a/crates/axon-route/src/router.rs
+++ b/crates/axon-route/src/router.rs
@@ -2,7 +2,7 @@
 
 use axon_api::{
     AdapterOptions, ChunkHint, ChunkProfile, ExecutionAffinity, ParserHint, ProviderRequirement,
-    ResolvedSource, RoutePlan, SourceKind, SourceRequest,
+    ResolvedSource, RoutePlan, SafetyClass, SourceKind, SourceRequest,
 };
 use axon_error::{ApiError, ErrorStage};
 
@@ -37,6 +37,7 @@ impl SourceRouter {
             .with_context("adapter", adapter.adapter.name.clone())
             .with_context("scope", format!("{scope:?}")));
         }
+        self.validate_options(request, adapter)?;
 
         Ok(RoutePlan {
             source,
@@ -96,6 +97,43 @@ impl SourceRouter {
                 )
             })
     }
+
+    fn validate_options(
+        &self,
+        request: &SourceRequest,
+        adapter: &AdapterDefinition,
+    ) -> Result<(), ApiError> {
+        for key in request.options.values.keys() {
+            if key != "allow_tool_execution" {
+                return Err(ApiError::new(
+                    "route.options.unsupported",
+                    ErrorStage::Routing,
+                    "unsupported route option for selected adapter",
+                )
+                .with_context("adapter", adapter.adapter.name.clone())
+                .with_context("option", key.clone()));
+            }
+        }
+
+        if adapter.safety_class == SafetyClass::ToolExecution {
+            let allowed = request
+                .options
+                .values
+                .get("allow_tool_execution")
+                .and_then(|value| value.as_bool())
+                == Some(true);
+            if !allowed {
+                return Err(ApiError::new(
+                    "route.tool_execution.denied",
+                    ErrorStage::Routing,
+                    "tool execution sources require explicit allow_tool_execution=true",
+                )
+                .with_context("adapter", adapter.adapter.name.clone()));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 fn execution_affinity(adapter: &AdapterDefinition) -> ExecutionAffinity {
@@ -118,7 +156,7 @@ fn chunking_hints(source_kind: SourceKind) -> Vec<ChunkHint> {
         SourceKind::Git | SourceKind::Local => ChunkProfile::CodeAst,
         SourceKind::Session => ChunkProfile::Session,
         SourceKind::Youtube => ChunkProfile::Transcript,
-        SourceKind::Registry | SourceKind::McpTool | SourceKind::CliTool => {
+        SourceKind::Registry | SourceKind::McpTool | SourceKind::CliTool | SourceKind::Upload => {
             ChunkProfile::Structured
         }
         _ => ChunkProfile::Markdown,

--- a/crates/axon-route/src/router.rs
+++ b/crates/axon-route/src/router.rs
@@ -71,7 +71,7 @@ impl SourceRouter {
             credential_requirements: adapter.credential_requirements.clone(),
             execution_affinity: execution_affinity(adapter),
             safety_class: adapter.safety_class,
-            option_schema_id: format!("adapter:{}:options:v1", adapter.adapter.name),
+            option_schema_id: adapter.option_schema_id.clone(),
             validated_options: AdapterOptions {
                 values: request.options.values.clone(),
             },
@@ -161,13 +161,16 @@ impl SourceRouter {
         policy: RouteSecurityPolicy,
     ) -> Result<(), ApiError> {
         for key in request.options.values.keys() {
-            return Err(ApiError::new(
-                "route.options.unsupported",
-                ErrorStage::Routing,
-                "unsupported route option for selected adapter",
-            )
-            .with_context("adapter", adapter.adapter.name.clone())
-            .with_context("option", key.clone()));
+            if !adapter.allowed_option_keys.contains(key) {
+                return Err(ApiError::new(
+                    "route.options.unsupported",
+                    ErrorStage::Routing,
+                    "unsupported route option for selected adapter schema",
+                )
+                .with_context("adapter", adapter.adapter.name.clone())
+                .with_context("option_schema_id", adapter.option_schema_id.clone())
+                .with_context("option", key.clone()));
+            }
         }
 
         if adapter.safety_class == SafetyClass::ToolExecution && !policy.allow_tool_execution {

--- a/crates/axon-route/src/router.rs
+++ b/crates/axon-route/src/router.rs
@@ -138,6 +138,32 @@ impl SourceRouter {
                 .with_context("adapter", name.to_string())
                 .with_context("source_kind", format!("{:?}", source.source_kind)));
             }
+            let Some(candidate) = source
+                .candidate_adapters
+                .iter()
+                .find(|candidate| candidate.adapter.name == name)
+            else {
+                return Err(ApiError::new(
+                    "route.adapter.unsupported_source",
+                    ErrorStage::Routing,
+                    "requested adapter was not produced by source resolution",
+                )
+                .with_context("adapter", name.to_string())
+                .with_context("canonical_uri", source.canonical_uri.clone()));
+            };
+            let has_provider_specific_candidate = source
+                .candidate_adapters
+                .iter()
+                .any(|candidate| candidate.confidence >= 1.0);
+            if has_provider_specific_candidate && candidate.confidence < 1.0 {
+                return Err(ApiError::new(
+                    "route.adapter.unsupported_source",
+                    ErrorStage::Routing,
+                    "requested adapter does not match resolved provider family",
+                )
+                .with_context("adapter", name.to_string())
+                .with_context("canonical_uri", source.canonical_uri.clone()));
+            }
             return Ok(adapter);
         }
 
@@ -220,10 +246,27 @@ fn chunking_hints(source_kind: SourceKind) -> Vec<ChunkHint> {
 
 fn parser_hints(source_kind: SourceKind) -> Vec<ParserHint> {
     vec![ParserHint {
-        parser_id: format!("{source_kind:?}").to_ascii_lowercase(),
+        parser_id: source_kind_key(source_kind).to_string(),
         reason: "route default parser".to_string(),
         options: Default::default(),
     }]
+}
+
+fn source_kind_key(source_kind: SourceKind) -> &'static str {
+    match source_kind {
+        SourceKind::Web => "web",
+        SourceKind::Local => "local",
+        SourceKind::Git => "git",
+        SourceKind::Registry => "registry",
+        SourceKind::Feed => "feed",
+        SourceKind::Reddit => "reddit",
+        SourceKind::Youtube => "youtube",
+        SourceKind::Session => "session",
+        SourceKind::CliTool => "cli_tool",
+        SourceKind::McpTool => "mcp_tool",
+        SourceKind::Memory => "memory",
+        SourceKind::Upload => "upload",
+    }
 }
 
 fn graph_fact_kinds(source_kind: SourceKind) -> Vec<String> {

--- a/crates/axon-route/src/router.rs
+++ b/crates/axon-route/src/router.rs
@@ -7,12 +7,21 @@ use axon_api::{
 use axon_error::{ApiError, ErrorStage};
 
 use crate::capability::{AdapterDefinition, AdapterRegistry};
+use crate::source_id::source_id;
 
 pub type RouteDecision = RoutePlan;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RouteSecurityPolicy {
-    pub allow_tool_execution: bool,
+    allow_tool_execution: bool,
+}
+
+impl RouteSecurityPolicy {
+    pub fn trusted_tool_execution() -> Self {
+        Self {
+            allow_tool_execution: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -39,6 +48,7 @@ impl SourceRouter {
         source: ResolvedSource,
         policy: RouteSecurityPolicy,
     ) -> Result<RoutePlan, ApiError> {
+        self.validate_source(&source)?;
         let scope = request.scope.unwrap_or(source.default_scope);
         let adapter = self.select_adapter(request, &source)?;
 
@@ -71,6 +81,38 @@ impl SourceRouter {
             watch_supported: adapter.watch_supported,
             refresh_supported: adapter.refresh_supported,
         })
+    }
+
+    fn validate_source(&self, source: &ResolvedSource) -> Result<(), ApiError> {
+        let expected = source_id(source.source_kind, &source.canonical_uri);
+        if source.source_id != expected {
+            return Err(ApiError::new(
+                "route.source.invalid",
+                ErrorStage::Routing,
+                "resolved source id does not match canonical identity",
+            ));
+        }
+
+        for candidate in &source.candidate_adapters {
+            let Some(adapter) = self.adapters.find(&candidate.adapter.name) else {
+                return Err(ApiError::new(
+                    "route.source.invalid",
+                    ErrorStage::Routing,
+                    "resolved source references an unregistered adapter",
+                )
+                .with_context("adapter", candidate.adapter.name.clone()));
+            };
+            if adapter.source_kind != source.source_kind {
+                return Err(ApiError::new(
+                    "route.source.invalid",
+                    ErrorStage::Routing,
+                    "resolved source adapter candidate does not match source kind",
+                )
+                .with_context("adapter", candidate.adapter.name.clone()));
+            }
+        }
+
+        Ok(())
     }
 
     fn select_adapter(

--- a/crates/axon-route/src/router.rs
+++ b/crates/axon-route/src/router.rs
@@ -1,3 +1,125 @@
-//! Marker module for the target `axon-route::router` boundary.
+//! Source router boundary.
 
-pub const MODULE_NAME: &str = "router";
+use axon_api::{
+    AdapterOptions, ChunkHint, ChunkProfile, ExecutionAffinity, ParserHint, ProviderRequirement,
+    ResolvedSource, RoutePlan, SourceKind, SourceRequest,
+};
+use axon_error::{ApiError, ErrorStage};
+
+use crate::capability::{AdapterDefinition, AdapterRegistry};
+
+pub type RouteDecision = RoutePlan;
+
+#[derive(Debug, Clone)]
+pub struct SourceRouter {
+    adapters: AdapterRegistry,
+}
+
+impl SourceRouter {
+    pub fn new(adapters: AdapterRegistry) -> Self {
+        Self { adapters }
+    }
+
+    pub fn route(
+        &self,
+        request: &SourceRequest,
+        source: ResolvedSource,
+    ) -> Result<RoutePlan, ApiError> {
+        let scope = request.scope.unwrap_or(source.default_scope);
+        let adapter = request
+            .adapter
+            .as_deref()
+            .and_then(|name| self.adapters.find(name))
+            .or_else(|| {
+                source
+                    .candidate_adapters
+                    .first()
+                    .and_then(|candidate| self.adapters.find(&candidate.adapter.name))
+            })
+            .ok_or_else(|| {
+                ApiError::new(
+                    "route.adapter.missing",
+                    ErrorStage::Routing,
+                    "no adapter supports resolved source",
+                )
+            })?;
+
+        if !adapter.supported_scopes.contains(&scope) {
+            return Err(ApiError::new(
+                "source.scope.unsupported",
+                ErrorStage::Routing,
+                "adapter does not support requested source scope",
+            )
+            .with_context("adapter", adapter.adapter.name.clone())
+            .with_context("scope", format!("{scope:?}")));
+        }
+
+        Ok(RoutePlan {
+            source,
+            adapter: adapter.adapter.clone(),
+            scope,
+            provider_requirements: provider_requirements(adapter),
+            credential_requirements: adapter.credential_requirements.clone(),
+            execution_affinity: execution_affinity(adapter),
+            safety_class: adapter.safety_class,
+            option_schema_id: format!("adapter:{}:options:v1", adapter.adapter.name),
+            validated_options: AdapterOptions {
+                values: request.options.values.clone(),
+            },
+            chunking_hints: chunking_hints(adapter.source_kind),
+            parser_hints: parser_hints(adapter.source_kind),
+            graph_fact_kinds: graph_fact_kinds(adapter.source_kind),
+            watch_supported: adapter.watch_supported,
+            refresh_supported: adapter.refresh_supported,
+        })
+    }
+}
+
+fn execution_affinity(adapter: &AdapterDefinition) -> ExecutionAffinity {
+    if adapter.source_kind == SourceKind::CliTool || adapter.source_kind == SourceKind::McpTool {
+        ExecutionAffinity::ProviderBound
+    } else {
+        adapter.execution_affinity
+    }
+}
+
+fn provider_requirements(adapter: &AdapterDefinition) -> Vec<ProviderRequirement> {
+    if !adapter.provider_requirements.is_empty() {
+        return adapter.provider_requirements.clone();
+    }
+    Vec::new()
+}
+
+fn chunking_hints(source_kind: SourceKind) -> Vec<ChunkHint> {
+    let profile = match source_kind {
+        SourceKind::Git | SourceKind::Local => ChunkProfile::CodeAst,
+        SourceKind::Session => ChunkProfile::Session,
+        SourceKind::Youtube => ChunkProfile::Transcript,
+        SourceKind::Registry | SourceKind::McpTool | SourceKind::CliTool => {
+            ChunkProfile::Structured
+        }
+        _ => ChunkProfile::Markdown,
+    };
+    vec![ChunkHint {
+        profile,
+        reason: "route default chunk profile".to_string(),
+        options: Default::default(),
+    }]
+}
+
+fn parser_hints(source_kind: SourceKind) -> Vec<ParserHint> {
+    vec![ParserHint {
+        parser_id: format!("{source_kind:?}").to_ascii_lowercase(),
+        reason: "route default parser".to_string(),
+        options: Default::default(),
+    }]
+}
+
+fn graph_fact_kinds(source_kind: SourceKind) -> Vec<String> {
+    match source_kind {
+        SourceKind::Git => vec!["repo".to_string(), "package_manifest".to_string()],
+        SourceKind::Registry => vec!["package".to_string()],
+        SourceKind::CliTool | SourceKind::McpTool => vec!["tool".to_string()],
+        _ => vec!["source".to_string()],
+    }
+}

--- a/crates/axon-route/src/source_id.rs
+++ b/crates/axon-route/src/source_id.rs
@@ -1,3 +1,21 @@
-//! Marker module for the target `axon-route::source_id` boundary.
+//! Stable source identity construction.
 
-pub const MODULE_NAME: &str = "source_id";
+use axon_api::{SourceId, SourceKind};
+use sha2::{Digest, Sha256};
+
+pub fn source_id(source_kind: SourceKind, canonical_uri: &str) -> SourceId {
+    SourceId::new(format!(
+        "src_{}",
+        stable_hash(&format!("{source_kind:?}:{canonical_uri}:v1"))[..16].to_string()
+    ))
+}
+
+pub fn local_project_key(path: &str) -> String {
+    format!("lp_{}", &stable_hash(path)[..16])
+}
+
+pub fn stable_hash(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    hex::encode(hasher.finalize())
+}

--- a/crates/axon-route/src/source_id.rs
+++ b/crates/axon-route/src/source_id.rs
@@ -6,7 +6,11 @@ use sha2::{Digest, Sha256};
 pub fn source_id(source_kind: SourceKind, canonical_uri: &str) -> SourceId {
     SourceId::new(format!(
         "src_{}",
-        stable_hash(&format!("{source_kind:?}:{canonical_uri}:v1"))[..16].to_string()
+        stable_hash(&format!(
+            "{}:{canonical_uri}:v1",
+            source_kind_key(source_kind)
+        ))[..16]
+            .to_string()
     ))
 }
 
@@ -18,4 +22,21 @@ pub fn stable_hash(value: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(value.as_bytes());
     hex::encode(hasher.finalize())
+}
+
+fn source_kind_key(source_kind: SourceKind) -> &'static str {
+    match source_kind {
+        SourceKind::Web => "web",
+        SourceKind::Local => "local",
+        SourceKind::Git => "git",
+        SourceKind::Registry => "registry",
+        SourceKind::Feed => "feed",
+        SourceKind::Reddit => "reddit",
+        SourceKind::Youtube => "youtube",
+        SourceKind::Session => "session",
+        SourceKind::CliTool => "cli_tool",
+        SourceKind::McpTool => "mcp_tool",
+        SourceKind::Memory => "memory",
+        SourceKind::Upload => "upload",
+    }
 }

--- a/docs/pipeline-unification/crates/axon-route/README.md
+++ b/docs/pipeline-unification/crates/axon-route/README.md
@@ -42,12 +42,15 @@ testing.rs
 - `SourceResolver`
 - `SourceRouter`
 - `ResolvedSource`
+- `RoutePlan`
 - `RouteDecision`
 - `CanonicalUri`
 - `SourceId`
 - `SourceScope`
 - `AuthorityRecord`
 - `AliasRecord`
+- `AdapterDefinition`
+- `AdapterRegistry`
 - `AdapterMatch`
 
 ## Dependencies Allowed

--- a/docs/pipeline-unification/delivery/local-source-ledger-spike-notes.md
+++ b/docs/pipeline-unification/delivery/local-source-ledger-spike-notes.md
@@ -59,9 +59,12 @@ These pieces should not be carried forward as-is:
 
 ## Follow-Up PR Boundaries
 
-- PR3 should promote the spike shape into real local-source service boundaries.
-- PR4 should introduce committed-generation publish and source-owned cleanup debt
-  execution.
-- PR5 should cut CLI/MCP/REST to the unified source command/action/route model.
-- PR6 should move the proven code into the target crates once behavior is stable
-  enough to relocate without guessing.
+- PR5 is the resolver/router registry: source canonicalization, source IDs,
+  authority/alias mapping, adapter capability/scope metadata, and route-time
+  validation before acquisition.
+- PR6 is the local-source ledger spike: local source adapter prototype, ledger
+  draft/generation row, `SourceDocument`, and existing prepare path proof.
+- Later lifecycle PRs introduce committed-generation publish and source-owned
+  cleanup debt execution.
+- Public CLI/MCP/REST cutover is intentionally later, after source-family ports
+  and generated-surface removal checks are ready.

--- a/docs/pipeline-unification/foundation/crate-structure.md
+++ b/docs/pipeline-unification/foundation/crate-structure.md
@@ -442,7 +442,9 @@ router.rs
 canonical.rs
 authority.rs
 source_id.rs
-patterns.rs
+alias.rs
+scope.rs
+capability.rs
 testing.rs
 ```
 
@@ -452,11 +454,13 @@ Must expose:
 - `SourceRouter`
 - `ResolvedSource`
 - `RoutePlan`
+- `RouteDecision`
 - canonical URI utilities
 - source id/fingerprint utilities
 - adapter candidate matching
 - authority map lookup hooks
-- fake resolver/router
+- alias records
+- adapter capability/scope registry
 
 Must not own:
 

--- a/xtask/src/checks/repo_structure_spec.rs
+++ b/xtask/src/checks/repo_structure_spec.rs
@@ -16,6 +16,11 @@ pub const REQUIRED_WORKSPACE_MEMBERS: &[&str] = &[
     "crates/axon-vectors",
     "crates/axon-llm",
     "crates/axon-adapters",
+    // Phase 4 / PR5 route crate graduated from PR0 skeleton status:
+    // it now owns source resolving, canonicalization, routing, adapter
+    // capability metadata, authority aliases, stable source IDs, and sidecar
+    // tests.
+    "crates/axon-route",
     "crates/axon-crawl",
     "crates/axon-vector",
     "crates/axon-ingest",
@@ -50,20 +55,6 @@ pub const TARGET_CRATES: &[TargetCrate] = &[
             "span",
             "log",
             "collector",
-            "testing",
-        ],
-    },
-    TargetCrate {
-        name: "axon-route",
-        modules: &[
-            "resolver",
-            "router",
-            "canonical",
-            "source_id",
-            "scope",
-            "authority",
-            "alias",
-            "capability",
             "testing",
         ],
     },

--- a/xtask/src/checks/repo_structure_tests.rs
+++ b/xtask/src/checks/repo_structure_tests.rs
@@ -116,10 +116,10 @@ fn missing_target_crate_fails() {
 #[test]
 fn broken_agent_memory_symlink_fails() {
     let fixture = complete_fixture();
-    fs::remove_file(fixture.root.join("crates/axon-route/src/AGENTS.md")).unwrap();
+    fs::remove_file(fixture.root.join("crates/axon-observe/src/AGENTS.md")).unwrap();
     write_symlink(
         "../CLAUDE.md",
-        &fixture.root.join("crates/axon-route/src/AGENTS.md"),
+        &fixture.root.join("crates/axon-observe/src/AGENTS.md"),
     );
 
     let err = check_root(&fixture.root).unwrap_err();
@@ -129,23 +129,23 @@ fn broken_agent_memory_symlink_fails() {
 #[test]
 fn missing_target_module_fails() {
     let fixture = complete_fixture();
-    fs::remove_file(fixture.root.join("crates/axon-route/src/resolver.rs")).unwrap();
+    fs::remove_file(fixture.root.join("crates/axon-observe/src/event.rs")).unwrap();
 
     let err = check_root(&fixture.root).unwrap_err();
-    assert!(err.contains("resolver.rs"), "{err}");
+    assert!(err.contains("event.rs"), "{err}");
 }
 
 #[test]
 fn missing_target_module_declaration_fails() {
     let fixture = complete_fixture();
     write(
-        &fixture.root.join("crates/axon-route/src/lib.rs"),
-        "pub const CRATE_NAME: &str = \"axon-route\";\n",
+        &fixture.root.join("crates/axon-observe/src/lib.rs"),
+        "pub const CRATE_NAME: &str = \"axon-observe\";\n",
     );
 
     let err = check_root(&fixture.root).unwrap_err();
     assert!(
-        err.contains("lib.rs is missing module declaration: pub mod resolver;"),
+        err.contains("lib.rs is missing module declaration: pub mod event;"),
         "{err}"
     );
 }
@@ -154,8 +154,8 @@ fn missing_target_module_declaration_fails() {
 fn unexpected_target_module_declaration_fails() {
     let fixture = complete_fixture();
     write(
-        &fixture.root.join("crates/axon-route/src/lib.rs"),
-        "pub mod resolver;\npub mod surprise;\n",
+        &fixture.root.join("crates/axon-observe/src/lib.rs"),
+        "pub mod event;\npub mod surprise;\n",
     );
 
     let err = check_root(&fixture.root).unwrap_err();
@@ -169,7 +169,7 @@ fn unexpected_target_module_declaration_fails() {
 fn unexpected_target_module_file_fails() {
     let fixture = complete_fixture();
     write(
-        &fixture.root.join("crates/axon-route/src/surprise.rs"),
+        &fixture.root.join("crates/axon-observe/src/surprise.rs"),
         "pub const MODULE_NAME: &str = \"surprise\";\n",
     );
 
@@ -227,13 +227,13 @@ fn package_metadata_dependencies_are_allowed() {
 fn target_package_name_fails() {
     let fixture = complete_fixture();
     write(
-        &fixture.root.join("crates/axon-memory/Cargo.toml"),
+        &fixture.root.join("crates/axon-observe/Cargo.toml"),
         "[package]\nname = \"fixture\"\nrust-version.workspace = true\n\n[dependencies]\n",
     );
 
     let err = check_root(&fixture.root).unwrap_err();
     assert!(
-        err.contains("PR0 target crate axon-memory must set package.name = \"axon-memory\""),
+        err.contains("PR0 target crate axon-observe must set package.name = \"axon-observe\""),
         "{err}"
     );
 }
@@ -242,13 +242,13 @@ fn target_package_name_fails() {
 fn missing_target_rust_version_fails() {
     let fixture = complete_fixture();
     write(
-        &fixture.root.join("crates/axon-memory/Cargo.toml"),
-        "[package]\nname = \"axon-memory\"\n\n[dependencies]\n",
+        &fixture.root.join("crates/axon-observe/Cargo.toml"),
+        "[package]\nname = \"axon-observe\"\n\n[dependencies]\n",
     );
 
     let err = check_root(&fixture.root).unwrap_err();
     assert!(
-        err.contains("PR0 target crate axon-memory must set rust-version.workspace = true"),
+        err.contains("PR0 target crate axon-observe must set rust-version.workspace = true"),
         "{err}"
     );
 }


### PR DESCRIPTION
## Summary

Implements issue #298 planned PR5 / Phase 4 resolver-router registry work:

- adds real `axon-route` `SourceResolver` and `SourceRouter` behavior
- normalizes source inputs across web, local, git/GitHub/GitLab/Gitea, registry packages, feeds, Reddit, YouTube, sessions, uploads, CLI tools, and MCP tools
- adds stable source IDs, authority entrypoint mapping, alias API, query normalization/redaction, and local path privacy/equivalence handling
- adds adapter capability/scope registry and route-time validation for unsupported scopes, unknown/invalid adapters, unsupported options, tool-execution opt-in, credentials requirements, and first-class map scope
- graduates `axon-route` out of PR0 skeleton enforcement and aligns stale PR5 docs with the live dependency order

No public CLI/MCP/REST wiring is included; that remains a later cutover PR per #298.

## Tests

- `cargo test -p axon-route --locked`
- `cargo test -p xtask repo_structure --locked`
- `cargo check -p axon-route --locked`
- `cargo xtask check-repo-structure`
- `cargo xtask check-layering`
- `cargo xtask schemas generate --check`
- `cargo fmt --all --check`
- `git diff --check`

Closes no issue; contributes to #298.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a resolver–router registry in `axon-route` to canonicalize sources, assign stable IDs, and deterministically route via adapter metadata with strict route-time validation. Hardens normalization, option schema checks, and policy-gated tool execution; adds comprehensive normalization/routing/validation tests. Contributes to #298 (Phase 4/PR5).

- New Features
  - `SourceResolver` and `SourceRouter` with deterministic adapter selection and authority entrypoint mapping; `RouteSecurityPolicy` to gate tool execution.
  - Canonicalizes web, local, git (incl. GitHub owner/repo shorthand and subpaths; GitLab, Gitea), registries (`crates`, `npm`, `pypi`, `docker`), feeds, Reddit, YouTube, sessions, uploads, CLI, and MCP; preserves non-default ports; respects explicit `http`; blocks spoofed provider subdomains; redacts sensitive query values.
  - Authority/alias registry with adapter hints; stable `SourceId`; local path privacy/equivalence with `~` and `..` normalization.
  - Adapter capability registry: supported scopes (incl. `Map`), safety class, execution affinity, provider/credential requirements, watch/refresh flags, chunking/parser hints, and option schema via `option_schema_id` and allowed keys.
  - Route-time validation for unsupported scopes, unknown/invalid adapters, unsupported options, required credentials, policy gating, and forged identity checks.

- Dependencies
  - Add `axon-api`, `axon-error`, `hex`, `sha2`, `url`.

<sup>Written for commit f279f21b745855ebbfb33ce06f7779599f68840a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source canonicalization, authority/alias resolution, and routing support for a wider range of source types.
  * Introduced adapter capability metadata and route planning with scope, safety, and credential checks.

* **Bug Fixes**
  * Improved URL normalization by removing tracking parameters and redacting sensitive query values.
  * Added stable local path handling and deterministic source identity generation.

* **Documentation**
  * Updated public API and crate-structure docs to reflect the expanded routing surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->