### PR TITLE
fix(axon-vectors): clear never_loops clippy error blocking full-workspace clippy (#298)

### DIFF
--- a/crates/axon-vectors/src/payload.rs
+++ b/crates/axon-vectors/src/payload.rs
@@ -291,7 +291,7 @@ fn validate_source_range_order(
     range: &SourceRange,
     field: &str,
 ) -> Result<(), VectorPayloadValidationError> {
-    for suffix in [
+    if let Some(suffix) = [
         range_starts_after(range.line_start, range.line_end, "line"),
         range_starts_after(range.byte_start, range.byte_end, "byte"),
         range_starts_after(range.char_start, range.char_end, "char"),
@@ -299,6 +299,7 @@ fn validate_source_range_order(
     ]
     .into_iter()
     .flatten()
+    .next()
     {
         return Err(VectorPayloadValidationError::InvalidFieldShape {
             field: format!("{field}.{suffix}"),

--- a/docs/reference/sources/vector-payload.md
+++ b/docs/reference/sources/vector-payload.md
@@ -118,7 +118,7 @@ Vector payload docs are paired with the DTO definitions in `docs/reference/api/s
 | Path | SHA-256 |
 |---|---|
 | `crates/axon-api/src/source/vector.rs` | `sha256:97c767a15c9f88a3a7278ac32c6b7b1a4fce722223e9dd3c5f59079fee69b9ac` |
-| `crates/axon-vectors/src/payload.rs` | `sha256:cea034a48f79b54f2662125db097afaeffc14cff02f277a74b37991d5d0306f0` |
+| `crates/axon-vectors/src/payload.rs` | `sha256:c0699b368629fff2354088e568c95eb1fb10efdbd4d3817f3d336dbc1d3e5060` |
 | `crates/axon-vectors/src/point.rs` | `sha256:95b94d69355176f4d424840b13a4bee6e324b7bf3995038e737f4d14e323c487` |
 | `docs/pipeline-unification/schemas/vector-payload-schema.md` | `sha256:ef84517d66acc0e35fe0b432df3cee52fc07e6643006003eca0ec0c29a5cde7f` |
 | `docs/pipeline-unification/sources/chunking-contract.md` | `sha256:c05b4d85b293af0200445e89adf99db1db55d3cf2e7d003fa38844efb682d8d8` |

--- a/docs/reference/sources/vector-payload.schema.json
+++ b/docs/reference/sources/vector-payload.schema.json
@@ -4560,7 +4560,7 @@
         "path": "crates/axon-api/src/source/vector.rs"
       },
       {
-        "checksum": "sha256:cea034a48f79b54f2662125db097afaeffc14cff02f277a74b37991d5d0306f0",
+        "checksum": "sha256:c0699b368629fff2354088e568c95eb1fb10efdbd4d3817f3d336dbc1d3e5060",
         "kind": "rust_module",
         "path": "crates/axon-vectors/src/payload.rs"
       },


### PR DESCRIPTION
One-line, behavior-preserving fix: `validate_source_range_order` used a `for`-loop that always returned on the first iteration (clippy `never_loops` hard error). Rewritten as `if let Some(..) = […].into_iter().flatten().next()` — identical behavior (errors on the first invalid range).

This error was pre-existing on the base tree and blocked `cargo clippy --workspace` for every agent working in the repo. Verified: `cargo clippy -p axon-vectors` now finishes with no hard errors; `cargo fmt --check` clean; payload tests unchanged (the 5 pre-existing failures are identical with/without this change — stash-confirmed — and tracked separately).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Clippy `never_loops` error in `axon-vectors` by rewriting `validate_source_range_order` to use `if let` with `.into_iter().flatten().next()` instead of a loop that returned immediately. Regenerates vector-payload docs/schema checksums to reflect the `payload.rs` change; behavior unchanged and `cargo clippy --workspace` is unblocked.

<sup>Written for commit 143f7c4f0a0acadcca9bd23410c85252625e521b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reference metadata and checksums for source documentation.
* **Refactor**
  * Streamlined a validation check without changing the resulting error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->