### PR TITLE
feat(axon-embedding): wire real TEI embedding client (#298 P10 data plane)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,10 @@ dependencies = [
  "axon-api",
  "axon-error",
  "axon-observe",
+ "httpmock",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
  "tokio",
  "uuid",
 ]

--- a/crates/axon-embedding/Cargo.toml
+++ b/crates/axon-embedding/Cargo.toml
@@ -11,7 +11,12 @@ async-trait = "0.1"
 axon-api = { path = "../axon-api" }
 axon-error = { path = "../axon-error" }
 axon-observe = { path = "../axon-observe" }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 
 [dev-dependencies]
+httpmock = "0.8"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }

--- a/crates/axon-embedding/src/capability.rs
+++ b/crates/axon-embedding/src/capability.rs
@@ -98,6 +98,39 @@ pub fn unavailable_embedding_provider_capability(
     })
 }
 
+/// Build an `Available`/`Healthy` embedding capability for a wired provider.
+///
+/// Mirrors [`unavailable_embedding_provider_capability`] but reports the
+/// provider as reachable: `Healthy` health, no `last_error`, and a reservation
+/// state with `capacity` granted units. No network call is performed — the
+/// capability reflects static config so it stays unit-testable.
+#[allow(clippy::too_many_arguments)]
+pub fn available_embedding_provider_capability(
+    provider_id: ProviderId,
+    implementation: impl Into<String>,
+    limits: ProviderLimits,
+    features: Vec<String>,
+    cost_class: ProviderCostClass,
+    capacity: u32,
+    embedding: EmbeddingCapabilityConfig,
+) -> ProviderCapability {
+    embedding_provider_capability(ProviderCapabilityConfig {
+        provider_id,
+        implementation: implementation.into(),
+        health: HealthStatus::Healthy,
+        limits,
+        features,
+        cooldown_until: None,
+        last_error: None,
+        reservation_policy: embedding_reservation_policy(true, QueuePolicy::Fifo, 0),
+        reservation_state: embedding_reservation_state(capacity),
+        cost_class,
+        degraded_modes: Vec::new(),
+        fake_overrides_supported: false,
+        embedding: embedding_capability(embedding),
+    })
+}
+
 pub fn embedding_reservation_policy(
     supports_reservations: bool,
     queue_policy: QueuePolicy,

--- a/crates/axon-embedding/src/lib.rs
+++ b/crates/axon-embedding/src/lib.rs
@@ -21,6 +21,10 @@ pub const CRATE_NAME: &str = "axon-embedding";
 mod provider_tests;
 
 #[cfg(test)]
+#[path = "tei_client_tests.rs"]
+mod tei_client_tests;
+
+#[cfg(test)]
 #[path = "reservation_compat_tests.rs"]
 mod reservation_compat_tests;
 

--- a/crates/axon-embedding/src/provider_tests.rs
+++ b/crates/axon-embedding/src/provider_tests.rs
@@ -265,14 +265,14 @@ async fn tei_adapter_config_is_reflected_in_capabilities_without_network_calls()
     let capability = provider.capabilities().await.unwrap();
     let embedding = capability.embedding.unwrap();
 
+    // The TEI provider is now wired: it reports Available/Healthy with no
+    // not_wired error and non-zero reservation capacity.
     assert_eq!(capability.provider_id, ProviderId::new("tei"));
-    assert_eq!(capability.health, HealthStatus::Unavailable);
-    assert_eq!(
-        capability.last_error.unwrap().code.to_string(),
-        "provider.not_wired"
-    );
-    assert_eq!(capability.reservation_state.available_units, 0);
+    assert_eq!(capability.health, HealthStatus::Healthy);
+    assert!(capability.last_error.is_none());
+    assert_eq!(capability.reservation_state.available_units, 64);
     assert_eq!(capability.limits.timeout_ms, Some(30_000));
+    assert!(capability.features.contains(&"http_client".to_string()));
     assert_eq!(embedding.model_id, "qwen3-embedding");
     assert_eq!(embedding.dimensions, 1024);
     assert_eq!(embedding.batch_limits.max_items, 64);
@@ -316,18 +316,11 @@ async fn openai_compat_adapter_config_is_reflected_in_capabilities_without_netwo
     assert_eq!(embedding.max_batch_tokens, 196_608);
 }
 
+// OpenAiCompat remains a shell in this PR — assert its not_wired behavior
+// separately now that TEI is a real client. (The TEI half of the old combined
+// test moved to the mock-server tests in `tei_client_tests.rs`.)
 #[tokio::test]
-async fn adapter_shell_embed_returns_not_wired_error() {
-    let tei = tei::TeiEmbeddingProvider::new(tei::TeiEmbeddingConfig {
-        endpoint: "http://tei.local:8080".to_string(),
-        model: "qwen3-embedding".to_string(),
-        dimensions: 1024,
-        timeout: Duration::from_secs(30),
-        max_batch_inputs: 64,
-        max_input_tokens: 8192,
-        max_batch_tokens: 131_072,
-        instruction_support: InstructionSupport::QueryAndDocument,
-    });
+async fn openai_compat_shell_embed_returns_not_wired_error() {
     let openai =
         openai_compat::OpenAiCompatEmbeddingProvider::new(openai_compat::OpenAiCompatConfig {
             base_url: "https://llm.example.test/v1".to_string(),
@@ -339,14 +332,11 @@ async fn adapter_shell_embed_returns_not_wired_error() {
             max_batch_tokens: 196_608,
         });
 
-    let tei_err = tei.embed(batch(JobPriority::Background)).await.unwrap_err();
     let openai_err = openai
         .embed(batch(JobPriority::Background))
         .await
         .unwrap_err();
 
-    assert_eq!(tei_err.code.to_string(), "provider.not_wired");
-    assert_eq!(tei_err.provider_id.as_deref(), Some("tei"));
     assert_eq!(openai_err.code.to_string(), "provider.not_wired");
     assert_eq!(openai_err.provider_id.as_deref(), Some("openai-compat"));
 }

--- a/crates/axon-embedding/src/tei.rs
+++ b/crates/axon-embedding/src/tei.rs
@@ -1,12 +1,22 @@
-//! TEI embedding provider shell.
+//! TEI embedding provider — real reqwest-backed `/embed` client.
+//!
+//! Ports request/response shape, 413 batch-split, and 429/5xx retry behaviour
+//! from the legacy `axon-vector` TEI client. The HTTP transport lives in
+//! [`client`]; this module owns batch validation, instruction prefixing, order
+//! preservation, dimension validation, and capability reporting.
 
-use std::time::Duration;
+mod client;
+
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use axon_api::source::*;
+use axon_error::ErrorStage;
 
-use crate::capability::{EmbeddingCapabilityConfig, unavailable_embedding_provider_capability};
-use crate::provider::{EmbeddingProvider, Result, not_wired_error};
+use crate::batch::validate_batch;
+use crate::capability::{EmbeddingCapabilityConfig, available_embedding_provider_capability};
+use crate::provider::{EmbeddingProvider, Result};
+use client::{TeiClient, TeiClientParams};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TeiEmbeddingConfig {
@@ -19,6 +29,10 @@ pub struct TeiEmbeddingConfig {
     pub max_batch_tokens: u32,
     pub instruction_support: InstructionSupport,
 }
+
+/// Total attempts per request = 1 initial + 5 retries, matching the legacy
+/// client's default `tei_max_retries = 5`.
+const MAX_ATTEMPTS: usize = 6;
 
 #[derive(Debug, Clone)]
 pub struct TeiEmbeddingProvider {
@@ -33,16 +47,113 @@ impl TeiEmbeddingProvider {
     pub fn config(&self) -> &TeiEmbeddingConfig {
         &self.config
     }
+
+    fn error(&self, code: &str, message: &str) -> ApiError {
+        ApiError::new(code, ErrorStage::Embedding, message.to_string()).with_provider_id("tei")
+    }
+
+    /// Whether a batch-level instruction should be applied, given the provider's
+    /// configured instruction support. `None` support never applies it.
+    fn instruction_enabled(&self) -> bool {
+        self.config.instruction_support != InstructionSupport::None
+    }
+
+    /// Build the ordered list of request texts, prepending the instruction to
+    /// each input when one is present and instruction support permits it.
+    fn request_texts(&self, batch: &EmbeddingBatch) -> Vec<String> {
+        match &batch.instruction {
+            Some(instruction) if self.instruction_enabled() && !instruction.is_empty() => batch
+                .items
+                .iter()
+                .map(|item| format!("{instruction}{}", item.text))
+                .collect(),
+            _ => batch.items.iter().map(|item| item.text.clone()).collect(),
+        }
+    }
 }
 
 #[async_trait]
 impl EmbeddingProvider for TeiEmbeddingProvider {
-    async fn embed(&self, _batch: EmbeddingBatch) -> Result<EmbeddingResult> {
-        Err(not_wired_error("tei", "TEI"))
+    async fn embed(&self, batch: EmbeddingBatch) -> Result<EmbeddingResult> {
+        validate_batch(&batch)?;
+
+        let dimensions = self.config.dimensions;
+        if dimensions == 0 {
+            return Err(self.error(
+                "provider.invalid_dimensions",
+                "TEI provider dimensions must be greater than zero",
+            ));
+        }
+
+        let texts = self.request_texts(&batch);
+        let client = TeiClient::new(TeiClientParams {
+            endpoint: self.config.endpoint.clone(),
+            provider_id: "tei".to_string(),
+            max_batch_inputs: self.config.max_batch_inputs.max(1) as usize,
+            max_attempts: MAX_ATTEMPTS,
+            request_timeout: self.config.timeout,
+        })?;
+
+        let started = Instant::now();
+        let outcome = client.embed_all(&texts).await?;
+        let duration_ms = started.elapsed().as_millis() as u64;
+        let raw = outcome.vectors;
+        let requests = outcome.requests;
+
+        if raw.len() != batch.items.len() {
+            return Err(self.error(
+                "embedding.tei.count_mismatch",
+                &format!(
+                    "TEI returned {} vectors for {} inputs",
+                    raw.len(),
+                    batch.items.len()
+                ),
+            ));
+        }
+
+        // Map response vectors back to items by request order — TEI returns
+        // embeddings in the order they were submitted.
+        let mut vectors = Vec::with_capacity(raw.len());
+        let mut warnings = Vec::new();
+        for (item, values) in batch.items.iter().zip(raw) {
+            if values.len() as u32 != dimensions {
+                warnings.push(SourceWarning {
+                    code: "embedding.tei.dimension_mismatch".to_string(),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "TEI vector length {} does not match configured dimensions {}",
+                        values.len(),
+                        dimensions
+                    ),
+                    source_item_key: None,
+                    retryable: false,
+                });
+            }
+            vectors.push(EmbeddingVector {
+                chunk_id: item.chunk_id.clone(),
+                values,
+            });
+        }
+
+        Ok(EmbeddingResult {
+            batch_id: batch.batch_id,
+            job_id: batch.job_id,
+            provider_id: ProviderId::new("tei"),
+            model: self.config.model.clone(),
+            dimensions,
+            vectors,
+            usage: ProviderUsage {
+                input_tokens: None,
+                output_tokens: None,
+                requests,
+                duration_ms,
+            },
+            warnings,
+        })
     }
 
     async fn capabilities(&self) -> Result<ProviderCapability> {
-        Ok(unavailable_embedding_provider_capability(
+        Ok(available_embedding_provider_capability(
             ProviderId::new("tei"),
             "tei",
             ProviderLimits {
@@ -50,9 +161,9 @@ impl EmbeddingProvider for TeiEmbeddingProvider {
                 timeout_ms: Some(self.config.timeout.as_millis() as u64),
                 ..ProviderLimits::default()
             },
-            vec!["dense_embeddings".to_string(), "http_shell".to_string()],
-            not_wired_error("tei", "TEI"),
+            vec!["dense_embeddings".to_string(), "http_client".to_string()],
             ProviderCostClass::Internal,
+            self.config.max_batch_inputs,
             EmbeddingCapabilityConfig {
                 model_id: self.config.model.clone(),
                 dimensions: self.config.dimensions,

--- a/crates/axon-embedding/src/tei/client.rs
+++ b/crates/axon-embedding/src/tei/client.rs
@@ -1,0 +1,305 @@
+//! Reqwest-backed TEI `/embed` HTTP client.
+//!
+//! Behaviour is ported from the legacy `axon-vector` TEI client
+//! (`crates/axon-vector/src/ops/tei/tei_client.rs`): request/response wire shape,
+//! 413 recursive batch-split, and 429/5xx exponential-backoff retries.
+//!
+//! Credentials never leak into [`ApiError`] messages — only the opaque marker
+//! `"configured"` is attached to error context, mirroring the qdrant store's
+//! redaction pattern.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use axon_api::source::ApiError;
+use axon_error::ErrorStage;
+use reqwest::{Client, StatusCode};
+
+/// Opaque endpoint context marker attached to errors.
+///
+/// The raw URL and any embedded credentials are intentionally never surfaced.
+pub const ENDPOINT_MARKER: &str = "configured";
+
+/// Cap on exponential backoff before jitter, matching the legacy client.
+const MAX_BACKOFF_MS: u64 = 60_000;
+
+/// Absolute ceiling on the client-side batch size, matching the legacy client's
+/// `tei_max_client_batch_size.clamp(1, 256)`.
+const MAX_CLIENT_BATCH_SIZE: usize = 256;
+
+/// Environment knob mirroring the legacy client's `TEI_MAX_CLIENT_BATCH_SIZE`.
+const TEI_MAX_CLIENT_BATCH_SIZE_ENV: &str = "TEI_MAX_CLIENT_BATCH_SIZE";
+
+/// Tunables for a single `embed_all` invocation.
+#[derive(Debug, Clone)]
+pub struct TeiClientParams {
+    pub endpoint: String,
+    pub provider_id: String,
+    /// Initial per-request chunk size (`config.max_batch_inputs`).
+    pub max_batch_inputs: usize,
+    /// Total attempts = retries + 1; matches legacy `tei_max_retries + 1`.
+    pub max_attempts: usize,
+    pub request_timeout: Duration,
+}
+
+/// Wire shape for a TEI `/embed` request body: `{"inputs": [...], "truncate": true}`.
+#[derive(serde::Serialize)]
+struct EmbedRequest<'a> {
+    inputs: &'a [String],
+    truncate: bool,
+}
+
+/// A single TEI request outcome after retries: either the decoded vectors or a
+/// "chunk too large, split and retry" signal (HTTP 413).
+enum ChunkOutcome {
+    Vectors(Vec<Vec<f32>>),
+    Split,
+}
+
+/// Result of an `embed_all` call: the ordered vectors plus how many HTTP
+/// requests were actually issued (initial batches + retries + 413 splits).
+#[derive(Debug)]
+pub struct TeiEmbedOutcome {
+    pub vectors: Vec<Vec<f32>>,
+    pub requests: u64,
+}
+
+/// Reqwest-backed TEI embed transport carrying a redaction-safe embed URL.
+#[derive(Debug)]
+pub struct TeiClient {
+    client: Client,
+    embed_url: String,
+    provider_id: String,
+    max_batch_inputs: usize,
+    max_attempts: usize,
+    request_timeout: Duration,
+    requests: AtomicU64,
+}
+
+impl TeiClient {
+    /// Build a transport for the configured TEI endpoint.
+    ///
+    /// The `/embed` path is appended to the configured base. The reqwest client
+    /// carries no per-request timeout; each request applies `request_timeout`.
+    pub fn new(params: TeiClientParams) -> Result<Self, ApiError> {
+        let client = Client::builder().build().map_err(|err| {
+            transport_error(
+                "embedding.tei.client_init",
+                "failed to build TEI HTTP client",
+                error_category(&err),
+            )
+            .with_provider_id(&params.provider_id)
+        })?;
+        let base = params.endpoint.trim().trim_end_matches('/');
+        let embed_url = format!("{base}/embed");
+        let max_batch_inputs = resolve_batch_size(params.max_batch_inputs);
+        Ok(Self {
+            client,
+            embed_url,
+            provider_id: params.provider_id,
+            max_batch_inputs,
+            max_attempts: params.max_attempts.max(1),
+            request_timeout: params.request_timeout,
+            requests: AtomicU64::new(0),
+        })
+    }
+
+    /// Embed every input, preserving order. Returns one vector per input at the
+    /// same index. Splits initial batches on HTTP 413 and retries 429/5xx.
+    pub async fn embed_all(&self, inputs: &[String]) -> Result<TeiEmbedOutcome, ApiError> {
+        if inputs.is_empty() {
+            return Ok(TeiEmbedOutcome {
+                vectors: Vec::new(),
+                requests: 0,
+            });
+        }
+
+        // Pre-size output so out-of-order splits can index directly by position.
+        let mut slots: Vec<Vec<f32>> = vec![Vec::new(); inputs.len()];
+
+        // Work queue of (absolute-offset, sub-slice) pairs still to embed.
+        let mut pending: Vec<(usize, &[String])> = Vec::new();
+        let mut start = 0usize;
+        for chunk in inputs.chunks(self.max_batch_inputs) {
+            pending.push((start, chunk));
+            start += chunk.len();
+        }
+
+        while let Some((offset, chunk)) = pending.pop() {
+            match self.send_chunk_with_retries(chunk).await? {
+                ChunkOutcome::Vectors(batch) => {
+                    if batch.len() != chunk.len() {
+                        return Err(self.error(
+                            "embedding.tei.count_mismatch",
+                            &format!(
+                                "TEI returned {} vectors for a {}-input batch",
+                                batch.len(),
+                                chunk.len()
+                            ),
+                        ));
+                    }
+                    for (i, vec) in batch.into_iter().enumerate() {
+                        slots[offset + i] = vec;
+                    }
+                }
+                ChunkOutcome::Split => {
+                    let mid = chunk.len() / 2;
+                    let (left, right) = chunk.split_at(mid);
+                    pending.push((offset, left));
+                    pending.push((offset + mid, right));
+                }
+            }
+        }
+
+        Ok(TeiEmbedOutcome {
+            vectors: slots,
+            requests: self.requests.load(Ordering::Relaxed),
+        })
+    }
+
+    /// Send one chunk, retrying transport errors and 429/5xx, and signalling a
+    /// split on 413 for multi-input chunks.
+    async fn send_chunk_with_retries(&self, chunk: &[String]) -> Result<ChunkOutcome, ApiError> {
+        let body = EmbedRequest {
+            inputs: chunk,
+            truncate: true,
+        };
+        let started = Instant::now();
+        let mut last: Option<ApiError> = None;
+
+        for attempt in 1..=self.max_attempts {
+            self.requests.fetch_add(1, Ordering::Relaxed);
+            let send = self
+                .client
+                .post(&self.embed_url)
+                .timeout(self.request_timeout)
+                .json(&body)
+                .send()
+                .await;
+
+            let resp = match send {
+                Ok(resp) => resp,
+                Err(err) => {
+                    last = Some(self.transport(error_category(&err)));
+                    if attempt < self.max_attempts {
+                        tokio::time::sleep(retry_delay(attempt, started)).await;
+                    }
+                    continue;
+                }
+            };
+
+            let status = resp.status();
+            if status.is_success() {
+                return match resp.json::<Vec<Vec<f32>>>().await {
+                    Ok(vectors) => Ok(ChunkOutcome::Vectors(vectors)),
+                    Err(err) => Err(self.transport(error_category(&err))),
+                };
+            }
+
+            // 413 = payload too large; split multi-input chunks and retry halves.
+            if is_batch_too_large(status) && chunk.len() > 1 {
+                return Ok(ChunkOutcome::Split);
+            }
+
+            let retryable = is_retryable_status(status);
+            last = Some(self.status_error(status));
+            if retryable && attempt < self.max_attempts {
+                tokio::time::sleep(retry_delay(attempt, started)).await;
+                continue;
+            }
+            return Err(last.unwrap());
+        }
+
+        Err(last.unwrap_or_else(|| {
+            self.error(
+                "embedding.tei.exhausted",
+                "TEI embed exhausted all attempts",
+            )
+        }))
+    }
+
+    fn error(&self, code: &str, message: &str) -> ApiError {
+        ApiError::new(code, ErrorStage::Embedding, message.to_string())
+            .with_context("endpoint", ENDPOINT_MARKER)
+            .with_provider_id(&self.provider_id)
+    }
+
+    fn transport(&self, category: &str) -> ApiError {
+        // reqwest's Display can carry the request URL, so it is never embedded.
+        ApiError::new(
+            "embedding.tei.transport",
+            ErrorStage::Embedding,
+            format!("TEI transport error ({category})"),
+        )
+        .with_context("endpoint", ENDPOINT_MARKER)
+        .with_provider_id(&self.provider_id)
+    }
+
+    fn status_error(&self, status: StatusCode) -> ApiError {
+        ApiError::new(
+            "embedding.tei.status",
+            ErrorStage::Embedding,
+            format!("TEI returned status {}", status.as_u16()),
+        )
+        .with_context("endpoint", ENDPOINT_MARKER)
+        .with_context("status", status.as_u16().to_string())
+        .with_provider_id(&self.provider_id)
+    }
+}
+
+/// Resolve the initial client-side batch size, honouring the
+/// `TEI_MAX_CLIENT_BATCH_SIZE` env knob (matching the legacy client), then
+/// clamping to `[1, 256]`.
+fn resolve_batch_size(config_batch: usize) -> usize {
+    let base = std::env::var(TEI_MAX_CLIENT_BATCH_SIZE_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(config_batch);
+    base.clamp(1, MAX_CLIENT_BATCH_SIZE)
+}
+
+/// 429 and any 5xx are retryable; everything else (including 413) is not.
+pub fn is_retryable_status(status: StatusCode) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// HTTP 413 signals the batch is too large for the server and must be split.
+pub fn is_batch_too_large(status: StatusCode) -> bool {
+    status == StatusCode::PAYLOAD_TOO_LARGE
+}
+
+fn error_category(err: &reqwest::Error) -> &'static str {
+    if err.is_timeout() {
+        "timeout"
+    } else if err.is_connect() {
+        "connect"
+    } else if err.is_decode() {
+        "decode"
+    } else {
+        "request"
+    }
+}
+
+fn transport_error(code: &str, message: &str, category: &str) -> ApiError {
+    ApiError::new(
+        code,
+        ErrorStage::Embedding,
+        format!("{message} ({category})"),
+    )
+    .with_context("endpoint", ENDPOINT_MARKER)
+}
+
+/// Exponential backoff (1s, 2s, 4s, …, capped at 60s) with lightweight jitter
+/// derived from the elapsed clock — no `rand` dependency, mirroring the qdrant
+/// store's `retry_delay`.
+pub fn retry_delay(attempt: usize, started: Instant) -> Duration {
+    let exponent = (attempt as u32).saturating_sub(1);
+    let base_ms = 1000_u64.saturating_mul(2u64.saturating_pow(exponent));
+    let capped_ms = base_ms.min(MAX_BACKOFF_MS);
+    let jitter_ms = (started.elapsed().subsec_nanos() as u64) % 500;
+    Duration::from_millis(capped_ms + jitter_ms)
+}
+
+#[cfg(test)]
+#[path = "client_tests.rs"]
+mod tests;

--- a/crates/axon-embedding/src/tei/client_tests.rs
+++ b/crates/axon-embedding/src/tei/client_tests.rs
@@ -1,0 +1,45 @@
+use super::*;
+use std::time::Instant;
+
+#[test]
+fn is_retryable_status_covers_429_and_5xx_only() {
+    assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+    assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
+    assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE));
+    assert!(is_retryable_status(StatusCode::GATEWAY_TIMEOUT));
+    assert!(!is_retryable_status(StatusCode::OK));
+    assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
+    // 413 drives the batch-split path, not the generic retry path.
+    assert!(!is_retryable_status(StatusCode::PAYLOAD_TOO_LARGE));
+}
+
+#[test]
+fn is_batch_too_large_is_413_only() {
+    assert!(is_batch_too_large(StatusCode::PAYLOAD_TOO_LARGE));
+    assert!(!is_batch_too_large(StatusCode::UNPROCESSABLE_ENTITY));
+    assert!(!is_batch_too_large(StatusCode::OK));
+}
+
+#[test]
+fn retry_delay_grows_exponentially_and_caps() {
+    let now = Instant::now();
+    assert!(retry_delay(1, now).as_millis() >= 1000);
+    assert!(retry_delay(2, now).as_millis() >= 2000);
+    assert!(retry_delay(3, now).as_millis() >= 4000);
+    // Capped at 60_000 + <500ms jitter.
+    assert!(retry_delay(100, now).as_millis() <= 60_500);
+}
+
+#[test]
+fn retry_delay_attempt_zero_does_not_panic() {
+    // saturating_sub(1) clamps to 0 → base 1000ms, no u32 underflow.
+    assert!(retry_delay(0, Instant::now()).as_millis() >= 1000);
+}
+
+#[test]
+fn resolve_batch_size_clamps_to_valid_range() {
+    // Env var is not set in this test, so config value is used and clamped.
+    assert_eq!(resolve_batch_size(64), 64);
+    assert_eq!(resolve_batch_size(0), 1);
+    assert_eq!(resolve_batch_size(10_000), 256);
+}

--- a/crates/axon-embedding/src/tei_client_tests.rs
+++ b/crates/axon-embedding/src/tei_client_tests.rs
@@ -1,0 +1,266 @@
+//! Real-client integration tests for [`TeiEmbeddingProvider`] against a mock
+//! HTTP server (httpmock). No live TEI is required.
+
+use std::time::Duration;
+
+use axon_api::source::*;
+use httpmock::prelude::*;
+use uuid::Uuid;
+
+use crate::provider::EmbeddingProvider;
+use crate::tei::{TeiEmbeddingConfig, TeiEmbeddingProvider};
+
+fn config(
+    endpoint: String,
+    dimensions: u32,
+    instruction: InstructionSupport,
+) -> TeiEmbeddingConfig {
+    TeiEmbeddingConfig {
+        endpoint,
+        model: "qwen3-embedding".to_string(),
+        dimensions,
+        timeout: Duration::from_secs(5),
+        max_batch_inputs: 64,
+        max_input_tokens: 8192,
+        max_batch_tokens: 131_072,
+        instruction_support: instruction,
+    }
+}
+
+fn input(chunk_id: &str, text: &str) -> EmbeddingInput {
+    EmbeddingInput {
+        chunk_id: ChunkId::new(chunk_id),
+        text: text.to_string(),
+        content_kind: ContentKind::PlainText,
+        metadata: MetadataMap::new(),
+    }
+}
+
+fn batch(items: Vec<EmbeddingInput>, instruction: Option<String>) -> EmbeddingBatch {
+    EmbeddingBatch {
+        batch_id: BatchId::new(Uuid::from_u128(1)),
+        job_id: JobId::new(Uuid::from_u128(2)),
+        provider_id: ProviderId::new("tei"),
+        model: "qwen3-embedding".to_string(),
+        items,
+        instruction,
+        priority: JobPriority::Background,
+        metadata: MetadataMap::new(),
+    }
+}
+
+#[tokio::test]
+async fn embed_returns_vectors_in_request_order() {
+    let server = MockServer::start_async().await;
+    server
+        .mock_async(|when, then| {
+            when.method(POST).path("/embed").body_includes("truncate");
+            then.status(200).json_body(serde_json::json!([
+                [0.1_f32, 0.2_f32],
+                [0.3_f32, 0.4_f32],
+                [0.5_f32, 0.6_f32],
+            ]));
+        })
+        .await;
+
+    let provider =
+        TeiEmbeddingProvider::new(config(server.base_url(), 2, InstructionSupport::None));
+    let result = provider
+        .embed(batch(
+            vec![
+                input("chunk-a", "first"),
+                input("chunk-b", "second"),
+                input("chunk-c", "third"),
+            ],
+            None,
+        ))
+        .await
+        .expect("embed should succeed");
+
+    let ids: Vec<_> = result
+        .vectors
+        .iter()
+        .map(|v| v.chunk_id.0.as_str())
+        .collect();
+    assert_eq!(ids, vec!["chunk-a", "chunk-b", "chunk-c"]);
+    assert_eq!(result.vectors[0].values, vec![0.1_f32, 0.2_f32]);
+    assert_eq!(result.dimensions, 2);
+    assert_eq!(result.provider_id, ProviderId::new("tei"));
+    assert_eq!(result.model, "qwen3-embedding");
+    assert_eq!(result.usage.requests, 1);
+    assert!(result.warnings.is_empty());
+}
+
+#[tokio::test]
+async fn embed_prepends_instruction_when_support_enabled() {
+    let server = MockServer::start_async().await;
+    // Only fires when the request body carries the instruction-prefixed text.
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/embed")
+                .body_includes("PREFIX::hello");
+            then.status(200)
+                .json_body(serde_json::json!([[1.0_f32, 2.0_f32]]));
+        })
+        .await;
+
+    let provider = TeiEmbeddingProvider::new(config(
+        server.base_url(),
+        2,
+        InstructionSupport::QueryAndDocument,
+    ));
+    let result = provider
+        .embed(batch(
+            vec![input("chunk-a", "hello")],
+            Some("PREFIX::".to_string()),
+        ))
+        .await
+        .expect("embed should succeed with instruction");
+
+    mock.assert_async().await;
+    assert_eq!(result.vectors.len(), 1);
+}
+
+#[tokio::test]
+async fn embed_ignores_instruction_when_support_none() {
+    let server = MockServer::start_async().await;
+    // Fires only for the RAW text (no prefix). If the provider wrongly prefixed
+    // the input, this mock would not match and the request would 404.
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/embed")
+                .body_includes("\"inputs\":[\"hello\"]");
+            then.status(200)
+                .json_body(serde_json::json!([[1.0_f32, 2.0_f32]]));
+        })
+        .await;
+
+    let provider =
+        TeiEmbeddingProvider::new(config(server.base_url(), 2, InstructionSupport::None));
+    let result = provider
+        .embed(batch(
+            vec![input("chunk-a", "hello")],
+            Some("PREFIX::".to_string()),
+        ))
+        .await
+        .expect("embed should succeed ignoring instruction");
+
+    mock.assert_async().await;
+    assert_eq!(result.vectors.len(), 1);
+}
+
+#[tokio::test]
+async fn embed_splits_batch_on_413() {
+    let server = MockServer::start_async().await;
+    // 413 mock registered first (higher priority) — fires only on the full
+    // 2-input batch (both inputs present in the body).
+    server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/embed")
+                .body_includes("split-alpha")
+                .body_includes("split-beta");
+            then.status(413);
+        })
+        .await;
+    // 200 fallback for the single-input halves after the split.
+    server
+        .mock_async(|when, then| {
+            when.method(POST).path("/embed");
+            then.status(200)
+                .json_body(serde_json::json!([[0.1_f32, 0.2_f32]]));
+        })
+        .await;
+
+    let provider =
+        TeiEmbeddingProvider::new(config(server.base_url(), 2, InstructionSupport::None));
+    let result = provider
+        .embed(batch(
+            vec![
+                input("chunk-a", "split-alpha"),
+                input("chunk-b", "split-beta"),
+            ],
+            None,
+        ))
+        .await
+        .expect("embed should succeed after 413 split");
+
+    assert_eq!(result.vectors.len(), 2);
+    let ids: Vec<_> = result
+        .vectors
+        .iter()
+        .map(|v| v.chunk_id.0.as_str())
+        .collect();
+    assert_eq!(ids, vec!["chunk-a", "chunk-b"]);
+    // 1 full-batch request (413) + 2 single-input requests after split.
+    assert_eq!(result.usage.requests, 3);
+}
+
+#[tokio::test]
+async fn embed_surfaces_dimension_mismatch_warning() {
+    let server = MockServer::start_async().await;
+    server
+        .mock_async(|when, then| {
+            when.method(POST).path("/embed");
+            // Server returns a 3-dim vector though config expects 2.
+            then.status(200)
+                .json_body(serde_json::json!([[0.1_f32, 0.2_f32, 0.3_f32]]));
+        })
+        .await;
+
+    let provider =
+        TeiEmbeddingProvider::new(config(server.base_url(), 2, InstructionSupport::None));
+    let result = provider
+        .embed(batch(vec![input("chunk-a", "hello")], None))
+        .await
+        .expect("embed should succeed but warn");
+
+    assert_eq!(result.vectors.len(), 1);
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(result.warnings[0].code, "embedding.tei.dimension_mismatch");
+}
+
+#[tokio::test]
+async fn embed_rejects_zero_dimensions_without_network() {
+    let provider = TeiEmbeddingProvider::new(config(
+        "http://127.0.0.1:1".to_string(),
+        0,
+        InstructionSupport::None,
+    ));
+    let err = provider
+        .embed(batch(vec![input("chunk-a", "hello")], None))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code.to_string(), "provider.invalid_dimensions");
+    assert_eq!(err.provider_id.as_deref(), Some("tei"));
+}
+
+#[tokio::test]
+async fn embed_surfaces_status_error_without_leaking_endpoint() {
+    let server = MockServer::start_async().await;
+    server
+        .mock_async(|when, then| {
+            when.method(POST).path("/embed");
+            then.status(400);
+        })
+        .await;
+
+    let provider =
+        TeiEmbeddingProvider::new(config(server.base_url(), 2, InstructionSupport::None));
+    let err = provider
+        .embed(batch(vec![input("chunk-a", "hello")], None))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code.to_string(), "embedding.tei.status");
+    assert_eq!(err.provider_id.as_deref(), Some("tei"));
+    // Endpoint is redacted to the opaque marker — the host/port never leak.
+    assert_eq!(
+        err.details.get("endpoint").map(String::as_str),
+        Some("configured")
+    );
+    assert!(!err.message.contains(&server.base_url()));
+    assert!(!err.message.contains("127.0.0.1"));
+}


### PR DESCRIPTION
Part of #298 Phase 10 — data-plane unit B (embedding). Follows the real QdrantVectorStore (#324).

## What
Replaces the deliberate `not_wired` PR9 shell in `TeiEmbeddingProvider::embed()` with a real reqwest-backed TEI `/embed` client, ported from the legacy `axon-vector/src/ops/tei/tei_client.rs`.

- POSTs `{"inputs":[…],"truncate":true}`; decodes `Vec<Vec<f32>>` in request order; maps vectors back to `items[i].chunk_id`.
- **413** → recursive half-split-and-retry (multi-input chunks only), recombined in order.
- **429/5xx** → up to 6 attempts (matches legacy `tei_max_retries=5`), exponential backoff capped at 60s + rand-free jitter. Initial batch size = `max_batch_inputs`, `TEI_MAX_CLIENT_BATCH_SIZE` override, clamped [1,256].
- Instruction prefixed per-item only when `instruction_support != None` and non-empty.
- Dimension validation → per-item `SourceWarning` on mismatch (partial results still flow); `ProviderUsage` populated (request count via AtomicU64, wall-time).
- **Redaction**: endpoint/api-key never enter `ApiError` (only `endpoint="configured"`), same pattern as the Qdrant store.
- `capabilities()` now returns an **available** capability (new `available_embedding_provider_capability` builder), no more `not_wired`. `OpenAiCompat` stays a shell (out of scope).

## Contract tests
Updated the stale `provider.not_wired` assertions: capabilities now asserted Healthy/available; the combined "both not_wired" test split so `OpenAiCompat` keeps its shell assertion and TEI's real behavior moves to httpmock-backed `tei_client_tests.rs` (order preservation, instruction on/off, 413 split w/ request-count, dimension-mismatch warning, redaction, zero-dim rejection — all without live TEI).

## Verification
- `cargo check -p axon-embedding` clean; downstream (axon-retrieval, axon-services) compile; fmt clean.
- `cargo test -p axon-embedding`: **35 passed, 0 failed** (httpmock, no live services).
- Adversarial verify verdict: **SOLID** (only advisory pre-existing `result_large_err` clippy notes).
- Monolith-compliant (files ≤500 lines, no mod.rs, sidecar `*_tests.rs`).

Next P10 slice: production `ServiceContext` composition wiring this + `SqliteLedgerStore` + `QdrantVectorStore` so `axon <source>` indexes end-to-end.

Bead: axon_rust-bpxk6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the TEI “not_wired” shell with a real `reqwest`-backed `/embed` client to enable production embeddings with batching, retries, and healthy capability reporting. Part of #298 (P10 data plane, embedding).

- **New Features**
  - Implemented `TeiEmbeddingProvider::embed()` using TEI `/embed` (POST `{"inputs":[...],"truncate":true}`), preserving request order.
  - 413 handling: recursive half-split for multi-input batches; 429/5xx retries up to 6 attempts with exponential backoff (max 60s) and jitter.
  - Instruction prefixing only when supported; initial batch from config, overridable via `TEI_MAX_CLIENT_BATCH_SIZE`, clamped to [1,256].
  - Dimension validation adds per-item warnings on mismatch; partial results still returned; usage now tracks request count and wall-time.
  - Capabilities report Available/Healthy via `available_embedding_provider_capability`, include `http_client`, and expose non-zero reservation capacity.
  - Error redaction: endpoint/api key never leak; only endpoint="configured".
  - Tests use `httpmock` to verify order, instruction on/off, 413 split, dimension mismatch warnings, and redaction; `OpenAiCompat` remains a shell and is tested separately.

- **Dependencies**
  - Added `reqwest`, `serde`, `serde_json`; dev: `httpmock`. Expanded `tokio` features for tests.

<sup>Written for commit 8307850b8455ae682ec56d09adbbc15a40442da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

