### PR TITLE
feat(axon-vectors): implement live Qdrant VectorStore (#298 P10 data plane)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,8 +996,11 @@ dependencies = [
  "axon-api",
  "axon-error",
  "qdrant-client",
+ "reqwest 0.13.4",
+ "serde",
  "serde_json",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/crates/axon-vectors/Cargo.toml
+++ b/crates/axon-vectors/Cargo.toml
@@ -10,9 +10,13 @@ license.workspace = true
 async-trait = "0.1"
 axon-api = { path = "../axon-api" }
 axon-error = { path = "../axon-error" }
+qdrant-client = { version = "1.18.0", default-features = false, features = ["serde"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
+url = "2"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 
 [dev-dependencies]
-qdrant-client = { version = "1.18.0", default-features = false, features = ["serde"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }

--- a/crates/axon-vectors/src/CLAUDE.md
+++ b/crates/axon-vectors/src/CLAUDE.md
@@ -8,10 +8,16 @@ contract (owns / API / deps / tests):
 · behavior spec:
 [../../../docs/pipeline-unification/runtime/storage-contract.md](../../../docs/pipeline-unification/runtime/storage-contract.md).
 
-## Status — PR0 skeleton
-Modules below are **markers only**. Real implementation lands in **Phase 7**,
-decomposed out of `axon-vector`'s Qdrant/persistence logic. Do not add embedding
-generation, chunking, ledger commits, or RAG synthesis here.
+## Status — Phase 10 (Qdrant store live)
+Most modules are still **markers** pending later phases, but `qdrant.rs` is now a
+**live** `VectorStore` over the Qdrant REST API (reqwest): GET-then-PUT-on-404
+collection ensure, named dense + bm42 sparse RRF hybrid search, generation-aware
+publish (`mark_generation_committed` flips visibility in place;
+`mark_unchanged_items_committed` carries points into the new generation without
+mutating the old one). Wire logic lives in `qdrant/{http,convert,store_impl,
+search,commit}.rs`. Credentials from the configured URL are stripped before any
+error is surfaced (only the `endpoint = "configured"` marker leaks). Do not add
+embedding generation, chunking, ledger commits, or RAG synthesis here.
 
 ## Module map
 | File | Owns |

--- a/crates/axon-vectors/src/lib.rs
+++ b/crates/axon-vectors/src/lib.rs
@@ -12,8 +12,7 @@ pub mod payload;
 pub mod payload_families;
 mod payload_redaction;
 pub mod point;
-#[cfg(test)]
-mod qdrant;
+pub mod qdrant;
 pub mod query;
 mod sparse;
 pub mod store;
@@ -22,6 +21,8 @@ pub mod testing;
 mod validation;
 
 pub const CRATE_NAME: &str = "axon-vectors";
+
+pub use qdrant::QdrantVectorStore;
 
 #[cfg(test)]
 #[path = "store_tests.rs"]
@@ -46,3 +47,7 @@ mod local_payload_tests;
 #[cfg(test)]
 #[path = "qdrant_tests.rs"]
 mod qdrant_tests;
+
+#[cfg(test)]
+#[path = "qdrant_live_tests.rs"]
+mod qdrant_live_tests;

--- a/crates/axon-vectors/src/qdrant.rs
+++ b/crates/axon-vectors/src/qdrant.rs
@@ -1,27 +1,37 @@
-//! Qdrant target boundary shell and conversion helpers.
+//! Live Qdrant vector store over the REST API.
+//!
+//! [`QdrantVectorStore`] implements [`crate::store::VectorStore`] against a
+//! Qdrant instance addressed by the URL passed to [`QdrantVectorStore::new`].
+//! Submodules split the concern:
+//! - [`http`] — reqwest transport with credential redaction and retries.
+//! - [`convert`] — request-shape conversion (`qdrant_client`-typed validators
+//!   plus the REST JSON bodies actually sent).
+//! - [`store_impl`] — the `VectorStore` trait implementation.
+//! - [`search`] — `/points/query` named-dense and dense+bm42 RRF hybrid.
+//! - [`commit`] — generation-aware publish (`mark_*_committed`).
 
-use std::collections::HashMap;
+pub(crate) mod commit;
+pub mod convert;
+mod http;
+mod search;
+mod store_impl;
 
-use async_trait::async_trait;
 use axon_api::source::*;
-use qdrant_client::qdrant::{
-    CreateCollection, CreateFieldIndexCollection, DenseVector, FieldCondition, FieldType, Filter,
-    HnswConfigDiff, Match, NamedVectors, OptimizersConfigDiff, PointStruct, QuantizationConfig,
-    QuantizationType, ScalarQuantization, SparseVector as QdrantSparseVector,
-    SparseVectorConfig as QdrantSparseVectorConfig, SparseVectorParams, Value,
-    Vector as QdrantVector, VectorParams, VectorParamsMap, Vectors, VectorsConfig, condition,
-    r#match, quantization_config, vector, vectors, vectors_config,
-};
 
-use crate::collection::{normalize_collection_spec, validate_collection_spec};
-use crate::filter::{PATH_PREFIX, SEARCH_GENERATION_FIELD, validate_search_filters};
-use crate::store::{Result, VectorStore};
-use crate::validation::validate_upsert_batch;
+// Re-export the request-shape conversion helpers exercised by the crate's
+// contract tests and any transport that needs the typed builders.
+pub use convert::{
+    QdrantCollectionSettings, qdrant_collection_request, qdrant_filter,
+    qdrant_payload_index_requests, qdrant_upsert_points,
+};
 
 #[allow(dead_code)]
 pub const MODULE_NAME: &str = "qdrant";
 
-#[allow(dead_code)]
+/// Qdrant-backed [`VectorStore`](crate::store::VectorStore).
+///
+/// The `url` is stored verbatim and parsed (with credentials stripped) per
+/// request; it is never surfaced in error details.
 #[derive(Debug, Clone)]
 pub struct QdrantVectorStore {
     url: String,
@@ -29,6 +39,7 @@ pub struct QdrantVectorStore {
 }
 
 impl QdrantVectorStore {
+    /// Build a store for the Qdrant instance at `url`.
     pub fn new(url: impl Into<String>, provider_id: impl Into<String>) -> Self {
         Self {
             url: url.into(),
@@ -36,419 +47,92 @@ impl QdrantVectorStore {
         }
     }
 
-    #[allow(dead_code)]
+    /// The configured Qdrant URL (may embed credentials — do not log).
     pub fn url(&self) -> &str {
         &self.url
     }
 
-    fn not_wired(&self, stage: axon_error::ErrorStage) -> ApiError {
-        ApiError::new(
-            "vector.not_wired",
-            stage,
-            "target Qdrant vector store is not wired to the live runtime yet",
-        )
-        .with_provider_id(&self.provider_id.0)
-        .with_context("endpoint", "configured")
+    /// The provider id used in capability snapshots and error attribution.
+    pub fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
     }
 }
 
-#[async_trait]
-impl VectorStore for QdrantVectorStore {
-    async fn ensure_collection(&self, _spec: CollectionSpec) -> Result<()> {
-        Err(self.not_wired(axon_error::ErrorStage::Upserting))
-    }
-
-    async fn upsert(&self, _batch: VectorPointBatch) -> Result<VectorStoreWriteResult> {
-        Err(self.not_wired(axon_error::ErrorStage::Upserting))
-    }
-
-    async fn mark_generation_committed(
-        &self,
-        _collection: String,
-        _source_id: SourceId,
-        _generation: SourceGenerationId,
-    ) -> Result<VectorStoreWriteResult> {
-        Err(self.not_wired(axon_error::ErrorStage::Publishing))
-    }
-
-    async fn mark_unchanged_items_committed(
-        &self,
-        _collection: String,
-        _source_id: SourceId,
-        _previous_generation: SourceGenerationId,
-        _committed_generation: SourceGenerationId,
-        _source_item_keys: Vec<SourceItemKey>,
-    ) -> Result<VectorStoreWriteResult> {
-        Err(self.not_wired(axon_error::ErrorStage::Publishing))
-    }
-
-    async fn delete(&self, _selector: VectorDeleteSelector) -> Result<VectorStoreDeleteResult> {
-        Err(self.not_wired(axon_error::ErrorStage::Cleaning))
-    }
-
-    async fn search(&self, _request: VectorSearchRequest) -> Result<VectorSearchResult> {
-        Err(self.not_wired(axon_error::ErrorStage::Retrieving))
-    }
-
-    async fn capabilities(&self) -> Result<ProviderCapability> {
-        Ok(ProviderCapability {
-            provider_id: self.provider_id.clone(),
-            provider_kind: ProviderKind::Vector,
-            implementation: "qdrant-target-shell".to_string(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
-            health: HealthStatus::Unavailable,
-            limits: ProviderLimits::default(),
-            features: vec![
-                "dense".to_string(),
-                "sparse".to_string(),
-                "payload_filters".to_string(),
-                "payload_indexes".to_string(),
-            ],
-            cooldown_until: None,
-            last_error: Some(self.not_wired(axon_error::ErrorStage::Observing)),
-            reservation_policy: ReservationPolicy {
-                supports_reservations: false,
-                queue_policy: QueuePolicy::Fifo,
-                interactive_reserve: 0,
-                cooldown_after_failures: 1,
-                cooldown_secs: 30,
-                retry_backoff_ms: None,
-            },
-            reservation_state: ReservationStateSnapshot {
-                queued: 0,
-                active: 0,
-                available_units: 0,
-                oldest_queued_ms: None,
-                priority_breakdown: Default::default(),
-                states: vec![ReservationState::Failed],
-            },
-            cost_class: ProviderCostClass::Internal,
-            degraded_modes: Vec::new(),
-            fake_overrides_supported: false,
-            embedding: None,
-            llm: None,
-            vector_store: Some(VectorStoreCapability {
-                dense: true,
-                sparse: true,
-                hybrid: true,
-                payload_filters: true,
-                payload_indexes: Vec::new(),
-                delete_by_filter: true,
-                generation_publish: false,
-                collection_aliases: true,
-                consistency: VectorConsistency::Strong,
-            }),
-            fetch: None,
-            render: None,
-            credential: None,
-        })
-    }
-}
-
-pub fn qdrant_collection_request(spec: &CollectionSpec) -> Result<CreateCollection> {
-    let spec = normalize_collection_spec(spec.clone());
-    validate_collection_spec(&spec)?;
-    let settings = QdrantCollectionSettings::default();
-    let mut dense = HashMap::new();
-    dense.insert(
-        spec.dense.name.clone(),
-        VectorParams {
-            size: u64::from(spec.dense.dimensions),
-            distance: qdrant_distance(spec.dense.distance) as i32,
-            hnsw_config: None,
-            quantization_config: None,
-            on_disk: Some(settings.dense_on_disk),
-            datatype: None,
-            multivector_config: None,
+/// Build the capability snapshot for this store.
+///
+/// Reports live health by probing the Qdrant root endpoint; declares dense +
+/// sparse + hybrid + generation-publish support.
+pub(crate) async fn capability_snapshot(store: &QdrantVectorStore) -> ProviderCapability {
+    let (health, last_error) = probe_health(store).await;
+    ProviderCapability {
+        provider_id: store.provider_id().clone(),
+        provider_kind: ProviderKind::Vector,
+        implementation: "qdrant".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        health,
+        limits: ProviderLimits::default(),
+        features: vec![
+            "dense".to_string(),
+            "sparse".to_string(),
+            "hybrid".to_string(),
+            "payload_filters".to_string(),
+            "payload_indexes".to_string(),
+            "generation_publish".to_string(),
+        ],
+        cooldown_until: None,
+        last_error,
+        reservation_policy: ReservationPolicy {
+            supports_reservations: false,
+            queue_policy: QueuePolicy::Fifo,
+            interactive_reserve: 0,
+            cooldown_after_failures: 1,
+            cooldown_secs: 30,
+            retry_backoff_ms: None,
         },
-    );
-
-    Ok(CreateCollection {
-        collection_name: spec.collection.clone(),
-        vectors_config: Some(VectorsConfig {
-            config: Some(vectors_config::Config::ParamsMap(VectorParamsMap {
-                map: dense,
-            })),
+        reservation_state: ReservationStateSnapshot {
+            queued: 0,
+            active: 0,
+            available_units: 0,
+            oldest_queued_ms: None,
+            priority_breakdown: Default::default(),
+            states: Vec::new(),
+        },
+        cost_class: ProviderCostClass::Internal,
+        degraded_modes: Vec::new(),
+        fake_overrides_supported: false,
+        embedding: None,
+        llm: None,
+        vector_store: Some(VectorStoreCapability {
+            dense: true,
+            sparse: true,
+            hybrid: true,
+            payload_filters: true,
+            payload_indexes: Vec::new(),
+            delete_by_filter: true,
+            generation_publish: true,
+            collection_aliases: true,
+            consistency: VectorConsistency::Strong,
         }),
-        sparse_vectors_config: spec.sparse.as_ref().map(|sparse| {
-            let mut map = HashMap::new();
-            map.insert(
-                sparse.name.clone(),
-                SparseVectorParams {
-                    index: None,
-                    modifier: Some(qdrant_sparse_modifier(sparse.modifier) as i32),
-                },
-            );
-            QdrantSparseVectorConfig { map }
-        }),
-        hnsw_config: Some(HnswConfigDiff {
-            m: Some(settings.hnsw_m),
-            ef_construct: Some(settings.hnsw_ef_construct),
-            full_scan_threshold: None,
-            max_indexing_threads: None,
-            on_disk: Some(settings.hnsw_on_disk),
-            payload_m: None,
-            inline_storage: None,
-        }),
-        wal_config: None,
-        optimizers_config: Some(OptimizersConfigDiff {
-            deleted_threshold: None,
-            vacuum_min_vector_number: None,
-            default_segment_number: None,
-            max_segment_size: None,
-            memmap_threshold: None,
-            indexing_threshold: Some(settings.indexing_threshold),
-            flush_interval_sec: None,
-            deprecated_max_optimization_threads: None,
-            max_optimization_threads: None,
-            prevent_unoptimized: None,
-        }),
-        shard_number: None,
-        on_disk_payload: None,
-        timeout: None,
-        replication_factor: None,
-        write_consistency_factor: None,
-        quantization_config: Some(QuantizationConfig {
-            quantization: Some(quantization_config::Quantization::Scalar(
-                ScalarQuantization {
-                    r#type: QuantizationType::Int8 as i32,
-                    quantile: Some(settings.quantization_quantile),
-                    always_ram: Some(settings.quantization_always_ram),
-                },
-            )),
-        }),
-        sharding_method: None,
-        strict_mode_config: None,
-        metadata: HashMap::new(),
-    })
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct QdrantCollectionSettings {
-    pub dense_on_disk: bool,
-    pub hnsw_m: u64,
-    pub hnsw_ef_construct: u64,
-    pub hnsw_on_disk: bool,
-    pub indexing_threshold: u64,
-    pub quantization_quantile: f32,
-    pub quantization_always_ram: bool,
-}
-
-impl Default for QdrantCollectionSettings {
-    fn default() -> Self {
-        Self {
-            dense_on_disk: true,
-            hnsw_m: 32,
-            hnsw_ef_construct: 256,
-            hnsw_on_disk: false,
-            indexing_threshold: 20_000,
-            quantization_quantile: 0.99,
-            quantization_always_ram: true,
-        }
+        fetch: None,
+        render: None,
+        credential: None,
     }
 }
 
-pub fn qdrant_payload_index_requests(spec: &CollectionSpec) -> Vec<CreateFieldIndexCollection> {
-    normalize_collection_spec(spec.clone())
-        .payload_indexes
-        .iter()
-        .map(|index| CreateFieldIndexCollection {
-            collection_name: spec.collection.clone(),
-            wait: Some(true),
-            field_name: index.field_name.clone(),
-            field_type: Some(qdrant_field_type(index.field_schema.clone()) as i32),
-            field_index_params: None,
-            ordering: None,
-            timeout: None,
-        })
-        .collect()
-}
-
-pub fn qdrant_filter(request: &VectorSearchRequest) -> Result<Option<Filter>> {
-    validate_search_filters(request)?;
-    let mut conditions = Vec::new();
-    for (field, value) in request.filters.iter() {
-        if field == PATH_PREFIX {
-            return Err(ApiError::new(
-                "vector.qdrant.path_prefix_unsupported",
-                axon_error::ErrorStage::Retrieving,
-                "target Qdrant path-prefix filters require live prefix-query wiring",
-            ));
-        }
-        conditions.extend(qdrant_field_conditions(field, value));
-    }
-    if let Some(generation) = &request.generation {
-        let value = serde_json::Value::from(generation.0.clone());
-        conditions.push(field_condition(SEARCH_GENERATION_FIELD, &value));
-    }
-    Ok((!conditions.is_empty()).then_some(Filter {
-        should: Vec::new(),
-        must: conditions,
-        must_not: Vec::new(),
-        min_should: None,
-    }))
-}
-
-pub fn qdrant_upsert_points(
-    spec: &CollectionSpec,
-    batch: &VectorPointBatch,
-) -> Result<Vec<PointStruct>> {
-    let batch_sparse = validate_upsert_batch(spec, batch, axon_error::ErrorStage::Upserting)?;
-    batch
-        .points
-        .iter()
-        .map(|point| {
-            let mut named = HashMap::new();
-            named.insert(
-                spec.dense.name.clone(),
-                qdrant_dense_vector(point.vector.clone()),
-            );
-            let sparse_vector = point
-                .sparse_vector
-                .as_ref()
-                .or_else(|| batch_sparse.get(&point.chunk_id.0));
-            if let (Some(sparse_spec), Some(sparse_vector)) = (spec.sparse.as_ref(), sparse_vector)
-            {
-                named.insert(
-                    sparse_spec.name.clone(),
-                    qdrant_sparse_vector(
-                        sparse_vector.indices.clone(),
-                        sparse_vector.values.clone(),
-                    ),
-                );
-            }
-            Ok(PointStruct {
-                id: Some(point.point_id.0.as_str().into()),
-                payload: point
-                    .payload
-                    .iter()
-                    .map(|(field, value)| (field.clone(), json_to_qdrant_value(value)))
-                    .collect(),
-                vectors: Some(Vectors {
-                    vectors_options: Some(vectors::VectorsOptions::Vectors(NamedVectors {
-                        vectors: named,
-                    })),
-                }),
-            })
-        })
-        .collect()
-}
-
-#[allow(deprecated)]
-fn qdrant_dense_vector(data: Vec<f32>) -> QdrantVector {
-    QdrantVector {
-        data: Vec::new(),
-        indices: None,
-        vectors_count: None,
-        vector: Some(vector::Vector::Dense(DenseVector { data })),
-    }
-}
-
-#[allow(deprecated)]
-fn qdrant_sparse_vector(indices: Vec<u32>, values: Vec<f32>) -> QdrantVector {
-    QdrantVector {
-        data: Vec::new(),
-        indices: None,
-        vectors_count: None,
-        vector: Some(vector::Vector::Sparse(QdrantSparseVector {
-            indices,
-            values,
-        })),
-    }
-}
-
-pub(crate) fn qdrant_field_conditions(
-    field: &str,
-    value: &serde_json::Value,
-) -> Vec<qdrant_client::qdrant::Condition> {
-    let Some(values) = value.as_array() else {
-        return vec![field_condition(field, value)];
+/// Probe the Qdrant root for liveness. Any transport/status failure downgrades
+/// health to `Unavailable` and carries a redaction-safe last error.
+async fn probe_health(store: &QdrantVectorStore) -> (HealthStatus, Option<ApiError>) {
+    let http = match store.http() {
+        Ok(http) => http,
+        Err(err) => return (HealthStatus::Unavailable, Some(err)),
     };
-    if values.is_empty() {
-        return vec![field_condition(
-            "__axon_match_none",
-            &serde_json::json!("__never__"),
-        )];
-    }
-    if values.len() == 1 {
-        return vec![field_condition(field, &values[0])];
-    }
-    vec![qdrant_client::qdrant::Condition {
-        condition_one_of: Some(condition::ConditionOneOf::Filter(Filter {
-            should: values
-                .iter()
-                .map(|value| field_condition(field, value))
-                .collect(),
-            must: Vec::new(),
-            must_not: Vec::new(),
-            min_should: None,
-        })),
-    }]
-}
-
-fn field_condition(field: &str, value: &serde_json::Value) -> qdrant_client::qdrant::Condition {
-    qdrant_client::qdrant::Condition {
-        condition_one_of: Some(condition::ConditionOneOf::Field(FieldCondition {
-            key: field.to_string(),
-            r#match: Some(Match {
-                match_value: Some(qdrant_match_value(value)),
-            }),
-            range: None,
-            geo_bounding_box: None,
-            geo_radius: None,
-            values_count: None,
-            geo_polygon: None,
-            datetime_range: None,
-            is_empty: None,
-            is_null: None,
-        })),
-    }
-}
-
-fn qdrant_match_value(value: &serde_json::Value) -> r#match::MatchValue {
-    if let Some(value) = value.as_i64() {
-        return r#match::MatchValue::Integer(value);
-    }
-    if let Some(value) = value.as_bool() {
-        return r#match::MatchValue::Boolean(value);
-    }
-    r#match::MatchValue::Keyword(match value {
-        serde_json::Value::String(value) => value.clone(),
-        other => other.to_string(),
-    })
-}
-
-fn json_to_qdrant_value(value: &serde_json::Value) -> Value {
-    serde_json::from_value(value.clone()).unwrap_or_else(|_| Value {
-        kind: Some(qdrant_client::qdrant::value::Kind::StringValue(
-            value.to_string(),
-        )),
-    })
-}
-
-fn qdrant_distance(distance: VectorDistance) -> qdrant_client::qdrant::Distance {
-    match distance {
-        VectorDistance::Cosine => qdrant_client::qdrant::Distance::Cosine,
-        VectorDistance::Dot => qdrant_client::qdrant::Distance::Dot,
-        VectorDistance::Euclid => qdrant_client::qdrant::Distance::Euclid,
-        VectorDistance::Manhattan => qdrant_client::qdrant::Distance::Manhattan,
-    }
-}
-
-fn qdrant_sparse_modifier(modifier: SparseVectorModifier) -> qdrant_client::qdrant::Modifier {
-    match modifier {
-        SparseVectorModifier::None => qdrant_client::qdrant::Modifier::None,
-        SparseVectorModifier::Idf => qdrant_client::qdrant::Modifier::Idf,
-    }
-}
-
-fn qdrant_field_type(schema: PayloadFieldSchema) -> FieldType {
-    match schema {
-        PayloadFieldSchema::Keyword => FieldType::Keyword,
-        PayloadFieldSchema::Integer => FieldType::Integer,
-        PayloadFieldSchema::Float => FieldType::Float,
-        PayloadFieldSchema::Boolean => FieldType::Bool,
-        PayloadFieldSchema::Datetime => FieldType::Datetime,
-        PayloadFieldSchema::Text => FieldType::Text,
+    // `GET /` returns a small JSON envelope (`{"title":...,"version":...}`).
+    let url = format!("{}/", http.endpoint().root());
+    match http
+        .get_json(axon_error::ErrorStage::Observing, &url, "qdrant_health")
+        .await
+    {
+        Ok(_) => (HealthStatus::Healthy, None),
+        Err(err) => (HealthStatus::Unavailable, Some(err)),
     }
 }

--- a/crates/axon-vectors/src/qdrant/commit.rs
+++ b/crates/axon-vectors/src/qdrant/commit.rs
@@ -1,0 +1,246 @@
+//! Generation-aware publish operations over the Qdrant REST API.
+//!
+//! Upserted points land with `committed_generation = "uncommitted"` (stamped by
+//! the point builder) so in-flight generations stay invisible to
+//! committed-generation searches until publish. `mark_generation_committed`
+//! flips the matching points' `committed_generation`/`document_status` in place;
+//! `mark_unchanged_items_committed` copies carried-forward points into the new
+//! committed generation without mutating the previous generation's points.
+
+use axon_api::source::*;
+use serde::Deserialize;
+
+use super::QdrantVectorStore;
+use super::http::QdrantHttp;
+use super::store_impl::request_usage;
+use crate::store::Result;
+use crate::store_helpers::stage_header;
+
+const SCROLL_PAGE_LIMIT: u64 = 256;
+
+/// Set `committed_generation`/`document_status` = published on every point whose
+/// `source_id` + `source_generation` match, via a filtered set-payload.
+pub async fn mark_generation_committed_rest(
+    store: &QdrantVectorStore,
+    http: &QdrantHttp,
+    collection: String,
+    source_id: SourceId,
+    generation: SourceGenerationId,
+) -> Result<VectorStoreWriteResult> {
+    let stage = axon_error::ErrorStage::Publishing;
+    store
+        .require_collection_spec(http, &collection, stage)
+        .await?;
+
+    let filter = super::convert::eq2_filter_json(
+        "source_id",
+        &source_id.0,
+        "source_generation",
+        &generation.0,
+    );
+    let matched = count_points(http, &collection, &filter, stage).await?;
+
+    let body = serde_json::json!({
+        "payload": {
+            "committed_generation": generation.0,
+            "document_status": "published",
+        },
+        "filter": filter,
+    });
+    let url = http
+        .endpoint()
+        .collection_path(&collection, "points/payload?wait=true");
+    let _ack: SimpleAck = http
+        .post_json(stage, &url, &body, "qdrant_mark_generation_committed")
+        .await?;
+
+    Ok(VectorStoreWriteResult {
+        header: stage_header(PipelinePhase::Publishing),
+        collection,
+        points_attempted: matched,
+        points_written: matched,
+        payload_indexes_created: Vec::new(),
+        usage: request_usage(2),
+    })
+}
+
+/// Copy unchanged carried-forward points into the newly committed generation.
+///
+/// Scrolls every point whose `source_id` + `committed_generation` match the
+/// previous generation and whose `source_item_key` is in `source_item_keys`,
+/// then re-upserts a copy with a generation-suffixed id and the new
+/// generation/status stamped — leaving the previous generation intact.
+pub async fn mark_unchanged_items_committed_rest(
+    store: &QdrantVectorStore,
+    http: &QdrantHttp,
+    collection: String,
+    source_id: SourceId,
+    previous_generation: SourceGenerationId,
+    committed_generation: SourceGenerationId,
+    source_item_keys: Vec<SourceItemKey>,
+) -> Result<VectorStoreWriteResult> {
+    let stage = axon_error::ErrorStage::Publishing;
+    store
+        .require_collection_spec(http, &collection, stage)
+        .await?;
+
+    let live_keys: std::collections::BTreeSet<String> =
+        source_item_keys.into_iter().map(|key| key.0).collect();
+    if live_keys.is_empty() {
+        return Ok(empty_commit(collection));
+    }
+
+    let filter = super::convert::eq2_filter_json(
+        "source_id",
+        &source_id.0,
+        "committed_generation",
+        &previous_generation.0,
+    );
+    let points = scroll_points(http, &collection, &filter, stage).await?;
+
+    let mut carried = Vec::new();
+    for point in points {
+        let payload = point.payload;
+        let item = payload.get("source_item_key").and_then(|v| v.as_str());
+        if item.is_none_or(|item| !live_keys.contains(item)) {
+            continue;
+        }
+        let mut payload = payload;
+        payload.insert(
+            "source_generation".to_string(),
+            serde_json::Value::from(committed_generation.0.clone()),
+        );
+        payload.insert(
+            "committed_generation".to_string(),
+            serde_json::Value::from(committed_generation.0.clone()),
+        );
+        payload.insert(
+            "document_status".to_string(),
+            serde_json::Value::from("published"),
+        );
+        let new_id = format!("{}::{}", point_id_string(&point.id), committed_generation.0);
+        carried.push(serde_json::json!({
+            "id": new_id,
+            "vector": point.vector,
+            "payload": payload,
+        }));
+    }
+
+    let attempted = carried.len() as u64;
+    if attempted > 0 {
+        let url = http
+            .endpoint()
+            .collection_path(&collection, "points?wait=true");
+        let body = serde_json::json!({ "points": carried });
+        http.put_json(stage, &url, &body, "qdrant_mark_unchanged_items_committed")
+            .await?;
+    }
+
+    Ok(VectorStoreWriteResult {
+        header: stage_header(PipelinePhase::Publishing),
+        collection,
+        points_attempted: attempted,
+        points_written: attempted,
+        payload_indexes_created: Vec::new(),
+        usage: request_usage(2),
+    })
+}
+
+fn empty_commit(collection: String) -> VectorStoreWriteResult {
+    VectorStoreWriteResult {
+        header: stage_header(PipelinePhase::Publishing),
+        collection,
+        points_attempted: 0,
+        points_written: 0,
+        payload_indexes_created: Vec::new(),
+        usage: request_usage(1),
+    }
+}
+
+#[derive(Deserialize)]
+struct SimpleAck {
+    #[serde(default, rename = "result")]
+    _result: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct CountResponse {
+    result: CountResult,
+}
+
+#[derive(Deserialize)]
+struct CountResult {
+    #[serde(default)]
+    count: u64,
+}
+
+async fn count_points(
+    http: &QdrantHttp,
+    collection: &str,
+    filter: &serde_json::Value,
+    stage: axon_error::ErrorStage,
+) -> Result<u64> {
+    let url = http.endpoint().collection_path(collection, "points/count");
+    let body = serde_json::json!({ "filter": filter, "exact": true });
+    let response: CountResponse = http.post_json(stage, &url, &body, "qdrant_count").await?;
+    Ok(response.result.count)
+}
+
+#[derive(Deserialize)]
+struct ScrollPoint {
+    id: serde_json::Value,
+    #[serde(default)]
+    vector: serde_json::Value,
+    #[serde(default)]
+    payload: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct ScrollResult {
+    #[serde(default)]
+    points: Vec<ScrollPoint>,
+    #[serde(default)]
+    next_page_offset: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct ScrollResponse {
+    result: ScrollResult,
+}
+
+async fn scroll_points(
+    http: &QdrantHttp,
+    collection: &str,
+    filter: &serde_json::Value,
+    stage: axon_error::ErrorStage,
+) -> Result<Vec<ScrollPoint>> {
+    let url = http.endpoint().collection_path(collection, "points/scroll");
+    let mut offset: Option<serde_json::Value> = None;
+    let mut all = Vec::new();
+    loop {
+        let mut body = serde_json::json!({
+            "filter": filter,
+            "limit": SCROLL_PAGE_LIMIT,
+            "with_payload": true,
+            "with_vector": true,
+        });
+        if let Some(offset) = &offset {
+            body["offset"] = offset.clone();
+        }
+        let response: ScrollResponse = http.post_json(stage, &url, &body, "qdrant_scroll").await?;
+        all.extend(response.result.points);
+        match response.result.next_page_offset {
+            Some(next) if !next.is_null() => offset = Some(next),
+            _ => break,
+        }
+    }
+    Ok(all)
+}
+
+fn point_id_string(id: &serde_json::Value) -> String {
+    match id {
+        serde_json::Value::String(value) => value.clone(),
+        serde_json::Value::Number(value) => value.to_string(),
+        other => other.to_string(),
+    }
+}

--- a/crates/axon-vectors/src/qdrant/convert.rs
+++ b/crates/axon-vectors/src/qdrant/convert.rs
@@ -1,0 +1,342 @@
+//! Request-shape conversion for Qdrant.
+//!
+//! Two families live here:
+//! - `qdrant_client`-typed builders (`qdrant_collection_request`,
+//!   `qdrant_upsert_points`, `qdrant_filter`, `qdrant_payload_index_requests`)
+//!   are the contract-tested request-shape validators.
+//! - `*_json` builders produce the REST bodies actually sent over reqwest.
+
+use std::collections::HashMap;
+
+use axon_api::source::*;
+use qdrant_client::qdrant::{
+    CreateCollection, CreateFieldIndexCollection, DenseVector, FieldCondition, FieldType, Filter,
+    HnswConfigDiff, Match, NamedVectors, OptimizersConfigDiff, PointStruct, QuantizationConfig,
+    QuantizationType, ScalarQuantization, SparseVector as QdrantSparseVector,
+    SparseVectorConfig as QdrantSparseVectorConfig, SparseVectorParams, Value,
+    Vector as QdrantVector, VectorParams, VectorParamsMap, Vectors, VectorsConfig, condition,
+    r#match, quantization_config, vector, vectors, vectors_config,
+};
+
+use crate::collection::{normalize_collection_spec, validate_collection_spec};
+use crate::filter::{PATH_PREFIX, SEARCH_GENERATION_FIELD, validate_search_filters};
+use crate::store::Result;
+use crate::validation::validate_upsert_batch;
+
+// ---------------------------------------------------------------------------
+// qdrant_client-typed request builders (contract-tested shape validators)
+// ---------------------------------------------------------------------------
+
+pub fn qdrant_collection_request(spec: &CollectionSpec) -> Result<CreateCollection> {
+    let spec = normalize_collection_spec(spec.clone());
+    validate_collection_spec(&spec)?;
+    let settings = QdrantCollectionSettings::default();
+    let mut dense = HashMap::new();
+    dense.insert(
+        spec.dense.name.clone(),
+        VectorParams {
+            size: u64::from(spec.dense.dimensions),
+            distance: qdrant_distance(spec.dense.distance) as i32,
+            hnsw_config: None,
+            quantization_config: None,
+            on_disk: Some(settings.dense_on_disk),
+            datatype: None,
+            multivector_config: None,
+        },
+    );
+
+    Ok(CreateCollection {
+        collection_name: spec.collection.clone(),
+        vectors_config: Some(VectorsConfig {
+            config: Some(vectors_config::Config::ParamsMap(VectorParamsMap {
+                map: dense,
+            })),
+        }),
+        sparse_vectors_config: spec.sparse.as_ref().map(|sparse| {
+            let mut map = HashMap::new();
+            map.insert(
+                sparse.name.clone(),
+                SparseVectorParams {
+                    index: None,
+                    modifier: Some(qdrant_sparse_modifier(sparse.modifier) as i32),
+                },
+            );
+            QdrantSparseVectorConfig { map }
+        }),
+        hnsw_config: Some(HnswConfigDiff {
+            m: Some(settings.hnsw_m),
+            ef_construct: Some(settings.hnsw_ef_construct),
+            full_scan_threshold: None,
+            max_indexing_threads: None,
+            on_disk: Some(settings.hnsw_on_disk),
+            payload_m: None,
+            inline_storage: None,
+        }),
+        wal_config: None,
+        optimizers_config: Some(OptimizersConfigDiff {
+            deleted_threshold: None,
+            vacuum_min_vector_number: None,
+            default_segment_number: None,
+            max_segment_size: None,
+            memmap_threshold: None,
+            indexing_threshold: Some(settings.indexing_threshold),
+            flush_interval_sec: None,
+            deprecated_max_optimization_threads: None,
+            max_optimization_threads: None,
+            prevent_unoptimized: None,
+        }),
+        shard_number: None,
+        on_disk_payload: None,
+        timeout: None,
+        replication_factor: None,
+        write_consistency_factor: None,
+        quantization_config: Some(QuantizationConfig {
+            quantization: Some(quantization_config::Quantization::Scalar(
+                ScalarQuantization {
+                    r#type: QuantizationType::Int8 as i32,
+                    quantile: Some(settings.quantization_quantile),
+                    always_ram: Some(settings.quantization_always_ram),
+                },
+            )),
+        }),
+        sharding_method: None,
+        strict_mode_config: None,
+        metadata: HashMap::new(),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct QdrantCollectionSettings {
+    pub dense_on_disk: bool,
+    pub hnsw_m: u64,
+    pub hnsw_ef_construct: u64,
+    pub hnsw_on_disk: bool,
+    pub indexing_threshold: u64,
+    pub quantization_quantile: f32,
+    pub quantization_always_ram: bool,
+}
+
+impl Default for QdrantCollectionSettings {
+    fn default() -> Self {
+        Self {
+            dense_on_disk: true,
+            hnsw_m: 32,
+            hnsw_ef_construct: 256,
+            hnsw_on_disk: false,
+            indexing_threshold: 20_000,
+            quantization_quantile: 0.99,
+            quantization_always_ram: true,
+        }
+    }
+}
+
+pub fn qdrant_payload_index_requests(spec: &CollectionSpec) -> Vec<CreateFieldIndexCollection> {
+    normalize_collection_spec(spec.clone())
+        .payload_indexes
+        .iter()
+        .map(|index| CreateFieldIndexCollection {
+            collection_name: spec.collection.clone(),
+            wait: Some(true),
+            field_name: index.field_name.clone(),
+            field_type: Some(qdrant_field_type(index.field_schema.clone()) as i32),
+            field_index_params: None,
+            ordering: None,
+            timeout: None,
+        })
+        .collect()
+}
+
+pub fn qdrant_filter(request: &VectorSearchRequest) -> Result<Option<Filter>> {
+    validate_search_filters(request)?;
+    let mut conditions = Vec::new();
+    for (field, value) in request.filters.iter() {
+        if field == PATH_PREFIX {
+            return Err(ApiError::new(
+                "vector.qdrant.path_prefix_unsupported",
+                axon_error::ErrorStage::Retrieving,
+                "target Qdrant path-prefix filters require live prefix-query wiring",
+            ));
+        }
+        conditions.extend(qdrant_field_conditions(field, value));
+    }
+    if let Some(generation) = &request.generation {
+        let value = serde_json::Value::from(generation.0.clone());
+        conditions.push(field_condition(SEARCH_GENERATION_FIELD, &value));
+    }
+    Ok((!conditions.is_empty()).then_some(Filter {
+        should: Vec::new(),
+        must: conditions,
+        must_not: Vec::new(),
+        min_should: None,
+    }))
+}
+
+pub fn qdrant_upsert_points(
+    spec: &CollectionSpec,
+    batch: &VectorPointBatch,
+) -> Result<Vec<PointStruct>> {
+    let batch_sparse = validate_upsert_batch(spec, batch, axon_error::ErrorStage::Upserting)?;
+    batch
+        .points
+        .iter()
+        .map(|point| {
+            let mut named = HashMap::new();
+            named.insert(
+                spec.dense.name.clone(),
+                qdrant_dense_vector(point.vector.clone()),
+            );
+            let sparse_vector = point
+                .sparse_vector
+                .as_ref()
+                .or_else(|| batch_sparse.get(&point.chunk_id.0));
+            if let (Some(sparse_spec), Some(sparse_vector)) = (spec.sparse.as_ref(), sparse_vector)
+            {
+                named.insert(
+                    sparse_spec.name.clone(),
+                    qdrant_sparse_vector(
+                        sparse_vector.indices.clone(),
+                        sparse_vector.values.clone(),
+                    ),
+                );
+            }
+            Ok(PointStruct {
+                id: Some(point.point_id.0.as_str().into()),
+                payload: point
+                    .payload
+                    .iter()
+                    .map(|(field, value)| (field.clone(), json_to_qdrant_value(value)))
+                    .collect(),
+                vectors: Some(Vectors {
+                    vectors_options: Some(vectors::VectorsOptions::Vectors(NamedVectors {
+                        vectors: named,
+                    })),
+                }),
+            })
+        })
+        .collect()
+}
+
+#[allow(deprecated)]
+fn qdrant_dense_vector(data: Vec<f32>) -> QdrantVector {
+    QdrantVector {
+        data: Vec::new(),
+        indices: None,
+        vectors_count: None,
+        vector: Some(vector::Vector::Dense(DenseVector { data })),
+    }
+}
+
+#[allow(deprecated)]
+fn qdrant_sparse_vector(indices: Vec<u32>, values: Vec<f32>) -> QdrantVector {
+    QdrantVector {
+        data: Vec::new(),
+        indices: None,
+        vectors_count: None,
+        vector: Some(vector::Vector::Sparse(QdrantSparseVector {
+            indices,
+            values,
+        })),
+    }
+}
+
+pub(crate) fn qdrant_field_conditions(
+    field: &str,
+    value: &serde_json::Value,
+) -> Vec<qdrant_client::qdrant::Condition> {
+    let Some(values) = value.as_array() else {
+        return vec![field_condition(field, value)];
+    };
+    if values.is_empty() {
+        return vec![field_condition(
+            "__axon_match_none",
+            &serde_json::json!("__never__"),
+        )];
+    }
+    if values.len() == 1 {
+        return vec![field_condition(field, &values[0])];
+    }
+    vec![qdrant_client::qdrant::Condition {
+        condition_one_of: Some(condition::ConditionOneOf::Filter(Filter {
+            should: values
+                .iter()
+                .map(|value| field_condition(field, value))
+                .collect(),
+            must: Vec::new(),
+            must_not: Vec::new(),
+            min_should: None,
+        })),
+    }]
+}
+
+fn field_condition(field: &str, value: &serde_json::Value) -> qdrant_client::qdrant::Condition {
+    qdrant_client::qdrant::Condition {
+        condition_one_of: Some(condition::ConditionOneOf::Field(FieldCondition {
+            key: field.to_string(),
+            r#match: Some(Match {
+                match_value: Some(qdrant_match_value(value)),
+            }),
+            range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            values_count: None,
+            geo_polygon: None,
+            datetime_range: None,
+            is_empty: None,
+            is_null: None,
+        })),
+    }
+}
+
+fn qdrant_match_value(value: &serde_json::Value) -> r#match::MatchValue {
+    if let Some(value) = value.as_i64() {
+        return r#match::MatchValue::Integer(value);
+    }
+    if let Some(value) = value.as_bool() {
+        return r#match::MatchValue::Boolean(value);
+    }
+    r#match::MatchValue::Keyword(match value {
+        serde_json::Value::String(value) => value.clone(),
+        other => other.to_string(),
+    })
+}
+
+fn json_to_qdrant_value(value: &serde_json::Value) -> Value {
+    serde_json::from_value(value.clone()).unwrap_or_else(|_| Value {
+        kind: Some(qdrant_client::qdrant::value::Kind::StringValue(
+            value.to_string(),
+        )),
+    })
+}
+
+fn qdrant_distance(distance: VectorDistance) -> qdrant_client::qdrant::Distance {
+    match distance {
+        VectorDistance::Cosine => qdrant_client::qdrant::Distance::Cosine,
+        VectorDistance::Dot => qdrant_client::qdrant::Distance::Dot,
+        VectorDistance::Euclid => qdrant_client::qdrant::Distance::Euclid,
+        VectorDistance::Manhattan => qdrant_client::qdrant::Distance::Manhattan,
+    }
+}
+
+fn qdrant_sparse_modifier(modifier: SparseVectorModifier) -> qdrant_client::qdrant::Modifier {
+    match modifier {
+        SparseVectorModifier::None => qdrant_client::qdrant::Modifier::None,
+        SparseVectorModifier::Idf => qdrant_client::qdrant::Modifier::Idf,
+    }
+}
+
+fn qdrant_field_type(schema: PayloadFieldSchema) -> FieldType {
+    match schema {
+        PayloadFieldSchema::Keyword => FieldType::Keyword,
+        PayloadFieldSchema::Integer => FieldType::Integer,
+        PayloadFieldSchema::Float => FieldType::Float,
+        PayloadFieldSchema::Boolean => FieldType::Bool,
+        PayloadFieldSchema::Datetime => FieldType::Datetime,
+        PayloadFieldSchema::Text => FieldType::Text,
+    }
+}
+
+mod rest;
+pub use rest::{
+    canonical_uri_filter_json, collection_create_json, eq_filter_json, eq2_filter_json,
+    payload_index_json, search_filter_json, upsert_points_json,
+};

--- a/crates/axon-vectors/src/qdrant/convert/rest.rs
+++ b/crates/axon-vectors/src/qdrant/convert/rest.rs
@@ -167,13 +167,16 @@ pub fn canonical_uri_filter_json(canonical_uri: &str, prefix: bool) -> serde_jso
     } else {
         json!({ "value": canonical_uri })
     };
+    // A bare `should` array already means "match at least one" (Qdrant defaults
+    // min_should to 1). Do NOT add a sibling `"min_should": {"min_count": 1}` —
+    // Qdrant's MinShould requires the matched conditions nested *inside*
+    // min_should, so a sibling form is rejected with HTTP 400.
     json!({
         "should": [
             { "key": "url", "match": matcher.clone() },
             { "key": "source_item_key", "match": matcher.clone() },
             { "key": "chunk_locator.canonical_uri", "match": matcher },
         ],
-        "min_should": { "min_count": 1 }
     })
 }
 
@@ -187,9 +190,10 @@ fn condition_json(field: &str, value: &serde_json::Value) -> serde_json::Value {
     if values.len() == 1 {
         return match_json(field, &values[0]);
     }
+    // Bare `should` = OR (min_should defaults to 1). A sibling min_should object
+    // is both redundant and malformed for Qdrant's REST filter API.
     json!({
         "should": values.iter().map(|value| match_json(field, value)).collect::<Vec<_>>(),
-        "min_should": { "min_count": 1 }
     })
 }
 
@@ -207,3 +211,7 @@ fn match_json(field: &str, value: &serde_json::Value) -> serde_json::Value {
     };
     json!({ "key": field, "match": matcher })
 }
+
+#[cfg(test)]
+#[path = "rest_tests.rs"]
+mod rest_tests;

--- a/crates/axon-vectors/src/qdrant/convert/rest.rs
+++ b/crates/axon-vectors/src/qdrant/convert/rest.rs
@@ -1,0 +1,209 @@
+//! REST JSON request bodies sent over reqwest.
+//!
+//! Split out of `convert.rs` to stay under the 500-line monolith cap; these are
+//! the bodies actually posted to Qdrant (the sibling `qdrant_client`-typed
+//! builders remain the contract-tested shape validators).
+
+use axon_api::source::*;
+use serde_json::json;
+
+use super::QdrantCollectionSettings;
+use crate::filter::validate_search_filters;
+use crate::filter::{PATH_PREFIX, SEARCH_GENERATION_FIELD};
+use crate::store::Result;
+use crate::validation::validate_upsert_batch;
+
+fn schema_kind(schema: &PayloadFieldSchema) -> &'static str {
+    match schema {
+        PayloadFieldSchema::Keyword => "keyword",
+        PayloadFieldSchema::Integer => "integer",
+        PayloadFieldSchema::Float => "float",
+        PayloadFieldSchema::Boolean => "bool",
+        PayloadFieldSchema::Datetime => "datetime",
+        PayloadFieldSchema::Text => "text",
+    }
+}
+
+fn distance_kind(distance: VectorDistance) -> &'static str {
+    match distance {
+        VectorDistance::Cosine => "Cosine",
+        VectorDistance::Dot => "Dot",
+        VectorDistance::Euclid => "Euclid",
+        VectorDistance::Manhattan => "Manhattan",
+    }
+}
+
+fn sparse_modifier_kind(modifier: SparseVectorModifier) -> &'static str {
+    match modifier {
+        SparseVectorModifier::None => "none",
+        SparseVectorModifier::Idf => "idf",
+    }
+}
+
+/// REST body for `PUT /collections/{name}` — named dense + optional sparse.
+pub fn collection_create_json(spec: &CollectionSpec) -> serde_json::Value {
+    let settings = QdrantCollectionSettings::default();
+    let mut vectors = serde_json::Map::new();
+    vectors.insert(
+        spec.dense.name.clone(),
+        json!({
+            "size": spec.dense.dimensions,
+            "distance": distance_kind(spec.dense.distance),
+            "on_disk": settings.dense_on_disk,
+        }),
+    );
+    let mut body = json!({
+        "vectors": vectors,
+        "hnsw_config": {
+            "m": settings.hnsw_m,
+            "ef_construct": settings.hnsw_ef_construct,
+            "on_disk": settings.hnsw_on_disk,
+        },
+        "quantization_config": {
+            "scalar": {
+                "type": "int8",
+                "quantile": settings.quantization_quantile,
+                "always_ram": settings.quantization_always_ram,
+            }
+        },
+        "optimizers_config": { "indexing_threshold": settings.indexing_threshold },
+    });
+    if let Some(sparse) = &spec.sparse {
+        body["sparse_vectors"] = json!({
+            sparse.name.clone(): { "modifier": sparse_modifier_kind(sparse.modifier) }
+        });
+    }
+    body
+}
+
+/// REST body for `PUT /collections/{name}/index` — one per payload index.
+pub fn payload_index_json(index: &PayloadIndexSpec) -> serde_json::Value {
+    json!({
+        "field_name": index.field_name,
+        "field_schema": schema_kind(&index.field_schema),
+    })
+}
+
+/// REST body for `PUT /collections/{name}/points` — named dense + sparse arms.
+pub fn upsert_points_json(
+    spec: &CollectionSpec,
+    batch: &VectorPointBatch,
+) -> Result<serde_json::Value> {
+    let batch_sparse = validate_upsert_batch(spec, batch, axon_error::ErrorStage::Upserting)?;
+    let points = batch
+        .points
+        .iter()
+        .map(|point| {
+            let mut vectors = serde_json::Map::new();
+            vectors.insert(spec.dense.name.clone(), json!(point.vector));
+            let sparse = point
+                .sparse_vector
+                .as_ref()
+                .or_else(|| batch_sparse.get(&point.chunk_id.0));
+            if let (Some(sparse_cfg), Some(sparse)) = (spec.sparse.as_ref(), sparse) {
+                vectors.insert(
+                    sparse_cfg.name.clone(),
+                    json!({ "indices": sparse.indices, "values": sparse.values }),
+                );
+            }
+            json!({
+                "id": point.point_id.0,
+                "vector": vectors,
+                "payload": serde_json::Value::Object(point.payload.0.clone().into_iter().collect()),
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({ "points": points }))
+}
+
+/// Search-request filter as REST JSON (generation-fenced on
+/// `committed_generation`). Returns `None` when there are no conditions.
+pub fn search_filter_json(request: &VectorSearchRequest) -> Result<Option<serde_json::Value>> {
+    validate_search_filters(request)?;
+    let mut must = Vec::new();
+    for (field, value) in request.filters.iter() {
+        if field == PATH_PREFIX {
+            return Err(ApiError::new(
+                "vector.qdrant.path_prefix_unsupported",
+                axon_error::ErrorStage::Retrieving,
+                "target Qdrant path-prefix filters require live prefix-query wiring",
+            ));
+        }
+        must.push(condition_json(field, value));
+    }
+    if let Some(generation) = &request.generation {
+        must.push(match_json(
+            SEARCH_GENERATION_FIELD,
+            &serde_json::Value::from(generation.0.clone()),
+        ));
+    }
+    Ok((!must.is_empty()).then(|| json!({ "must": must })))
+}
+
+/// Equality filter over a single payload field (used by delete/commit paths).
+pub fn eq_filter_json(field: &str, value: &str) -> serde_json::Value {
+    json!({ "must": [match_json(field, &serde_json::Value::from(value))] })
+}
+
+/// Two-field equality filter (used by generation-scoped commit/delete).
+pub fn eq2_filter_json(
+    field_a: &str,
+    value_a: &str,
+    field_b: &str,
+    value_b: &str,
+) -> serde_json::Value {
+    json!({
+        "must": [
+            match_json(field_a, &serde_json::Value::from(value_a)),
+            match_json(field_b, &serde_json::Value::from(value_b)),
+        ]
+    })
+}
+
+/// Prefix or exact filter over the canonical-uri family fields.
+pub fn canonical_uri_filter_json(canonical_uri: &str, prefix: bool) -> serde_json::Value {
+    let matcher = if prefix {
+        json!({ "text": canonical_uri })
+    } else {
+        json!({ "value": canonical_uri })
+    };
+    json!({
+        "should": [
+            { "key": "url", "match": matcher.clone() },
+            { "key": "source_item_key", "match": matcher.clone() },
+            { "key": "chunk_locator.canonical_uri", "match": matcher },
+        ],
+        "min_should": { "min_count": 1 }
+    })
+}
+
+fn condition_json(field: &str, value: &serde_json::Value) -> serde_json::Value {
+    let Some(values) = value.as_array() else {
+        return match_json(field, value);
+    };
+    if values.is_empty() {
+        return match_json("__axon_match_none", &serde_json::Value::from("__never__"));
+    }
+    if values.len() == 1 {
+        return match_json(field, &values[0]);
+    }
+    json!({
+        "should": values.iter().map(|value| match_json(field, value)).collect::<Vec<_>>(),
+        "min_should": { "min_count": 1 }
+    })
+}
+
+fn match_json(field: &str, value: &serde_json::Value) -> serde_json::Value {
+    let matcher = if let Some(int) = value.as_i64() {
+        json!({ "value": int })
+    } else if let Some(boolean) = value.as_bool() {
+        json!({ "value": boolean })
+    } else {
+        let keyword = match value {
+            serde_json::Value::String(value) => value.clone(),
+            other => other.to_string(),
+        };
+        json!({ "value": keyword })
+    };
+    json!({ "key": field, "match": matcher })
+}

--- a/crates/axon-vectors/src/qdrant/convert/rest_tests.rs
+++ b/crates/axon-vectors/src/qdrant/convert/rest_tests.rs
@@ -1,0 +1,55 @@
+//! Regression tests for the raw-JSON Qdrant filter builders.
+//!
+//! These pin the wire shape of OR filters: a bare `should` array (which Qdrant
+//! treats as min_should = 1) with NO sibling `min_should` object. A sibling
+//! `"min_should": {"min_count": 1}` is malformed for Qdrant's REST filter API
+//! (MinShould requires the conditions nested inside it) and is rejected with
+//! HTTP 400 at runtime — a defect unit tests over self-constructed JSON missed.
+
+use super::*;
+
+#[test]
+fn canonical_uri_filter_has_bare_should_without_min_should() {
+    let filter = canonical_uri_filter_json("https://example.com/docs", false);
+    let should = filter
+        .get("should")
+        .and_then(|value| value.as_array())
+        .expect("canonical-uri filter must expose a `should` array");
+    assert_eq!(
+        should.len(),
+        3,
+        "url + source_item_key + canonical_uri arms"
+    );
+    assert!(
+        filter.get("min_should").is_none(),
+        "must NOT emit a sibling min_should object (Qdrant 400s on it): {filter}"
+    );
+}
+
+#[test]
+fn multi_value_condition_is_bare_should_without_min_should() {
+    let value = serde_json::json!(["rust", "python", "go"]);
+    let condition = condition_json("code_language", &value);
+    let should = condition
+        .get("should")
+        .and_then(|value| value.as_array())
+        .expect("multi-value OR condition must expose a `should` array");
+    assert_eq!(should.len(), 3);
+    assert!(
+        condition.get("min_should").is_none(),
+        "multi-value OR condition must NOT emit a sibling min_should: {condition}"
+    );
+}
+
+#[test]
+fn single_value_condition_is_a_flat_match() {
+    let condition = condition_json("code_language", &serde_json::json!(["rust"]));
+    assert!(
+        condition.get("should").is_none(),
+        "a single-value filter collapses to a flat match, not a should array"
+    );
+    assert_eq!(
+        condition.get("key").and_then(|value| value.as_str()),
+        Some("code_language")
+    );
+}

--- a/crates/axon-vectors/src/qdrant/http.rs
+++ b/crates/axon-vectors/src/qdrant/http.rs
@@ -1,0 +1,319 @@
+//! Reqwest-backed Qdrant REST transport.
+//!
+//! Credentials never leak into [`ApiError`] details: [`QdrantEndpoint`] splits
+//! the user-supplied URL into a bare `scheme://host[:port]` base and an
+//! extracted API key (from userinfo or the `api_key` query parameter). Only the
+//! opaque marker `"configured"` is ever attached to error context.
+
+use std::time::{Duration, Instant};
+
+use axon_api::source::ApiError;
+use reqwest::{Client, Method, StatusCode};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// Opaque endpoint context marker attached to errors.
+///
+/// The raw URL and any embedded credentials are intentionally never surfaced.
+pub const ENDPOINT_MARKER: &str = "configured";
+
+const MAX_ATTEMPTS: usize = 4;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A Qdrant REST endpoint with credentials split away from the base URL.
+#[derive(Debug, Clone)]
+pub struct QdrantEndpoint {
+    /// `scheme://host[:port]` with no path, query, or userinfo.
+    base: String,
+    /// Optional API key extracted from userinfo password or `api_key` query.
+    api_key: Option<String>,
+}
+
+impl QdrantEndpoint {
+    /// Parse the configured URL into a redaction-safe base + optional API key.
+    ///
+    /// Best-effort: if the URL cannot be parsed the trimmed input is used as the
+    /// base and no key is extracted. Path and query segments are discarded so a
+    /// value like `http://host:6333/collections?api_key=…` cannot leak.
+    pub fn parse(url: &str) -> Self {
+        let trimmed = url.trim();
+        match url::Url::parse(trimmed) {
+            Ok(parsed) => {
+                let mut api_key = None;
+                if !parsed.password().unwrap_or_default().is_empty() {
+                    api_key = parsed.password().map(ToString::to_string);
+                } else if !parsed.username().is_empty() {
+                    // A bare `token@host` form carries the key as the username.
+                    api_key = Some(parsed.username().to_string());
+                }
+                if api_key.is_none() {
+                    api_key = parsed
+                        .query_pairs()
+                        .find(|(key, _)| key == "api_key")
+                        .map(|(_, value)| value.into_owned());
+                }
+                let scheme = parsed.scheme();
+                let base = match (parsed.host_str(), parsed.port()) {
+                    (Some(host), Some(port)) => format!("{scheme}://{host}:{port}"),
+                    (Some(host), None) => format!("{scheme}://{host}"),
+                    _ => trimmed.to_string(),
+                };
+                Self { base, api_key }
+            }
+            Err(_) => Self {
+                base: trimmed.trim_end_matches('/').to_string(),
+                api_key: None,
+            },
+        }
+    }
+
+    /// Build a full request URL for a collection sub-path (e.g. `points/query`).
+    pub fn collection_path(&self, collection: &str, suffix: &str) -> String {
+        let suffix = suffix.trim_start_matches('/');
+        if suffix.is_empty() {
+            format!("{}/collections/{}", self.base, collection)
+        } else {
+            format!("{}/collections/{}/{}", self.base, collection, suffix)
+        }
+    }
+
+    /// The bare `scheme://host[:port]` root, used for liveness probes.
+    pub fn root(&self) -> &str {
+        &self.base
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
+    }
+}
+
+/// Reqwest client wrapper carrying a parsed, redaction-safe endpoint.
+#[derive(Debug, Clone)]
+pub struct QdrantHttp {
+    client: Client,
+    endpoint: QdrantEndpoint,
+    provider_id: String,
+}
+
+impl QdrantHttp {
+    /// Construct a transport for the configured Qdrant URL, attributing every
+    /// surfaced error to `provider_id`.
+    pub fn new(url: &str, provider_id: &str) -> Result<Self, ApiError> {
+        let client = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|err| {
+                transport_error("vector.qdrant.client_init", &err.to_string())
+                    .with_provider_id(provider_id)
+            })?;
+        Ok(Self {
+            client,
+            endpoint: QdrantEndpoint::parse(url),
+            provider_id: provider_id.to_string(),
+        })
+    }
+
+    /// Endpoint accessor for URL construction.
+    pub fn endpoint(&self) -> &QdrantEndpoint {
+        &self.endpoint
+    }
+
+    /// GET a collection sub-resource, returning the parsed JSON on 2xx, `None`
+    /// on 404, and an error otherwise. Never leaks the URL into error details.
+    pub async fn get_json(
+        &self,
+        stage: axon_error::ErrorStage,
+        url: &str,
+        context: &str,
+    ) -> Result<Option<serde_json::Value>, ApiError> {
+        let resp = self
+            .request(Method::GET)
+            .get(url)
+            .send()
+            .await
+            .map_err(|err| self.transport(stage, context, &err))?;
+        let status = resp.status();
+        if status == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            return Err(self.status_error(stage, context, status));
+        }
+        let body = resp
+            .json::<serde_json::Value>()
+            .await
+            .map_err(|err| self.transport(stage, context, &err))?;
+        Ok(Some(body))
+    }
+
+    /// PUT a JSON body, tolerating 409 (collection already exists).
+    pub async fn put_json<B: Serialize + ?Sized>(
+        &self,
+        stage: axon_error::ErrorStage,
+        url: &str,
+        body: &B,
+        context: &str,
+    ) -> Result<(), ApiError> {
+        let resp = self
+            .request(Method::PUT)
+            .put(url)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| self.transport(stage, context, &err))?;
+        let status = resp.status();
+        if status == StatusCode::CONFLICT || status.is_success() {
+            return Ok(());
+        }
+        Err(self.status_error(stage, context, status))
+    }
+
+    /// POST a JSON body and parse the response, retrying on 429/5xx.
+    pub async fn post_json<B, T>(
+        &self,
+        stage: axon_error::ErrorStage,
+        url: &str,
+        body: &B,
+        context: &str,
+    ) -> Result<T, ApiError>
+    where
+        B: Serialize + ?Sized,
+        T: DeserializeOwned,
+    {
+        let started = Instant::now();
+        let mut last: Option<ApiError> = None;
+        for attempt in 1..=MAX_ATTEMPTS {
+            match self.request(Method::POST).post(url).json(body).send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    let retryable =
+                        status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+                    if retryable && attempt < MAX_ATTEMPTS {
+                        last = Some(self.status_error(stage, context, status));
+                        tokio::time::sleep(retry_delay(attempt, started)).await;
+                        continue;
+                    }
+                    if !status.is_success() {
+                        return Err(self.status_error(stage, context, status));
+                    }
+                    return resp
+                        .json::<T>()
+                        .await
+                        .map_err(|err| self.transport(stage, context, &err));
+                }
+                Err(err) => {
+                    last = Some(self.transport(stage, context, &err));
+                    if attempt < MAX_ATTEMPTS {
+                        tokio::time::sleep(retry_delay(attempt, started)).await;
+                    }
+                }
+            }
+        }
+        Err(last.unwrap_or_else(|| {
+            transport_error(
+                "vector.qdrant.transport",
+                &format!("{context}: request failed"),
+            )
+            .with_context("endpoint", ENDPOINT_MARKER)
+            .with_provider_id(&self.provider_id)
+        }))
+    }
+
+    fn request(&self, _method: Method) -> AuthedBuilder<'_> {
+        AuthedBuilder {
+            client: &self.client,
+            api_key: self.endpoint.api_key(),
+        }
+    }
+
+    fn transport(
+        &self,
+        stage: axon_error::ErrorStage,
+        context: &str,
+        err: &reqwest::Error,
+    ) -> ApiError {
+        // Only the redaction-safe category is surfaced; reqwest's Display can
+        // include the request URL, so it is never embedded in the message.
+        ApiError::new(
+            "vector.qdrant.transport",
+            stage,
+            format!(
+                "{context}: qdrant transport error ({})",
+                error_category(err)
+            ),
+        )
+        .with_context("endpoint", ENDPOINT_MARKER)
+        .with_provider_id(&self.provider_id)
+    }
+
+    fn status_error(
+        &self,
+        stage: axon_error::ErrorStage,
+        context: &str,
+        status: StatusCode,
+    ) -> ApiError {
+        ApiError::new(
+            "vector.qdrant.status",
+            stage,
+            format!("{context}: qdrant returned status {}", status.as_u16()),
+        )
+        .with_context("endpoint", ENDPOINT_MARKER)
+        .with_context("status", status.as_u16().to_string())
+        .with_provider_id(&self.provider_id)
+    }
+}
+
+/// Small builder that injects the `api-key` header when configured.
+struct AuthedBuilder<'a> {
+    client: &'a Client,
+    api_key: Option<&'a str>,
+}
+
+impl<'a> AuthedBuilder<'a> {
+    fn get(self, url: &str) -> reqwest::RequestBuilder {
+        self.apply(self.client.get(url))
+    }
+
+    fn put(self, url: &str) -> reqwest::RequestBuilder {
+        self.apply(self.client.put(url))
+    }
+
+    fn post(self, url: &str) -> reqwest::RequestBuilder {
+        self.apply(self.client.post(url))
+    }
+
+    fn apply(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self.api_key {
+            Some(key) => builder.header("api-key", key),
+            None => builder,
+        }
+    }
+}
+
+fn error_category(err: &reqwest::Error) -> &'static str {
+    if err.is_timeout() {
+        "timeout"
+    } else if err.is_connect() {
+        "connect"
+    } else if err.is_decode() {
+        "decode"
+    } else {
+        "request"
+    }
+}
+
+fn transport_error(code: &str, message: &str) -> ApiError {
+    ApiError::new(code, axon_error::ErrorStage::Observing, message.to_string())
+        .with_context("endpoint", ENDPOINT_MARKER)
+}
+
+/// Exponential backoff with lightweight jitter derived from the elapsed clock.
+fn retry_delay(attempt: usize, started: Instant) -> Duration {
+    let base_ms = 250_u64.saturating_mul(1u64 << attempt.saturating_sub(1));
+    let jitter_ms = (started.elapsed().subsec_nanos() as u64) % 100;
+    Duration::from_millis(base_ms + jitter_ms)
+}
+
+#[cfg(test)]
+#[path = "http_tests.rs"]
+mod tests;

--- a/crates/axon-vectors/src/qdrant/http_tests.rs
+++ b/crates/axon-vectors/src/qdrant/http_tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+#[test]
+fn endpoint_strips_userinfo_and_query_into_base_and_key() {
+    let endpoint = QdrantEndpoint::parse("http://token:secret@qdrant.internal:6333/x?api_key=k1");
+    assert_eq!(endpoint.root(), "http://qdrant.internal:6333");
+    assert_eq!(
+        endpoint.collection_path("axon", "points/query"),
+        "http://qdrant.internal:6333/collections/axon/points/query"
+    );
+    // The base carries no credentials, path, or query.
+    assert!(!endpoint.root().contains("secret"));
+    assert!(!endpoint.root().contains("token"));
+    assert!(!endpoint.root().contains("api_key"));
+    assert!(!endpoint.root().ends_with("/x"));
+}
+
+#[test]
+fn endpoint_extracts_api_key_from_query_when_no_userinfo() {
+    let endpoint = QdrantEndpoint::parse("https://host:6333?api_key=abc123");
+    assert_eq!(endpoint.root(), "https://host:6333");
+    assert_eq!(endpoint.api_key(), Some("abc123"));
+}
+
+#[test]
+fn endpoint_bare_token_userinfo_is_treated_as_api_key() {
+    let endpoint = QdrantEndpoint::parse("http://sometoken@host:6333");
+    assert_eq!(endpoint.api_key(), Some("sometoken"));
+    assert_eq!(endpoint.root(), "http://host:6333");
+}
+
+#[test]
+fn endpoint_without_port_keeps_scheme_and_host() {
+    let endpoint = QdrantEndpoint::parse("http://localhost");
+    assert_eq!(endpoint.root(), "http://localhost");
+    assert_eq!(endpoint.api_key(), None);
+}
+
+#[test]
+fn collection_path_with_empty_suffix_targets_the_collection_root() {
+    let endpoint = QdrantEndpoint::parse("http://host:6333");
+    assert_eq!(
+        endpoint.collection_path("axon", ""),
+        "http://host:6333/collections/axon"
+    );
+}

--- a/crates/axon-vectors/src/qdrant/search.rs
+++ b/crates/axon-vectors/src/qdrant/search.rs
@@ -1,0 +1,196 @@
+//! Qdrant `/points/query` search: named-dense and dense+bm42 RRF hybrid.
+
+use axon_api::source::*;
+use serde::Deserialize;
+
+use super::convert::search_filter_json;
+use super::http::QdrantHttp;
+use crate::filter::validate_search_filters;
+
+/// Default per-arm prefetch window before RRF fusion.
+const DEFAULT_HYBRID_CANDIDATES: usize = 100;
+const HNSW_EF_SEARCH: usize = 128;
+
+/// A single scored hit from Qdrant's query response.
+#[derive(Debug, Deserialize)]
+struct QdrantSearchHit {
+    id: serde_json::Value,
+    #[serde(default)]
+    score: f64,
+    #[serde(default)]
+    payload: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QdrantQueryPoints {
+    #[serde(default)]
+    points: Vec<QdrantSearchHit>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QdrantQueryResponse {
+    result: QdrantQueryPoints,
+}
+
+/// Execute a search request against a live Qdrant collection.
+///
+/// Runs dense+bm42 RRF hybrid when a sparse vector is present (or `hybrid` is
+/// requested and the collection is sparse-capable); otherwise a named-dense
+/// `/points/query`. Filters — including the generation fence on
+/// `committed_generation` — are converted to a Qdrant filter and applied.
+pub async fn qdrant_search(
+    http: &QdrantHttp,
+    spec: &CollectionSpec,
+    request: &VectorSearchRequest,
+) -> Result<VectorSearchResult, ApiError> {
+    let stage = axon_error::ErrorStage::Retrieving;
+    let dense = request.dense_vector.as_deref().ok_or_else(|| {
+        ApiError::new(
+            "vector.missing_query_vector",
+            stage,
+            "qdrant vector store search requires a dense query vector",
+        )
+    })?;
+    if dense.len() as u32 != spec.dense.dimensions {
+        return Err(ApiError::new(
+            "vector.dimension_mismatch",
+            stage,
+            format!(
+                "query vector dimensions {} do not match collection dimensions {}",
+                dense.len(),
+                spec.dense.dimensions
+            ),
+        ));
+    }
+    let wants_sparse = request.sparse_vector.is_some() || request.hybrid == Some(true);
+    if wants_sparse && spec.sparse.is_none() {
+        return Err(ApiError::new(
+            "vector.sparse_not_configured",
+            stage,
+            format!(
+                "collection {} does not declare a sparse vector namespace",
+                request.collection
+            ),
+        ));
+    }
+    validate_search_filters(request)?;
+    let filter_json = search_filter_json(request)?;
+
+    let limit = request.limit.max(1) as usize;
+    let dense_name = &spec.dense.name;
+
+    let body = match (&request.sparse_vector, spec.sparse.as_ref()) {
+        (Some(sparse), Some(sparse_cfg)) => hybrid_body(
+            dense,
+            dense_name,
+            sparse,
+            &sparse_cfg.name,
+            limit,
+            filter_json.as_ref(),
+        ),
+        _ => named_dense_body(dense, dense_name, limit, filter_json.as_ref()),
+    };
+
+    let url = http
+        .endpoint()
+        .collection_path(&request.collection, "points/query");
+    let parsed: QdrantQueryResponse = http.post_json(stage, &url, &body, "qdrant_search").await?;
+
+    let results = parsed.result.points.into_iter().map(hit_to_match).collect();
+    Ok(VectorSearchResult {
+        collection: request.collection.clone(),
+        results,
+        limit: request.limit,
+        next_cursor: None,
+        warnings: Vec::new(),
+        metadata: MetadataMap::new(),
+    })
+}
+
+fn hybrid_body(
+    dense: &[f32],
+    dense_name: &str,
+    sparse: &SparseVector,
+    sparse_name: &str,
+    limit: usize,
+    filter: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let candidates = DEFAULT_HYBRID_CANDIDATES.max(limit);
+    let mut body = serde_json::json!({
+        "prefetch": [
+            {
+                "query": dense,
+                "using": dense_name,
+                "limit": candidates,
+                "params": dense_params(),
+            },
+            {
+                "query": { "indices": sparse.indices, "values": sparse.values },
+                "using": sparse_name,
+                "limit": candidates,
+            }
+        ],
+        "query": { "fusion": "rrf" },
+        "limit": limit,
+        "with_payload": true,
+        "with_vector": false,
+    });
+    if let Some(filter) = filter {
+        body["filter"] = filter.clone();
+    }
+    body
+}
+
+fn named_dense_body(
+    dense: &[f32],
+    dense_name: &str,
+    limit: usize,
+    filter: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "query": dense,
+        "using": dense_name,
+        "limit": limit,
+        "with_payload": true,
+        "with_vector": false,
+        "params": dense_params(),
+    });
+    if let Some(filter) = filter {
+        body["filter"] = filter.clone();
+    }
+    body
+}
+
+fn dense_params() -> serde_json::Value {
+    serde_json::json!({
+        "hnsw_ef": HNSW_EF_SEARCH,
+        "quantization": { "rescore": true, "oversampling": 1.5 },
+    })
+}
+
+fn hit_to_match(hit: QdrantSearchHit) -> VectorSearchMatch {
+    let payload = MetadataMap(hit.payload.into_iter().collect());
+    let point_id = point_id_string(&hit.id);
+    VectorSearchMatch {
+        point_id: VectorPointId::new(point_id),
+        score: hit.score,
+        chunk_id: payload_str(&payload, "chunk_id").map(ChunkId::new),
+        document_id: payload_str(&payload, "document_id").map(DocumentId::new),
+        source_id: payload_str(&payload, "source_id").map(SourceId::new),
+        source_item_key: payload_str(&payload, "source_item_key").map(SourceItemKey::new),
+        text: payload_str(&payload, "chunk_text"),
+        payload,
+    }
+}
+
+fn point_id_string(id: &serde_json::Value) -> String {
+    match id {
+        serde_json::Value::String(value) => value.clone(),
+        serde_json::Value::Number(value) => value.to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn payload_str(payload: &MetadataMap, field: &str) -> Option<String> {
+    payload.get(field)?.as_str().map(ToString::to_string)
+}

--- a/crates/axon-vectors/src/qdrant/store_impl.rs
+++ b/crates/axon-vectors/src/qdrant/store_impl.rs
@@ -1,0 +1,386 @@
+//! Live `VectorStore` implementation over the Qdrant REST API.
+
+use async_trait::async_trait;
+use axon_api::source::*;
+
+use super::commit::{mark_generation_committed_rest, mark_unchanged_items_committed_rest};
+use super::convert::{
+    canonical_uri_filter_json, collection_create_json, eq_filter_json, eq2_filter_json,
+    payload_index_json, upsert_points_json,
+};
+use super::http::QdrantHttp;
+use super::search::qdrant_search;
+use super::{QdrantVectorStore, capability_snapshot};
+use crate::collection::{
+    check_collection_drift, normalize_collection_spec, validate_collection_spec,
+};
+use crate::filter::{selector_collection, validate_delete_selector};
+use crate::store::{Result, VectorStore};
+use crate::store_helpers::{delete_result, stage_header};
+
+impl QdrantVectorStore {
+    /// Build (or reuse) the redaction-safe reqwest transport.
+    pub(super) fn http(&self) -> Result<QdrantHttp> {
+        QdrantHttp::new(self.url(), &self.provider_id().0)
+    }
+
+    /// Fetch and detect the on-disk spec for `collection`, or `None` if absent.
+    pub(super) async fn fetch_collection_spec(
+        &self,
+        http: &QdrantHttp,
+        collection: &str,
+        stage: axon_error::ErrorStage,
+    ) -> Result<Option<CollectionSpec>> {
+        let url = http.endpoint().collection_path(collection, "");
+        let body = http.get_json(stage, &url, "qdrant_get_collection").await?;
+        Ok(body.and_then(|body| detect_collection_spec(collection, &body)))
+    }
+
+    /// Load the collection spec or return a `collection_not_found` error.
+    pub(super) async fn require_collection_spec(
+        &self,
+        http: &QdrantHttp,
+        collection: &str,
+        stage: axon_error::ErrorStage,
+    ) -> Result<CollectionSpec> {
+        self.fetch_collection_spec(http, collection, stage)
+            .await?
+            .ok_or_else(|| {
+                ApiError::new(
+                    "vector.collection_not_found",
+                    stage,
+                    format!("collection {collection} has not been ensured"),
+                )
+            })
+    }
+}
+
+#[async_trait]
+impl VectorStore for QdrantVectorStore {
+    async fn ensure_collection(&self, spec: CollectionSpec) -> Result<()> {
+        let stage = axon_error::ErrorStage::Upserting;
+        let http = self.http()?;
+        let spec = normalize_collection_spec(spec);
+        validate_collection_spec(&spec)?;
+
+        if let Some(existing) = self
+            .fetch_collection_spec(&http, &spec.collection, stage)
+            .await?
+        {
+            check_collection_drift(&existing, &spec)?;
+            // Existing collection: still (idempotently) ensure payload indexes.
+            self.ensure_payload_indexes(&http, &spec, stage).await?;
+            return Ok(());
+        }
+
+        let url = http.endpoint().collection_path(&spec.collection, "");
+        http.put_json(
+            stage,
+            &url,
+            &collection_create_json(&spec),
+            "qdrant_create_collection",
+        )
+        .await?;
+        self.ensure_payload_indexes(&http, &spec, stage).await?;
+        Ok(())
+    }
+
+    async fn upsert(&self, batch: VectorPointBatch) -> Result<VectorStoreWriteResult> {
+        let stage = axon_error::ErrorStage::Upserting;
+        let http = self.http()?;
+        let spec = self
+            .require_collection_spec(&http, &batch.collection, stage)
+            .await?;
+        let body = upsert_points_json(&spec, &batch)?;
+        let url = http
+            .endpoint()
+            .collection_path(&batch.collection, "points?wait=true");
+        http.put_json(stage, &url, &body, "qdrant_upsert").await?;
+        let points_written = batch.points.len() as u64;
+        Ok(VectorStoreWriteResult {
+            header: stage_header(PipelinePhase::Upserting),
+            collection: batch.collection,
+            points_attempted: points_written,
+            points_written,
+            payload_indexes_created: batch
+                .payload_indexes
+                .into_iter()
+                .map(|index| index.field_name)
+                .collect(),
+            usage: request_usage(1),
+        })
+    }
+
+    async fn mark_generation_committed(
+        &self,
+        collection: String,
+        source_id: SourceId,
+        generation: SourceGenerationId,
+    ) -> Result<VectorStoreWriteResult> {
+        let http = self.http()?;
+        mark_generation_committed_rest(self, &http, collection, source_id, generation).await
+    }
+
+    async fn mark_unchanged_items_committed(
+        &self,
+        collection: String,
+        source_id: SourceId,
+        previous_generation: SourceGenerationId,
+        committed_generation: SourceGenerationId,
+        source_item_keys: Vec<SourceItemKey>,
+    ) -> Result<VectorStoreWriteResult> {
+        let http = self.http()?;
+        mark_unchanged_items_committed_rest(
+            self,
+            &http,
+            collection,
+            source_id,
+            previous_generation,
+            committed_generation,
+            source_item_keys,
+        )
+        .await
+    }
+
+    async fn delete(&self, selector: VectorDeleteSelector) -> Result<VectorStoreDeleteResult> {
+        let stage = axon_error::ErrorStage::Cleaning;
+        let http = self.http()?;
+        validate_delete_selector(&selector)?;
+        let collection = selector_collection(&selector).to_string();
+        self.require_collection_spec(&http, &collection, stage)
+            .await?;
+        let body = delete_body(&selector);
+        let url = http
+            .endpoint()
+            .collection_path(&collection, "points/delete?wait=true");
+        // The REST delete API acknowledges the operation but returns no scanned
+        // count, so `points_deleted` reflects the acknowledged op, not a tally.
+        let _ack: DeleteResponse = http.post_json(stage, &url, &body, "qdrant_delete").await?;
+        Ok(delete_result(collection, 0))
+    }
+
+    async fn search(&self, request: VectorSearchRequest) -> Result<VectorSearchResult> {
+        let stage = axon_error::ErrorStage::Retrieving;
+        let http = self.http()?;
+        let spec = self
+            .require_collection_spec(&http, &request.collection, stage)
+            .await?;
+        qdrant_search(&http, &spec, &request).await
+    }
+
+    async fn capabilities(&self) -> Result<ProviderCapability> {
+        Ok(capability_snapshot(self).await)
+    }
+}
+
+impl QdrantVectorStore {
+    pub(super) async fn ensure_payload_indexes(
+        &self,
+        http: &QdrantHttp,
+        spec: &CollectionSpec,
+        stage: axon_error::ErrorStage,
+    ) -> Result<()> {
+        let url = http
+            .endpoint()
+            .collection_path(&spec.collection, "index?wait=true");
+        for index in &spec.payload_indexes {
+            http.put_json(
+                stage,
+                &url,
+                &payload_index_json(index),
+                "qdrant_payload_index",
+            )
+            .await?;
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn request_usage(requests: u64) -> ProviderUsage {
+    ProviderUsage {
+        input_tokens: None,
+        output_tokens: None,
+        requests,
+        duration_ms: 0,
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct DeleteResponse {
+    #[serde(default, rename = "result")]
+    _result: Option<serde_json::Value>,
+}
+
+fn delete_body(selector: &VectorDeleteSelector) -> serde_json::Value {
+    match selector {
+        VectorDeleteSelector::Points { point_ids, .. } => serde_json::json!({
+            "points": point_ids.iter().map(|id| id.0.clone()).collect::<Vec<_>>()
+        }),
+        VectorDeleteSelector::Chunks { chunk_ids, .. } => {
+            let ids = chunk_ids.iter().map(|id| id.0.clone()).collect::<Vec<_>>();
+            serde_json::json!({
+                "filter": {
+                    "must": [{ "key": "chunk_id", "match": { "any": ids } }]
+                }
+            })
+        }
+        VectorDeleteSelector::Source {
+            source_id,
+            generation,
+            ..
+        } => {
+            let filter = match generation {
+                Some(generation) => eq2_filter_json(
+                    "source_id",
+                    &source_id.0,
+                    "source_generation",
+                    &generation.0,
+                ),
+                None => eq_filter_json("source_id", &source_id.0),
+            };
+            serde_json::json!({ "filter": filter })
+        }
+        VectorDeleteSelector::Generation {
+            source_id,
+            generation,
+            ..
+        } => serde_json::json!({
+            "filter": eq2_filter_json(
+                "source_id",
+                &source_id.0,
+                "source_generation",
+                &generation.0,
+            )
+        }),
+        VectorDeleteSelector::Document {
+            document_id,
+            generation,
+            ..
+        } => {
+            let filter = match generation {
+                Some(generation) => eq2_filter_json(
+                    "document_id",
+                    &document_id.0,
+                    "source_generation",
+                    &generation.0,
+                ),
+                None => eq_filter_json("document_id", &document_id.0),
+            };
+            serde_json::json!({ "filter": filter })
+        }
+        VectorDeleteSelector::CanonicalUri {
+            canonical_uri,
+            match_prefix,
+            ..
+        } => serde_json::json!({
+            "filter": canonical_uri_filter_json(canonical_uri, *match_prefix)
+        }),
+        VectorDeleteSelector::Filter { filter, .. } => {
+            let must = filter
+                .as_object()
+                .map(|object| {
+                    object
+                        .iter()
+                        .map(|(field, value)| {
+                            serde_json::json!({ "key": field, "match": { "value": value } })
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            serde_json::json!({ "filter": { "must": must } })
+        }
+    }
+}
+
+/// Interpret a Qdrant collection GET body into a [`CollectionSpec`].
+///
+/// Returns `None` when the body lacks a usable dense-vector config (e.g. an
+/// error envelope), so callers treat it as "collection absent".
+fn detect_collection_spec(collection: &str, body: &serde_json::Value) -> Option<CollectionSpec> {
+    let params = body.pointer("/result/config/params")?;
+    let vectors = params.get("vectors")?;
+
+    // Named-mode: {"vectors": {"<name>": {"size": N, "distance": "Cosine"}}}
+    let (dense_name, dense_cfg) = if vectors.get("size").is_some() {
+        ("dense".to_string(), vectors.clone())
+    } else {
+        let object = vectors.as_object()?;
+        let (name, cfg) = object.iter().next()?;
+        (name.clone(), cfg.clone())
+    };
+    let dimensions = dense_cfg.get("size").and_then(|v| v.as_u64())? as u32;
+    let distance = dense_cfg
+        .get("distance")
+        .and_then(|v| v.as_str())
+        .and_then(parse_distance)
+        .unwrap_or(VectorDistance::Cosine);
+
+    let sparse = params
+        .get("sparse_vectors")
+        .and_then(|v| v.as_object())
+        .and_then(|map| map.iter().next())
+        .map(|(name, cfg)| SparseVectorConfig {
+            name: name.clone(),
+            modifier: match cfg.get("modifier").and_then(|v| v.as_str()) {
+                Some("idf") => SparseVectorModifier::Idf,
+                _ => SparseVectorModifier::None,
+            },
+        });
+
+    let payload_indexes = body
+        .pointer("/result/payload_schema")
+        .and_then(|schema| schema.as_object())
+        .map(|schema| {
+            schema
+                .iter()
+                .filter_map(|(field, cfg)| {
+                    let data_type = cfg.get("data_type").and_then(|v| v.as_str())?;
+                    Some(PayloadIndexSpec {
+                        field_name: field.clone(),
+                        field_schema: parse_field_schema(data_type),
+                        required_for_filters: true,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(CollectionSpec {
+        collection: collection.to_string(),
+        dense: VectorConfig {
+            name: dense_name,
+            dimensions,
+            distance,
+        },
+        payload_indexes,
+        sparse,
+        aliases: Vec::new(),
+        distance: None,
+        metadata: MetadataMap::new(),
+    })
+}
+
+fn parse_field_schema(data_type: &str) -> PayloadFieldSchema {
+    match data_type {
+        "integer" => PayloadFieldSchema::Integer,
+        "float" => PayloadFieldSchema::Float,
+        "bool" => PayloadFieldSchema::Boolean,
+        "datetime" => PayloadFieldSchema::Datetime,
+        "text" => PayloadFieldSchema::Text,
+        _ => PayloadFieldSchema::Keyword,
+    }
+}
+
+fn parse_distance(value: &str) -> Option<VectorDistance> {
+    match value {
+        "Cosine" => Some(VectorDistance::Cosine),
+        "Dot" => Some(VectorDistance::Dot),
+        "Euclid" => Some(VectorDistance::Euclid),
+        "Manhattan" => Some(VectorDistance::Manhattan),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "store_impl_tests.rs"]
+mod tests;

--- a/crates/axon-vectors/src/qdrant/store_impl_tests.rs
+++ b/crates/axon-vectors/src/qdrant/store_impl_tests.rs
@@ -1,0 +1,96 @@
+use super::*;
+use axon_api::source::*;
+use serde_json::json;
+
+#[test]
+fn detect_named_mode_collection_with_sparse_and_indexes() {
+    let body = json!({
+        "result": {
+            "config": {
+                "params": {
+                    "vectors": { "dense": { "size": 1024, "distance": "Cosine" } },
+                    "sparse_vectors": { "bm42": { "modifier": "idf" } }
+                }
+            },
+            "payload_schema": {
+                "source_id": { "data_type": "keyword" },
+                "chunk_index": { "data_type": "integer" }
+            }
+        }
+    });
+    let spec = detect_collection_spec("axon", &body).expect("named spec");
+    assert_eq!(spec.dense.name, "dense");
+    assert_eq!(spec.dense.dimensions, 1024);
+    assert_eq!(spec.dense.distance, VectorDistance::Cosine);
+    let sparse = spec.sparse.expect("sparse config");
+    assert_eq!(sparse.name, "bm42");
+    assert_eq!(sparse.modifier, SparseVectorModifier::Idf);
+    assert!(
+        spec.payload_indexes
+            .iter()
+            .any(|index| index.field_name == "source_id"
+                && index.field_schema == PayloadFieldSchema::Keyword)
+    );
+    assert!(
+        spec.payload_indexes
+            .iter()
+            .any(|index| index.field_name == "chunk_index"
+                && index.field_schema == PayloadFieldSchema::Integer)
+    );
+}
+
+#[test]
+fn detect_unnamed_mode_collection_uses_default_dense_name() {
+    let body = json!({
+        "result": { "config": { "params": {
+            "vectors": { "size": 384, "distance": "Dot" }
+        } } }
+    });
+    let spec = detect_collection_spec("legacy", &body).expect("unnamed spec");
+    assert_eq!(spec.dense.name, "dense");
+    assert_eq!(spec.dense.dimensions, 384);
+    assert_eq!(spec.dense.distance, VectorDistance::Dot);
+    assert!(spec.sparse.is_none());
+}
+
+#[test]
+fn detect_returns_none_for_error_envelope() {
+    let body = json!({ "status": { "error": "boom" } });
+    assert!(detect_collection_spec("axon", &body).is_none());
+}
+
+#[test]
+fn delete_body_for_points_lists_ids() {
+    let selector = VectorDeleteSelector::Points {
+        collection: "axon".to_string(),
+        point_ids: vec![VectorPointId::new("p1"), VectorPointId::new("p2")],
+    };
+    let body = delete_body(&selector);
+    assert_eq!(body["points"], json!(["p1", "p2"]));
+}
+
+#[test]
+fn delete_body_for_chunks_uses_any_match_filter() {
+    let selector = VectorDeleteSelector::Chunks {
+        collection: "axon".to_string(),
+        chunk_ids: vec![ChunkId::new("c1")],
+    };
+    let body = delete_body(&selector);
+    assert_eq!(body["filter"]["must"][0]["key"], json!("chunk_id"));
+    assert_eq!(body["filter"]["must"][0]["match"]["any"], json!(["c1"]));
+}
+
+#[test]
+fn delete_body_for_generation_fences_on_source_and_generation() {
+    let selector = VectorDeleteSelector::Generation {
+        collection: "axon".to_string(),
+        source_id: SourceId::new("src"),
+        generation: SourceGenerationId::new("7"),
+    };
+    let body = delete_body(&selector);
+    let must = body["filter"]["must"].as_array().expect("must array");
+    assert_eq!(must.len(), 2);
+    let keys: Vec<&str> = must.iter().filter_map(|c| c["key"].as_str()).collect();
+    assert!(keys.contains(&"source_id"));
+    assert!(keys.contains(&"source_generation"));
+}

--- a/crates/axon-vectors/src/qdrant_live_tests.rs
+++ b/crates/axon-vectors/src/qdrant_live_tests.rs
@@ -1,0 +1,152 @@
+//! Live round-trip tests against a real Qdrant instance.
+//!
+//! These are `#[ignore]`d because they require a reachable Qdrant. Point them at
+//! one with `AXON_TEST_QDRANT_URL` (defaults to `http://127.0.0.1:6333`) and run:
+//!
+//! ```bash
+//! AXON_TEST_QDRANT_URL=http://127.0.0.1:6333 \
+//!   cargo test -p axon-vectors --lib -- --ignored qdrant_live
+//! ```
+//!
+//! They validate the observable behavior the `FakeVectorStore` oracle defines:
+//! ensure/upsert/search plus the generation-visibility contract (uncommitted
+//! points stay invisible to a committed-generation search until publish).
+
+use axon_api::source::*;
+
+use crate::point::VectorPointBatchBuilder;
+use crate::qdrant::QdrantVectorStore;
+use crate::store::VectorStore;
+use crate::testing::{
+    test_collection_spec, test_embedding_result_for, test_prepared_document,
+    test_vector_build_context,
+};
+
+fn live_url() -> String {
+    std::env::var("AXON_TEST_QDRANT_URL").unwrap_or_else(|_| "http://127.0.0.1:6333".to_string())
+}
+
+fn unique_collection(prefix: &str) -> String {
+    format!("{prefix}-{}", uuid::Uuid::new_v4().simple())
+}
+
+async fn cleanup(store: &QdrantVectorStore, collection: &str) {
+    let _ = store
+        .delete(VectorDeleteSelector::Filter {
+            collection: collection.to_string(),
+            filter: serde_json::json!({}),
+        })
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "requires a live Qdrant (set AXON_TEST_QDRANT_URL)"]
+async fn qdrant_live_ensure_upsert_search_round_trip() {
+    let store = QdrantVectorStore::new(live_url(), "qdrant-live");
+    let collection = unique_collection("axon-live-search");
+
+    let mut spec = test_collection_spec(3);
+    spec.collection = collection.clone();
+    spec.dense.name = "dense".to_string();
+    store.ensure_collection(spec.clone()).await.unwrap();
+
+    let document = test_prepared_document();
+    let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
+    let mut batch = VectorPointBatchBuilder::new(
+        spec.clone(),
+        document,
+        embeddings,
+        test_vector_build_context(),
+    )
+    .build()
+    .unwrap();
+    batch.collection = collection.clone();
+
+    let write = store.upsert(batch.clone()).await.unwrap();
+    assert_eq!(write.points_written, batch.points.len() as u64);
+
+    let search = VectorSearchRequest {
+        collection: collection.clone(),
+        query: "docs".to_string(),
+        limit: 10,
+        dense_vector: Some(batch.points[0].vector.clone()),
+        sparse_vector: None,
+        filters: MetadataMap::new(),
+        hybrid: Some(false),
+        generation: None,
+        graph_refs: Vec::new(),
+        metadata: MetadataMap::new(),
+    };
+    let results = store.search(search).await.unwrap();
+    assert!(
+        results
+            .results
+            .iter()
+            .any(|hit| hit.point_id == batch.points[0].point_id),
+        "upserted point should be retrievable"
+    );
+
+    cleanup(&store, &collection).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a live Qdrant (set AXON_TEST_QDRANT_URL)"]
+async fn qdrant_live_generation_becomes_visible_only_after_commit() {
+    let store = QdrantVectorStore::new(live_url(), "qdrant-live");
+    let collection = unique_collection("axon-live-gen");
+
+    let mut spec = test_collection_spec(3);
+    spec.collection = collection.clone();
+    spec.dense.name = "dense".to_string();
+    store.ensure_collection(spec.clone()).await.unwrap();
+
+    let document = test_prepared_document();
+    let source_id = SourceId::new(document.source_id.0.clone());
+    let generation = SourceGenerationId::new(document.generation.0.clone());
+    let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
+    let mut batch = VectorPointBatchBuilder::new(
+        spec.clone(),
+        document,
+        embeddings,
+        test_vector_build_context(),
+    )
+    .build()
+    .unwrap();
+    batch.collection = collection.clone();
+    let query_vector = batch.points[0].vector.clone();
+    store.upsert(batch).await.unwrap();
+
+    let committed_search = |generation: &str| VectorSearchRequest {
+        collection: collection.clone(),
+        query: "docs".to_string(),
+        limit: 10,
+        dense_vector: Some(query_vector.clone()),
+        sparse_vector: None,
+        filters: MetadataMap::new(),
+        hybrid: Some(false),
+        generation: Some(SourceGenerationId::new(generation)),
+        graph_refs: Vec::new(),
+        metadata: MetadataMap::new(),
+    };
+
+    // Before publish, the generation is invisible to a committed search.
+    let pre = store.search(committed_search(&generation.0)).await.unwrap();
+    assert!(
+        pre.results.is_empty(),
+        "uncommitted points must be invisible to a committed-generation search"
+    );
+
+    store
+        .mark_generation_committed(collection.clone(), source_id, generation.clone())
+        .await
+        .unwrap();
+
+    // After publish, the same committed search now returns the points.
+    let post = store.search(committed_search(&generation.0)).await.unwrap();
+    assert!(
+        !post.results.is_empty(),
+        "committed points must be visible to a committed-generation search"
+    );
+
+    cleanup(&store, &collection).await;
+}

--- a/crates/axon-vectors/src/qdrant_tests.rs
+++ b/crates/axon-vectors/src/qdrant_tests.rs
@@ -578,23 +578,45 @@ fn duplicate_points_are_rejected_before_qdrant_conversion() {
     assert_eq!(err.code.to_string(), "vector.duplicate_point_id");
 }
 
-#[tokio::test]
-async fn qdrant_vector_store_live_calls_return_not_wired_errors() {
-    let raw_url = "http://token:secret@127.0.0.1:6334/path?api_key=hunter2";
-    let store = QdrantVectorStore::new(raw_url, "target-qdrant");
+// Unreachable endpoint: connection is refused quickly, so live calls fail with
+// a redaction-safe transport error rather than blocking on the request timeout.
+// `hunter2` and the raw URL must never appear in any surfaced error detail.
+const UNREACHABLE_QDRANT_URL: &str = "http://token:secret@127.0.0.1:1/path?api_key=hunter2";
 
-    let err = store
-        .ensure_collection(test_collection_spec(3))
-        .await
-        .unwrap_err();
-    assert_eq!(err.code.to_string(), "vector.not_wired");
+fn assert_redacted(err: &ApiError) {
     assert_eq!(err.provider_id.as_deref(), Some("target-qdrant"));
     assert_eq!(
         err.details.get("endpoint").map(String::as_str),
         Some("configured")
     );
-    assert!(!err.details.values().any(|value| value.contains(raw_url)));
-    assert!(!err.details.values().any(|value| value.contains("hunter2")));
+    assert!(
+        !err.message.contains("hunter2") && !err.message.contains("secret"),
+        "message leaked credentials: {}",
+        err.message
+    );
+    assert!(
+        !err.message.contains(UNREACHABLE_QDRANT_URL),
+        "message leaked raw url: {}",
+        err.message
+    );
+    for value in err.details.values() {
+        assert!(!value.contains("hunter2"), "detail leaked api key: {value}");
+        assert!(
+            !value.contains(UNREACHABLE_QDRANT_URL),
+            "detail leaked raw url: {value}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn qdrant_vector_store_live_calls_surface_redaction_safe_transport_errors() {
+    let store = QdrantVectorStore::new(UNREACHABLE_QDRANT_URL, "target-qdrant");
+
+    let err = store
+        .ensure_collection(test_collection_spec(3))
+        .await
+        .unwrap_err();
+    assert_redacted(&err);
 
     let document = test_prepared_document();
     let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
@@ -635,25 +657,26 @@ async fn qdrant_vector_store_live_calls_return_not_wired_errors() {
         store.delete(delete).await.unwrap_err(),
         store.search(search).await.unwrap_err(),
     ] {
-        assert_eq!(err.code.to_string(), "vector.not_wired");
-        assert_eq!(err.provider_id.as_deref(), Some("target-qdrant"));
+        assert_redacted(&err);
     }
+}
 
+#[tokio::test]
+async fn qdrant_capabilities_report_generation_publish_and_redact_on_probe_failure() {
+    let store = QdrantVectorStore::new(UNREACHABLE_QDRANT_URL, "target-qdrant");
     let capability = store.capabilities().await.unwrap();
+
     assert_eq!(capability.provider_kind, ProviderKind::Vector);
+    assert_eq!(capability.implementation, "qdrant");
+    // The instance is unreachable, so the liveness probe downgrades health.
     assert_eq!(capability.health, HealthStatus::Unavailable);
     let last_error = capability.last_error.as_ref().unwrap();
-    assert_eq!(
-        last_error.details.get("endpoint").map(String::as_str),
-        Some("configured")
-    );
-    assert!(
-        !last_error
-            .details
-            .values()
-            .any(|value| value.contains(raw_url))
-    );
+    assert_redacted(last_error);
+
     let vector_store = capability.vector_store.unwrap();
     assert!(vector_store.dense);
-    assert!(!vector_store.generation_publish);
+    assert!(vector_store.sparse);
+    assert!(vector_store.hybrid);
+    // Generation-aware publish is now supported by the live store.
+    assert!(vector_store.generation_publish);
 }


### PR DESCRIPTION
Part of #298 Phase 10 (surface cutover) — builds the production data plane the new bridges need.

## What
Replaces the `not_wired` `QdrantVectorStore` stub with a real reqwest-backed REST implementation and un-gates `mod qdrant` from `#[cfg(test)]` (`pub use qdrant::QdrantVectorStore`).

- **ensure_collection**: GET-then-PUT-on-404, drift-check on existing collections, idempotent payload-index PUTs.
- **upsert**: named dense + optional bm42 sparse arms, `wait=true`.
- **search**: named-dense or dense+bm42 **RRF** hybrid via `/points/query`; generation-fenced on `committed_generation`.
- **mark_generation_committed / mark_unchanged_items_committed**: generation-aware visibility staging (new vs legacy) — unchanged items copied into the new generation without mutating the previous committed one.
- **delete**: every `VectorDeleteSelector` variant → point-id list / Qdrant filter.
- **Redaction** (tested): endpoint userinfo + `?api_key` stripped; errors only ever carry `endpoint="configured"`.

## Fix from adversarial review
The initial build emitted a malformed `min_should` object on raw-JSON OR filters (would HTTP 400 at runtime for multi-value filters and CanonicalUri deletes). Fixed to a bare `should` array + `rest_tests.rs` regression tests pinning the wire shape.

## Verification
- `cargo check -p axon-vectors` clean; downstream consumers compile; `cargo xtask check-layering` OK.
- `cargo test -p axon-vectors`: **99 passed, 0 failed, 2 ignored** (live Qdrant round-trip, need `AXON_TEST_QDRANT_URL`).
- Monolith-compliant (files ≤500 lines, no mod.rs, sidecar `*_tests.rs`).

Not yet wired into a production `ServiceContext` (no live call-site constructs it yet) — that composition + `axon <source>` dispatch is the next P10 slice. This PR just makes the real store exist and be correct.

Bead: axon_rust-bpxk6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a live `QdrantVectorStore` over the Qdrant REST API, replacing the stub to support ensure, upsert, search (dense and hybrid), delete, and generation-aware publish. Part of #298 Phase 10 (production data plane), with credential redaction and health-aware capabilities.

- **New Features**
  - Real REST-backed `QdrantVectorStore` using `reqwest`; `mod qdrant` is live and `pub use`d.
  - Ensure: GET-then-PUT on 404, drift-checks, idempotent payload-index PUTs.
  - Upsert: named dense + optional bm42 sparse; `wait=true`.
  - Search: named-dense or dense+bm42 RRF hybrid via `/points/query`, fenced on `committed_generation`.
  - Publish: `mark_generation_committed` and `mark_unchanged_items_committed` for generation-aware visibility.
  - Delete: all `VectorDeleteSelector` variants (point-ids and filters).
  - Transport: endpoint parsing with API-key header, retries on 429/5xx, and strict URL/credential redaction in errors; capabilities probe downgrades health when unreachable.
  - Tests: unit + live round-trip (ignored unless `AXON_TEST_QDRANT_URL` is set).

- **Bug Fixes**
  - Fixed malformed OR filter JSON (removed sibling `min_should`; now a bare `should` array). Added regression tests to pin the wire shape.

<sup>Written for commit 840dbbf5b7c989e2ff0bd19d6f7e880973c956e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

