### PR TITLE
fix(retrieval): url→item_canonical_uri fallback — new-pipeline content is retrievable (#298)

### DIFF
--- a/crates/axon-vector/src/ops/qdrant/types.rs
+++ b/crates/axon-vector/src/ops/qdrant/types.rs
@@ -4,6 +4,13 @@ use serde::Deserialize;
 pub struct QdrantPayload {
     #[serde(default)]
     pub url: String,
+    /// New unified-pipeline points carry `item_canonical_uri` (the source
+    /// canonical URI) instead of a bare `url`. Retrieval falls back to this when
+    /// `url` is empty so new-pipeline content is not skipped as url-less. Legacy
+    /// points have `url` and no `item_canonical_uri`, so this stays empty for
+    /// them and behavior is unchanged.
+    #[serde(default)]
+    pub item_canonical_uri: String,
     #[serde(default)]
     pub chunk_text: String,
     #[serde(default)]

--- a/crates/axon-vector/src/ops/qdrant/utils.rs
+++ b/crates/axon-vector/src/ops/qdrant/utils.rs
@@ -126,7 +126,15 @@ pub fn payload_text_typed(payload: &QdrantPayload) -> &str {
 }
 
 pub fn payload_url_typed(payload: &QdrantPayload) -> &str {
-    payload.url.as_str()
+    // Legacy points carry `url`; new unified-pipeline points carry
+    // `item_canonical_uri` instead. Fall back so retrieval does not skip
+    // new-pipeline content as url-less (build_candidates_from_hits drops
+    // url-empty hits). Prod points keep `url`, so this is a no-op for them.
+    if !payload.url.is_empty() {
+        payload.url.as_str()
+    } else {
+        payload.item_canonical_uri.as_str()
+    }
 }
 
 pub fn payload_url(payload: &serde_json::Value) -> String {


### PR DESCRIPTION
**Closes the retrieval gap.** All 8 source families indexed, but `axon query`/`ask` returned nothing for new-pipeline content. Root cause (found by running the binary): new-pipeline points carry **`item_canonical_uri`**, not a bare `url` — and `build_candidates_from_hits` (retrieval.rs:177) **drops any hit with an empty url**, so every new-content hit was skipped → empty candidate pool → "No results."

## Fix — surgical, zero prod regression
Add `item_canonical_uri` to the typed `QdrantPayload` (serde default) and have `payload_url_typed` fall back to it when `url` is empty. Legacy/prod points keep `url` (fallback stays empty for them → unchanged). One change fixes **query, ask, and evaluate** (shared `build_candidates_from_hits`), and **preserves the full legacy rerank + diverse-select + snippet quality** — far better than a wholesale retrieval-subsystem rewrite.

## Verified live (both new + prod)
- `axon query "rust programming language"` on a new web collection → **rust-lang.org/learn (rerank 1.105) + /community (0.549)** with snippets + URLs.
- `axon ask …` → cited synthesis (S1–S4 rust-lang.org).
- **prod `axon`** query → still returns results, unchanged (no regression).

This makes the **full core loop — index → hybrid retrieve — work end-to-end for all 8 families.**

> Note: a pre-existing `ensure_payload_indexes_fires_one_put_per_field` test failure exists on main independent of this change (fails with these files stashed) — separate issue, not introduced here.

Builds on #334/#335/#336/#337.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes retrieval for new unified-pipeline content by falling back to item_canonical_uri when url is empty. Legacy behavior is unchanged, so prod ranking/snippets stay intact.

- **Bug Fixes**
  - Added `item_canonical_uri` to typed `QdrantPayload` (serde default).
  - Updated `payload_url_typed` to fall back to `item_canonical_uri` when `url` is empty, restoring results for query/ask/evaluate on new collections.

<sup>Written for commit 0582481be8724b81ba03fad837df6aec056dfb13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

