### PR TITLE
feat(xtask): add check-doc-links and check-doc-contracts (docs-generator-contract gaps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,10 @@ jobs:
           echo "AXON_ALLOW_FALLBACK_WEB_ASSETS=1" >> "$GITHUB_ENV"
       - name: Enforce modern Rust module style (no mod.rs)
         run: cargo xtask check-no-mod-rs
+      - name: Check generated-doc relative links resolve
+        run: cargo xtask check-doc-links
+      - name: Check generated docs do not reference removed surfaces
+        run: cargo xtask check-doc-contracts
 
   sqlite-migrations:
     name: sqlite-migrations

--- a/xtask/src/checks.rs
+++ b/xtask/src/checks.rs
@@ -5,6 +5,8 @@ pub mod android_api_contract;
 pub mod api_parity;
 pub mod broken_symlinks;
 pub mod claude_symlinks;
+pub mod doc_contracts;
+pub mod doc_links;
 pub mod env_staged;
 pub mod layering;
 pub mod mcp_http;
@@ -32,6 +34,8 @@ pub fn check(root: &Path) -> Result<()> {
     claude_symlinks::check(root)?;
     repo_structure::check(root)?;
     broken_symlinks::check(root)?;
+    doc_links::check(root)?;
+    doc_contracts::check(root)?;
     sqlite_migrations::check(root)?;
     secrets::check(root)?;
     release_versions::check_local(root)?;

--- a/xtask/src/checks/doc_contracts.rs
+++ b/xtask/src/checks/doc_contracts.rs
@@ -1,0 +1,114 @@
+//! `cargo xtask check-doc-contracts` — generated reference docs must not reference
+//! removed public surfaces.
+//!
+//! The schema generator's removed-surface drift check (`schemas generate --check`)
+//! matches JSON-quoted tokens against the generated **JSON** artifacts. It does not
+//! look at the prose markdown under `docs/reference/**`. This check closes that gap
+//! for the distinctive removed DTO **type names** (e.g. `EmbedRequest`): if one of
+//! them reappears as a word in a generated markdown doc, that doc is stale and CI
+//! fails. It is the `check-doc-contracts` deliverable from
+//! `docs-generator-contract.md` ("generated doc references removed surfaces").
+//!
+//! Only the unscoped (`global`) removed-surface rules are used, because those are
+//! the type names (`*Request`). The command/route/config tokens (`"embed"`,
+//! `/v1/scrape`, …) are ordinary words in prose and are intentionally excluded to
+//! avoid false positives — they remain covered against the JSON artifacts by the
+//! schema generator.
+
+use anyhow::{Result, bail};
+use std::path::Path;
+
+use walkdir::WalkDir;
+
+use crate::schemas::registry::REMOVED_SURFACE_RULES;
+
+/// Removed type-name tokens (quotes stripped) that must not appear in generated
+/// markdown. Derived from the unscoped `global(...)` removed-surface rules so the
+/// two lists never drift apart.
+pub fn removed_doc_type_tokens() -> Vec<String> {
+    REMOVED_SURFACE_RULES
+        .iter()
+        .filter(|rule| rule.path_contains.is_empty())
+        .map(|rule| rule.token.trim_matches('"').to_string())
+        .collect()
+}
+
+/// A removed type name found in a generated markdown doc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocContractViolation {
+    pub source: String,
+    pub token: String,
+}
+
+pub fn check(root: &Path) -> Result<()> {
+    let docs_root = root.join("docs/reference");
+    if !docs_root.is_dir() {
+        println!("check-doc-contracts: docs/reference absent, skipping.");
+        return Ok(());
+    }
+    let tokens = removed_doc_type_tokens();
+    let mut violations = Vec::new();
+    let mut checked = 0usize;
+    for entry in WalkDir::new(&docs_root).into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        checked += 1;
+        let content = std::fs::read_to_string(path)?;
+        for token in &tokens {
+            if contains_word(&content, token) {
+                violations.push(DocContractViolation {
+                    source: path
+                        .strip_prefix(root)
+                        .unwrap_or(path)
+                        .to_string_lossy()
+                        .into_owned(),
+                    token: token.clone(),
+                });
+            }
+        }
+    }
+    if !violations.is_empty() {
+        let mut msg = format!(
+            "check-doc-contracts: {} removed-surface reference(s) in generated docs:\n",
+            violations.len()
+        );
+        for v in &violations {
+            msg.push_str(&format!(
+                "  {} references removed `{}`\n",
+                v.source, v.token
+            ));
+        }
+        bail!(msg);
+    }
+    println!("check-doc-contracts: {checked} markdown file(s), no removed-surface references.");
+    Ok(())
+}
+
+/// True when `needle` appears in `haystack` bounded by non-identifier characters
+/// (so `EmbedRequest` does not match inside `MyEmbedRequestExt`).
+fn contains_word(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    let bytes = haystack.as_bytes();
+    let n = needle.as_bytes();
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let mut i = 0;
+    while let Some(pos) = haystack[i..].find(needle) {
+        let start = i + pos;
+        let end = start + needle.len();
+        let before_ok = start == 0 || !is_ident(bytes[start - 1]);
+        let after_ok = end >= bytes.len() || !is_ident(bytes[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        i = start + n.len();
+    }
+    false
+}
+
+#[cfg(test)]
+#[path = "doc_contracts_tests.rs"]
+mod tests;

--- a/xtask/src/checks/doc_contracts_tests.rs
+++ b/xtask/src/checks/doc_contracts_tests.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+use std::fs;
+
+#[test]
+fn removed_tokens_are_the_request_type_names_without_quotes() {
+    let tokens = removed_doc_type_tokens();
+    assert!(tokens.contains(&"EmbedRequest".to_string()));
+    assert!(tokens.contains(&"IngestRequest".to_string()));
+    assert!(tokens.contains(&"CrawlRequest".to_string()));
+    // The command/route words must NOT be in the doc-prose token set.
+    assert!(!tokens.iter().any(|t| t == "embed" || t == "/v1/embed"));
+}
+
+#[test]
+fn contains_word_respects_identifier_boundaries() {
+    assert!(contains_word("see EmbedRequest here", "EmbedRequest"));
+    assert!(contains_word("`EmbedRequest`", "EmbedRequest"));
+    assert!(!contains_word("MyEmbedRequestExt", "EmbedRequest"));
+    assert!(!contains_word("EmbedRequestable", "EmbedRequest"));
+}
+
+#[test]
+fn check_passes_on_clean_docs() {
+    let root = tempfile::tempdir().unwrap();
+    let ref_dir = root.path().join("docs/reference/api");
+    fs::create_dir_all(&ref_dir).unwrap();
+    fs::write(
+        ref_dir.join("dto.md"),
+        "The SourceRequest replaces the old shapes.",
+    )
+    .unwrap();
+    check(root.path()).expect("clean docs pass");
+}
+
+#[test]
+fn check_fails_when_removed_type_leaks_into_docs() {
+    let root = tempfile::tempdir().unwrap();
+    let ref_dir = root.path().join("docs/reference/api");
+    fs::create_dir_all(&ref_dir).unwrap();
+    fs::write(ref_dir.join("dto.md"), "Use `EmbedRequest` to embed.").unwrap();
+    let err = check(root.path()).expect_err("leaked removed type must fail");
+    assert!(err.to_string().contains("EmbedRequest"));
+}
+
+#[test]
+fn check_skips_when_reference_dir_absent() {
+    let root = tempfile::tempdir().unwrap();
+    check(root.path()).expect("absent docs/reference is not a failure");
+}

--- a/xtask/src/checks/doc_links.rs
+++ b/xtask/src/checks/doc_links.rs
@@ -1,0 +1,155 @@
+//! `cargo xtask check-doc-links` — relative-link checker for generated reference docs.
+//!
+//! Walks `docs/reference/**/*.md` and verifies every relative markdown link target
+//! resolves to a file that exists on disk. External links (`http(s)://`, `mailto:`,
+//! `tel:`, protocol-relative `//`) and pure in-page anchors (`#section`) are skipped;
+//! a `#fragment`/`?query` suffix on a relative path is stripped before resolution.
+//!
+//! This is the `check-doc-links` deliverable from `docs-generator-contract.md`
+//! ("link checker fails" drift). It is intentionally standalone (does not require the
+//! full `xtask docs` generator) so broken links in already-generated reference docs
+//! fail CI today.
+
+use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+/// A relative markdown link whose target does not exist on disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrokenLink {
+    /// Repo-relative path of the markdown file containing the link.
+    pub source: String,
+    /// The raw link target as written in the markdown.
+    pub target: String,
+}
+
+pub fn check(root: &Path) -> Result<()> {
+    let docs_root = root.join("docs/reference");
+    if !docs_root.is_dir() {
+        // Nothing generated yet — not a failure.
+        println!("check-doc-links: docs/reference absent, skipping.");
+        return Ok(());
+    }
+    let mut broken = Vec::new();
+    let mut checked = 0usize;
+    for entry in WalkDir::new(&docs_root).into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        checked += 1;
+        let content = std::fs::read_to_string(path)?;
+        let dir = path.parent().unwrap_or(root);
+        for target in extract_relative_link_targets(&content) {
+            if link_target_exists(dir, &target) {
+                continue;
+            }
+            broken.push(BrokenLink {
+                source: rel(root, path),
+                target,
+            });
+        }
+    }
+    if !broken.is_empty() {
+        let mut msg = format!("check-doc-links: {} broken link(s):\n", broken.len());
+        for b in &broken {
+            msg.push_str(&format!("  {} -> {}\n", b.source, b.target));
+        }
+        bail!(msg);
+    }
+    println!("check-doc-links: {checked} markdown file(s), no broken relative links.");
+    Ok(())
+}
+
+/// Extract the raw target of every inline markdown link/image (`](target)`) that
+/// looks like a relative path we should resolve. Skips external schemes and pure
+/// anchors. Reference-style links (`[a][b]`) are not resolved.
+pub fn extract_relative_link_targets(content: &str) -> Vec<String> {
+    let bytes = content.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b']' && bytes[i + 1] == b'(' {
+            // Read until the matching ')'.
+            let start = i + 2;
+            let mut j = start;
+            let mut depth = 1;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+                j += 1;
+            }
+            if j <= bytes.len() && j > start {
+                let raw = content[start..j].trim();
+                // A link target may carry a " title" after the URL: `](url "t")`.
+                let target = raw.split_whitespace().next().unwrap_or(raw);
+                if is_resolvable_relative_target(target) {
+                    out.push(target.to_string());
+                }
+            }
+            i = j + 1;
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+fn is_resolvable_relative_target(target: &str) -> bool {
+    if target.is_empty() {
+        return false;
+    }
+    // Pure in-page anchor.
+    if target.starts_with('#') {
+        return false;
+    }
+    // External / non-path schemes and protocol-relative URLs.
+    let lower = target.to_ascii_lowercase();
+    if lower.starts_with("http://")
+        || lower.starts_with("https://")
+        || lower.starts_with("mailto:")
+        || lower.starts_with("tel:")
+        || lower.starts_with("//")
+        || lower.contains("://")
+    {
+        return false;
+    }
+    true
+}
+
+fn link_target_exists(dir: &Path, target: &str) -> bool {
+    // Strip a `#fragment` and/or `?query` suffix before resolving the path part.
+    let path_part = target
+        .split('#')
+        .next()
+        .unwrap_or(target)
+        .split('?')
+        .next()
+        .unwrap_or(target);
+    if path_part.is_empty() {
+        // Link was a pure fragment/query against the same file.
+        return true;
+    }
+    let candidate: PathBuf = dir.join(path_part);
+    candidate.exists()
+}
+
+fn rel(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+#[path = "doc_links_tests.rs"]
+mod tests;

--- a/xtask/src/checks/doc_links_tests.rs
+++ b/xtask/src/checks/doc_links_tests.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+use std::fs;
+
+#[test]
+fn extracts_relative_targets_and_skips_external_and_anchors() {
+    let md = "See [a](./a.md) and [b](sub/b.md#frag) and [ext](https://x.y) \
+              and [anchor](#top) and ![img](img/p.png) and [mail](mailto:x@y.z).";
+    let targets = extract_relative_link_targets(md);
+    assert_eq!(targets, vec!["./a.md", "sub/b.md#frag", "img/p.png"]);
+}
+
+#[test]
+fn strips_fragment_and_query_before_resolving() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("a.md"), "x").unwrap();
+    assert!(link_target_exists(dir.path(), "a.md#section"));
+    assert!(link_target_exists(dir.path(), "a.md?v=1"));
+    assert!(!link_target_exists(dir.path(), "missing.md#section"));
+}
+
+#[test]
+fn check_passes_when_all_links_resolve() {
+    let root = tempfile::tempdir().unwrap();
+    let ref_dir = root.path().join("docs/reference/sub");
+    fs::create_dir_all(&ref_dir).unwrap();
+    fs::write(ref_dir.join("target.md"), "# target").unwrap();
+    fs::write(
+        root.path().join("docs/reference/index.md"),
+        "[ok](sub/target.md) [ext](https://ok) [anchor](#x)",
+    )
+    .unwrap();
+    check(root.path()).expect("all links resolve");
+}
+
+#[test]
+fn check_fails_on_broken_relative_link() {
+    let root = tempfile::tempdir().unwrap();
+    let ref_dir = root.path().join("docs/reference");
+    fs::create_dir_all(&ref_dir).unwrap();
+    fs::write(ref_dir.join("index.md"), "[bad](does/not/exist.md)").unwrap();
+    let err = check(root.path()).expect_err("broken link must fail");
+    assert!(err.to_string().contains("does/not/exist.md"));
+}
+
+#[test]
+fn check_skips_when_reference_dir_absent() {
+    let root = tempfile::tempdir().unwrap();
+    check(root.path()).expect("absent docs/reference is not a failure");
+}
+
+#[test]
+fn ignores_title_suffix_in_link() {
+    let targets = extract_relative_link_targets("[a](./a.md \"the title\")");
+    assert_eq!(targets, vec!["./a.md"]);
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -33,6 +33,10 @@ enum Command {
     CheckRepoStructure,
     /// Fail if any symlink in the worktree points to a non-existent target.
     CheckBrokenSymlinks,
+    /// Fail if any relative markdown link in docs/reference points to a missing file.
+    CheckDocLinks,
+    /// Fail if generated reference docs reference a removed public surface.
+    CheckDocContracts,
     /// Verify SQLite job migrations are append-only and checksum-pinned.
     CheckSqliteMigrations,
     /// Regenerate the SQLite job migration checksum manifest after adding a migration.
@@ -129,6 +133,8 @@ fn main() -> Result<()> {
         Command::CheckClaudeSymlinks => checks::claude_symlinks::check(&root),
         Command::CheckRepoStructure => checks::repo_structure::check(&root),
         Command::CheckBrokenSymlinks => checks::broken_symlinks::check(&root),
+        Command::CheckDocLinks => checks::doc_links::check(&root),
+        Command::CheckDocContracts => checks::doc_contracts::check(&root),
         Command::CheckSqliteMigrations => checks::sqlite_migrations::check(&root),
         Command::UpdateSqliteMigrationChecksums => checks::sqlite_migrations::update(&root),
         Command::CheckSecrets => checks::secrets::check(&root),
@@ -198,4 +204,4 @@ fn main() -> Result<()> {
 mod bench_embed;
 mod checks;
 mod pre_push;
-mod schemas;
+pub mod schemas;

--- a/xtask/src/schemas.rs
+++ b/xtask/src/schemas.rs
@@ -1,6 +1,6 @@
 mod artifact;
 mod families;
-mod registry;
+pub mod registry;
 mod schema_json;
 mod source_input;
 


### PR DESCRIPTION
## What

Implements two `docs-generator-contract.md` / `schema-generator-contract.md` deliverables that verification found **genuinely absent** on main:

- **`cargo xtask check-doc-links`** — walks `docs/reference/**/*.md` and fails on any broken *relative* markdown link (external URLs, `mailto:`, `tel:`, and pure `#anchor`s skipped; `#frag`/`?query` stripped before resolution).
- **`cargo xtask check-doc-contracts`** — fails when a removed DTO **type name** (`EmbedRequest`, `IngestRequest`, `CrawlRequest`, `ScrapeRequest`, `PurgeRequest`, `CodeSearchRequest`) leaks into generated reference markdown. The schema generator's removed-surface drift only matches JSON-quoted tokens against the JSON artifacts; this closes the prose-doc gap. Tokens are **derived** from the unscoped `global()` entries of `REMOVED_SURFACE_RULES` so the lists never drift; command/route/config words are intentionally excluded to avoid prose false-positives.

## Wiring
- Both added to the `cargo xtask check` aggregate and exposed as standalone subcommands (the contract's Required CI commands).
- CI steps added alongside the other xtask checks (same refactor gating).

## Verification
- `cargo test -p xtask doc_` → 11 pass.
- Both run clean against the real 82-file `docs/reference` tree.
- fmt + clippy clean on the new files; full `cargo build -p xtask` green.
- xtask is a dev-only tree (no component shipping path) → no version bump.

## Context
Part of issue #298 gap-fill. Verification showed the *other* half of the requested work (provider-reservation scheduler + interactive-anti-starvation proof) already exists on main (`axon-embedding`/`axon-observe` reservation runtime + `background_reservations_preserve_interactive_capacity`), so this PR is the genuinely-missing docs-check portion. Remaining docs-generator items (cross-schema aggregate checks, dep-graph snapshots, per-crate public-API doc generator) are the larger cohesive `xtask/src/docs` subsystem.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two `cargo xtask` checks to enforce the docs-generator contract: `check-doc-links` validates relative links in `docs/reference`, and `check-doc-contracts` blocks references to removed DTO type names. Wired into `cargo xtask check` and CI. Part of Linear #298 gap-fill.

- New Features
  - `cargo xtask check-doc-links`: walks `docs/reference/**/*.md`; fails on broken relative links; skips `http(s)://`, `mailto:`, `tel:`, `//`, and pure `#anchor`; strips `#frag`/`?query`.
  - `cargo xtask check-doc-contracts`: fails if removed DTO type names (e.g., `EmbedRequest`, `IngestRequest`) appear in generated docs; tokens derived from global `REMOVED_SURFACE_RULES`; command/route/config words ignored to reduce false positives.
  - CI: both checks added to `cargo xtask check` and the workflow.

<sup>Written for commit 7d00a5dffcfc09053a04571aaa21dff6cdbfa2fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

