### PR TITLE
test(reddit): round-trip dump test through the real adapter reader (#298)

### DIFF
--- a/crates/axon-adapters/src/reddit.rs
+++ b/crates/axon-adapters/src/reddit.rs
@@ -7,7 +7,7 @@
 //! Keeping the network out of the adapter makes it unit-testable with fixture
 //! dumps and matches how the `git`/`web` adapters read prepared inputs.
 
-mod dump;
+pub mod dump;
 mod metadata;
 mod target;
 

--- a/crates/axon-adapters/src/reddit/dump.rs
+++ b/crates/axon-adapters/src/reddit/dump.rs
@@ -93,7 +93,13 @@ pub struct RedditDumpComment {
 }
 
 /// Parse a prepared Reddit JSON dump file into its post items.
-pub(super) fn parse_dump(bytes: &[u8]) -> Result<Vec<RedditDumpItem>> {
+///
+/// Public so the services acquire mapping (`axon_services::reddit_acquire`)
+/// can round-trip its produced dump JSON through the adapter's real
+/// deserialize path in tests — mirroring how `axon_adapters::youtube::dump`
+/// exposes `read_youtube_dump`. A field/serde drift in these dump structs
+/// then breaks that round-trip test.
+pub fn parse_dump(bytes: &[u8]) -> Result<Vec<RedditDumpItem>> {
     serde_json::from_slice::<Vec<RedditDumpItem>>(bytes).map_err(|err| {
         ApiError::new(
             "adapter.reddit.dump_invalid",

--- a/crates/axon-services/src/reddit_acquire/map_tests.rs
+++ b/crates/axon-services/src/reddit_acquire/map_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use axon_adapters::reddit::dump::{RedditDumpItem, parse_dump};
 use serde_json::json;
 
 #[test]
@@ -214,37 +215,12 @@ fn thread_without_comment_listing_maps_post_only() {
 
 #[test]
 fn serialized_dump_deserializes_back_into_dump_shape() {
-    // The serialized dump MUST round-trip through a struct with the exact field
-    // names the adapter's `RedditDumpItem`/`RedditDumpComment` deserialize
-    // targets use — this guards against a field-name drift between the acquire
-    // mapping and the adapter parser.
-    #[derive(serde::Deserialize)]
-    struct MirrorItem {
-        title: Option<String>,
-        #[serde(default)]
-        selftext: Option<String>,
-        permalink: Option<String>,
-        author: Option<String>,
-        score: Option<i64>,
-        subreddit: Option<String>,
-        domain: Option<String>,
-        num_comments: Option<u64>,
-        upvote_ratio: Option<f64>,
-        is_video: Option<bool>,
-        distinguished: Option<String>,
-        gilded: Option<u64>,
-        link_flair_text: Option<String>,
-        created_utc: Option<u64>,
-        #[serde(default)]
-        comments: Vec<MirrorComment>,
-    }
-    #[derive(serde::Deserialize)]
-    struct MirrorComment {
-        body: String,
-        #[serde(default)]
-        parent_text: Option<String>,
-    }
-
+    // The highest-risk assertion: the serialized dump MUST round-trip through
+    // the ADAPTER's REAL deserialize path (`axon_adapters::reddit::dump::parse_dump`
+    // → `RedditDumpItem`/`RedditDumpComment`), not a hand-copied mirror struct.
+    // If a field name or serde attribute drifts between this acquire mapping and
+    // the adapter's dump structs, this fails — mirroring how the youtube slice
+    // round-trips through `read_youtube_dump`.
     let thread = json!([
         {
             "data": {
@@ -272,28 +248,13 @@ fn serialized_dump_deserializes_back_into_dump_shape() {
     let item = map_thread(&thread).expect("maps");
     let bytes = serde_json::to_vec(&vec![item]).expect("serialize dump");
 
-    let parsed: Vec<MirrorItem> =
-        serde_json::from_slice(&bytes).expect("dump must parse into adapter dump shape");
+    let parsed: Vec<RedditDumpItem> =
+        parse_dump(&bytes).expect("dump must parse into the adapter's real dump shape");
     assert_eq!(parsed.len(), 1);
     assert_eq!(parsed[0].title.as_deref(), Some("Roundtrip"));
     assert_eq!(parsed[0].score, Some(7));
     assert_eq!(parsed[0].created_utc, Some(1_700_000_000));
     assert_eq!(parsed[0].comments.len(), 1);
     assert_eq!(parsed[0].comments[0].body, "hi");
-    // Silence dead-field warnings on the mirror structs — the deserialize itself
-    // is the assertion.
-    let _ = (
-        &parsed[0].selftext,
-        &parsed[0].permalink,
-        &parsed[0].author,
-        &parsed[0].subreddit,
-        &parsed[0].domain,
-        &parsed[0].num_comments,
-        &parsed[0].upvote_ratio,
-        &parsed[0].is_video,
-        &parsed[0].distinguished,
-        &parsed[0].gilded,
-        &parsed[0].link_flair_text,
-        &parsed[0].comments[0].parent_text,
-    );
+    assert_eq!(parsed[0].comments[0].parent_text, None);
 }


### PR DESCRIPTION
Follow-up from the reddit acquisition slice (#331) — applies the youtube pattern so the dump round-trip test guards against adapter drift.

## What
- `axon-adapters/src/reddit.rs`: `mod dump` → `pub mod dump` + `parse_dump` `pub(super)` → `pub` (mirrors youtube's `read_youtube_dump`).
- `reddit_acquire/map_tests.rs`: deleted the 50-line hand-copied `MirrorItem`/`MirrorComment`; the round-trip test now imports `axon_adapters::reddit::dump::{RedditDumpItem, parse_dump}` and deserializes the serialized dump through the adapter's **real** `parse_dump` path. Net −33 lines.

## Why
The old test round-tripped through a hand-copied mirror struct, so a future adapter field/serde change wouldn't be caught. Now it goes through the real type.

## Verification
- `cargo check -p axon-adapters -p axon-services` clean; fmt clean.
- `cargo test -p axon-services reddit`: 32 passed.
- Verify verdict: **SOLID** (noted the value-assertions cover a subset of fields — strictly better than the mirror; full `deny_unknown_fields` coverage is a possible later tightening).
- Scope limited to axon-adapters + axon-services/reddit_acquire; no CLI/MCP/web touched.

Closes the reddit dump-test-hardening follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the reddit dump round-trip test by parsing through the real adapter to catch field/serde drift between the acquire mapping and adapter structs. Exposes the dump reader so the test imports `RedditDumpItem` and uses `parse_dump`, removing hand-copied mirror types.

- **Refactors**
  - `axon-adapters`: made `reddit::dump` public and `parse_dump` public (mirrors the YouTube dump pattern).
  - `axon-services/reddit_acquire`: test now uses `RedditDumpItem` + `parse_dump`; deleted mirror structs (net −33 LOC).

<sup>Written for commit 7e8e7754364954a7ee959fe67850852e33be4698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

