### PR TITLE
fix(document): char-boundary panic in line_number_at — feed/non-ASCII indexing (#298)

### DIFF
--- a/crates/axon-document/src/text.rs
+++ b/crates/axon-document/src/text.rs
@@ -101,7 +101,13 @@ fn bounded_windows(text: &str, start: usize, end: usize) -> Vec<(usize, usize)> 
 }
 
 fn line_number_at(text: &str, byte: usize) -> u32 {
-    let capped = byte.min(text.len());
+    // `byte` may land mid-UTF-8-char (e.g. non-ASCII feed/web content), which
+    // would panic slicing `text[..capped]`. Back off to the nearest char
+    // boundary at or below the cap; newlines are ASCII so the count is exact.
+    let mut capped = byte.min(text.len());
+    while capped > 0 && !text.is_char_boundary(capped) {
+        capped -= 1;
+    }
     1 + text[..capped].bytes().filter(|b| *b == b'\n').count() as u32
 }
 


### PR DESCRIPTION
`line_number_at` sliced `text[..byte.min(len)]`, which **panics** when the byte index lands mid-UTF-8-char. Real crash found running `axon source <feed-url>`: panicked at `text.rs:105` on non-ASCII feed content.

Fix: back off to the nearest char boundary at/below the cap; newlines are ASCII so the newline count stays exact.

**Verified live:** `axon source https://blog.rust-lang.org/feed.xml` now indexes **10 docs / 70 chunks / 70 points** (was a hard panic). Affects feed + any non-ASCII web content.

Part of the source-family index sweep: local/git/web/feed/youtube now index end-to-end; reddit (secret-redaction false-positive, bead axon_rust-0ryve) and registry/sessions (acquisition unbuilt) remain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a panic in `line_number_at` when the byte index lands inside a UTF-8 character, so non-ASCII feeds and web pages no longer crash during indexing.

- **Bug Fixes**
  - Back off to the nearest UTF-8 char boundary before slicing (`text[..capped]`).
  - Newline count remains exact (newlines are ASCII).
  - Verified: `axon source https://blog.rust-lang.org/feed.xml` indexes 10 docs / 70 chunks / 70 points.

<sup>Written for commit ca61e3a270339043613423c0a99ec27ac3af05f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

