### PR TITLE
feat(adapters): add git source adapter (#298 P9)

### DIFF
--- a/crates/axon-adapters/src/git.rs
+++ b/crates/axon-adapters/src/git.rs
@@ -1,3 +1,408 @@
-//! Marker module for the target `axon-adapters::git` boundary.
+//! Git repository source adapter (GitHub / GitLab / Gitea / generic git).
+//!
+//! Like the `local` adapter, this operates on an already-materialized
+//! filesystem tree — a `repo_root` option pointing at a checked-out clone,
+//! prepared by the caller (the services bridge performs the network clone).
+//! Keeping the network out of the adapter makes it unit-testable with fixture
+//! repositories and matches how the `web` adapter reads a prepared crawl.
+
+mod metadata;
+mod target;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use axon_api::source::*;
+use ignore::{DirEntry, WalkBuilder};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::adapter::{Result, SourceAdapter};
+use crate::capability::AdapterCapability;
+use crate::manifest::item_identity;
+
+use self::metadata::git_source_document;
+pub use self::target::{GitTarget, parse_git_target};
 
 pub const MODULE_NAME: &str = "git";
+
+const ADAPTER_NAME: &str = "git";
+
+#[derive(Debug, Clone, Default)]
+pub struct GitSourceAdapter;
+
+impl GitSourceAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl SourceAdapter for GitSourceAdapter {
+    fn name(&self) -> &str {
+        ADAPTER_NAME
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    async fn capabilities(&self) -> Result<AdapterCapability> {
+        Ok(git_capability(self.version()))
+    }
+
+    async fn discover(&self, plan: &SourcePlan) -> Result<SourceManifest> {
+        let plan = plan.clone();
+        tokio::task::spawn_blocking(move || discover_sync(&plan))
+            .await
+            .map_err(blocking_join_error)?
+    }
+
+    async fn acquire(
+        &self,
+        plan: &SourcePlan,
+        diff: &SourceManifestDiff,
+    ) -> Result<SourceAcquisition> {
+        let plan = plan.clone();
+        let diff = diff.clone();
+        tokio::task::spawn_blocking(move || acquire_sync(&plan, &diff))
+            .await
+            .map_err(blocking_join_error)?
+    }
+
+    async fn normalize(
+        &self,
+        plan: &SourcePlan,
+        acquisition: SourceAcquisition,
+    ) -> Result<StageExecutionResult<Vec<SourceDocument>>> {
+        validate_adapter(plan)?;
+        let target = git_target(plan)?;
+        let documents = acquisition
+            .fetched_items
+            .iter()
+            .map(|item| git_source_document(plan, &target, &acquisition, item))
+            .collect::<Vec<_>>();
+        Ok(StageExecutionResult {
+            header: stage_header(
+                plan.job_id,
+                "git_normalize",
+                PipelinePhase::Normalizing,
+                documents.len(),
+            ),
+            data: documents,
+        })
+    }
+}
+
+fn git_capability(version: &str) -> AdapterCapability {
+    AdapterCapability::new(
+        AdapterRef {
+            name: ADAPTER_NAME.to_string(),
+            version: version.to_string(),
+        },
+        SourceKind::Git,
+        SourceScope::Repo,
+    )
+    .with_scope(SourceScope::Directory)
+}
+
+fn discover_sync(plan: &SourcePlan) -> Result<SourceManifest> {
+    git_capability(env!("CARGO_PKG_VERSION")).validate_scope(plan.route.scope)?;
+    validate_adapter(plan)?;
+    let target = git_target(plan)?;
+    let root = repo_root(plan)?;
+
+    let mut files = collect_files(&root)?;
+    files.sort();
+
+    let base_uri = target.web_url.trim_end_matches('/').to_string();
+    let mut items = Vec::new();
+    for file in files {
+        let key = relative_key(&root, &file)?;
+        let path = safe_item_path(&root, &key)?;
+        let meta = fs::metadata(&path).map_err(|err| fs_error("stat_failed", &path, err))?;
+        if !meta.is_file() {
+            continue;
+        }
+        let content_hash = content_fingerprint(&path)?;
+        let identity = item_identity(SourceKind::Git, &base_uri, &key)?;
+        let mut item_metadata = MetadataMap::new();
+        item_metadata.insert("git_relative_path".to_string(), json!(key));
+        items.push(ManifestItem {
+            source_id: plan.route.source.source_id.clone(),
+            source_item_key: identity.source_item_key,
+            canonical_uri: identity.canonical_uri,
+            item_kind: ItemKind::RepoFile,
+            content_kind: Some(content_kind_for(&file)),
+            display_path: Some(key),
+            parent_key: None,
+            size_bytes: Some(meta.len()),
+            content_hash: Some(content_hash),
+            mtime: None,
+            version: None,
+            fetch_plan: None,
+            metadata: item_metadata,
+            graph_hints: Vec::new(),
+        });
+    }
+    items.sort_by(|left, right| left.source_item_key.cmp(&right.source_item_key));
+
+    Ok(SourceManifest {
+        source_id: plan.route.source.source_id.clone(),
+        generation: SourceGenerationId::from("gen_git_discovery"),
+        adapter: plan.route.adapter.clone(),
+        scope: plan.route.scope,
+        items,
+        created_at: timestamp(),
+        metadata: manifest_metadata(&target),
+    })
+}
+
+fn acquire_sync(plan: &SourcePlan, diff: &SourceManifestDiff) -> Result<SourceAcquisition> {
+    validate_adapter(plan)?;
+    let root = repo_root(plan)?;
+    let manifest_items = diff
+        .added
+        .iter()
+        .chain(diff.modified.iter())
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut fetched_items = Vec::with_capacity(manifest_items.len());
+    for item in &manifest_items {
+        let key = item
+            .display_path
+            .clone()
+            .unwrap_or_else(|| item.source_item_key.0.clone());
+        let path = safe_item_path(&root, &key)?;
+        let text = fs::read_to_string(&path).map_err(|err| fs_error("read_failed", &path, err))?;
+        fetched_items.push(AcquiredSourceItem {
+            manifest_item: item.clone(),
+            fetch_status: LifecycleStatus::Completed,
+            content_ref: ContentRef::InlineText { text },
+            raw_artifact_id: None,
+            headers: RedactedHeaders {
+                headers: Vec::new(),
+            },
+            fetched_at: timestamp(),
+            metadata: MetadataMap::new(),
+        });
+    }
+
+    let target = git_target(plan)?;
+    let manifest = SourceManifest {
+        source_id: plan.route.source.source_id.clone(),
+        generation: diff.next_generation.clone(),
+        adapter: plan.route.adapter.clone(),
+        scope: plan.route.scope,
+        items: manifest_items,
+        created_at: timestamp(),
+        metadata: manifest_metadata(&target),
+    };
+    Ok(SourceAcquisition {
+        header: stage_header(
+            plan.job_id,
+            "git_fetch",
+            PipelinePhase::Fetching,
+            fetched_items.len(),
+        ),
+        source_id: manifest.source_id.clone(),
+        generation: manifest.generation.clone(),
+        adapter: manifest.adapter.clone(),
+        scope: manifest.scope,
+        manifest,
+        fetched_items,
+        artifacts: Vec::new(),
+    })
+}
+
+fn manifest_metadata(target: &GitTarget) -> MetadataMap {
+    let mut metadata = MetadataMap::new();
+    metadata.insert("git_provider".to_string(), json!(target.provider));
+    metadata.insert("git_host".to_string(), json!(target.host));
+    metadata.insert("git_repo".to_string(), json!(target.repo));
+    if let Some(owner) = &target.owner {
+        metadata.insert("git_owner".to_string(), json!(owner));
+    }
+    metadata.insert("git_web_url".to_string(), json!(target.web_url));
+    metadata
+}
+
+/// The prepared clone root, passed by the services bridge as a validated option.
+fn repo_root(plan: &SourcePlan) -> Result<PathBuf> {
+    plan.route
+        .validated_options
+        .values
+        .get("repo_root")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            ApiError::new(
+                "adapter.git.repo_root.required",
+                axon_error::ErrorStage::Planning,
+                "git adapter requires a repo_root option pointing at a checked-out clone",
+            )
+        })
+}
+
+fn git_target(plan: &SourcePlan) -> Result<GitTarget> {
+    parse_git_target(&plan.request.source)
+}
+
+fn validate_adapter(plan: &SourcePlan) -> Result<()> {
+    if plan.route.adapter.name == ADAPTER_NAME {
+        return Ok(());
+    }
+    Err(ApiError::new(
+        "adapter.git.mismatch",
+        axon_error::ErrorStage::Routing,
+        "route selected a different adapter",
+    )
+    .with_context("adapter", plan.route.adapter.name.clone()))
+}
+
+fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut builder = WalkBuilder::new(root);
+    builder
+        .follow_links(false)
+        .hidden(false)
+        .git_ignore(true)
+        .git_exclude(true)
+        .parents(false)
+        .filter_entry(should_descend_entry);
+    let mut files = Vec::new();
+    for entry in builder.build() {
+        let entry = entry.map_err(|err| {
+            ApiError::new(
+                "adapter.git.walk_failed",
+                axon_error::ErrorStage::Discovering,
+                err.to_string(),
+            )
+        })?;
+        if entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_file())
+        {
+            files.push(entry.into_path());
+        }
+    }
+    Ok(files)
+}
+
+fn should_descend_entry(entry: &DirEntry) -> bool {
+    entry.file_name().to_str() != Some(".git")
+}
+
+fn relative_key(root: &Path, file: &Path) -> Result<String> {
+    let relative = file.strip_prefix(root).unwrap_or(file);
+    let key = relative
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("/");
+    if key.is_empty() {
+        return Err(ApiError::new(
+            "adapter.git.item_key.invalid",
+            axon_error::ErrorStage::Normalizing,
+            "git item key must not be empty",
+        ));
+    }
+    Ok(key)
+}
+
+fn safe_item_path(root: &Path, key: &str) -> Result<PathBuf> {
+    if Path::new(key).is_absolute() || key.split('/').any(|part| part == "..") {
+        return Err(ApiError::new(
+            "adapter.git.path.escape",
+            axon_error::ErrorStage::Fetching,
+            "git item key must stay inside the repo root",
+        )
+        .with_context("key", key.to_string()));
+    }
+    Ok(root.join(key))
+}
+
+fn content_fingerprint(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).map_err(|err| fs_error("read_failed", path, err))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(hex_prefix(&hasher.finalize(), 16))
+}
+
+fn content_kind_for(path: &Path) -> ContentKind {
+    match path.extension().and_then(|ext| ext.to_str()).unwrap_or("") {
+        "md" | "markdown" => ContentKind::Markdown,
+        "html" | "htm" => ContentKind::Html,
+        "json" => ContentKind::Json,
+        "yaml" | "yml" => ContentKind::Yaml,
+        "toml" => ContentKind::Toml,
+        "xml" => ContentKind::Xml,
+        "rs" | "go" | "js" | "jsx" | "ts" | "tsx" | "py" | "java" | "kt" | "swift" | "c" | "cc"
+        | "cpp" | "h" | "hpp" | "cs" | "rb" | "php" | "sh" | "zsh" | "fish" => ContentKind::Code,
+        _ => ContentKind::PlainText,
+    }
+}
+
+fn fs_error(code: &str, path: &Path, err: std::io::Error) -> ApiError {
+    ApiError::new(
+        format!("adapter.git.{code}"),
+        axon_error::ErrorStage::Fetching,
+        err.to_string(),
+    )
+    .with_context("path", path.display().to_string())
+}
+
+fn blocking_join_error(err: tokio::task::JoinError) -> ApiError {
+    ApiError::new(
+        "adapter.git.blocking_task_failed",
+        axon_error::ErrorStage::Planning,
+        err.to_string(),
+    )
+}
+
+fn stage_header(
+    job_id: JobId,
+    stage_id: &'static str,
+    phase: PipelinePhase,
+    item_count: usize,
+) -> StageResultHeader {
+    StageResultHeader {
+        job_id,
+        stage_id: StageId::new(Uuid::new_v5(&Uuid::NAMESPACE_OID, stage_id.as_bytes())),
+        phase,
+        status: LifecycleStatus::Completed,
+        started_at: timestamp(),
+        completed_at: Some(timestamp()),
+        counts: StageCounts {
+            items_total: Some(item_count as u64),
+            items_done: item_count as u64,
+            documents_total: Some(item_count as u64),
+            documents_done: item_count as u64,
+            chunks_total: None,
+            chunks_done: 0,
+            bytes_total: None,
+            bytes_done: 0,
+        },
+        warnings: Vec::new(),
+        error: None,
+    }
+}
+
+pub(crate) fn timestamp() -> Timestamp {
+    Timestamp(chrono::Utc::now().to_rfc3339())
+}
+
+pub(crate) fn hex_prefix(digest: &[u8], hex_chars: usize) -> String {
+    use std::fmt::Write as _;
+    let mut token = String::with_capacity(hex_chars);
+    for byte in &digest[..(hex_chars / 2).min(digest.len())] {
+        let _ = write!(&mut token, "{byte:02x}");
+    }
+    token
+}
+
+#[cfg(test)]
+#[path = "git_tests.rs"]
+mod tests;

--- a/crates/axon-adapters/src/git/metadata.rs
+++ b/crates/axon-adapters/src/git/metadata.rs
@@ -1,0 +1,62 @@
+//! Git `SourceDocument` construction — stamps only approved git metadata
+//! fields onto normalized documents.
+
+use axon_api::source::*;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use super::{GitTarget, hex_prefix};
+
+pub(super) fn git_source_document(
+    plan: &SourcePlan,
+    target: &GitTarget,
+    acquisition: &SourceAcquisition,
+    item: &AcquiredSourceItem,
+) -> SourceDocument {
+    let mut metadata = MetadataMap::new();
+    metadata.insert("source_family".to_string(), json!("code"));
+    metadata.insert("source_type".to_string(), json!("git_code"));
+    metadata.insert("source_kind".to_string(), json!("git"));
+    metadata.insert("source_adapter".to_string(), json!(plan.route.adapter.name));
+    metadata.insert("source_scope".to_string(), json!(plan.route.scope));
+    metadata.insert("git_provider".to_string(), json!(target.provider));
+    metadata.insert("git_host".to_string(), json!(target.host));
+    metadata.insert("git_repo".to_string(), json!(target.repo));
+    if let Some(owner) = &target.owner {
+        metadata.insert("git_owner".to_string(), json!(owner));
+    }
+    metadata.insert("git_web_url".to_string(), json!(target.web_url));
+    metadata.insert(
+        "item_canonical_uri".to_string(),
+        json!(item.manifest_item.canonical_uri),
+    );
+    metadata.insert("committed_generation".to_string(), json!("uncommitted"));
+    metadata.insert("visibility".to_string(), json!("internal"));
+    metadata.insert("redaction_status".to_string(), json!("clean"));
+    SourceDocument {
+        document_id: git_document_id(&acquisition.source_id, &item.manifest_item.source_item_key),
+        source_id: acquisition.source_id.clone(),
+        source_item_key: item.manifest_item.source_item_key.clone(),
+        canonical_uri: item.manifest_item.canonical_uri.clone(),
+        content_kind: item
+            .manifest_item
+            .content_kind
+            .unwrap_or(ContentKind::PlainText),
+        content: item.content_ref.clone(),
+        metadata,
+        title: item.manifest_item.display_path.clone(),
+        language: None,
+        path: item.manifest_item.display_path.clone(),
+        mime_type: None,
+        structured_payload: None,
+        artifact_id: item.raw_artifact_id.clone(),
+        chunk_hints: plan.route.chunking_hints.clone(),
+        parser_hints: plan.route.parser_hints.clone(),
+    }
+}
+
+fn git_document_id(source_id: &SourceId, item_key: &SourceItemKey) -> DocumentId {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("{}\0{}", source_id.0, item_key.0).as_bytes());
+    DocumentId::from(format!("doc_git_{}", hex_prefix(&hasher.finalize(), 24)))
+}

--- a/crates/axon-adapters/src/git/target.rs
+++ b/crates/axon-adapters/src/git/target.rs
@@ -1,0 +1,87 @@
+//! Git target parsing — normalizes an `https` clone URL into provider / host /
+//! owner / repo parts. Ported from the legacy `axon-ingest::generic_git`
+//! parser, minus the network/config coupling.
+
+use axon_api::source::ApiError;
+use axon_error::ErrorStage;
+use url::Url;
+
+use crate::adapter::Result;
+
+/// A parsed git repository target. `web_url` has any embedded credentials
+/// stripped and the trailing `.git` removed, so it is safe to surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitTarget {
+    pub clone_url: String,
+    pub web_url: String,
+    pub host: String,
+    pub owner: Option<String>,
+    pub repo: String,
+    pub provider: String,
+}
+
+fn err(code: &str, message: impl Into<String>) -> ApiError {
+    ApiError::new(format!("adapter.git.{code}"), ErrorStage::Planning, message)
+}
+
+/// Provider label derived from the host (github/gitlab/gitea/git).
+fn provider_for_host(host: &str) -> String {
+    if host.contains("github") {
+        "github".to_string()
+    } else if host.contains("gitlab") {
+        "gitlab".to_string()
+    } else if host.contains("gitea") || host.contains("forgejo") || host.contains("codeberg") {
+        "gitea".to_string()
+    } else {
+        "git".to_string()
+    }
+}
+
+/// Parse a `git:`-prefixed or bare `https://host/owner/repo(.git)` target.
+pub fn parse_git_target(input: &str) -> Result<GitTarget> {
+    let raw = input.trim();
+    let raw = raw.strip_prefix("git:").unwrap_or(raw).trim();
+    let url = Url::parse(raw).map_err(|e| err("target.invalid", e.to_string()))?;
+    if url.scheme() != "https" {
+        return Err(err(
+            "target.scheme",
+            "git adapter requires an https clone URL",
+        ));
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| err("target.host", "git target is missing host"))?
+        .to_ascii_lowercase();
+    let path = url.path().trim_matches('/');
+    if path.is_empty() {
+        return Err(err("target.path", "git target is missing repository path"));
+    }
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    let repo = segments
+        .last()
+        .copied()
+        .unwrap_or(path)
+        .trim_end_matches(".git")
+        .to_string();
+    let owner = if segments.len() >= 2 {
+        Some(segments[segments.len() - 2].to_string())
+    } else {
+        None
+    };
+    let mut web = url.clone();
+    let _ = web.set_username("");
+    let _ = web.set_password(None);
+    let web_url = web.as_str().trim_end_matches(".git").to_string();
+    Ok(GitTarget {
+        clone_url: url.to_string(),
+        web_url,
+        provider: provider_for_host(&host),
+        host,
+        owner,
+        repo,
+    })
+}
+
+#[cfg(test)]
+#[path = "target_tests.rs"]
+mod tests;

--- a/crates/axon-adapters/src/git/target_tests.rs
+++ b/crates/axon-adapters/src/git/target_tests.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+#[test]
+fn parses_github_https_target() {
+    let t = parse_git_target("https://github.com/jmagar/axon.git").unwrap();
+    assert_eq!(t.provider, "github");
+    assert_eq!(t.host, "github.com");
+    assert_eq!(t.owner.as_deref(), Some("jmagar"));
+    assert_eq!(t.repo, "axon");
+    assert_eq!(t.web_url, "https://github.com/jmagar/axon");
+    assert_eq!(t.clone_url, "https://github.com/jmagar/axon.git");
+}
+
+#[test]
+fn detects_gitlab_and_gitea_providers() {
+    assert_eq!(
+        parse_git_target("https://gitlab.com/group/proj")
+            .unwrap()
+            .provider,
+        "gitlab"
+    );
+    assert_eq!(
+        parse_git_target("https://codeberg.org/o/r")
+            .unwrap()
+            .provider,
+        "gitea"
+    );
+    assert_eq!(
+        parse_git_target("https://git.example.com/o/r")
+            .unwrap()
+            .provider,
+        "git"
+    );
+}
+
+#[test]
+fn strips_embedded_credentials_from_web_url() {
+    let t = parse_git_target("https://user:token@github.com/o/secret.git").unwrap();
+    assert_eq!(t.web_url, "https://github.com/o/secret");
+    assert!(!t.web_url.contains("token"));
+    assert!(!t.web_url.contains("user"));
+}
+
+#[test]
+fn accepts_git_prefix() {
+    let t = parse_git_target("git:https://github.com/o/r").unwrap();
+    assert_eq!(t.repo, "r");
+}
+
+#[test]
+fn rejects_non_https() {
+    assert!(parse_git_target("git@github.com:o/r.git").is_err());
+    assert!(parse_git_target("http://github.com/o/r").is_err());
+    assert!(parse_git_target("https://github.com").is_err());
+}
+
+#[test]
+fn nested_group_owner_is_last_path_segment_before_repo() {
+    let t = parse_git_target("https://gitlab.com/group/sub/proj.git").unwrap();
+    assert_eq!(t.owner.as_deref(), Some("sub"));
+    assert_eq!(t.repo, "proj");
+}

--- a/crates/axon-adapters/src/git_tests.rs
+++ b/crates/axon-adapters/src/git_tests.rs
@@ -1,0 +1,191 @@
+use super::*;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const TARGET_URL: &str = "https://github.com/jmagar/fixture-repo";
+
+fn fixture_repo() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("axon-git-test-{}", Uuid::new_v4()));
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(dir.join("README.md"), "# Fixture\n").unwrap();
+    fs::write(dir.join("src/lib.rs"), "pub fn hi() {}\n").unwrap();
+    // A .git directory that must be excluded from the walk.
+    fs::create_dir_all(dir.join(".git")).unwrap();
+    fs::write(dir.join(".git/config"), "[core]\n").unwrap();
+    dir
+}
+
+fn git_plan(repo_root: &Path, scope: SourceScope, with_repo_root: bool) -> SourcePlan {
+    let mut values = MetadataMap::new();
+    if with_repo_root {
+        values.insert(
+            "repo_root".to_string(),
+            repo_root.to_string_lossy().to_string().into(),
+        );
+    }
+    let adapter = AdapterRef {
+        name: "git".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    SourcePlan {
+        job_id: JobId::new(Uuid::from_u128(298298)),
+        request: SourceRequest::new(TARGET_URL.to_string()),
+        route: RoutePlan {
+            source: ResolvedSource {
+                requested_uri: TARGET_URL.to_string(),
+                canonical_uri: "git://github.com/jmagar/fixture-repo".to_string(),
+                source_id: SourceId::from("src_git_test"),
+                source_kind: SourceKind::Git,
+                display_name: "git test".to_string(),
+                candidate_adapters: vec![AdapterCandidate {
+                    adapter: adapter.clone(),
+                    supported_scopes: vec![scope],
+                    confidence: 1.0,
+                    reason: "test".to_string(),
+                }],
+                default_scope: scope,
+                available_scopes: vec![scope],
+                authority: AuthorityLevel::Inferred,
+                confidence: 1.0,
+                reason: "test".to_string(),
+                authority_hint: None,
+                warnings: Vec::new(),
+            },
+            adapter,
+            scope,
+            provider_requirements: Vec::new(),
+            credential_requirements: Vec::new(),
+            execution_affinity: ExecutionAffinity::Worker,
+            safety_class: SafetyClass::LocalFilesystem,
+            option_schema_id: "adapter:git:options:v1".to_string(),
+            validated_options: AdapterOptions { values },
+            chunking_hints: Vec::new(),
+            parser_hints: Vec::new(),
+            graph_fact_kinds: Vec::new(),
+            watch_supported: true,
+            refresh_supported: true,
+        },
+        stage_plan: Vec::new(),
+        limits: EffectiveLimits {
+            request: SourceLimits::default(),
+            adapter_defaults: SourceLimits::default(),
+            config_defaults: SourceLimits::default(),
+            effective: SourceLimits::default(),
+        },
+        config_snapshot_id: ConfigSnapshotId::from("cfg_git_test"),
+        provider_reservations: Vec::new(),
+    }
+}
+
+fn diff_from(plan: &SourcePlan, items: Vec<ManifestItem>) -> SourceManifestDiff {
+    let added = items.len() as u64;
+    SourceManifestDiff {
+        header: stage_header(plan.job_id, "git_diff", PipelinePhase::Diffing, items.len()),
+        source_id: plan.route.source.source_id.clone(),
+        previous_generation: None,
+        next_generation: SourceGenerationId::from("gen_git_test"),
+        added: items,
+        modified: Vec::new(),
+        removed: Vec::new(),
+        unchanged: Vec::new(),
+        skipped: Vec::new(),
+        failed: Vec::new(),
+        counts: DiffCounts {
+            added,
+            modified: 0,
+            removed: 0,
+            unchanged: 0,
+            skipped: 0,
+            failed: 0,
+        },
+    }
+}
+
+#[tokio::test]
+async fn capabilities_advertise_git_repo_scope() {
+    let cap = GitSourceAdapter::new().capabilities().await.unwrap();
+    assert!(cap.validate_scope(SourceScope::Repo).is_ok());
+    assert!(cap.validate_scope(SourceScope::Directory).is_ok());
+    assert!(cap.validate_scope(SourceScope::Page).is_err());
+}
+
+#[tokio::test]
+async fn discover_lists_repo_files_and_excludes_git_dir() {
+    let repo = fixture_repo();
+    let plan = git_plan(&repo, SourceScope::Repo, true);
+    let manifest = GitSourceAdapter::new().discover(&plan).await.unwrap();
+    let keys: Vec<_> = manifest
+        .items
+        .iter()
+        .filter_map(|i| i.display_path.clone())
+        .collect();
+    assert!(keys.contains(&"README.md".to_string()));
+    assert!(keys.contains(&"src/lib.rs".to_string()));
+    assert!(
+        !keys.iter().any(|k| k.starts_with(".git")),
+        "the .git directory must be excluded, got {keys:?}"
+    );
+    assert!(
+        manifest
+            .items
+            .iter()
+            .all(|i| i.item_kind == ItemKind::RepoFile)
+    );
+    assert_eq!(
+        manifest
+            .metadata
+            .get("git_provider")
+            .and_then(|v| v.as_str()),
+        Some("github")
+    );
+    fs::remove_dir_all(&repo).ok();
+}
+
+#[tokio::test]
+async fn acquire_then_normalize_stamps_git_metadata() {
+    let repo = fixture_repo();
+    let plan = git_plan(&repo, SourceScope::Repo, true);
+    let adapter = GitSourceAdapter::new();
+    let manifest = adapter.discover(&plan).await.unwrap();
+    let diff = diff_from(&plan, manifest.items.clone());
+    let acquisition = adapter.acquire(&plan, &diff).await.unwrap();
+    assert_eq!(acquisition.fetched_items.len(), manifest.items.len());
+
+    let normalized = adapter.normalize(&plan, acquisition).await.unwrap();
+    let readme = normalized
+        .data
+        .iter()
+        .find(|d| d.path.as_deref() == Some("README.md"))
+        .expect("README document present");
+    assert_eq!(
+        readme.metadata.get("source_type").and_then(|v| v.as_str()),
+        Some("git_code")
+    );
+    assert_eq!(
+        readme.metadata.get("git_repo").and_then(|v| v.as_str()),
+        Some("fixture-repo")
+    );
+    assert_eq!(
+        readme.metadata.get("git_owner").and_then(|v| v.as_str()),
+        Some("jmagar")
+    );
+    assert!(matches!(&readme.content, ContentRef::InlineText { text } if text.contains("Fixture")));
+    fs::remove_dir_all(&repo).ok();
+}
+
+#[tokio::test]
+async fn discover_without_repo_root_option_errors() {
+    let plan = git_plan(Path::new("/does/not/matter"), SourceScope::Repo, false);
+    let err = GitSourceAdapter::new().discover(&plan).await.unwrap_err();
+    assert_eq!(err.code.to_string(), "adapter.git.repo_root.required");
+}
+
+#[tokio::test]
+async fn discover_rejects_unsupported_scope() {
+    let repo = fixture_repo();
+    let plan = git_plan(&repo, SourceScope::Page, true);
+    let err = GitSourceAdapter::new().discover(&plan).await.unwrap_err();
+    assert!(err.code.to_string().contains("scope"));
+    fs::remove_dir_all(&repo).ok();
+}


### PR DESCRIPTION
Adds `GitSourceAdapter` — the last family adapter (git: GitHub/GitLab/Gitea/generic). Pure + unit-testable: reads a prepared `repo_root` clone, walks files excluding `.git`, stamps approved git metadata, emits `SourceDocument`. Ports the legacy `generic_git` URL parser. **11 tests pass** (target parser + adapter discover/acquire/normalize). Mirrors the merged local/web/family adapters exactly; `pub` API so no dead code. The git services bridge follows separately (with the other families').

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `GitSourceAdapter` to ingest Git repos from a prepared `repo_root` clone, with safe URL parsing and approved git metadata on documents. Completes the family adapter set for P9 (#298).

- **New Features**
  - `GitSourceAdapter`: discover/acquire/normalize from a local clone; walks files and excludes `.git`.
  - `GitTarget` parser: accepts `git:`-prefixed HTTPS URLs, detects provider (GitHub/GitLab/Gitea/generic), strips credentials, ports legacy parser.
  - Normalization stamps approved metadata (`git_provider`, `git_host`, `git_owner`, `git_repo`, `git_web_url`) and sets `content_kind` by file extension.
  - Capabilities advertise repo and directory scope; added 11 tests for parser and adapter paths.

- **Migration**
  - Pass a validated `repo_root` option pointing at a checked-out clone (the services bridge performs the clone).
  - Only `https` URLs are supported; SSH-style URLs are rejected.

<sup>Written for commit eda81d8771d627f7a712a273ed5d5a7107264ba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

