### PR TITLE
feat(axon-services): production ServiceContext data-plane composition (#298 P10)

### DIFF
--- a/crates/axon-services/src/context.rs
+++ b/crates/axon-services/src/context.rs
@@ -13,6 +13,8 @@ use axon_jobs::boundary::JobStore;
 use axon_ledger::store::LedgerStore;
 use axon_vectors::store::VectorStore;
 
+mod target_runtime;
+
 #[derive(Clone)]
 pub struct ServiceContext {
     pub cfg: Arc<Config>,
@@ -85,10 +87,11 @@ impl ServiceContext {
         spawn_freshness_scheduler: bool,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let jobs = resolve_runtime_with_workers(Arc::clone(&cfg), spawn_workers).await?;
+        let target_local_source = Self::build_target_local_source(&cfg, &jobs, spawn_workers).await;
         let context = Self {
             cfg: Arc::clone(&cfg),
             jobs: Arc::clone(&jobs),
-            target_local_source: None,
+            target_local_source,
         };
         if spawn_freshness_scheduler {
             crate::freshness::spawn_freshness_scheduler(context.clone());
@@ -97,6 +100,39 @@ impl ServiceContext {
             spawn_queue_summary_logger(Arc::clone(&jobs), cfg.queue_summary_secs);
         }
         Ok(context)
+    }
+
+    /// Construct the production target local-source runtime, when applicable.
+    ///
+    /// Only worker-bearing contexts (`spawn_workers`, i.e. `serve`/`mcp` and
+    /// foreground `--wait`) attach it, and only when both `qdrant_url` and
+    /// `tei_url` are configured. Missing endpoints leave it unset rather than
+    /// failing startup; a construction error (e.g. the ledger migrations) is
+    /// logged and treated as absent so the process still comes up.
+    async fn build_target_local_source(
+        cfg: &Config,
+        jobs: &Arc<dyn ServiceJobRuntime>,
+        spawn_workers: bool,
+    ) -> Option<Arc<TargetLocalSourceRuntime>> {
+        if !spawn_workers || cfg.qdrant_url.trim().is_empty() || cfg.tei_url.trim().is_empty() {
+            return None;
+        }
+        let Some(pool) = jobs.sqlite_pool() else {
+            return None;
+        };
+        let store: Arc<dyn JobStore> = Arc::new(axon_jobs::unified::SqliteUnifiedJobStore::new(
+            (*pool).clone(),
+        ));
+        match TargetLocalSourceRuntime::from_config(cfg, store).await {
+            Ok(runtime) => Some(Arc::new(runtime)),
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "failed to construct target local-source runtime; continuing without it"
+                );
+                None
+            }
+        }
     }
 
     /// Create a ServiceContext without in-process workers (enqueue-only in the SQLite runtime).
@@ -141,11 +177,11 @@ impl ServiceContext {
         self
     }
 
-    /// Inject the target source runtime for PR11 tests.
+    /// Inject the target source runtime.
     ///
-    /// Production contexts intentionally leave this unset until the target
-    /// Qdrant/vector provider wiring lands in the provider/backend phase.
-    #[cfg(test)]
+    /// Used both by tests (with fakes via the `#[cfg(test)]`
+    /// [`TargetLocalSourceRuntime::new`]) and by production startup (with the
+    /// real stores via [`TargetLocalSourceRuntime::from_config`]).
     pub fn with_target_local_source_runtime(mut self, runtime: TargetLocalSourceRuntime) -> Self {
         self.target_local_source = Some(Arc::new(runtime));
         self

--- a/crates/axon-services/src/context/target_runtime.rs
+++ b/crates/axon-services/src/context/target_runtime.rs
@@ -1,0 +1,135 @@
+//! Production composition for [`TargetLocalSourceRuntime`].
+//!
+//! The `#[cfg(test)]` [`TargetLocalSourceRuntime::new`] constructor (in
+//! `context.rs`) wires fakes for unit tests. This module owns the real
+//! data-plane composition: it builds the ledger / vector / embedding stores from
+//! [`Config`] so long-lived processes (`serve`, `mcp`) carry a working target
+//! local-source runtime.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axon_api::source::{InstructionSupport, ProviderId, ProviderKind};
+use axon_core::config::Config;
+use axon_embedding::reservation::{ProviderReservationConfig, ProviderReservationManager};
+use axon_embedding::tei::{TeiEmbeddingConfig, TeiEmbeddingProvider};
+use axon_jobs::boundary::JobStore;
+use axon_ledger::sqlite::SqliteLedgerStore;
+use axon_vectors::qdrant::QdrantVectorStore;
+
+use super::TargetLocalSourceRuntime;
+
+/// Provider id for the target local-source embedding provider.
+const EMBEDDING_PROVIDER_ID: &str = "target-local-embed";
+/// Provider id for the target local-source vector store.
+const VECTOR_PROVIDER_ID: &str = "target-local-vector";
+
+/// Embedding model shipped in the Axon stack (TEI Qwen3-Embedding-0.6B).
+///
+/// There is no dedicated `Config` field for the embedding model/dimensions yet
+/// (the TEI endpoint serves a fixed model), so these mirror the deployed stack.
+const EMBEDDING_MODEL: &str = "Qwen3-Embedding-0.6B";
+/// Dense vector dimensionality produced by [`EMBEDDING_MODEL`].
+const EMBEDDING_DIMENSIONS: u32 = 1024;
+/// Max input tokens per embedding request (mirrors the provider capability).
+const MAX_INPUT_TOKENS: u32 = 8192;
+/// Max tokens pooled into one TEI embed batch.
+const MAX_BATCH_TOKENS: u32 = 65_536;
+
+/// Reservation capacities mirror the `#[cfg(test)]` `new()` constructor so the
+/// production runtime behaves identically to the fixtures exercised in tests.
+const RESERVATION_CAPACITY: u32 = 2;
+const RESERVATION_INTERACTIVE_RESERVE: u32 = 1;
+const RESERVATION_COOLDOWN_AFTER_FAILURES: u32 = 1;
+const RESERVATION_COOLDOWN_SECS: u64 = 30;
+
+impl TargetLocalSourceRuntime {
+    /// Build the production target local-source runtime from [`Config`].
+    ///
+    /// Constructs the three real data-plane stores:
+    /// - the SQLite ledger at a sibling of the jobs DB (`ledger.db`), running
+    ///   migrations on connect;
+    /// - the Qdrant vector store addressed by `cfg.qdrant_url`;
+    /// - the TEI embedding provider addressed by `cfg.tei_url`.
+    ///
+    /// The `jobs` [`JobStore`] is supplied by the caller (built from the shared
+    /// SQLite pool of the job runtime). Vector/embedding constructors do not
+    /// connect eagerly; only the ledger `connect` performs I/O (migrations).
+    pub async fn from_config(
+        cfg: &Config,
+        jobs: Arc<dyn JobStore>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let ledger = SqliteLedgerStore::connect(&ledger_connect_str(cfg))
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+
+        let embedding_provider = TeiEmbeddingProvider::new(TeiEmbeddingConfig {
+            endpoint: cfg.tei_url.clone(),
+            model: EMBEDDING_MODEL.to_string(),
+            dimensions: EMBEDDING_DIMENSIONS,
+            timeout: Duration::from_millis(cfg.tei_request_timeout_ms),
+            max_batch_inputs: cfg.tei_max_client_batch_size as u32,
+            max_input_tokens: MAX_INPUT_TOKENS,
+            max_batch_tokens: MAX_BATCH_TOKENS,
+            instruction_support: InstructionSupport::QueryAndDocument,
+        });
+
+        let vector_store = QdrantVectorStore::new(cfg.qdrant_url.clone(), VECTOR_PROVIDER_ID);
+
+        let embedding_provider_id = ProviderId::new(EMBEDDING_PROVIDER_ID);
+        let vector_provider_id = ProviderId::new(VECTOR_PROVIDER_ID);
+
+        Ok(Self {
+            jobs,
+            ledger: Arc::new(ledger),
+            embedding_provider: Arc::new(embedding_provider),
+            vector_store: Arc::new(vector_store),
+            embedding_reservations: Arc::new(ProviderReservationManager::new(reservation_config(
+                embedding_provider_id.clone(),
+                ProviderKind::Embedding,
+            ))),
+            vector_reservations: Arc::new(ProviderReservationManager::new(reservation_config(
+                vector_provider_id.clone(),
+                ProviderKind::Vector,
+            ))),
+            embedding_provider_id,
+            vector_provider_id,
+            embedding_model: EMBEDDING_MODEL.to_string(),
+            embedding_dimensions: EMBEDDING_DIMENSIONS,
+        })
+    }
+}
+
+/// Reservation config mirroring the capacities of the `#[cfg(test)]` `new()`.
+fn reservation_config(
+    provider_id: ProviderId,
+    provider_kind: ProviderKind,
+) -> ProviderReservationConfig {
+    ProviderReservationConfig {
+        provider_id,
+        provider_kind,
+        capacity: RESERVATION_CAPACITY,
+        interactive_reserve: RESERVATION_INTERACTIVE_RESERVE,
+        cooldown_after_failures: RESERVATION_COOLDOWN_AFTER_FAILURES,
+        cooldown_secs: RESERVATION_COOLDOWN_SECS,
+    }
+}
+
+/// Derive the ledger SQLite connect string as a sibling of the jobs DB.
+///
+/// Mirrors the jobs-DB path derivation (`AXON_SQLITE_PATH` / `$AXON_DATA_DIR`)
+/// by reusing `cfg.sqlite_path`'s parent directory and pointing at `ledger.db`.
+/// The `sqlite://…?mode=rwc` form creates the file if missing (matching the
+/// jobs pool), whereas a bare filesystem path would fail to auto-create.
+fn ledger_connect_str(cfg: &Config) -> String {
+    let ledger_path = cfg
+        .sqlite_path
+        .parent()
+        .map(|parent| parent.join("ledger.db"))
+        .unwrap_or_else(|| std::path::PathBuf::from("ledger.db"));
+    format!("sqlite://{}?mode=rwc", ledger_path.display())
+}
+
+#[cfg(test)]
+#[path = "target_runtime_tests.rs"]
+mod tests;

--- a/crates/axon-services/src/context/target_runtime_tests.rs
+++ b/crates/axon-services/src/context/target_runtime_tests.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use axon_core::config::Config;
+use axon_jobs::boundary::{FakeJobWatchStore, JobStore};
+
+use crate::context::TargetLocalSourceRuntime;
+
+/// `from_config` builds the three real stores + reservations against a temp
+/// ledger DB and dummy Qdrant/TEI URLs. No live Qdrant/TEI is required: the
+/// vector/embedding constructors do not connect, and `SqliteLedgerStore::connect`
+/// only runs migrations against a real (temp) SQLite file.
+#[tokio::test]
+async fn from_config_populates_provider_metadata() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let mut cfg = Config::test_default();
+    // sqlite_path's parent dir is where the sibling ledger.db is created.
+    cfg.sqlite_path = tmp.path().join("jobs.db");
+    cfg.qdrant_url = "http://127.0.0.1:53333".to_string();
+    cfg.tei_url = "http://127.0.0.1:52000".to_string();
+
+    let jobs: Arc<dyn JobStore> = Arc::new(FakeJobWatchStore::new());
+
+    let runtime = TargetLocalSourceRuntime::from_config(&cfg, jobs)
+        .await
+        .expect("build target local-source runtime");
+
+    assert_eq!(runtime.embedding_provider_id.0, "target-local-embed");
+    assert_eq!(runtime.vector_provider_id.0, "target-local-vector");
+    assert_eq!(runtime.embedding_model, "Qwen3-Embedding-0.6B");
+    assert_eq!(runtime.embedding_dimensions, 1024);
+
+    // The sibling ledger DB was created next to the jobs DB.
+    assert!(tmp.path().join("ledger.db").exists());
+}


### PR DESCRIPTION
Part of #298 Phase 10 — final data-plane unit. Ties together the three now-real stores (Qdrant #324, TEI #325, ledger already real) so a live process carries a working `TargetLocalSourceRuntime`.

## What
- New `TargetLocalSourceRuntime::from_config(cfg, jobs)` (production async constructor in `context/target_runtime.rs`) building the **real** stores: `SqliteLedgerStore::connect` (sibling `ledger.db` derived from `cfg.sqlite_path`, `sqlite://…?mode=rwc` auto-create), `QdrantVectorStore::new(cfg.qdrant_url, …)`, `TeiEmbeddingProvider::new(TeiEmbeddingConfig{…})` + reservation managers (mirrors the `#[cfg(test)]` `new()` capacities, which is kept for fake-based tests).
- **Startup wiring**: `ServiceContext::build` attaches the runtime via `build_target_local_source` only for worker-bearing contexts (`serve`/`mcp`/foreground `--wait`) **and** only when both `qdrant_url` and `tei_url` are set; otherwise `target_local_source = None` (no startup failure). A `from_config` error → `tracing::warn!` + treated as absent. JobStore built from the shared SQLite pool via `jobs.sqlite_pool()`.
- Un-gated `with_target_local_source_runtime` as real pub API.

## Known caveat (documented in-code)
No Config field exists yet for the embedding **model/dimensions**, so those are module constants matching the deployed stack (`Qwen3-Embedding-0.6B` @ 1024-dim, same values as the embedding tests/fakes). Flagged with a doc-comment to swap for `cfg` fields when the parallel config-field change lands.

## Verification
- `cargo check -p axon-services` clean; fmt clean.
- `cargo test -p axon-services`: **458 passed, 0 failed** (+1 new `from_config_populates_provider_metadata` — builds the runtime against a temp SQLite ledger + dummy Qdrant/TEI URLs, asserts provider IDs/model/dims + ledger.db creation; no live services).
- Adversarial verify verdict: **SOLID**.
- Monolith-compliant (context.rs 256, target_runtime.rs 135; no mod.rs; sidecar tests).

Next P10 slice: `axon source <path>` CLI command dispatching to `index_local_source_with_job` via this runtime — makes local indexing work end-to-end.

Bead: axon_rust-bpxk6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires up the production data-plane for local source indexing by building the SQLite ledger, Qdrant vector store, and TEI embedding provider from config. Worker processes now start with a functional `TargetLocalSourceRuntime` when endpoints are set, addressing #298 P10.

- **New Features**
  - Added `TargetLocalSourceRuntime::from_config(cfg, jobs)` that constructs real stores: SQLite ledger (`ledger.db` sibling to `cfg.sqlite_path` with `sqlite://...?mode=rwc`), Qdrant via `cfg.qdrant_url`, and TEI via `cfg.tei_url`, plus mirrored reservation managers.
  - `ServiceContext::build` now attaches the runtime only for worker-bearing contexts and only when both URLs are configured; build errors log a warning and continue without the runtime. Uses the shared jobs SQLite pool for the `JobStore`.
  - Ungated `with_target_local_source_runtime` for production use; test-only `new()` remains for fakes.
  - Temporarily fixes embedding model/dimensions to Qwen3-Embedding-0.6B (1024) until config fields land.
  - Added test `from_config_populates_provider_metadata` to assert provider IDs/model/dims and `ledger.db` creation without requiring live Qdrant/TEI.

<sup>Written for commit c2c695d859dd2ad8f5c1c16c0a5db581c9a29f8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

