### PR TITLE
fix(axon-vectors): align sparse test fixtures

### DIFF
--- a/crates/axon-vectors/src/point_tests.rs
+++ b/crates/axon-vectors/src/point_tests.rs
@@ -64,22 +64,17 @@ fn prepared_document_and_embeddings_build_validated_points() {
 }
 
 #[test]
-fn absolute_local_chunk_locator_paths_fail_payload_validation() {
+fn absolute_local_chunk_locator_paths_skip_forbidden_chunk() {
     let mut document = test_prepared_document();
     document.chunks[0].chunk_locator.path = Some("/home/jmagar/workspace/private.rs".to_string());
     let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
 
-    let err = builder(test_collection_spec(3), document, embeddings)
+    let batch = builder(test_collection_spec(3), document, embeddings)
         .build()
-        .unwrap_err();
+        .unwrap();
 
-    assert!(matches!(
-        err,
-        VectorPointBatchBuildError::Payload {
-            chunk_id,
-            source: crate::payload::VectorPayloadValidationError::ForbiddenValue { field },
-        } if chunk_id == ChunkId::new("chunk-web-1") && field == "chunk_locator.path"
-    ));
+    assert_eq!(batch.points.len(), 1);
+    assert_eq!(batch.points[0].chunk_id, ChunkId::new("chunk-web-2"));
 }
 
 #[test]
@@ -385,22 +380,17 @@ fn document_body_examples_do_not_trigger_metadata_redaction_guardrails() {
 }
 
 #[test]
-fn document_body_secret_examples_fail_before_vector_point_build() {
+fn document_body_secret_examples_skip_forbidden_chunk() {
     let mut document = test_prepared_document();
     document.chunks[0].content = "TOKEN=value".to_string();
     let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
 
-    let err = builder(test_collection_spec(3), document, embeddings)
+    let batch = builder(test_collection_spec(3), document, embeddings)
         .build()
-        .unwrap_err();
+        .unwrap();
 
-    assert!(matches!(
-        err,
-        VectorPointBatchBuildError::Payload {
-            chunk_id,
-            source: crate::payload::VectorPayloadValidationError::ForbiddenValue { field }
-        } if chunk_id == ChunkId::new("chunk-web-1") && field == "chunk_text"
-    ));
+    assert_eq!(batch.points.len(), 1);
+    assert_eq!(batch.points[0].chunk_id, ChunkId::new("chunk-web-2"));
 }
 
 #[test]

--- a/crates/axon-vectors/src/qdrant_tests.rs
+++ b/crates/axon-vectors/src/qdrant_tests.rs
@@ -12,8 +12,8 @@ use crate::qdrant::{
 };
 use crate::store::VectorStore;
 use crate::testing::{
-    test_collection_spec, test_embedding_result_for, test_prepared_document,
-    test_vector_build_context,
+    test_collection_spec, test_collection_spec_hybrid, test_embedding_result_for,
+    test_prepared_document, test_vector_build_context,
 };
 
 #[test]
@@ -349,7 +349,7 @@ fn empty_array_filter_values_convert_to_match_none_qdrant_filter() {
 
 #[test]
 fn vector_point_batch_converts_to_qdrant_points_without_dropping_payload_fields() {
-    let mut spec = test_collection_spec(3);
+    let mut spec = test_collection_spec_hybrid(3);
     spec.dense.name = "dense_docs".to_string();
     let document = test_prepared_document();
     let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
@@ -469,12 +469,8 @@ fn sparse_vectors_for_dense_only_collections_are_rejected_before_qdrant_conversi
 
 #[test]
 fn vector_point_batch_merges_batch_level_sparse_vectors_by_chunk_id() {
-    let mut spec = test_collection_spec(3);
+    let mut spec = test_collection_spec_hybrid(3);
     spec.dense.name = "dense_docs".to_string();
-    spec.sparse = Some(SparseVectorConfig {
-        name: "bm42".to_string(),
-        modifier: SparseVectorModifier::Idf,
-    });
     let document = test_prepared_document();
     let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
     let mut batch = VectorPointBatchBuilder::new(
@@ -485,6 +481,9 @@ fn vector_point_batch_merges_batch_level_sparse_vectors_by_chunk_id() {
     )
     .build()
     .unwrap();
+    for point in &mut batch.points {
+        point.sparse_vector = None;
+    }
     batch.sparse_vectors = Some(vec![SparseVector {
         chunk_id: batch.points[0].chunk_id.clone(),
         indices: vec![2],
@@ -540,7 +539,7 @@ fn malformed_sparse_vectors_are_rejected_before_qdrant_conversion() {
 
 #[test]
 fn invalid_payloads_are_rejected_before_qdrant_conversion() {
-    let spec = test_collection_spec(3);
+    let spec = test_collection_spec_hybrid(3);
     let document = test_prepared_document();
     let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
     let mut batch = VectorPointBatchBuilder::new(
@@ -560,7 +559,7 @@ fn invalid_payloads_are_rejected_before_qdrant_conversion() {
 
 #[test]
 fn duplicate_points_are_rejected_before_qdrant_conversion() {
-    let spec = test_collection_spec(3);
+    let spec = test_collection_spec_hybrid(3);
     let document = test_prepared_document();
     let embeddings = test_embedding_result_for(&document, "text-embedding-test", 3);
     let mut batch = VectorPointBatchBuilder::new(

--- a/crates/axon-vectors/src/store_mode_tests.rs
+++ b/crates/axon-vectors/src/store_mode_tests.rs
@@ -7,8 +7,8 @@ use serde_json::json;
 use crate::point::VectorPointBatchBuilder;
 use crate::store::{FakeVectorMode, FakeVectorStore, VectorStore};
 use crate::testing::{
-    test_collection_spec, test_embedding_result_for, test_prepared_document,
-    test_vector_build_context,
+    test_collection_spec, test_collection_spec_hybrid, test_embedding_result_for,
+    test_prepared_document, test_vector_build_context,
 };
 
 fn batch() -> VectorPointBatch {
@@ -43,7 +43,7 @@ fn search() -> VectorSearchRequest {
 async fn fake_vector_store_can_simulate_partial_failure_and_slow_write() {
     let partial = FakeVectorStore::new("fake-vector").with_mode(FakeVectorMode::PartialFailure);
     partial
-        .ensure_collection(test_collection_spec(3))
+        .ensure_collection(test_collection_spec_hybrid(3))
         .await
         .unwrap();
     let err = partial.upsert(batch()).await.unwrap_err();
@@ -51,7 +51,7 @@ async fn fake_vector_store_can_simulate_partial_failure_and_slow_write() {
     assert_eq!(partial.search(search()).await.unwrap().results.len(), 1);
 
     let slow = FakeVectorStore::new("fake-vector").with_mode(FakeVectorMode::SlowWrite);
-    slow.ensure_collection(test_collection_spec(3))
+    slow.ensure_collection(test_collection_spec_hybrid(3))
         .await
         .unwrap();
     let written = slow.upsert(batch()).await.unwrap();
@@ -64,7 +64,7 @@ async fn fake_vector_store_invalid_payload_errors_do_not_echo_raw_discriminators
     let raw_visibility = "customer-alpha-supervalue-12345";
     let store = FakeVectorStore::new("fake-vector");
     store
-        .ensure_collection(test_collection_spec(3))
+        .ensure_collection(test_collection_spec_hybrid(3))
         .await
         .unwrap();
     let mut batch = batch();
@@ -82,7 +82,7 @@ async fn fake_vector_store_invalid_payload_errors_do_not_echo_raw_discriminators
 async fn url_delete_selector_matches_canonical_payload_fields() {
     let store = FakeVectorStore::new("fake-vector");
     store
-        .ensure_collection(test_collection_spec(3))
+        .ensure_collection(test_collection_spec_hybrid(3))
         .await
         .unwrap();
     let mut batch = batch();


### PR DESCRIPTION
## Summary
- use hybrid test collection specs where shared vector batches now include BM42 sparse vectors
- clear auto point sparse vectors in the batch-level sparse fallback test
- update point redaction tests to assert forbidden chunks are skipped, matching current builder behavior

## Verification
- cargo fmt --check
- cargo test -p axon-vectors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns axon-vectors tests with hybrid dense+sparse collections and current builder behavior. Tests now expect forbidden chunks to be skipped and verify batch-level sparse vector merging.

- **Bug Fixes**
  - Switch shared fixtures to hybrid specs so batches include BM42 sparse vectors.
  - Clear per-point sparse vectors in merge tests to validate batch-level sparse fallback.
  - Use hybrid specs across Qdrant and fake store tests; update redaction tests to expect skipped chunks.

<sup>Written for commit 87658b256329ab679f07fe19783c3aac21d6a060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch processing so invalid or forbidden content no longer stops the entire operation; allowed items continue to be processed.
  * Better handling for hybrid vector data during writes and updates, reducing failures in mixed-vector workflows.

* **Tests**
  * Updated coverage to reflect the new behavior and ensure batch and upsert flows keep working as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->