### PR TITLE
Phase 7 parser metadata graph gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,8 +874,10 @@ name = "axon-parse"
 version = "6.2.2"
 dependencies = [
  "axon-api",
+ "axon-graph",
  "chrono",
  "serde_json",
+ "serde_yaml",
  "uuid",
 ]
 
@@ -6631,6 +6633,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8503,6 +8518,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "async-trait",
  "axon-api",
  "axon-error",
+ "axon-vectors",
  "chrono",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "axon-api",
  "axon-core",
  "axon-crawl",
+ "axon-graph",
  "axon-ingest",
  "axon-llm",
  "base64",

--- a/crates/axon-document/src/chunk_router.rs
+++ b/crates/axon-document/src/chunk_router.rs
@@ -20,6 +20,12 @@ impl ChunkRouter {
         if is_api_schema(doc) {
             return Ok(ChunkingProfile::ApiSchema);
         }
+        if is_tool_output(doc) {
+            return Ok(ChunkingProfile::ToolOutput);
+        }
+        if is_env_example(doc) {
+            return Ok(ChunkingProfile::StructuredRecords);
+        }
         if is_manifest(doc) {
             return Ok(ChunkingProfile::CodeManifest);
         }
@@ -112,15 +118,39 @@ fn is_manifest(doc: &SourceDocument) -> bool {
                     | "Dockerfile"
                     | "docker-compose.yml"
                     | "docker-compose.yaml"
-                    | ".env.example"
                     | "Chart.yaml"
                     | "values.yaml"
                     | "kustomization.yaml"
                     | "kustomization.yml"
             ) || filename.ends_with(".tf")
                 || filename.ends_with(".tfvars")
-                || filename.ends_with(".env.example")
         })
+}
+
+fn is_env_example(doc: &SourceDocument) -> bool {
+    doc.path
+        .as_deref()
+        .or_else(|| doc.canonical_uri.rsplit('/').next())
+        .is_some_and(|path| {
+            let filename = path.rsplit('/').next().unwrap_or(path);
+            matches!(
+                filename,
+                ".env.example"
+                    | ".env.sample"
+                    | ".env.template"
+                    | "example.env"
+                    | "env.example"
+                    | "env.sample"
+                    | "env.template"
+            ) || filename.ends_with(".env.example")
+        })
+}
+
+fn is_tool_output(doc: &SourceDocument) -> bool {
+    doc.path
+        .as_deref()
+        .or_else(|| doc.canonical_uri.rsplit('/').next())
+        .is_some_and(|path| path.rsplit('/').next().unwrap_or(path) == "tool-output.jsonl")
 }
 
 fn is_api_schema(doc: &SourceDocument) -> bool {

--- a/crates/axon-document/src/chunk_router.rs
+++ b/crates/axon-document/src/chunk_router.rs
@@ -23,6 +23,9 @@ impl ChunkRouter {
         if is_tool_output(doc) {
             return Ok(ChunkingProfile::ToolOutput);
         }
+        if is_session_turns(doc) {
+            return Ok(ChunkingProfile::SessionTurns);
+        }
         if is_env_example(doc) {
             return Ok(ChunkingProfile::StructuredRecords);
         }
@@ -151,6 +154,13 @@ fn is_tool_output(doc: &SourceDocument) -> bool {
         .as_deref()
         .or_else(|| doc.canonical_uri.rsplit('/').next())
         .is_some_and(|path| path.rsplit('/').next().unwrap_or(path) == "tool-output.jsonl")
+}
+
+fn is_session_turns(doc: &SourceDocument) -> bool {
+    doc.path
+        .as_deref()
+        .or_else(|| doc.canonical_uri.rsplit('/').next())
+        .is_some_and(|path| path.rsplit('/').next().unwrap_or(path) == "session.jsonl")
 }
 
 fn is_api_schema(doc: &SourceDocument) -> bool {

--- a/crates/axon-document/src/chunk_router_tests.rs
+++ b/crates/axon-document/src/chunk_router_tests.rs
@@ -110,6 +110,61 @@ fn router_selects_phase_7_parser_profiles_by_path() {
 }
 
 #[test]
+fn chunk_profile_completeness_covers_required_profiles() {
+    let cases = [
+        (
+            source_doc(ContentKind::Code, "pub fn run() {}\n").with_path("src/lib.rs"),
+            ChunkingProfile::CodeSymbol,
+        ),
+        (
+            source_doc(ContentKind::PlainText, "FROM alpine\n").with_path("Dockerfile"),
+            ChunkingProfile::CodeManifest,
+        ),
+        (
+            source_doc(ContentKind::Markdown, "# Heading\n"),
+            ChunkingProfile::MarkdownSections,
+        ),
+        (
+            source_doc(ContentKind::Html, "<article>Body</article>"),
+            ChunkingProfile::HtmlArticle,
+        ),
+        (
+            source_doc(ContentKind::PlainText, "plain text"),
+            ChunkingProfile::PlainTextWindows,
+        ),
+        (
+            source_doc(ContentKind::Transcript, "user: hi"),
+            ChunkingProfile::TranscriptSegments,
+        ),
+        (
+            source_doc(ContentKind::PlainText, "PORT=3000").with_path(".env.example"),
+            ChunkingProfile::StructuredRecords,
+        ),
+        (
+            source_doc(ContentKind::Yaml, "openapi: 3.1.0").with_path("openapi.yaml"),
+            ChunkingProfile::ApiSchema,
+        ),
+        (
+            source_doc(ContentKind::PlainText, r#"{"tool":"shell"}"#)
+                .with_path("tool-output.jsonl"),
+            ChunkingProfile::ToolOutput,
+        ),
+        (
+            source_doc(ContentKind::PlainText, r#"{"role":"user"}"#).with_path("session.jsonl"),
+            ChunkingProfile::SessionTurns,
+        ),
+        (
+            source_doc(ContentKind::BinaryMetadata, "meta"),
+            ChunkingProfile::AtomicMetadata,
+        ),
+    ];
+
+    for (doc, expected) in cases {
+        assert_eq!(ChunkRouter::default().route(&doc).unwrap(), expected);
+    }
+}
+
+#[test]
 fn router_ignores_generic_profile_metadata() {
     let mut doc = source_doc(ContentKind::PlainText, "release profile text");
     doc.metadata = metadata([("profile", json!("production"))]);

--- a/crates/axon-document/src/chunk_router_tests.rs
+++ b/crates/axon-document/src/chunk_router_tests.rs
@@ -93,6 +93,23 @@ fn router_selects_profile_from_document_shape_when_no_override_exists() {
 }
 
 #[test]
+fn router_selects_phase_7_parser_profiles_by_path() {
+    assert_eq!(route_for_path("Dockerfile"), ChunkingProfile::CodeManifest);
+    assert_eq!(
+        route_for_path("docker-compose.yml"),
+        ChunkingProfile::CodeManifest
+    );
+    assert_eq!(
+        route_for_path(".env.example"),
+        ChunkingProfile::StructuredRecords
+    );
+    assert_eq!(
+        route_for_path("tool-output.jsonl"),
+        ChunkingProfile::ToolOutput
+    );
+}
+
+#[test]
 fn router_ignores_generic_profile_metadata() {
     let mut doc = source_doc(ContentKind::PlainText, "release profile text");
     doc.metadata = metadata([("profile", json!("production"))]);
@@ -118,6 +135,8 @@ fn router_recognizes_common_manifest_and_config_files() {
         let doc = source_doc(ContentKind::PlainText, "name=value").with_path(path);
         let expected = if matches!(path, "openapi.yaml" | "schema.graphql" | "service.proto") {
             ChunkingProfile::ApiSchema
+        } else if matches!(path, ".env.example") {
+            ChunkingProfile::StructuredRecords
         } else {
             ChunkingProfile::CodeManifest
         };
@@ -169,4 +188,10 @@ fn metadata(entries: impl IntoIterator<Item = (&'static str, serde_json::Value)>
         map.insert(key.to_string(), value);
     }
     map
+}
+
+fn route_for_path(path: &str) -> ChunkingProfile {
+    ChunkRouter::default()
+        .route(&source_doc(ContentKind::PlainText, "body").with_path(path))
+        .unwrap()
 }

--- a/crates/axon-document/src/lib.rs
+++ b/crates/axon-document/src/lib.rs
@@ -14,6 +14,7 @@ pub mod preparer;
 pub mod profile;
 pub mod schema;
 pub mod session;
+pub mod source_range;
 pub mod testing;
 pub mod text;
 pub mod transcript;

--- a/crates/axon-document/src/preparer.rs
+++ b/crates/axon-document/src/preparer.rs
@@ -1,10 +1,8 @@
 //! Source document preparation entry point.
 
-use std::collections::HashSet;
-
 use axon_api::source::{
     ChunkId, ChunkLocator, CleanupKey, ContentRef, MetadataMap, PreparedChunk, PreparedDocument,
-    Severity, SourceItemKey, SourceRange, SourceWarning,
+    Severity, SourceItemKey, SourceWarning,
 };
 
 use crate::chunk::DocumentChunk;
@@ -12,8 +10,15 @@ use crate::chunk_router::ChunkRouter;
 use crate::parse::{DocumentParse, parse_document};
 use crate::prepared::{PrepareSourceDocumentRequest, PrepareSourceDocumentResult};
 use crate::profile::ChunkingProfile;
-use crate::source_range::{SourceRangeBounds, bounds_for_text, validate_source_range};
+use crate::source_range::bounds_for_text;
 use crate::{code, markdown, metadata, schema, session, text, transcript};
+
+mod validation;
+#[cfg(test)]
+pub(crate) use validation::validate_prepared_document;
+#[cfg(test)]
+pub(crate) use validation::validate_prepared_document_ranges_against_bounds;
+use validation::validate_prepared_document_with_bounds;
 
 #[derive(Debug, Default, Clone)]
 pub struct DocumentPreparer {
@@ -59,19 +64,7 @@ impl DocumentPreparer {
         let mut warnings = request.warnings;
         warnings.extend(content.warnings);
         warnings.extend(build.warnings);
-        let mut document_metadata = request.document.metadata;
-        document_metadata.insert(
-            "normalized_line_count".to_string(),
-            serde_json::json!(bounds.line_count),
-        );
-        document_metadata.insert(
-            "normalized_byte_len".to_string(),
-            serde_json::json!(bounds.byte_len),
-        );
-        document_metadata.insert(
-            "normalized_char_count".to_string(),
-            serde_json::json!(bounds.char_count),
-        );
+        let document_metadata = request.document.metadata;
         let document = PreparedDocument {
             document_id: request.document.document_id,
             source_id: request.document.source_id,
@@ -90,7 +83,7 @@ impl DocumentPreparer {
             warnings,
             errors: request.errors,
         };
-        validate_prepared_document(&document)?;
+        validate_prepared_document_with_bounds(&document, &bounds, &content.text)?;
         Ok(PrepareSourceDocumentResult { document })
     }
 }
@@ -346,85 +339,6 @@ fn build_prepared_chunk(
         metadata,
         content: chunk.content,
     }
-}
-
-pub(crate) fn validate_prepared_document(document: &PreparedDocument) -> Result<(), String> {
-    let mut errors = Vec::new();
-    let mut chunk_ids = HashSet::new();
-    let mut chunk_keys = HashSet::new();
-
-    if document.chunks.is_empty() {
-        errors.push("prepared document has no chunks".to_string());
-    }
-
-    for chunk in &document.chunks {
-        if !chunk_ids.insert(chunk.chunk_id.clone()) {
-            errors.push(format!("duplicate chunk id: {}", chunk.chunk_id.0));
-        }
-        if !chunk_keys.insert(chunk.chunk_key.clone()) {
-            errors.push(format!("duplicate chunk key: {}", chunk.chunk_key));
-        }
-        if chunk.content.trim().is_empty() {
-            errors.push(format!("empty content after trim: {}", chunk.chunk_id.0));
-        }
-        range_errors("source_range", &chunk.source_range, &mut errors);
-        range_errors("locator range", &chunk.chunk_locator.range, &mut errors);
-    }
-    if let Err(error) = validate_prepared_document_ranges(document) {
-        errors.push(error);
-    }
-
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(errors.join("; "))
-    }
-}
-
-pub(crate) fn validate_prepared_document_ranges(document: &PreparedDocument) -> Result<(), String> {
-    let Some(bounds) = document_bounds(document) else {
-        return Ok(());
-    };
-    for chunk in &document.chunks {
-        validate_source_range(&chunk.source_range, &bounds)
-            .map_err(|error| format!("chunk {} source_range {error}", chunk.chunk_id.0))?;
-        validate_source_range(&chunk.chunk_locator.range, &bounds)
-            .map_err(|error| format!("chunk {} locator range {error}", chunk.chunk_id.0))?;
-    }
-    for fact in &document.parse_facts {
-        if let Some(range) = &fact.range {
-            validate_source_range(range, &bounds)
-                .map_err(|error| format!("parse fact {} range {error}", fact.name))?;
-        }
-    }
-    Ok(())
-}
-
-fn document_bounds(document: &PreparedDocument) -> Option<SourceRangeBounds> {
-    Some(SourceRangeBounds {
-        line_count: document.metadata.get("normalized_line_count")?.as_u64()? as u32,
-        byte_len: document.metadata.get("normalized_byte_len")?.as_u64()?,
-        char_count: document.metadata.get("normalized_char_count")?.as_u64()?,
-    })
-}
-
-fn range_errors(label: &str, range: &SourceRange, errors: &mut Vec<String>) {
-    if starts_after(range.line_start, range.line_end) {
-        errors.push(format!("{label} line_start > line_end"));
-    }
-    if starts_after(range.byte_start, range.byte_end) {
-        errors.push(format!("{label} byte_start > byte_end"));
-    }
-    if starts_after(range.char_start, range.char_end) {
-        errors.push(format!("{label} char_start > char_end"));
-    }
-    if starts_after(range.time_start_ms, range.time_end_ms) {
-        errors.push(format!("{label} time_start_ms > time_end_ms"));
-    }
-}
-
-fn starts_after<T: Ord>(start: Option<T>, end: Option<T>) -> bool {
-    start.zip(end).is_some_and(|(start, end)| start > end)
 }
 
 fn merge_metadata(doc: &MetadataMap, mut chunk: MetadataMap) -> MetadataMap {

--- a/crates/axon-document/src/preparer.rs
+++ b/crates/axon-document/src/preparer.rs
@@ -12,6 +12,7 @@ use crate::chunk_router::ChunkRouter;
 use crate::parse::{DocumentParse, parse_document};
 use crate::prepared::{PrepareSourceDocumentRequest, PrepareSourceDocumentResult};
 use crate::profile::ChunkingProfile;
+use crate::source_range::{SourceRangeBounds, bounds_for_text, validate_source_range};
 use crate::{code, markdown, metadata, schema, session, text, transcript};
 
 #[derive(Debug, Default, Clone)]
@@ -43,6 +44,7 @@ impl DocumentPreparer {
                 .unwrap_or_else(|| self.router.route(&request.document))?,
         };
         let content = content_text(&request.document);
+        let bounds = bounds_for_text(&content.text);
         let effective_profile = content.force_profile.unwrap_or(profile);
         let build = build_chunks(
             effective_profile,
@@ -57,6 +59,19 @@ impl DocumentPreparer {
         let mut warnings = request.warnings;
         warnings.extend(content.warnings);
         warnings.extend(build.warnings);
+        let mut document_metadata = request.document.metadata;
+        document_metadata.insert(
+            "normalized_line_count".to_string(),
+            serde_json::json!(bounds.line_count),
+        );
+        document_metadata.insert(
+            "normalized_byte_len".to_string(),
+            serde_json::json!(bounds.byte_len),
+        );
+        document_metadata.insert(
+            "normalized_char_count".to_string(),
+            serde_json::json!(bounds.char_count),
+        );
         let document = PreparedDocument {
             document_id: request.document.document_id,
             source_id: request.document.source_id,
@@ -67,7 +82,7 @@ impl DocumentPreparer {
             chunking_profile: effective_profile.as_str().to_string(),
             chunking_method: effective_profile.as_str().to_string(),
             chunks: prepared_chunks,
-            metadata: request.document.metadata,
+            metadata: document_metadata,
             cleanup_keys: Vec::<CleanupKey>::new(),
             graph_refs: Vec::new(),
             parse_facts: request.parse_facts,
@@ -355,12 +370,42 @@ pub(crate) fn validate_prepared_document(document: &PreparedDocument) -> Result<
         range_errors("source_range", &chunk.source_range, &mut errors);
         range_errors("locator range", &chunk.chunk_locator.range, &mut errors);
     }
+    if let Err(error) = validate_prepared_document_ranges(document) {
+        errors.push(error);
+    }
 
     if errors.is_empty() {
         Ok(())
     } else {
         Err(errors.join("; "))
     }
+}
+
+pub(crate) fn validate_prepared_document_ranges(document: &PreparedDocument) -> Result<(), String> {
+    let Some(bounds) = document_bounds(document) else {
+        return Ok(());
+    };
+    for chunk in &document.chunks {
+        validate_source_range(&chunk.source_range, &bounds)
+            .map_err(|error| format!("chunk {} source_range {error}", chunk.chunk_id.0))?;
+        validate_source_range(&chunk.chunk_locator.range, &bounds)
+            .map_err(|error| format!("chunk {} locator range {error}", chunk.chunk_id.0))?;
+    }
+    for fact in &document.parse_facts {
+        if let Some(range) = &fact.range {
+            validate_source_range(range, &bounds)
+                .map_err(|error| format!("parse fact {} range {error}", fact.name))?;
+        }
+    }
+    Ok(())
+}
+
+fn document_bounds(document: &PreparedDocument) -> Option<SourceRangeBounds> {
+    Some(SourceRangeBounds {
+        line_count: document.metadata.get("normalized_line_count")?.as_u64()? as u32,
+        byte_len: document.metadata.get("normalized_byte_len")?.as_u64()?,
+        char_count: document.metadata.get("normalized_char_count")?.as_u64()?,
+    })
 }
 
 fn range_errors(label: &str, range: &SourceRange, errors: &mut Vec<String>) {

--- a/crates/axon-document/src/preparer/validation.rs
+++ b/crates/axon-document/src/preparer/validation.rs
@@ -1,0 +1,167 @@
+use std::collections::HashSet;
+
+use axon_api::source::{PreparedDocument, SourceRange};
+
+use crate::source_range::{SourceRangeBounds, validate_source_range};
+
+#[cfg(test)]
+pub(crate) fn validate_prepared_document(document: &PreparedDocument) -> Result<(), String> {
+    validate_prepared_document_inner(document, None, None)
+}
+
+pub(crate) fn validate_prepared_document_with_bounds(
+    document: &PreparedDocument,
+    bounds: &SourceRangeBounds,
+    source_text: &str,
+) -> Result<(), String> {
+    validate_prepared_document_inner(document, Some(bounds), Some(source_text))
+}
+
+fn validate_prepared_document_inner(
+    document: &PreparedDocument,
+    bounds: Option<&SourceRangeBounds>,
+    source_text: Option<&str>,
+) -> Result<(), String> {
+    let mut errors = Vec::new();
+    let mut chunk_ids = HashSet::new();
+    let mut chunk_keys = HashSet::new();
+
+    if document.chunks.is_empty() {
+        errors.push("prepared document has no chunks".to_string());
+    }
+
+    for chunk in &document.chunks {
+        if !chunk_ids.insert(chunk.chunk_id.clone()) {
+            errors.push(format!("duplicate chunk id: {}", chunk.chunk_id.0));
+        }
+        if !chunk_keys.insert(chunk.chunk_key.clone()) {
+            errors.push(format!("duplicate chunk key: {}", chunk.chunk_key));
+        }
+        if chunk.content.trim().is_empty() {
+            errors.push(format!("empty content after trim: {}", chunk.chunk_id.0));
+        }
+        range_errors("source_range", &chunk.source_range, &mut errors);
+        range_errors("locator range", &chunk.chunk_locator.range, &mut errors);
+    }
+    let range_result = if let Some(bounds) = bounds {
+        validate_prepared_document_ranges_against_bounds(document, bounds, source_text)
+    } else {
+        validate_prepared_document_ranges(document)
+    };
+    if let Err(error) = range_result {
+        errors.push(error);
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
+fn validate_prepared_document_ranges(document: &PreparedDocument) -> Result<(), String> {
+    let Some(bounds) = document_bounds(document) else {
+        return Ok(());
+    };
+    validate_prepared_document_ranges_against_bounds(document, &bounds, None)
+}
+
+pub(crate) fn validate_prepared_document_ranges_against_bounds(
+    document: &PreparedDocument,
+    bounds: &SourceRangeBounds,
+    source_text: Option<&str>,
+) -> Result<(), String> {
+    for chunk in &document.chunks {
+        validate_source_range(&chunk.source_range, bounds)
+            .map_err(|error| format!("chunk {} source_range {error}", chunk.chunk_id.0))?;
+        validate_source_range(&chunk.chunk_locator.range, bounds)
+            .map_err(|error| format!("chunk {} locator range {error}", chunk.chunk_id.0))?;
+    }
+    for fact in &document.parse_facts {
+        if let Some(range) = &fact.range {
+            validate_source_range(range, bounds)
+                .map_err(|error| format!("parse fact {} range {error}", fact.name))?;
+        }
+    }
+    for candidate in &document.graph_candidates {
+        validate_graph_candidate_ranges(candidate, bounds, source_text)?;
+    }
+    Ok(())
+}
+
+fn validate_graph_candidate_ranges(
+    candidate: &axon_api::source::GraphCandidate,
+    bounds: &SourceRangeBounds,
+    source_text: Option<&str>,
+) -> Result<(), String> {
+    for evidence in &candidate.evidence {
+        if let Some(range) = &evidence.range {
+            validate_source_range(range, bounds).map_err(|error| {
+                format!(
+                    "graph candidate {} evidence {} range {error}",
+                    candidate.candidate_id, evidence.evidence_id
+                )
+            })?;
+            if let (Some(source_text), Some(quote)) = (source_text, evidence.quote.as_deref())
+                && should_validate_quote(quote)
+                && let Some(slice) = line_slice_for_range(source_text, range)
+                && !slice.contains(quote)
+            {
+                return Err(format!(
+                    "graph candidate {} evidence {} quote outside source range",
+                    candidate.candidate_id, evidence.evidence_id
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn should_validate_quote(quote: &str) -> bool {
+    let trimmed = quote.trim();
+    !trimmed.is_empty() && !trimmed.to_ascii_lowercase().contains("redacted")
+}
+
+fn line_slice_for_range(text: &str, range: &SourceRange) -> Option<String> {
+    let start = range.line_start? as usize;
+    let end = range.line_end.unwrap_or(start as u32) as usize;
+    if start == 0 || end < start {
+        return None;
+    }
+    let lines = text
+        .lines()
+        .enumerate()
+        .filter_map(|(idx, line)| {
+            let line_no = idx + 1;
+            (line_no >= start && line_no <= end).then_some(line)
+        })
+        .collect::<Vec<_>>();
+    (!lines.is_empty()).then(|| lines.join("\n"))
+}
+
+fn document_bounds(document: &PreparedDocument) -> Option<SourceRangeBounds> {
+    Some(SourceRangeBounds {
+        line_count: document.metadata.get("normalized_line_count")?.as_u64()? as u32,
+        byte_len: document.metadata.get("normalized_byte_len")?.as_u64()?,
+        char_count: document.metadata.get("normalized_char_count")?.as_u64()?,
+    })
+}
+
+fn range_errors(label: &str, range: &SourceRange, errors: &mut Vec<String>) {
+    if starts_after(range.line_start, range.line_end) {
+        errors.push(format!("{label} line_start > line_end"));
+    }
+    if starts_after(range.byte_start, range.byte_end) {
+        errors.push(format!("{label} byte_start > byte_end"));
+    }
+    if starts_after(range.char_start, range.char_end) {
+        errors.push(format!("{label} char_start > char_end"));
+    }
+    if starts_after(range.time_start_ms, range.time_end_ms) {
+        errors.push(format!("{label} time_start_ms > time_end_ms"));
+    }
+}
+
+fn starts_after<T: Ord>(start: Option<T>, end: Option<T>) -> bool {
+    start.zip(end).is_some_and(|(start, end)| start > end)
+}

--- a/crates/axon-document/src/preparer_tests.rs
+++ b/crates/axon-document/src/preparer_tests.rs
@@ -6,7 +6,8 @@ use axon_api::source::{
 
 use crate::{
     ChunkingProfile, DocumentPreparer, PrepareSourceDocumentRequest,
-    preparer::validate_prepared_document, testing::RecordingPreparer,
+    preparer::{validate_prepared_document, validate_prepared_document_ranges},
+    testing::RecordingPreparer,
 };
 
 #[test]
@@ -125,6 +126,26 @@ fn validate_prepared_document_rejects_impossible_ranges_and_empty_content() {
     assert!(error.contains("empty content"));
     assert!(error.contains("source_range byte_start > byte_end"));
     assert!(error.contains("locator range line_start > line_end"));
+}
+
+#[test]
+fn preparer_degrades_chunk_and_parse_fact_ranges_outside_normalized_document() {
+    let prepared = DocumentPreparer::default()
+        .prepare(request(
+            ContentKind::PlainText,
+            "PORT=3000\n",
+            "gen-bounds",
+            ChunkingProfile::PlainTextWindows,
+        ))
+        .unwrap()
+        .document;
+    let mut invalid = prepared;
+    invalid.chunks[0].source_range.line_start = Some(9000);
+    invalid.chunks[0].source_range.line_end = Some(9001);
+
+    let err = validate_prepared_document_ranges(&invalid)
+        .expect_err("range outside normalized document rejected");
+    assert!(err.contains("outside normalized document"));
 }
 
 #[test]

--- a/crates/axon-document/src/preparer_tests.rs
+++ b/crates/axon-document/src/preparer_tests.rs
@@ -1,12 +1,13 @@
 use axon_api::source::{
     ChunkId, ContentKind, ContentRef, DocumentId, GraphCandidate, GraphCandidateProducer,
-    MetadataMap, Severity, SourceDocument, SourceError, SourceGenerationId, SourceId,
-    SourceItemKey, SourceParseFacts, SourceWarning,
+    GraphEvidence, MetadataMap, Severity, SourceDocument, SourceError, SourceGenerationId,
+    SourceId, SourceItemKey, SourceParseFacts, SourceRange, SourceWarning,
 };
 
 use crate::{
     ChunkingProfile, DocumentPreparer, PrepareSourceDocumentRequest,
-    preparer::{validate_prepared_document, validate_prepared_document_ranges},
+    preparer::{validate_prepared_document, validate_prepared_document_ranges_against_bounds},
+    source_range::bounds_for_text,
     testing::RecordingPreparer,
 };
 
@@ -143,9 +144,80 @@ fn preparer_degrades_chunk_and_parse_fact_ranges_outside_normalized_document() {
     invalid.chunks[0].source_range.line_start = Some(9000);
     invalid.chunks[0].source_range.line_end = Some(9001);
 
-    let err = validate_prepared_document_ranges(&invalid)
-        .expect_err("range outside normalized document rejected");
+    let bounds = bounds_for_text("PORT=3000\n");
+    let err =
+        validate_prepared_document_ranges_against_bounds(&invalid, &bounds, Some("PORT=3000\n"))
+            .expect_err("range outside normalized document rejected");
     assert!(err.contains("outside normalized document"));
+}
+
+#[test]
+fn preparer_rejects_graph_evidence_ranges_outside_normalized_document() {
+    let source_text = "FROM alpine:3\n";
+    let prepared = DocumentPreparer::default()
+        .prepare(request(
+            ContentKind::PlainText,
+            source_text,
+            "gen-graph-bounds",
+            ChunkingProfile::PlainTextWindows,
+        ))
+        .unwrap()
+        .document;
+    let mut invalid = prepared;
+    invalid.graph_candidates.push(GraphCandidate {
+        candidate_id: "cand-graph-range".to_string(),
+        job_id: serde_json::from_str("\"00000000-0000-0000-0000-000000000001\"").unwrap(),
+        source_id: SourceId::from("src-test"),
+        source_item_key: SourceItemKey::from("item-test"),
+        item_canonical_uri: "file:///test.md".to_string(),
+        document_id: Some(DocumentId::from("doc-test")),
+        kind: "container_manifest".to_string(),
+        merge_key: None,
+        producer: GraphCandidateProducer {
+            adapter: "axon-parse".to_string(),
+            parser: Some("docker_manifest".to_string()),
+            version: "test".to_string(),
+        },
+        nodes: Vec::new(),
+        edges: Vec::new(),
+        evidence: vec![GraphEvidence {
+            evidence_id: "ev-out-of-range".to_string(),
+            evidence_kind: "container_manifest".to_string(),
+            source_id: SourceId::from("src-test"),
+            source_item_key: SourceItemKey::from("item-test"),
+            document_id: Some(DocumentId::from("doc-test")),
+            chunk_id: None,
+            range: Some(SourceRange {
+                line_start: Some(2),
+                line_end: Some(2),
+                byte_start: None,
+                byte_end: None,
+                char_start: None,
+                char_end: None,
+                time_start_ms: None,
+                time_end_ms: None,
+                dom_selector: None,
+                json_pointer: None,
+                yaml_path: None,
+                xml_xpath: None,
+                csv_row: None,
+                session_turn_id: None,
+                turn_start: None,
+                turn_end: None,
+            }),
+            quote: Some("FROM alpine:3".to_string()),
+            confidence: 0.9,
+            metadata: MetadataMap::new(),
+        }],
+        confidence: 0.9,
+        metadata: MetadataMap::new(),
+    });
+
+    let bounds = bounds_for_text(source_text);
+    let err =
+        validate_prepared_document_ranges_against_bounds(&invalid, &bounds, Some(source_text))
+            .expect_err("graph evidence range outside normalized document rejected");
+    assert!(err.contains("graph candidate cand-graph-range evidence ev-out-of-range range"));
 }
 
 #[test]

--- a/crates/axon-document/src/source_range.rs
+++ b/crates/axon-document/src/source_range.rs
@@ -1,0 +1,38 @@
+use axon_api::source::SourceRange;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceRangeBounds {
+    pub line_count: u32,
+    pub byte_len: u64,
+    pub char_count: u64,
+}
+
+pub fn bounds_for_text(text: &str) -> SourceRangeBounds {
+    SourceRangeBounds {
+        line_count: text.lines().count().max(1) as u32,
+        byte_len: text.len() as u64,
+        char_count: text.chars().count() as u64,
+    }
+}
+
+pub fn validate_source_range(
+    range: &SourceRange,
+    bounds: &SourceRangeBounds,
+) -> Result<(), String> {
+    if let (Some(start), Some(end)) = (range.line_start, range.line_end)
+        && (start > end || end > bounds.line_count)
+    {
+        return Err("invalid source range outside normalized document".to_string());
+    }
+    if let (Some(start), Some(end)) = (range.byte_start, range.byte_end)
+        && (start > end || end > bounds.byte_len)
+    {
+        return Err("invalid source range outside normalized document".to_string());
+    }
+    if let (Some(start), Some(end)) = (range.char_start, range.char_end)
+        && (start > end || end > bounds.char_count)
+    {
+        return Err("invalid source range outside normalized document".to_string());
+    }
+    Ok(())
+}

--- a/crates/axon-extract/Cargo.toml
+++ b/crates/axon-extract/Cargo.toml
@@ -47,6 +47,7 @@ module_inception = "allow"              # src/crawl.rs: acceptable module name
 test-util = []
 
 [dev-dependencies]
+axon-graph = { path = "../axon-graph" }
 axon-core = { path = "../axon-core", features = ["test-util"] }
 httpmock = "0.8"
 serial_test = "3"

--- a/crates/axon-extract/src/lib.rs
+++ b/crates/axon-extract/src/lib.rs
@@ -38,3 +38,7 @@ pub use context::VerticalContext;
 pub use error::VerticalError;
 pub use registry::{dispatch_by_name, dispatch_by_url, list as list_extractors};
 pub use types::{ExtractorInfo, ScrapedDoc};
+
+#[cfg(test)]
+#[path = "vertical_parse_facts_tests.rs"]
+mod vertical_parse_facts_tests;

--- a/crates/axon-extract/src/types.rs
+++ b/crates/axon-extract/src/types.rs
@@ -1,5 +1,10 @@
 //! Shared types returned by vertical extractors.
 
+use axon_api::source::{
+    DocumentId, GraphCandidate, GraphCandidateProducer, GraphEdgeCandidate, GraphEvidence,
+    GraphNodeCandidate, JobId, MetadataMap, SourceId, SourceItemKey, SourceParseFacts,
+};
+
 /// Output of a successful vertical extraction.
 ///
 /// Carries enough information to build a `PreparedDoc` for embedding.
@@ -25,6 +30,131 @@ pub struct ScrapedDoc {
     /// Keys must follow the prefix convention: `pkg_*`, `git_*`, `hf_*`, etc.
     /// Absent beats null — only set keys that have actual values.
     pub extra: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct VerticalParseArtifacts {
+    pub facts: Vec<SourceParseFacts>,
+    pub graph_candidates: Vec<GraphCandidate>,
+}
+
+impl ScrapedDoc {
+    pub fn parse_artifacts(
+        &self,
+        job_id: JobId,
+        source_id: SourceId,
+        document_id: DocumentId,
+        source_item_key: SourceItemKey,
+    ) -> VerticalParseArtifacts {
+        let mut artifacts = VerticalParseArtifacts::default();
+        if self.extractor_name == "github_repo"
+            && let Some((owner, repo)) = github_repo_parts(&self.url)
+        {
+            let full_name = format!("{owner}/{repo}");
+            artifacts.facts.push(SourceParseFacts {
+                document_id: document_id.clone(),
+                source_item_key: source_item_key.clone(),
+                fact_kind: "repository".to_string(),
+                name: full_name.clone(),
+                value: serde_json::json!({
+                    "git_provider": "github",
+                    "git_owner": owner,
+                    "git_repo": repo,
+                    "vertical": self.extractor_name,
+                }),
+                parser_id: "vertical_github_repo".to_string(),
+                parser_version: self.extractor_version.to_string(),
+                parser_method: "vertical_metadata".to_string(),
+                range: None,
+                confidence: 0.95,
+                metadata: MetadataMap::new(),
+            });
+            artifacts.graph_candidates.push(github_repo_candidate(
+                self,
+                job_id,
+                source_id,
+                document_id,
+                source_item_key,
+                &owner,
+                &repo,
+            ));
+        }
+        artifacts
+    }
+}
+
+fn github_repo_parts(url: &str) -> Option<(String, String)> {
+    let parsed = url::Url::parse(url).ok()?;
+    if parsed.host_str()? != "github.com" {
+        return None;
+    }
+    let mut segments = parsed
+        .path_segments()?
+        .filter(|segment| !segment.is_empty());
+    let owner = segments.next()?.to_string();
+    let repo = segments.next()?.to_string();
+    segments.next().is_none().then_some((owner, repo))
+}
+
+fn github_repo_candidate(
+    doc: &ScrapedDoc,
+    job_id: JobId,
+    source_id: SourceId,
+    document_id: DocumentId,
+    source_item_key: SourceItemKey,
+    owner: &str,
+    repo: &str,
+) -> GraphCandidate {
+    let repo_key = format!("repo:github.com/{owner}/{repo}");
+    GraphCandidate {
+        candidate_id: format!("cand_vertical_github_repo_{owner}_{repo}"),
+        job_id,
+        source_id: source_id.clone(),
+        source_item_key: source_item_key.clone(),
+        item_canonical_uri: doc.url.clone(),
+        document_id: Some(document_id.clone()),
+        kind: "github_repo_metadata".to_string(),
+        merge_key: Some(format!("github_repo:github.com/{owner}/{repo}")),
+        producer: GraphCandidateProducer {
+            adapter: "axon-extract".to_string(),
+            parser: Some("vertical_github_repo".to_string()),
+            version: doc.extractor_version.to_string(),
+        },
+        nodes: vec![
+            GraphNodeCandidate {
+                node_kind: "web_page".to_string(),
+                stable_key: doc.url.clone(),
+                label: doc.title.clone().unwrap_or_else(|| doc.url.clone()),
+                properties: MetadataMap::new(),
+            },
+            GraphNodeCandidate {
+                node_kind: "repo".to_string(),
+                stable_key: repo_key.clone(),
+                label: format!("{owner}/{repo}"),
+                properties: MetadataMap::new(),
+            },
+        ],
+        edges: vec![GraphEdgeCandidate {
+            edge_kind: "official_for".to_string(),
+            from_stable_key: doc.url.clone(),
+            to_stable_key: repo_key,
+            properties: MetadataMap::new(),
+        }],
+        evidence: vec![GraphEvidence {
+            evidence_id: format!("ev_vertical_github_repo_{owner}_{repo}"),
+            evidence_kind: "github_homepage".to_string(),
+            source_id,
+            source_item_key,
+            document_id: Some(document_id),
+            chunk_id: None,
+            range: None,
+            quote: Some(doc.url.clone()),
+            confidence: 0.95,
+            metadata: MetadataMap::new(),
+        }],
+        confidence: 0.95,
+        metadata: MetadataMap::new(),
+    }
 }
 
 /// Catalog entry for one registered vertical extractor.

--- a/crates/axon-extract/src/vertical_parse_facts_tests.rs
+++ b/crates/axon-extract/src/vertical_parse_facts_tests.rs
@@ -1,0 +1,40 @@
+use axon_api::source::{DocumentId, JobId, SourceId, SourceItemKey};
+
+use crate::ScrapedDoc;
+
+#[test]
+fn github_repo_vertical_derives_parse_facts_and_graph_candidates() {
+    let doc = ScrapedDoc {
+        url: "https://github.com/jmagar/axon".to_string(),
+        markdown: "# jmagar/axon".to_string(),
+        title: Some("jmagar/axon".to_string()),
+        extractor_name: "github_repo",
+        extractor_version: 2,
+        structured: Some(serde_json::json!({ "full_name": "jmagar/axon" })),
+        follow_crawl_urls: Vec::new(),
+        extra: Some(serde_json::json!({
+            "git_provider": "github",
+            "git_owner": "jmagar",
+            "git_repo": "axon"
+        })),
+    };
+
+    let artifacts = doc.parse_artifacts(
+        serde_json::from_str::<JobId>("\"00000000-0000-0000-0000-00000000000a\"").unwrap(),
+        SourceId::from("src_github"),
+        DocumentId::from("doc_github"),
+        SourceItemKey::from("https://github.com/jmagar/axon"),
+    );
+
+    assert!(artifacts.facts.iter().any(|fact| {
+        fact.fact_kind == "repository"
+            && fact.name == "jmagar/axon"
+            && fact.parser_id == "vertical_github_repo"
+    }));
+    assert!(
+        artifacts
+            .graph_candidates
+            .iter()
+            .all(|candidate| axon_graph::candidate::validate_candidate(candidate).is_ok())
+    );
+}

--- a/crates/axon-extract/src/vertical_parse_facts_tests.rs
+++ b/crates/axon-extract/src/vertical_parse_facts_tests.rs
@@ -31,6 +31,13 @@ fn github_repo_vertical_derives_parse_facts_and_graph_candidates() {
             && fact.name == "jmagar/axon"
             && fact.parser_id == "vertical_github_repo"
     }));
+    assert!(artifacts.graph_candidates.iter().any(|candidate| {
+        candidate.kind == "github_repo_metadata"
+            && candidate
+                .edges
+                .iter()
+                .any(|edge| edge.edge_kind == "official_for")
+    }));
     assert!(
         artifacts
             .graph_candidates

--- a/crates/axon-graph/Cargo.toml
+++ b/crates/axon-graph/Cargo.toml
@@ -18,4 +18,5 @@ tokio = { version = "1", features = ["macros", "rt", "sync"] }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 
 [dev-dependencies]
+axon-vectors = { path = "../axon-vectors" }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/axon-graph/src/candidate.rs
+++ b/crates/axon-graph/src/candidate.rs
@@ -11,7 +11,7 @@
 
 use std::str::FromStr;
 
-use axon_api::source::{ApiError, GraphCandidate};
+use axon_api::source::{ApiError, GraphCandidate, SourceRange};
 
 use crate::edge::GraphEdgeKind;
 use crate::error::graph_validation_error;
@@ -75,9 +75,34 @@ pub fn validate_candidate(candidate: &GraphCandidate) -> Result<(), ApiError> {
 
     for evidence in &candidate.evidence {
         EvidenceKind::from_str(&evidence.evidence_kind)?;
+        if let Some(range) = &evidence.range {
+            validate_range_order(range)?;
+        }
     }
 
     Ok(())
+}
+
+fn validate_range_order(range: &SourceRange) -> Result<(), ApiError> {
+    if starts_after(range.line_start, range.line_end)
+        || starts_after(range.byte_start, range.byte_end)
+        || starts_after(range.char_start, range.char_end)
+        || starts_after(range.time_start_ms, range.time_end_ms)
+        || range
+            .turn_start
+            .as_ref()
+            .zip(range.turn_end.as_ref())
+            .is_some_and(|(start, end)| start > end)
+    {
+        return Err(graph_validation_error(
+            "invalid source range on graph evidence",
+        ));
+    }
+    Ok(())
+}
+
+fn starts_after<T: Ord>(start: Option<T>, end: Option<T>) -> bool {
+    start.zip(end).is_some_and(|(start, end)| start > end)
 }
 
 #[cfg(test)]

--- a/crates/axon-graph/src/candidate.rs
+++ b/crates/axon-graph/src/candidate.rs
@@ -15,6 +15,7 @@ use axon_api::source::{ApiError, GraphCandidate};
 
 use crate::edge::GraphEdgeKind;
 use crate::error::graph_validation_error;
+use crate::evidence::EvidenceKind;
 use crate::node::GraphNodeKind;
 
 /// Validate a candidate against the closed kind registry and candidate rules.
@@ -70,6 +71,10 @@ pub fn validate_candidate(candidate: &GraphCandidate) -> Result<(), ApiError> {
             "candidate {:?} declares edges but carries no evidence",
             candidate.candidate_id
         )));
+    }
+
+    for evidence in &candidate.evidence {
+        EvidenceKind::from_str(&evidence.evidence_kind)?;
     }
 
     Ok(())

--- a/crates/axon-graph/src/candidate_tests.rs
+++ b/crates/axon-graph/src/candidate_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use axon_api::source::{
     GraphCandidate, GraphCandidateProducer, GraphEdgeCandidate, GraphEvidence, GraphNodeCandidate,
-    JobId, MetadataMap, SourceId, SourceItemKey,
+    JobId, MetadataMap, SourceId, SourceItemKey, SourceRange,
 };
 use uuid::Uuid;
 
@@ -96,6 +96,32 @@ fn candidate_validation_rejects_unknown_evidence_kind() {
         "{}",
         err.message
     );
+}
+
+#[test]
+fn candidate_validation_rejects_invalid_evidence_source_range() {
+    let mut c = base_candidate();
+    c.evidence[0].range = Some(SourceRange {
+        line_start: Some(10),
+        line_end: Some(3),
+        byte_start: None,
+        byte_end: None,
+        char_start: None,
+        char_end: None,
+        time_start_ms: None,
+        time_end_ms: None,
+        dom_selector: None,
+        json_pointer: None,
+        yaml_path: None,
+        xml_xpath: None,
+        csv_row: None,
+        session_turn_id: None,
+        turn_start: None,
+        turn_end: None,
+    });
+
+    let err = validate_candidate(&c).expect_err("invalid source range rejected");
+    assert!(err.message.contains("invalid source range"));
 }
 
 #[test]

--- a/crates/axon-graph/src/candidate_tests.rs
+++ b/crates/axon-graph/src/candidate_tests.rs
@@ -87,6 +87,18 @@ fn unknown_edge_kind_is_rejected() {
 }
 
 #[test]
+fn candidate_validation_rejects_unknown_evidence_kind() {
+    let mut c = base_candidate();
+    c.evidence[0].evidence_kind = "tool_result".to_string();
+    let err = validate_candidate(&c).unwrap_err();
+    assert!(
+        err.message.contains("unknown graph evidence kind"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
 fn edge_referencing_missing_stable_key_is_rejected() {
     let mut c = base_candidate();
     c.edges[0].to_stable_key = "pkg:not-in-candidate".to_string();

--- a/crates/axon-graph/src/fixture_tests.rs
+++ b/crates/axon-graph/src/fixture_tests.rs
@@ -1,0 +1,148 @@
+use axon_api::source::{
+    ChunkId, DocumentId, GraphCandidate, GraphCandidateProducer, GraphEdgeCandidate, GraphEvidence,
+    GraphNodeCandidate, JobId, MetadataMap, SourceId, SourceItemKey, SourceRange,
+};
+use axon_vectors::payload::VectorPayload;
+use uuid::Uuid;
+
+use crate::candidate::validate_candidate;
+
+#[test]
+fn ledger_vector_graph_fixture_shares_source_generation_lineage() {
+    let source_id = SourceId::from("src_local_repo");
+    let generation = "7";
+    let document_id = DocumentId::from("doc_Dockerfile");
+    let chunk_id = ChunkId::from("chunk_Dockerfile_1");
+    let job_id = JobId::new(Uuid::from_u128(7));
+
+    let vector_payload = VectorPayload::try_from_metadata(metadata(serde_json::json!({
+        "payload_contract_version": "2026-07-01",
+        "collection": "axon",
+        "vector_point_id": "point_1",
+        "vector_namespace": "source",
+        "source_family": "local",
+        "source_kind": "local",
+        "source_adapter": "local",
+        "source_scope": "repo",
+        "source_id": source_id.0,
+        "source_canonical_uri": "file:///repo",
+        "source_generation": generation,
+        "committed_generation": generation,
+        "source_item_key": "Dockerfile",
+        "item_canonical_uri": "file:///repo/Dockerfile",
+        "document_id": document_id.0,
+        "chunk_id": chunk_id.0,
+        "content_kind": "structured",
+        "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "chunk_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "chunk_text": "Dockerfile image qdrant/qdrant:v1.13.1 exposes 6333",
+        "chunk_locator": {
+            "canonical_uri": "file:///repo/Dockerfile",
+            "path": "Dockerfile",
+            "heading_path": [],
+            "symbol": null,
+            "range": { "line_start": 1, "line_end": 2 }
+        },
+        "source_range": { "line_start": 1, "line_end": 2 },
+        "redaction_status": "clean",
+        "visibility": "public",
+        "job_id": job_id.0.to_string(),
+        "document_status": "published",
+        "embedding_model": "fake",
+        "embedding_dimensions": 8,
+        "embedding_provider": "fake",
+        "embedding_profile": "test",
+        "embedded_at": "2026-07-04T00:00:00Z",
+        "local_checkout": "local://src_local_repo"
+    })))
+    .expect("vector payload validates through production validator");
+
+    assert_eq!(vector_payload.metadata()["source_id"], source_id.0);
+    assert_eq!(vector_payload.metadata()["source_generation"], generation);
+    assert_eq!(
+        vector_payload.metadata()["committed_generation"],
+        generation
+    );
+    assert_eq!(vector_payload.metadata()["document_id"], document_id.0);
+    assert_eq!(vector_payload.metadata()["chunk_id"], chunk_id.0);
+
+    let candidate = GraphCandidate {
+        candidate_id: "cand_container_image".to_string(),
+        job_id,
+        source_id: source_id.clone(),
+        source_item_key: SourceItemKey::from("Dockerfile"),
+        item_canonical_uri: "file:///repo/Dockerfile".to_string(),
+        document_id: Some(document_id.clone()),
+        kind: "container_manifest".to_string(),
+        merge_key: Some("container_manifest:file:///repo/Dockerfile:qdrant".to_string()),
+        producer: GraphCandidateProducer {
+            adapter: "axon-parse".to_string(),
+            parser: Some("docker_manifest".to_string()),
+            version: "test".to_string(),
+        },
+        nodes: vec![
+            GraphNodeCandidate {
+                node_kind: "local_checkout".to_string(),
+                stable_key: "local://src_local_repo".to_string(),
+                label: "src_local_repo".to_string(),
+                properties: MetadataMap::new(),
+            },
+            GraphNodeCandidate {
+                node_kind: "container_image_tag".to_string(),
+                stable_key: "docker:qdrant/qdrant:v1.13.1".to_string(),
+                label: "qdrant/qdrant:v1.13.1".to_string(),
+                properties: MetadataMap::new(),
+            },
+        ],
+        edges: vec![GraphEdgeCandidate {
+            edge_kind: "repo_uses_container_image".to_string(),
+            from_stable_key: "local://src_local_repo".to_string(),
+            to_stable_key: "docker:qdrant/qdrant:v1.13.1".to_string(),
+            properties: MetadataMap::new(),
+        }],
+        evidence: vec![GraphEvidence {
+            evidence_id: "ev_1".to_string(),
+            evidence_kind: "container_manifest".to_string(),
+            source_id,
+            source_item_key: SourceItemKey::from("Dockerfile"),
+            document_id: Some(document_id),
+            chunk_id: Some(chunk_id),
+            range: Some(SourceRange {
+                line_start: Some(1),
+                line_end: Some(1),
+                byte_start: None,
+                byte_end: None,
+                char_start: None,
+                char_end: None,
+                time_start_ms: None,
+                time_end_ms: None,
+                dom_selector: None,
+                json_pointer: None,
+                yaml_path: None,
+                xml_xpath: None,
+                csv_row: None,
+                session_turn_id: None,
+                turn_start: None,
+                turn_end: None,
+            }),
+            quote: Some("FROM qdrant/qdrant:v1.13.1".to_string()),
+            confidence: 0.9,
+            metadata: MetadataMap::new(),
+        }],
+        confidence: 0.9,
+        metadata: MetadataMap::new(),
+    };
+
+    validate_candidate(&candidate).expect("fixture candidate validates");
+}
+
+fn metadata(value: serde_json::Value) -> MetadataMap {
+    MetadataMap(
+        value
+            .as_object()
+            .expect("fixture metadata object")
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    )
+}

--- a/crates/axon-graph/src/lib.rs
+++ b/crates/axon-graph/src/lib.rs
@@ -35,6 +35,9 @@ pub use store::{FakeGraphStore, GraphStore};
 
 pub const CRATE_NAME: &str = "axon-graph";
 
+#[cfg(test)]
+#[path = "fixture_tests.rs"]
+mod fixture_tests;
 pub mod schema_registry;
 #[cfg(test)]
 #[path = "store_tests.rs"]

--- a/crates/axon-parse/Cargo.toml
+++ b/crates/axon-parse/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 axon-api = { path = "../axon-api" }
 chrono = { version = "0.4", features = ["clock"] }
 serde_json = "1"
+serde_yaml = "0.9"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 
 [dev-dependencies]

--- a/crates/axon-parse/Cargo.toml
+++ b/crates/axon-parse/Cargo.toml
@@ -11,3 +11,6 @@ axon-api = { path = "../axon-api" }
 chrono = { version = "0.4", features = ["clock"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
+
+[dev-dependencies]
+axon-graph = { path = "../axon-graph" }

--- a/crates/axon-parse/src/builtins.rs
+++ b/crates/axon-parse/src/builtins.rs
@@ -12,8 +12,8 @@ pub fn production_registry() -> ParserRegistry {
         .with_parser(CodeSymbolsParser)
         .with_parser(ManifestParser)
         .with_parser(MarkdownParser)
-        .with_parser(SessionParser)
         .with_parser(ToolParser)
+        .with_parser(SessionParser)
 }
 
 struct CodeSymbolsParser;
@@ -133,7 +133,7 @@ impl SourceParser for SchemaParser {
                 "swagger.yaml".to_string(),
             ],
             sniff_prefixes: vec!["{\"openapi\"".to_string(), "type Query".to_string()],
-            priority: 5,
+            priority: 4,
         })
     }
 
@@ -229,10 +229,10 @@ impl SourceParser for ToolParser {
             parser_version: crate::facts::PARSER_VERSION.to_string(),
             content_kinds: vec![ContentKind::Structured],
             mime_types: Vec::new(),
-            file_extensions: vec!["jsonl".to_string()],
+            file_extensions: Vec::new(),
             path_suffixes: vec!["tool-output.jsonl".to_string()],
             sniff_prefixes: vec!["{\"tool\"".to_string()],
-            priority: 5,
+            priority: 4,
         })
     }
 

--- a/crates/axon-parse/src/builtins.rs
+++ b/crates/axon-parse/src/builtins.rs
@@ -2,14 +2,16 @@ use axon_api::source::{ContentKind, LifecycleStatus};
 
 use crate::parser::{ParseInput, ParseResult, ParserCapability, SourceParser, stage_header};
 use crate::registry::ParserRegistry;
-use crate::{code, manifest, markdown, schema, session, tool};
+use crate::{code, docker, env, manifest, markdown, schema, session, tool};
 
 pub fn production_registry() -> ParserRegistry {
     ParserRegistry::new()
+        .with_parser(SchemaParser)
+        .with_parser(DockerManifestParser)
+        .with_parser(EnvExampleParser)
         .with_parser(CodeSymbolsParser)
         .with_parser(ManifestParser)
         .with_parser(MarkdownParser)
-        .with_parser(SchemaParser)
         .with_parser(SessionParser)
         .with_parser(ToolParser)
 }
@@ -18,6 +20,8 @@ struct CodeSymbolsParser;
 struct ManifestParser;
 struct MarkdownParser;
 struct SchemaParser;
+struct DockerManifestParser;
+struct EnvExampleParser;
 struct SessionParser;
 struct ToolParser;
 
@@ -135,6 +139,64 @@ impl SourceParser for SchemaParser {
 
     fn parse(&self, input: &ParseInput) -> ParseResult {
         let (facts, graph_candidates) = schema::api_schema_facts(input);
+        completed_result(input, self.capability(), facts, graph_candidates)
+    }
+}
+
+impl SourceParser for DockerManifestParser {
+    fn capability(&self) -> &ParserCapability {
+        static CAPABILITY: std::sync::OnceLock<ParserCapability> = std::sync::OnceLock::new();
+        CAPABILITY.get_or_init(|| ParserCapability {
+            parser_id: "docker_manifest".to_string(),
+            parser_version: crate::facts::PARSER_VERSION.to_string(),
+            content_kinds: vec![ContentKind::PlainText, ContentKind::Yaml],
+            mime_types: Vec::new(),
+            file_extensions: Vec::new(),
+            path_suffixes: vec![
+                "Dockerfile".to_string(),
+                "Containerfile".to_string(),
+                "docker-compose.yml".to_string(),
+                "docker-compose.yaml".to_string(),
+                "compose.yml".to_string(),
+                "compose.yaml".to_string(),
+                ".devcontainer/devcontainer.json".to_string(),
+            ],
+            sniff_prefixes: vec!["FROM ".to_string(), "services:".to_string()],
+            priority: 4,
+        })
+    }
+
+    fn parse(&self, input: &ParseInput) -> ParseResult {
+        let (facts, graph_candidates) = docker::docker_parse_items(input);
+        completed_result(input, self.capability(), facts, graph_candidates)
+    }
+}
+
+impl SourceParser for EnvExampleParser {
+    fn capability(&self) -> &ParserCapability {
+        static CAPABILITY: std::sync::OnceLock<ParserCapability> = std::sync::OnceLock::new();
+        CAPABILITY.get_or_init(|| ParserCapability {
+            parser_id: "env_example".to_string(),
+            parser_version: crate::facts::PARSER_VERSION.to_string(),
+            content_kinds: vec![ContentKind::PlainText],
+            mime_types: Vec::new(),
+            file_extensions: Vec::new(),
+            path_suffixes: vec![
+                ".env.example".to_string(),
+                ".env.sample".to_string(),
+                ".env.template".to_string(),
+                "example.env".to_string(),
+                "env.example".to_string(),
+                "env.sample".to_string(),
+                "env.template".to_string(),
+            ],
+            sniff_prefixes: Vec::new(),
+            priority: 4,
+        })
+    }
+
+    fn parse(&self, input: &ParseInput) -> ParseResult {
+        let (facts, graph_candidates) = env::env_example_parse_items(input);
         completed_result(input, self.capability(), facts, graph_candidates)
     }
 }

--- a/crates/axon-parse/src/docker.rs
+++ b/crates/axon-parse/src/docker.rs
@@ -1,16 +1,15 @@
 use axon_api::source::{GraphCandidate, SourceParseFacts};
 use serde_json::json;
-use serde_yaml::Value as YamlValue;
 
 use crate::facts::{inline_text, source_fact};
 use crate::graph_candidate::candidate_edge;
 use crate::parser::ParseInput;
 
+mod compose;
+
 pub const MODULE_NAME: &str = "docker";
 
 const MAX_DOCKER_FILE_BYTES: usize = 512 * 1024;
-const MAX_COMPOSE_DEPTH: usize = 32;
-const MAX_COMPOSE_SERVICES: usize = 256;
 const MAX_GRAPH_CANDIDATES_PER_DOCUMENT: usize = 2_000;
 
 pub fn docker_parse_items(input: &ParseInput) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
@@ -23,7 +22,7 @@ pub fn docker_parse_items(input: &ParseInput) -> (Vec<SourceParseFacts>, Vec<Gra
     if is_dockerfile(path) {
         dockerfile_parse_items(input, text)
     } else {
-        compose_parse_items(input, text)
+        compose::compose_parse_items(input, text)
     }
 }
 
@@ -122,190 +121,6 @@ fn dockerfile_parse_items(
     (facts, candidates)
 }
 
-fn compose_parse_items(
-    input: &ParseInput,
-    text: &str,
-) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
-    let Ok(root) = serde_yaml::from_str::<YamlValue>(text) else {
-        return (Vec::new(), Vec::new());
-    };
-    if yaml_depth(&root) > MAX_COMPOSE_DEPTH {
-        return (Vec::new(), Vec::new());
-    }
-
-    let mut facts = Vec::new();
-    let mut candidates = Vec::new();
-    let Some(services) = mapping_get(&root, "services").and_then(YamlValue::as_mapping) else {
-        return (facts, candidates);
-    };
-
-    for (idx, (service_key, service_value)) in services.iter().enumerate() {
-        if idx >= MAX_COMPOSE_SERVICES {
-            break;
-        }
-        let Some(service) = service_key.as_str() else {
-            continue;
-        };
-        let line_no = line_for_token(text, &format!("{service}:"));
-        facts.push(source_fact(
-            input,
-            "docker_manifest",
-            "compose",
-            "runtime_service",
-            service,
-            json!({ "docker_service": service }),
-            Some(line_no),
-        ));
-        push_candidate(
-            &mut candidates,
-            candidate_edge(
-                input,
-                "docker_manifest",
-                "runtime_manifest",
-                "local_checkout",
-                &local_checkout_key(input),
-                "runtime_service",
-                &service_key_for(input, service),
-                "repo_declares_service",
-                "runtime_manifest",
-                Some(line_no),
-                Some(format!("{service}:")),
-            ),
-        );
-
-        let Some(service_map) = service_value.as_mapping() else {
-            continue;
-        };
-        if let Some(image) = map_get(service_map, "image").and_then(YamlValue::as_str) {
-            let image_line = line_for_token(text, image);
-            facts.push(source_fact(
-                input,
-                "docker_manifest",
-                "compose",
-                "container_image_tag",
-                image,
-                json!({ "docker_image": image, "docker_service": service }),
-                Some(image_line),
-            ));
-            push_candidate(
-                &mut candidates,
-                candidate_edge(
-                    input,
-                    "docker_manifest",
-                    "runtime_manifest",
-                    "runtime_service",
-                    &service_key_for(input, service),
-                    "container_image_tag",
-                    &format!("docker:{image}"),
-                    "service_uses_image",
-                    "runtime_manifest",
-                    Some(image_line),
-                    Some(format!("image: {image}")),
-                ),
-            );
-        }
-
-        for port in string_values(map_get(service_map, "ports")) {
-            let port_line = line_for_token(text, &port);
-            facts.push(source_fact(
-                input,
-                "docker_manifest",
-                "compose",
-                "network_endpoint",
-                port.clone(),
-                json!({ "docker_port": port, "docker_service": service }),
-                Some(port_line),
-            ));
-            push_candidate(
-                &mut candidates,
-                candidate_edge(
-                    input,
-                    "docker_manifest",
-                    "runtime_manifest",
-                    "runtime_service",
-                    &service_key_for(input, service),
-                    "network_endpoint",
-                    &format!("endpoint:{}:{service}:{port}", repo_key(input)),
-                    "service_exposes_endpoint",
-                    "runtime_manifest",
-                    Some(port_line),
-                    Some(port),
-                ),
-            );
-        }
-
-        for volume in string_values(map_get(service_map, "volumes")) {
-            let volume_line = line_for_token(text, &volume);
-            facts.push(source_fact(
-                input,
-                "docker_manifest",
-                "compose",
-                "volume_mount",
-                volume.clone(),
-                json!({ "docker_volume": volume, "docker_service": service }),
-                Some(volume_line),
-            ));
-            push_candidate(
-                &mut candidates,
-                candidate_edge(
-                    input,
-                    "docker_manifest",
-                    "runtime_manifest",
-                    "runtime_service",
-                    &service_key_for(input, service),
-                    "volume_mount",
-                    &format!("volume:{}:{service}:{volume}", repo_key(input)),
-                    "service_mounts_volume",
-                    "runtime_manifest",
-                    Some(volume_line),
-                    Some(volume),
-                ),
-            );
-        }
-
-        for key in environment_keys(map_get(service_map, "environment")) {
-            let secret = is_secret_key(&key);
-            let fact_kind = if secret {
-                "secret_reference"
-            } else {
-                "environment_variable"
-            };
-            let key_line = line_for_token(text, &key);
-            facts.push(source_fact(
-                input,
-                "docker_manifest",
-                "compose",
-                fact_kind,
-                key.clone(),
-                json!({ "key": key, "docker_service": service, "value_redacted": true }),
-                Some(key_line),
-            ));
-            push_candidate(
-                &mut candidates,
-                candidate_edge(
-                    input,
-                    "docker_manifest",
-                    "runtime_manifest",
-                    "runtime_service",
-                    &service_key_for(input, service),
-                    if secret {
-                        "secret_reference"
-                    } else {
-                        "environment_variable"
-                    },
-                    &format!("{}:{key}", if secret { "secret" } else { "env" }),
-                    "service_requires_env",
-                    "runtime_manifest",
-                    Some(key_line),
-                    Some(format!("{key}: <redacted>")),
-                ),
-            );
-        }
-    }
-
-    (facts, candidates)
-}
-
 fn env_candidate(
     input: &ParseInput,
     key: &str,
@@ -339,7 +154,7 @@ fn is_dockerfile(path: &str) -> bool {
         || path.ends_with("/Containerfile")
 }
 
-fn is_secret_key(key: &str) -> bool {
+pub(super) fn is_secret_key(key: &str) -> bool {
     let lower = key.to_ascii_lowercase();
     [
         "secret",
@@ -354,68 +169,25 @@ fn is_secret_key(key: &str) -> bool {
     .any(|needle| lower.contains(needle))
 }
 
-fn local_checkout_key(input: &ParseInput) -> String {
+pub(super) fn local_checkout_key(input: &ParseInput) -> String {
     format!("local://{}", input.document.source_id.0)
 }
 
-fn repo_key(input: &ParseInput) -> String {
+pub(super) fn repo_key(input: &ParseInput) -> String {
     input.document.source_id.0.clone()
 }
 
-fn service_key_for(input: &ParseInput, service: &str) -> String {
+pub(super) fn service_key_for(input: &ParseInput, service: &str) -> String {
     format!("service:{}:{service}", repo_key(input))
 }
 
-fn push_candidate(candidates: &mut Vec<GraphCandidate>, candidate: GraphCandidate) {
+pub(super) fn push_candidate(candidates: &mut Vec<GraphCandidate>, candidate: GraphCandidate) {
     if candidates.len() < MAX_GRAPH_CANDIDATES_PER_DOCUMENT {
         candidates.push(candidate);
     }
 }
 
-fn mapping_get<'a>(value: &'a YamlValue, key: &str) -> Option<&'a YamlValue> {
-    value.as_mapping()?.get(YamlValue::String(key.to_string()))
-}
-
-fn map_get<'a>(map: &'a serde_yaml::Mapping, key: &str) -> Option<&'a YamlValue> {
-    map.get(YamlValue::String(key.to_string()))
-}
-
-fn string_values(value: Option<&YamlValue>) -> Vec<String> {
-    match value {
-        Some(YamlValue::Sequence(values)) => values
-            .iter()
-            .filter_map(|value| value.as_str().map(ToOwned::to_owned))
-            .collect(),
-        Some(YamlValue::String(value)) => vec![value.clone()],
-        _ => Vec::new(),
-    }
-}
-
-fn environment_keys(value: Option<&YamlValue>) -> Vec<String> {
-    match value {
-        Some(YamlValue::Mapping(map)) => map
-            .keys()
-            .filter_map(|key| key.as_str().map(ToOwned::to_owned))
-            .collect(),
-        Some(YamlValue::Sequence(values)) => values
-            .iter()
-            .filter_map(|value| value.as_str())
-            .filter_map(|entry| entry.split_once('=').map(|(key, _)| key).or(Some(entry)))
-            .map(ToOwned::to_owned)
-            .collect(),
-        _ => Vec::new(),
-    }
-}
-
-fn yaml_depth(value: &YamlValue) -> usize {
-    match value {
-        YamlValue::Sequence(values) => 1 + values.iter().map(yaml_depth).max().unwrap_or(0),
-        YamlValue::Mapping(map) => 1 + map.values().map(yaml_depth).max().unwrap_or(0),
-        _ => 1,
-    }
-}
-
-fn line_for_token(text: &str, token: &str) -> u32 {
+pub(super) fn line_for_token(text: &str, token: &str) -> u32 {
     text.lines()
         .position(|line| line.contains(token))
         .map(|idx| idx as u32 + 1)

--- a/crates/axon-parse/src/docker.rs
+++ b/crates/axon-parse/src/docker.rs
@@ -1,10 +1,14 @@
-use axon_api::source::SourceParseFacts;
+use axon_api::source::{GraphCandidate, SourceParseFacts};
 use serde_json::json;
 
 use crate::facts::{inline_text, source_fact};
 use crate::parser::ParseInput;
 
 pub const MODULE_NAME: &str = "docker";
+
+pub fn docker_parse_items(input: &ParseInput) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
+    (docker_facts(input), Vec::new())
+}
 
 pub fn docker_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
     let path = input.document.path.as_deref().unwrap_or_default();

--- a/crates/axon-parse/src/docker.rs
+++ b/crates/axon-parse/src/docker.rs
@@ -1,116 +1,425 @@
 use axon_api::source::{GraphCandidate, SourceParseFacts};
 use serde_json::json;
+use serde_yaml::Value as YamlValue;
 
 use crate::facts::{inline_text, source_fact};
+use crate::graph_candidate::candidate_edge;
 use crate::parser::ParseInput;
 
 pub const MODULE_NAME: &str = "docker";
 
-pub fn docker_parse_items(input: &ParseInput) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
-    (docker_facts(input), Vec::new())
-}
+const MAX_DOCKER_FILE_BYTES: usize = 512 * 1024;
+const MAX_COMPOSE_DEPTH: usize = 32;
+const MAX_COMPOSE_SERVICES: usize = 256;
+const MAX_GRAPH_CANDIDATES_PER_DOCUMENT: usize = 2_000;
 
-pub fn docker_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
+pub fn docker_parse_items(input: &ParseInput) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
+    let text = inline_text(input);
+    if text.len() > MAX_DOCKER_FILE_BYTES {
+        return (Vec::new(), Vec::new());
+    }
+
     let path = input.document.path.as_deref().unwrap_or_default();
-    if path.eq_ignore_ascii_case("Dockerfile") || path.ends_with("/Dockerfile") {
-        dockerfile_facts(input)
+    if is_dockerfile(path) {
+        dockerfile_parse_items(input, text)
     } else {
-        compose_facts(input)
+        compose_parse_items(input, text)
     }
 }
 
-fn dockerfile_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
+pub fn docker_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
+    docker_parse_items(input).0
+}
+
+fn dockerfile_parse_items(
+    input: &ParseInput,
+    text: &str,
+) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
     let mut facts = Vec::new();
-    for (idx, line) in inline_text(input).lines().enumerate() {
+    let mut candidates = Vec::new();
+
+    for (idx, line) in text.lines().enumerate() {
+        let line_no = idx as u32 + 1;
         let trimmed = line.trim();
         if let Some(image) = trimmed.strip_prefix("FROM ") {
+            let image = image.split_whitespace().next().unwrap_or(image);
             facts.push(source_fact(
                 input,
+                "docker_manifest",
                 "dockerfile",
-                "line_heuristic",
                 "docker_base_image",
-                image.split_whitespace().next().unwrap_or(image),
-                json!({ "image": image.split_whitespace().next().unwrap_or(image) }),
-                Some(idx as u32 + 1),
+                image,
+                json!({ "docker_image": image }),
+                Some(line_no),
             ));
+            push_candidate(
+                &mut candidates,
+                candidate_edge(
+                    input,
+                    "docker_manifest",
+                    "container_manifest",
+                    "local_checkout",
+                    &local_checkout_key(input),
+                    "container_image_tag",
+                    &format!("docker:{image}"),
+                    "repo_uses_container_image",
+                    "container_manifest",
+                    Some(line_no),
+                    Some(line.to_string()),
+                ),
+            );
         } else if let Some(env) = trimmed.strip_prefix("ENV ") {
             let key = env.split(['=', ' ']).next().unwrap_or(env);
+            let secret = is_secret_key(key);
+            let fact_kind = if secret {
+                "secret_reference"
+            } else {
+                "environment_variable"
+            };
             facts.push(source_fact(
                 input,
+                "docker_manifest",
                 "dockerfile",
-                "line_heuristic",
-                "docker_env",
+                fact_kind,
                 key,
-                json!({ "key": key }),
-                Some(idx as u32 + 1),
+                json!({ "key": key, "value_redacted": true }),
+                Some(line_no),
             ));
+            push_candidate(
+                &mut candidates,
+                env_candidate(input, key, secret, line_no, format!("ENV {key}=<redacted>")),
+            );
         } else if let Some(port) = trimmed.strip_prefix("EXPOSE ") {
             let port = port.split_whitespace().next().unwrap_or(port);
             facts.push(source_fact(
                 input,
+                "docker_manifest",
                 "dockerfile",
-                "line_heuristic",
-                "docker_expose",
+                "network_endpoint",
                 port,
-                json!({ "port": port }),
-                Some(idx as u32 + 1),
+                json!({ "docker_port": port }),
+                Some(line_no),
             ));
+            push_candidate(
+                &mut candidates,
+                candidate_edge(
+                    input,
+                    "docker_manifest",
+                    "runtime_manifest",
+                    "local_checkout",
+                    &local_checkout_key(input),
+                    "network_endpoint",
+                    &format!("endpoint:{}:{port}", repo_key(input)),
+                    "service_exposes_endpoint",
+                    "runtime_manifest",
+                    Some(line_no),
+                    Some(line.to_string()),
+                ),
+            );
         }
     }
-    facts
+
+    (facts, candidates)
 }
 
-fn compose_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
-    let mut facts = Vec::new();
-    let mut in_services = false;
-    let mut current_service: Option<String> = None;
+fn compose_parse_items(
+    input: &ParseInput,
+    text: &str,
+) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
+    let Ok(root) = serde_yaml::from_str::<YamlValue>(text) else {
+        return (Vec::new(), Vec::new());
+    };
+    if yaml_depth(&root) > MAX_COMPOSE_DEPTH {
+        return (Vec::new(), Vec::new());
+    }
 
-    for (idx, line) in inline_text(input).lines().enumerate() {
-        let trimmed = line.trim();
-        if trimmed == "services:" {
-            in_services = true;
-            continue;
+    let mut facts = Vec::new();
+    let mut candidates = Vec::new();
+    let Some(services) = mapping_get(&root, "services").and_then(YamlValue::as_mapping) else {
+        return (facts, candidates);
+    };
+
+    for (idx, (service_key, service_value)) in services.iter().enumerate() {
+        if idx >= MAX_COMPOSE_SERVICES {
+            break;
         }
-        if !in_services {
+        let Some(service) = service_key.as_str() else {
             continue;
+        };
+        let line_no = line_for_token(text, &format!("{service}:"));
+        facts.push(source_fact(
+            input,
+            "docker_manifest",
+            "compose",
+            "runtime_service",
+            service,
+            json!({ "docker_service": service }),
+            Some(line_no),
+        ));
+        push_candidate(
+            &mut candidates,
+            candidate_edge(
+                input,
+                "docker_manifest",
+                "runtime_manifest",
+                "local_checkout",
+                &local_checkout_key(input),
+                "runtime_service",
+                &service_key_for(input, service),
+                "repo_declares_service",
+                "runtime_manifest",
+                Some(line_no),
+                Some(format!("{service}:")),
+            ),
+        );
+
+        let Some(service_map) = service_value.as_mapping() else {
+            continue;
+        };
+        if let Some(image) = map_get(service_map, "image").and_then(YamlValue::as_str) {
+            let image_line = line_for_token(text, image);
+            facts.push(source_fact(
+                input,
+                "docker_manifest",
+                "compose",
+                "container_image_tag",
+                image,
+                json!({ "docker_image": image, "docker_service": service }),
+                Some(image_line),
+            ));
+            push_candidate(
+                &mut candidates,
+                candidate_edge(
+                    input,
+                    "docker_manifest",
+                    "runtime_manifest",
+                    "runtime_service",
+                    &service_key_for(input, service),
+                    "container_image_tag",
+                    &format!("docker:{image}"),
+                    "service_uses_image",
+                    "runtime_manifest",
+                    Some(image_line),
+                    Some(format!("image: {image}")),
+                ),
+            );
         }
-        if line.starts_with("  ") && !line.starts_with("    ") && trimmed.ends_with(':') {
-            let service = trimmed.trim_end_matches(':').to_string();
-            current_service = Some(service.clone());
+
+        for port in string_values(map_get(service_map, "ports")) {
+            let port_line = line_for_token(text, &port);
             facts.push(source_fact(
                 input,
-                "docker_compose",
-                "line_heuristic",
-                "compose_service",
-                service,
-                json!({ "kind": "service" }),
-                Some(idx as u32 + 1),
+                "docker_manifest",
+                "compose",
+                "network_endpoint",
+                port.clone(),
+                json!({ "docker_port": port, "docker_service": service }),
+                Some(port_line),
             ));
-        } else if let Some(image) = trimmed.strip_prefix("image: ") {
-            let name = current_service.as_deref().unwrap_or(image);
+            push_candidate(
+                &mut candidates,
+                candidate_edge(
+                    input,
+                    "docker_manifest",
+                    "runtime_manifest",
+                    "runtime_service",
+                    &service_key_for(input, service),
+                    "network_endpoint",
+                    &format!("endpoint:{}:{service}:{port}", repo_key(input)),
+                    "service_exposes_endpoint",
+                    "runtime_manifest",
+                    Some(port_line),
+                    Some(port),
+                ),
+            );
+        }
+
+        for volume in string_values(map_get(service_map, "volumes")) {
+            let volume_line = line_for_token(text, &volume);
             facts.push(source_fact(
                 input,
-                "docker_compose",
-                "line_heuristic",
-                "compose_image",
-                name,
-                json!({ "image": image }),
-                Some(idx as u32 + 1),
+                "docker_manifest",
+                "compose",
+                "volume_mount",
+                volume.clone(),
+                json!({ "docker_volume": volume, "docker_service": service }),
+                Some(volume_line),
             ));
-        } else if trimmed.starts_with("- ") && current_service.is_some() {
-            let port = trimmed.trim_start_matches("- ").trim_matches('"');
+            push_candidate(
+                &mut candidates,
+                candidate_edge(
+                    input,
+                    "docker_manifest",
+                    "runtime_manifest",
+                    "runtime_service",
+                    &service_key_for(input, service),
+                    "volume_mount",
+                    &format!("volume:{}:{service}:{volume}", repo_key(input)),
+                    "service_mounts_volume",
+                    "runtime_manifest",
+                    Some(volume_line),
+                    Some(volume),
+                ),
+            );
+        }
+
+        for key in environment_keys(map_get(service_map, "environment")) {
+            let secret = is_secret_key(&key);
+            let fact_kind = if secret {
+                "secret_reference"
+            } else {
+                "environment_variable"
+            };
+            let key_line = line_for_token(text, &key);
             facts.push(source_fact(
                 input,
-                "docker_compose",
-                "line_heuristic",
-                "compose_port",
-                current_service.as_deref().unwrap_or("service"),
-                json!({ "port": port }),
-                Some(idx as u32 + 1),
+                "docker_manifest",
+                "compose",
+                fact_kind,
+                key.clone(),
+                json!({ "key": key, "docker_service": service, "value_redacted": true }),
+                Some(key_line),
             ));
+            push_candidate(
+                &mut candidates,
+                candidate_edge(
+                    input,
+                    "docker_manifest",
+                    "runtime_manifest",
+                    "runtime_service",
+                    &service_key_for(input, service),
+                    if secret {
+                        "secret_reference"
+                    } else {
+                        "environment_variable"
+                    },
+                    &format!("{}:{key}", if secret { "secret" } else { "env" }),
+                    "service_requires_env",
+                    "runtime_manifest",
+                    Some(key_line),
+                    Some(format!("{key}: <redacted>")),
+                ),
+            );
         }
     }
-    facts
+
+    (facts, candidates)
+}
+
+fn env_candidate(
+    input: &ParseInput,
+    key: &str,
+    secret: bool,
+    line_no: u32,
+    quote: String,
+) -> GraphCandidate {
+    candidate_edge(
+        input,
+        "docker_manifest",
+        "runtime_manifest",
+        "local_checkout",
+        &local_checkout_key(input),
+        if secret {
+            "secret_reference"
+        } else {
+            "environment_variable"
+        },
+        &format!("{}:{key}", if secret { "secret" } else { "env" }),
+        "repo_declares_env_var",
+        "runtime_manifest",
+        Some(line_no),
+        Some(quote),
+    )
+}
+
+fn is_dockerfile(path: &str) -> bool {
+    path.eq_ignore_ascii_case("Dockerfile")
+        || path.ends_with("/Dockerfile")
+        || path.eq_ignore_ascii_case("Containerfile")
+        || path.ends_with("/Containerfile")
+}
+
+fn is_secret_key(key: &str) -> bool {
+    let lower = key.to_ascii_lowercase();
+    [
+        "secret",
+        "password",
+        "token",
+        "api_key",
+        "apikey",
+        "private_key",
+        "database_url",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn local_checkout_key(input: &ParseInput) -> String {
+    format!("local://{}", input.document.source_id.0)
+}
+
+fn repo_key(input: &ParseInput) -> String {
+    input.document.source_id.0.clone()
+}
+
+fn service_key_for(input: &ParseInput, service: &str) -> String {
+    format!("service:{}:{service}", repo_key(input))
+}
+
+fn push_candidate(candidates: &mut Vec<GraphCandidate>, candidate: GraphCandidate) {
+    if candidates.len() < MAX_GRAPH_CANDIDATES_PER_DOCUMENT {
+        candidates.push(candidate);
+    }
+}
+
+fn mapping_get<'a>(value: &'a YamlValue, key: &str) -> Option<&'a YamlValue> {
+    value.as_mapping()?.get(YamlValue::String(key.to_string()))
+}
+
+fn map_get<'a>(map: &'a serde_yaml::Mapping, key: &str) -> Option<&'a YamlValue> {
+    map.get(YamlValue::String(key.to_string()))
+}
+
+fn string_values(value: Option<&YamlValue>) -> Vec<String> {
+    match value {
+        Some(YamlValue::Sequence(values)) => values
+            .iter()
+            .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+            .collect(),
+        Some(YamlValue::String(value)) => vec![value.clone()],
+        _ => Vec::new(),
+    }
+}
+
+fn environment_keys(value: Option<&YamlValue>) -> Vec<String> {
+    match value {
+        Some(YamlValue::Mapping(map)) => map
+            .keys()
+            .filter_map(|key| key.as_str().map(ToOwned::to_owned))
+            .collect(),
+        Some(YamlValue::Sequence(values)) => values
+            .iter()
+            .filter_map(|value| value.as_str())
+            .filter_map(|entry| entry.split_once('=').map(|(key, _)| key).or(Some(entry)))
+            .map(ToOwned::to_owned)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn yaml_depth(value: &YamlValue) -> usize {
+    match value {
+        YamlValue::Sequence(values) => 1 + values.iter().map(yaml_depth).max().unwrap_or(0),
+        YamlValue::Mapping(map) => 1 + map.values().map(yaml_depth).max().unwrap_or(0),
+        _ => 1,
+    }
+}
+
+fn line_for_token(text: &str, token: &str) -> u32 {
+    text.lines()
+        .position(|line| line.contains(token))
+        .map(|idx| idx as u32 + 1)
+        .unwrap_or(1)
 }
 
 #[cfg(test)]

--- a/crates/axon-parse/src/docker/compose.rs
+++ b/crates/axon-parse/src/docker/compose.rs
@@ -1,0 +1,443 @@
+use axon_api::source::{GraphCandidate, SourceParseFacts};
+use serde_json::json;
+use serde_yaml::Value as YamlValue;
+
+use crate::facts::source_fact;
+use crate::graph_candidate::candidate_edge;
+use crate::parser::ParseInput;
+
+const MAX_COMPOSE_DEPTH: usize = 32;
+const MAX_COMPOSE_SERVICES: usize = 256;
+
+pub(super) fn compose_parse_items(
+    input: &ParseInput,
+    text: &str,
+) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
+    let Ok(root) = serde_yaml::from_str::<YamlValue>(text) else {
+        return (Vec::new(), Vec::new());
+    };
+    if yaml_depth(&root) > MAX_COMPOSE_DEPTH {
+        return (Vec::new(), Vec::new());
+    }
+
+    let mut facts = Vec::new();
+    let mut candidates = Vec::new();
+    let Some(services) = mapping_get(&root, "services").and_then(YamlValue::as_mapping) else {
+        return (facts, candidates);
+    };
+
+    for (idx, (service_key, service_value)) in services.iter().enumerate() {
+        if idx >= MAX_COMPOSE_SERVICES {
+            break;
+        }
+        let Some(service) = service_key.as_str() else {
+            continue;
+        };
+        parse_service(
+            input,
+            text,
+            service,
+            service_value,
+            &mut facts,
+            &mut candidates,
+        );
+    }
+
+    (facts, candidates)
+}
+
+fn parse_service(
+    input: &ParseInput,
+    text: &str,
+    service: &str,
+    service_value: &YamlValue,
+    facts: &mut Vec<SourceParseFacts>,
+    candidates: &mut Vec<GraphCandidate>,
+) {
+    let line_no = super::line_for_token(text, &format!("{service}:"));
+    facts.push(source_fact(
+        input,
+        "docker_manifest",
+        "compose",
+        "runtime_service",
+        service,
+        json!({ "docker_service": service }),
+        Some(line_no),
+    ));
+    super::push_candidate(
+        candidates,
+        candidate_edge(
+            input,
+            "docker_manifest",
+            "runtime_manifest",
+            "local_checkout",
+            &super::local_checkout_key(input),
+            "runtime_service",
+            &super::service_key_for(input, service),
+            "repo_declares_service",
+            "runtime_manifest",
+            Some(line_no),
+            Some(format!("{service}:")),
+        ),
+    );
+
+    let Some(service_map) = service_value.as_mapping() else {
+        return;
+    };
+    parse_image(input, text, service, service_map, facts, candidates);
+    parse_string_list(
+        input,
+        text,
+        service,
+        service_map,
+        FieldListSpec {
+            yaml_key: "ports",
+            fact_kind: "network_endpoint",
+            value_key: "docker_port",
+            node_kind: "network_endpoint",
+            node_prefix: "endpoint",
+            edge_kind: "service_exposes_endpoint",
+        },
+        facts,
+        candidates,
+    );
+    parse_string_list(
+        input,
+        text,
+        service,
+        service_map,
+        FieldListSpec {
+            yaml_key: "volumes",
+            fact_kind: "volume_mount",
+            value_key: "docker_volume",
+            node_kind: "volume_mount",
+            node_prefix: "volume",
+            edge_kind: "service_mounts_volume",
+        },
+        facts,
+        candidates,
+    );
+    parse_environment(input, text, service, service_map, facts, candidates);
+    parse_env_files(input, text, service, service_map, facts, candidates);
+    parse_secrets(input, text, service, service_map, facts, candidates);
+    parse_dependencies(input, text, service, service_map, facts, candidates);
+}
+
+fn parse_image(
+    input: &ParseInput,
+    text: &str,
+    service: &str,
+    service_map: &serde_yaml::Mapping,
+    facts: &mut Vec<SourceParseFacts>,
+    candidates: &mut Vec<GraphCandidate>,
+) {
+    let Some(image) = map_get(service_map, "image").and_then(YamlValue::as_str) else {
+        return;
+    };
+    let image_line = super::line_for_token(text, image);
+    facts.push(source_fact(
+        input,
+        "docker_manifest",
+        "compose",
+        "container_image_tag",
+        image,
+        json!({ "docker_image": image, "docker_service": service }),
+        Some(image_line),
+    ));
+    super::push_candidate(
+        candidates,
+        candidate_edge(
+            input,
+            "docker_manifest",
+            "runtime_manifest",
+            "runtime_service",
+            &super::service_key_for(input, service),
+            "container_image_tag",
+            &format!("docker:{image}"),
+            "service_uses_image",
+            "runtime_manifest",
+            Some(image_line),
+            Some(format!("image: {image}")),
+        ),
+    );
+}
+
+struct FieldListSpec {
+    yaml_key: &'static str,
+    fact_kind: &'static str,
+    value_key: &'static str,
+    node_kind: &'static str,
+    node_prefix: &'static str,
+    edge_kind: &'static str,
+}
+
+fn parse_string_list(
+    input: &ParseInput,
+    text: &str,
+    service: &str,
+    service_map: &serde_yaml::Mapping,
+    spec: FieldListSpec,
+    facts: &mut Vec<SourceParseFacts>,
+    candidates: &mut Vec<GraphCandidate>,
+) {
+    for value in string_values(map_get(service_map, spec.yaml_key)) {
+        let line = super::line_for_token(text, &value);
+        facts.push(source_fact(
+            input,
+            "docker_manifest",
+            "compose",
+            spec.fact_kind,
+            value.clone(),
+            json!({ spec.value_key: value, "docker_service": service }),
+            Some(line),
+        ));
+        super::push_candidate(
+            candidates,
+            candidate_edge(
+                input,
+                "docker_manifest",
+                "runtime_manifest",
+                "runtime_service",
+                &super::service_key_for(input, service),
+                spec.node_kind,
+                &format!(
+                    "{}:{}:{service}:{value}",
+                    spec.node_prefix,
+                    super::repo_key(input)
+                ),
+                spec.edge_kind,
+                "runtime_manifest",
+                Some(line),
+                Some(value),
+            ),
+        );
+    }
+}
+
+fn parse_environment(
+    input: &ParseInput,
+    text: &str,
+    service: &str,
+    service_map: &serde_yaml::Mapping,
+    facts: &mut Vec<SourceParseFacts>,
+    candidates: &mut Vec<GraphCandidate>,
+) {
+    for key in environment_keys(map_get(service_map, "environment")) {
+        push_env_contract(input, text, service, key, facts, candidates);
+    }
+}
+
+fn push_env_contract(
+    input: &ParseInput,
+    text: &str,
+    service: &str,
+    key: String,
+    facts: &mut Vec<SourceParseFacts>,
+    candidates: &mut Vec<GraphCandidate>,
+) {
+    let secret = super::is_secret_key(&key);
+    let fact_kind = if secret {
+        "secret_reference"
+    } else {
+        "environment_variable"
+    };
+    let key_line = super::line_for_token(text, &key);
+    facts.push(source_fact(
+        input,
+        "docker_manifest",
+        "compose",
+        fact_kind,
+        key.clone(),
+        json!({ "key": key, "docker_service": service, "value_redacted": true }),
+        Some(key_line),
+    ));
+    super::push_candidate(
+        candidates,
+        candidate_edge(
+            input,
+            "docker_manifest",
+            "runtime_manifest",
+            "runtime_service",
+            &super::service_key_for(input, service),
+            if secret {
+                "secret_reference"
+            } else {
+                "environment_variable"
+            },
+            &format!("{}:{key}", if secret { "secret" } else { "env" }),
+            "service_requires_env",
+            "runtime_manifest",
+            Some(key_line),
+            Some(format!("{key}: <redacted>")),
+        ),
+    );
+}
+
+fn parse_env_files(
+    input: &ParseInput,
+    text: &str,
+    service: &str,
+    service_map: &serde_yaml::Mapping,
+    facts: &mut Vec<SourceParseFacts>,
+    candidates: &mut Vec<GraphCandidate>,
+) {
+    for env_file in string_values(map_get(service_map, "env_file")) {
+        let line = super::line_for_token(text, &env_file);
+        facts.push(source_fact(
+            input,
+            "docker_manifest",
+            "compose",
+            "env_file",
+            env_file.clone(),
+            json!({ "env_file": env_file, "docker_service": service }),
+            Some(line),
+        ));
+        super::push_candidate(
+            candidates,
+            candidate_edge(
+                input,
+                "docker_manifest",
+                "runtime_manifest",
+                "runtime_service",
+                &super::service_key_for(input, service),
+                "artifact",
+                &format!("artifact:env_file:{}:{env_file}", super::repo_key(input)),
+                "source_produced_artifact",
+                "runtime_manifest",
+                Some(line),
+                Some(env_file),
+            ),
+        );
+    }
+}
+
+fn parse_secrets(
+    input: &ParseInput,
+    text: &str,
+    service: &str,
+    service_map: &serde_yaml::Mapping,
+    facts: &mut Vec<SourceParseFacts>,
+    candidates: &mut Vec<GraphCandidate>,
+) {
+    for secret in service_secret_names(map_get(service_map, "secrets")) {
+        push_env_contract(input, text, service, secret, facts, candidates);
+    }
+}
+
+fn parse_dependencies(
+    input: &ParseInput,
+    text: &str,
+    service: &str,
+    service_map: &serde_yaml::Mapping,
+    facts: &mut Vec<SourceParseFacts>,
+    candidates: &mut Vec<GraphCandidate>,
+) {
+    for dependency in service_dependency_names(map_get(service_map, "depends_on")) {
+        let line = super::line_for_token(text, &dependency);
+        facts.push(source_fact(
+            input,
+            "docker_manifest",
+            "compose",
+            "service_dependency",
+            dependency.clone(),
+            json!({ "docker_service": service, "depends_on": dependency }),
+            Some(line),
+        ));
+        super::push_candidate(
+            candidates,
+            candidate_edge(
+                input,
+                "docker_manifest",
+                "runtime_manifest",
+                "runtime_service",
+                &super::service_key_for(input, service),
+                "runtime_service",
+                &super::service_key_for(input, &dependency),
+                "derived_from",
+                "runtime_manifest",
+                Some(line),
+                Some(dependency),
+            ),
+        );
+    }
+}
+
+fn mapping_get<'a>(value: &'a YamlValue, key: &str) -> Option<&'a YamlValue> {
+    value.as_mapping()?.get(YamlValue::String(key.to_string()))
+}
+
+fn map_get<'a>(map: &'a serde_yaml::Mapping, key: &str) -> Option<&'a YamlValue> {
+    map.get(YamlValue::String(key.to_string()))
+}
+
+fn string_values(value: Option<&YamlValue>) -> Vec<String> {
+    match value {
+        Some(YamlValue::Sequence(values)) => values
+            .iter()
+            .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+            .collect(),
+        Some(YamlValue::String(value)) => vec![value.clone()],
+        _ => Vec::new(),
+    }
+}
+
+fn environment_keys(value: Option<&YamlValue>) -> Vec<String> {
+    match value {
+        Some(YamlValue::Mapping(map)) => map
+            .keys()
+            .filter_map(|key| key.as_str().map(ToOwned::to_owned))
+            .collect(),
+        Some(YamlValue::Sequence(values)) => values
+            .iter()
+            .filter_map(|value| value.as_str())
+            .filter_map(|entry| entry.split_once('=').map(|(key, _)| key).or(Some(entry)))
+            .map(ToOwned::to_owned)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn service_secret_names(value: Option<&YamlValue>) -> Vec<String> {
+    match value {
+        Some(YamlValue::Sequence(values)) => values
+            .iter()
+            .filter_map(|value| match value {
+                YamlValue::String(secret) => Some(secret.clone()),
+                YamlValue::Mapping(map) => map
+                    .get(YamlValue::String("source".to_string()))
+                    .or_else(|| map.get(YamlValue::String("target".to_string())))
+                    .and_then(YamlValue::as_str)
+                    .map(ToOwned::to_owned),
+                _ => None,
+            })
+            .collect(),
+        Some(YamlValue::Mapping(map)) => map
+            .keys()
+            .filter_map(|key| key.as_str().map(ToOwned::to_owned))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn service_dependency_names(value: Option<&YamlValue>) -> Vec<String> {
+    match value {
+        Some(YamlValue::Sequence(values)) => values
+            .iter()
+            .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+            .collect(),
+        Some(YamlValue::Mapping(map)) => map
+            .keys()
+            .filter_map(|key| key.as_str().map(ToOwned::to_owned))
+            .collect(),
+        Some(YamlValue::String(value)) => vec![value.clone()],
+        _ => Vec::new(),
+    }
+}
+
+fn yaml_depth(value: &YamlValue) -> usize {
+    match value {
+        YamlValue::Sequence(values) => 1 + values.iter().map(yaml_depth).max().unwrap_or(0),
+        YamlValue::Mapping(map) => 1 + map.values().map(yaml_depth).max().unwrap_or(0),
+        _ => 1,
+    }
+}

--- a/crates/axon-parse/src/docker_tests.rs
+++ b/crates/axon-parse/src/docker_tests.rs
@@ -1,7 +1,7 @@
 use axon_api::source::*;
 use uuid::Uuid;
 
-use crate::docker::docker_facts;
+use crate::docker::{docker_facts, docker_parse_items};
 use crate::parser::ParseInput;
 
 fn input(path: &str, text: &str) -> ParseInput {
@@ -31,6 +31,104 @@ fn input(path: &str, text: &str) -> ParseInput {
     }
 }
 
+fn parse_fixture(path: &str, text: &str) -> crate::parser::ParseResult {
+    let input = input(path, text);
+    let (facts, graph_candidates) = docker_parse_items(&input);
+    crate::parser::ParseResult {
+        header: crate::parser::stage_header(&input, LifecycleStatus::Completed, Vec::new(), None),
+        document_id: input.document.document_id.clone(),
+        facts,
+        graph_candidates,
+        parser_id: "docker_manifest".to_string(),
+        parser_version: crate::facts::PARSER_VERSION.to_string(),
+        warnings: Vec::new(),
+        errors: Vec::new(),
+    }
+}
+
+fn has_fact(result: &crate::parser::ParseResult, fact_kind: &str, name: &str) -> bool {
+    result
+        .facts
+        .iter()
+        .any(|fact| fact.fact_kind == fact_kind && fact.name == name)
+}
+
+#[test]
+fn dockerfile_parser_emits_image_endpoint_env_and_graph_candidates() {
+    let result = parse_fixture(
+        "Dockerfile",
+        "FROM qdrant/qdrant:v1.13.1\nENV QDRANT__SERVICE__API_KEY=\nEXPOSE 6333\n",
+    );
+
+    assert!(has_fact(
+        &result,
+        "docker_base_image",
+        "qdrant/qdrant:v1.13.1"
+    ));
+    assert!(has_fact(
+        &result,
+        "secret_reference",
+        "QDRANT__SERVICE__API_KEY"
+    ));
+    assert!(has_fact(&result, "network_endpoint", "6333"));
+    assert!(result.graph_candidates.iter().any(|candidate| {
+        candidate
+            .nodes
+            .iter()
+            .any(|node| node.node_kind == "container_image_tag")
+    }));
+    assert!(
+        result
+            .graph_candidates
+            .iter()
+            .all(|candidate| axon_graph::candidate::validate_candidate(candidate).is_ok())
+    );
+}
+
+#[test]
+fn compose_parser_emits_service_image_port_volume_and_env_graph_candidates() {
+    let result = parse_fixture(
+        "docker-compose.yml",
+        r#"
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.13.1
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant-data:/qdrant/storage
+    environment:
+      QDRANT__SERVICE__API_KEY:
+volumes:
+  qdrant-data:
+"#,
+    );
+
+    assert!(has_fact(&result, "runtime_service", "qdrant"));
+    assert!(has_fact(
+        &result,
+        "container_image_tag",
+        "qdrant/qdrant:v1.13.1"
+    ));
+    assert!(has_fact(&result, "network_endpoint", "6333:6333"));
+    assert!(has_fact(
+        &result,
+        "volume_mount",
+        "qdrant-data:/qdrant/storage"
+    ));
+    assert!(has_fact(
+        &result,
+        "secret_reference",
+        "QDRANT__SERVICE__API_KEY"
+    ));
+    assert!(
+        result
+            .graph_candidates
+            .iter()
+            .all(|candidate| axon_graph::candidate::validate_candidate(candidate).is_ok())
+    );
+}
+
 #[test]
 fn extracts_dockerfile_and_compose_facts() {
     let dockerfile = docker_facts(&input(
@@ -39,15 +137,16 @@ fn extracts_dockerfile_and_compose_facts() {
     ));
     assert_eq!(dockerfile[0].name, "rust:1.86");
     assert_eq!(dockerfile[0].fact_kind, "docker_base_image");
-    assert_eq!(dockerfile[1].fact_kind, "docker_env");
-    assert_eq!(dockerfile[2].value["port"], "8080");
+    assert_eq!(dockerfile[1].fact_kind, "environment_variable");
+    assert_eq!(dockerfile[2].fact_kind, "network_endpoint");
+    assert_eq!(dockerfile[2].value["docker_port"], "8080");
 
     let compose = docker_facts(&input(
         "docker-compose.yaml",
         "services:\n  api:\n    image: ghcr.io/acme/api:latest\n    ports:\n      - \"8080:80\"\n",
     ));
-    assert_eq!(compose[0].fact_kind, "compose_service");
+    assert_eq!(compose[0].fact_kind, "runtime_service");
     assert_eq!(compose[0].name, "api");
-    assert_eq!(compose[1].fact_kind, "compose_image");
-    assert_eq!(compose[2].value["port"], "8080:80");
+    assert_eq!(compose[1].fact_kind, "container_image_tag");
+    assert_eq!(compose[2].value["docker_port"], "8080:80");
 }

--- a/crates/axon-parse/src/docker_tests.rs
+++ b/crates/axon-parse/src/docker_tests.rs
@@ -77,6 +77,7 @@ fn dockerfile_parser_emits_image_endpoint_env_and_graph_candidates() {
             .iter()
             .any(|node| node.node_kind == "container_image_tag")
     }));
+    assert!(!result.graph_candidates.is_empty());
     assert!(
         result
             .graph_candidates
@@ -121,6 +122,49 @@ volumes:
         "secret_reference",
         "QDRANT__SERVICE__API_KEY"
     ));
+    assert!(result.graph_candidates.iter().any(|candidate| {
+        candidate
+            .edges
+            .iter()
+            .any(|edge| edge.edge_kind == "service_uses_image")
+    }));
+    assert!(
+        result
+            .graph_candidates
+            .iter()
+            .all(|candidate| axon_graph::candidate::validate_candidate(candidate).is_ok())
+    );
+}
+
+#[test]
+fn compose_parser_emits_env_file_secrets_and_dependencies() {
+    let result = parse_fixture(
+        "docker-compose.yml",
+        r#"
+services:
+  api:
+    image: ghcr.io/acme/api:latest
+    env_file:
+      - .env
+    secrets:
+      - db_password
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: postgres:16
+"#,
+    );
+
+    assert!(has_fact(&result, "env_file", ".env"));
+    assert!(has_fact(&result, "secret_reference", "db_password"));
+    assert!(has_fact(&result, "service_dependency", "db"));
+    assert!(result.graph_candidates.iter().any(|candidate| {
+        candidate
+            .edges
+            .iter()
+            .any(|edge| edge.edge_kind == "derived_from")
+    }));
     assert!(
         result
             .graph_candidates

--- a/crates/axon-parse/src/env.rs
+++ b/crates/axon-parse/src/env.rs
@@ -2,46 +2,71 @@ use axon_api::source::{GraphCandidate, SourceParseFacts};
 use serde_json::json;
 
 use crate::facts::{inline_text, source_fact};
+use crate::graph_candidate::candidate_edge;
 use crate::parser::ParseInput;
 
 pub const MODULE_NAME: &str = "env";
 
 pub fn env_example_parse_items(input: &ParseInput) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
-    (env_example_facts(input), Vec::new())
+    let mut facts = Vec::new();
+    let mut candidates = Vec::new();
+    for (idx, line) in inline_text(input).lines().enumerate() {
+        let Some((key, value)) = parse_assignment(line) else {
+            continue;
+        };
+        let line_no = idx as u32 + 1;
+        let secret = is_secret_key(key) || value_suggests_secret(value);
+        let fact_kind = if secret {
+            "secret_reference"
+        } else {
+            "environment_variable"
+        };
+        facts.push(source_fact(
+            input,
+            "env_example",
+            "line_heuristic",
+            fact_kind,
+            key,
+            json!({
+                "key": key,
+                "has_default": !value.trim().is_empty(),
+                "value_redacted": !value.trim().is_empty(),
+            }),
+            Some(line_no),
+        ));
+        candidates.push(candidate_edge(
+            input,
+            "env_example",
+            "env_example",
+            "local_checkout",
+            &local_checkout_key(input),
+            if secret {
+                "secret_reference"
+            } else {
+                "environment_variable"
+            },
+            &format!("{}:{key}", if secret { "secret" } else { "env" }),
+            "repo_declares_env_var",
+            "env_example",
+            Some(line_no),
+            Some(format!("{key}=<redacted>")),
+        ));
+    }
+    (facts, candidates)
 }
 
 pub fn env_example_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
-    inline_text(input)
-        .lines()
-        .enumerate()
-        .filter_map(|(idx, line)| {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                return None;
-            }
-            let (key, value) = trimmed.split_once('=')?;
-            let key = key.trim();
-            if key.is_empty() {
-                return None;
-            }
-            let fact_kind = if is_secret_key(key) {
-                "secret_reference"
-            } else {
-                "env_var"
-            };
-            Some(source_fact(
-                input,
-                "env_example",
-                "line_heuristic",
-                fact_kind,
-                key,
-                json!({
-                    "has_default": !value.trim().is_empty(),
-                }),
-                Some(idx as u32 + 1),
-            ))
-        })
-        .collect()
+    env_example_parse_items(input).0
+}
+
+fn parse_assignment(line: &str) -> Option<(&str, &str)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let (key, value) = trimmed.split_once('=')?;
+    let key = key.trim();
+    (!key.is_empty()).then_some((key, value))
 }
 
 fn is_secret_key(key: &str) -> bool {
@@ -53,9 +78,22 @@ fn is_secret_key(key: &str) -> bool {
         "api_key",
         "apikey",
         "private_key",
+        "database_url",
     ]
     .iter()
     .any(|needle| lower.contains(needle))
+}
+
+fn value_suggests_secret(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.starts_with("sk-")
+        || lower.contains("://") && lower.contains('@') && lower.contains(':')
+        || lower.contains("password=")
+        || lower.contains("token=")
+}
+
+fn local_checkout_key(input: &ParseInput) -> String {
+    format!("local://{}", input.document.source_id.0)
 }
 
 #[cfg(test)]

--- a/crates/axon-parse/src/env.rs
+++ b/crates/axon-parse/src/env.rs
@@ -1,10 +1,14 @@
-use axon_api::source::SourceParseFacts;
+use axon_api::source::{GraphCandidate, SourceParseFacts};
 use serde_json::json;
 
 use crate::facts::{inline_text, source_fact};
 use crate::parser::ParseInput;
 
 pub const MODULE_NAME: &str = "env";
+
+pub fn env_example_parse_items(input: &ParseInput) -> (Vec<SourceParseFacts>, Vec<GraphCandidate>) {
+    (env_example_facts(input), Vec::new())
+}
 
 pub fn env_example_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
     inline_text(input)
@@ -20,11 +24,16 @@ pub fn env_example_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
             if key.is_empty() {
                 return None;
             }
+            let fact_kind = if is_secret_key(key) {
+                "secret_reference"
+            } else {
+                "env_var"
+            };
             Some(source_fact(
                 input,
                 "env_example",
                 "line_heuristic",
-                "env_var",
+                fact_kind,
                 key,
                 json!({
                     "has_default": !value.trim().is_empty(),
@@ -33,6 +42,20 @@ pub fn env_example_facts(input: &ParseInput) -> Vec<SourceParseFacts> {
             ))
         })
         .collect()
+}
+
+fn is_secret_key(key: &str) -> bool {
+    let lower = key.to_ascii_lowercase();
+    [
+        "secret",
+        "password",
+        "token",
+        "api_key",
+        "apikey",
+        "private_key",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
 }
 
 #[cfg(test)]

--- a/crates/axon-parse/src/env_tests.rs
+++ b/crates/axon-parse/src/env_tests.rs
@@ -1,7 +1,7 @@
 use axon_api::source::*;
 use uuid::Uuid;
 
-use crate::env::env_example_facts;
+use crate::env::{env_example_facts, env_example_parse_items};
 use crate::parser::ParseInput;
 
 fn input(text: &str) -> ParseInput {
@@ -31,6 +31,52 @@ fn input(text: &str) -> ParseInput {
     }
 }
 
+fn parse_fixture(path: &str, text: &str) -> crate::parser::ParseResult {
+    let mut input = input(text);
+    input.document.source_item_key = SourceItemKey::from(path);
+    input.document.canonical_uri = format!("file:///repo/{path}");
+    input.document.path = Some(path.to_string());
+    let (facts, graph_candidates) = env_example_parse_items(&input);
+    crate::parser::ParseResult {
+        header: crate::parser::stage_header(&input, LifecycleStatus::Completed, Vec::new(), None),
+        document_id: input.document.document_id.clone(),
+        facts,
+        graph_candidates,
+        parser_id: "env_example".to_string(),
+        parser_version: crate::facts::PARSER_VERSION.to_string(),
+        warnings: Vec::new(),
+        errors: Vec::new(),
+    }
+}
+
+fn has_fact(result: &crate::parser::ParseResult, fact_kind: &str, name: &str) -> bool {
+    result
+        .facts
+        .iter()
+        .any(|fact| fact.fact_kind == fact_kind && fact.name == name)
+}
+
+#[test]
+fn env_example_parser_never_emits_secret_values() {
+    let result = parse_fixture(
+        ".env.example",
+        "DATABASE_URL=postgres://user:pass@db/app\nOPENAI_API_KEY=sk-proj-secret\nPORT=3000\n",
+    );
+
+    assert!(has_fact(&result, "secret_reference", "DATABASE_URL"));
+    assert!(has_fact(&result, "secret_reference", "OPENAI_API_KEY"));
+    assert!(has_fact(&result, "environment_variable", "PORT"));
+    let serialized = serde_json::to_string(&result).expect("serialize parse result");
+    assert!(!serialized.contains("sk-proj-secret"));
+    assert!(!serialized.contains("user:pass"));
+    assert!(
+        result
+            .graph_candidates
+            .iter()
+            .all(|candidate| axon_graph::candidate::validate_candidate(candidate).is_ok())
+    );
+}
+
 #[test]
 fn extracts_env_example_keys_without_secret_values() {
     let facts = env_example_facts(&input(
@@ -38,7 +84,7 @@ fn extracts_env_example_keys_without_secret_values() {
     ));
 
     assert_eq!(facts.len(), 2);
-    assert_eq!(facts[0].fact_kind, "env_var");
+    assert_eq!(facts[0].fact_kind, "environment_variable");
     assert_eq!(facts[0].name, "API_URL");
     assert_eq!(facts[0].value["has_default"], true);
     assert_eq!(facts[1].value["has_default"], false);

--- a/crates/axon-parse/src/env_tests.rs
+++ b/crates/axon-parse/src/env_tests.rs
@@ -69,6 +69,7 @@ fn env_example_parser_never_emits_secret_values() {
     let serialized = serde_json::to_string(&result).expect("serialize parse result");
     assert!(!serialized.contains("sk-proj-secret"));
     assert!(!serialized.contains("user:pass"));
+    assert!(!result.graph_candidates.is_empty());
     assert!(
         result
             .graph_candidates

--- a/crates/axon-parse/src/graph_candidate.rs
+++ b/crates/axon-parse/src/graph_candidate.rs
@@ -102,6 +102,99 @@ pub fn graph_candidate(
     }
 }
 
+pub fn candidate_edge(
+    input: &ParseInput,
+    parser_id: &str,
+    candidate_kind: &str,
+    from_node_kind: &str,
+    from_stable_key: &str,
+    to_node_kind: &str,
+    to_stable_key: &str,
+    edge_kind: &str,
+    evidence_kind: &str,
+    line: Option<u32>,
+    quote: Option<String>,
+) -> GraphCandidate {
+    let evidence_range = line.map(|line| SourceRange {
+        line_start: Some(line),
+        line_end: Some(line),
+        byte_start: None,
+        byte_end: None,
+        char_start: None,
+        char_end: None,
+        time_start_ms: None,
+        time_end_ms: None,
+        dom_selector: None,
+        json_pointer: None,
+        yaml_path: None,
+        xml_xpath: None,
+        csv_row: None,
+        session_turn_id: None,
+        turn_start: None,
+        turn_end: None,
+    });
+    let candidate_token = stable_token(&format!(
+        "{}:{}:{to_stable_key}:{line:?}",
+        input.document.canonical_uri, candidate_kind
+    ));
+    let evidence_token = stable_token(&format!(
+        "{candidate_kind}:{to_stable_key}:{line:?}:{quote:?}"
+    ));
+
+    GraphCandidate {
+        candidate_id: format!("cand_{candidate_kind}_{candidate_token}"),
+        job_id: input.job_id,
+        source_id: input.document.source_id.clone(),
+        source_item_key: input.document.source_item_key.clone(),
+        item_canonical_uri: input.document.canonical_uri.clone(),
+        document_id: Some(input.document.document_id.clone()),
+        kind: candidate_kind.to_string(),
+        merge_key: Some(format!(
+            "{candidate_kind}:{}:{to_stable_key}",
+            input.document.canonical_uri
+        )),
+        producer: GraphCandidateProducer {
+            adapter: "axon-parse".to_string(),
+            parser: Some(parser_id.to_string()),
+            version: PARSER_VERSION.to_string(),
+        },
+        nodes: vec![
+            GraphNodeCandidate {
+                node_kind: from_node_kind.to_string(),
+                stable_key: from_stable_key.to_string(),
+                label: input.document.source_item_key.0.clone(),
+                properties: MetadataMap::new(),
+            },
+            GraphNodeCandidate {
+                node_kind: to_node_kind.to_string(),
+                stable_key: to_stable_key.to_string(),
+                label: to_stable_key.to_string(),
+                properties: MetadataMap::new(),
+            },
+        ],
+        edges: vec![GraphEdgeCandidate {
+            edge_kind: edge_kind.to_string(),
+            from_stable_key: from_stable_key.to_string(),
+            to_stable_key: to_stable_key.to_string(),
+            properties: MetadataMap::new(),
+        }],
+        evidence: vec![GraphEvidence {
+            evidence_id: format!("ev_{evidence_token}"),
+            evidence_kind: evidence_kind.to_string(),
+            source_id: input.document.source_id.clone(),
+            source_item_key: input.document.source_item_key.clone(),
+            document_id: Some(input.document.document_id.clone()),
+            chunk_id: None,
+            range: evidence_range,
+            quote,
+            confidence: 0.9,
+            metadata: MetadataMap::new(),
+        }],
+        confidence: 0.9,
+        metadata: MetadataMap::new(),
+    }
+}
+
 fn stable_token(value: &str) -> String {
     let mut hash = 0xcbf29ce484222325u64;
     for byte in value.bytes() {

--- a/crates/axon-parse/src/graph_candidate.rs
+++ b/crates/axon-parse/src/graph_candidate.rs
@@ -21,7 +21,7 @@ pub fn graph_candidate(
         "source_id={}|item={}|uri={}",
         input.document.source_id.0, input.document.source_item_key.0, input.document.canonical_uri
     );
-    let file_key = format!("source_item:{}", stable_token(&source_scope));
+    let file_key = format!("repo_file:{}", stable_token(&source_scope));
     let item_identity = format!("{source_scope}|kind={kind}|name={name}");
     let item_token = stable_token(&item_identity);
     let candidate_id = format!("cand_{kind}_{item_token}");
@@ -50,27 +50,27 @@ pub fn graph_candidate(
         },
         nodes: vec![
             GraphNodeCandidate {
-                node_kind: "source_item".to_string(),
+                node_kind: "repo_file".to_string(),
                 stable_key: file_key.clone(),
                 label: input.document.source_item_key.0.clone(),
                 properties: MetadataMap::new(),
             },
             GraphNodeCandidate {
-                node_kind: kind.to_string(),
+                node_kind: "artifact".to_string(),
                 stable_key: item_key.clone(),
                 label: name.to_string(),
                 properties: MetadataMap::new(),
             },
         ],
         edges: vec![GraphEdgeCandidate {
-            edge_kind: "declares".to_string(),
+            edge_kind: "source_indexed_as".to_string(),
             from_stable_key: file_key,
             to_stable_key: item_key,
             properties: MetadataMap::new(),
         }],
         evidence: vec![GraphEvidence {
             evidence_id,
-            evidence_kind: "source_line".to_string(),
+            evidence_kind: "text_mention".to_string(),
             source_id: input.document.source_id.clone(),
             source_item_key: input.document.source_item_key.clone(),
             document_id: Some(input.document.document_id.clone()),

--- a/crates/axon-parse/src/graph_candidate_tests.rs
+++ b/crates/axon-parse/src/graph_candidate_tests.rs
@@ -58,6 +58,7 @@ fn graph_candidate_keys_are_source_scoped_and_collision_resistant() {
     assert_ne!(left.nodes[1].stable_key, right.nodes[1].stable_key);
     assert_ne!(left.candidate_id, other_source.candidate_id);
     assert_ne!(left.nodes[0].stable_key, other_source.nodes[0].stable_key);
+    axon_graph::candidate::validate_candidate(&left).expect("legacy helper is contract-valid");
 }
 
 #[test]

--- a/crates/axon-parse/src/graph_candidate_tests.rs
+++ b/crates/axon-parse/src/graph_candidate_tests.rs
@@ -7,6 +7,27 @@ use crate::graph_candidate::graph_candidate;
 use crate::parser::ParseInput;
 
 #[test]
+fn parser_graph_candidate_uses_closed_source_graph_registry() {
+    let input = input("src-a", "Dockerfile", "file:///repo/Dockerfile");
+
+    let candidate = crate::graph_candidate::candidate_edge(
+        &input,
+        "docker_manifest",
+        "container_manifest",
+        "local_checkout",
+        "local://repo",
+        "container_image",
+        "docker:library/postgres",
+        "repo_uses_container_image",
+        "container_manifest",
+        Some(1),
+        Some("FROM postgres:16".to_string()),
+    );
+
+    axon_graph::candidate::validate_candidate(&candidate).expect("candidate is contract-valid");
+}
+
+#[test]
 fn graph_candidate_keys_are_source_scoped_and_collision_resistant() {
     let left = graph_candidate(
         &input("src-a", "foo-bar", "file:///repo-a/foo.rs"),

--- a/crates/axon-parse/src/markdown_tests.rs
+++ b/crates/axon-parse/src/markdown_tests.rs
@@ -66,8 +66,8 @@ fn extracts_markdown_heading_facts_and_candidates() {
 
     let candidate = &candidates[1];
     assert_eq!(candidate.kind, "markdown_heading");
-    assert_eq!(candidate.nodes[1].node_kind, "markdown_heading");
-    assert_eq!(candidate.edges[0].edge_kind, "declares");
+    assert_eq!(candidate.nodes[1].node_kind, "artifact");
+    assert_eq!(candidate.edges[0].edge_kind, "source_indexed_as");
     assert_eq!(
         candidate.evidence[0].quote.as_deref(),
         Some("## Source Pipeline")

--- a/crates/axon-parse/src/parser_tests.rs
+++ b/crates/axon-parse/src/parser_tests.rs
@@ -285,68 +285,112 @@ fn parser_family_completeness_routes_phase_7_fixtures() {
             "Cargo.toml",
             ContentKind::Toml,
             "[package]\nname = \"axon\"\n[dependencies]\ntokio = \"1\"\n",
+            "manifest",
         ),
         (
             "Cargo.lock",
             ContentKind::Toml,
             "[[package]]\nname = \"tokio\"\n",
+            "manifest",
         ),
-        ("lib.rs", ContentKind::Code, "pub fn run() {}\n"),
+        (
+            "lib.rs",
+            ContentKind::Code,
+            "pub fn run() {}\n",
+            "code_symbols",
+        ),
         (
             "package.json",
             ContentKind::Json,
             r#"{"dependencies":{"vite":"7"}}"#,
+            "manifest",
         ),
         (
             "pnpm-lock.yaml",
             ContentKind::Yaml,
             "dependencies:\n  vite: 7.0.0\n",
+            "manifest",
         ),
-        ("index.ts", ContentKind::Code, "export function run() {}\n"),
+        (
+            "index.ts",
+            ContentKind::Code,
+            "export function run() {}\n",
+            "code_symbols",
+        ),
         (
             "pyproject.toml",
             ContentKind::Toml,
             "[project]\ndependencies = [\"requests\"]\n",
+            "manifest",
         ),
-        ("requirements.txt", ContentKind::PlainText, "requests==2\n"),
-        ("module.py", ContentKind::Code, "def run():\n    pass\n"),
-        ("Dockerfile", ContentKind::PlainText, "FROM alpine:3\n"),
+        (
+            "requirements.txt",
+            ContentKind::PlainText,
+            "requests==2\n",
+            "manifest",
+        ),
+        (
+            "module.py",
+            ContentKind::Code,
+            "def run():\n    pass\n",
+            "code_symbols",
+        ),
+        (
+            "Dockerfile",
+            ContentKind::PlainText,
+            "FROM alpine:3\n",
+            "docker_manifest",
+        ),
         (
             "docker-compose.yml",
             ContentKind::Yaml,
             "services:\n  api:\n    image: alpine:3\n",
+            "docker_manifest",
         ),
-        (".env.example", ContentKind::PlainText, "PORT=3000\n"),
+        (
+            ".env.example",
+            ContentKind::PlainText,
+            "PORT=3000\n",
+            "env_example",
+        ),
         (
             "openapi.yaml",
             ContentKind::Yaml,
             "openapi: 3.1.0\npaths: {}\n",
+            "api_schema",
         ),
         (
             "schema.graphql",
             ContentKind::PlainText,
             "type Query { ping: String }\n",
+            "api_schema",
         ),
         (
             "session.jsonl",
             ContentKind::Transcript,
             r#"{"type":"message","role":"user","content":"hi"}"#,
+            "session_jsonl",
         ),
         (
             "tool-output.jsonl",
             ContentKind::Structured,
             r#"{"tool":"shell","action":"exec","output":"ok"}"#,
+            "tool_output_jsonl",
         ),
         (
             "mcp-tool-schema.json",
             ContentKind::Json,
             r#"{"name":"axon","inputSchema":{"type":"object"}}"#,
+            "api_schema",
         ),
     ];
 
-    for (path, kind, text) in cases {
+    for (path, kind, text, expected_parser) in cases {
         let result = registry.parse(&input(source_doc(kind, Some(path), None, text)));
-        assert_ne!(result.parser_id, "none", "{path} should route to a parser");
+        assert_eq!(
+            result.parser_id, expected_parser,
+            "{path} should route to {expected_parser}"
+        );
     }
 }
 

--- a/crates/axon-parse/src/parser_tests.rs
+++ b/crates/axon-parse/src/parser_tests.rs
@@ -278,6 +278,79 @@ fn production_registry_runs_real_parser_families() {
 }
 
 #[test]
+fn parser_family_completeness_routes_phase_7_fixtures() {
+    let registry = production_registry();
+    let cases = [
+        (
+            "Cargo.toml",
+            ContentKind::Toml,
+            "[package]\nname = \"axon\"\n[dependencies]\ntokio = \"1\"\n",
+        ),
+        (
+            "Cargo.lock",
+            ContentKind::Toml,
+            "[[package]]\nname = \"tokio\"\n",
+        ),
+        ("lib.rs", ContentKind::Code, "pub fn run() {}\n"),
+        (
+            "package.json",
+            ContentKind::Json,
+            r#"{"dependencies":{"vite":"7"}}"#,
+        ),
+        (
+            "pnpm-lock.yaml",
+            ContentKind::Yaml,
+            "dependencies:\n  vite: 7.0.0\n",
+        ),
+        ("index.ts", ContentKind::Code, "export function run() {}\n"),
+        (
+            "pyproject.toml",
+            ContentKind::Toml,
+            "[project]\ndependencies = [\"requests\"]\n",
+        ),
+        ("requirements.txt", ContentKind::PlainText, "requests==2\n"),
+        ("module.py", ContentKind::Code, "def run():\n    pass\n"),
+        ("Dockerfile", ContentKind::PlainText, "FROM alpine:3\n"),
+        (
+            "docker-compose.yml",
+            ContentKind::Yaml,
+            "services:\n  api:\n    image: alpine:3\n",
+        ),
+        (".env.example", ContentKind::PlainText, "PORT=3000\n"),
+        (
+            "openapi.yaml",
+            ContentKind::Yaml,
+            "openapi: 3.1.0\npaths: {}\n",
+        ),
+        (
+            "schema.graphql",
+            ContentKind::PlainText,
+            "type Query { ping: String }\n",
+        ),
+        (
+            "session.jsonl",
+            ContentKind::Transcript,
+            r#"{"type":"message","role":"user","content":"hi"}"#,
+        ),
+        (
+            "tool-output.jsonl",
+            ContentKind::Structured,
+            r#"{"tool":"shell","action":"exec","output":"ok"}"#,
+        ),
+        (
+            "mcp-tool-schema.json",
+            ContentKind::Json,
+            r#"{"name":"axon","inputSchema":{"type":"object"}}"#,
+        ),
+    ];
+
+    for (path, kind, text) in cases {
+        let result = registry.parse(&input(source_doc(kind, Some(path), None, text)));
+        assert_ne!(result.parser_id, "none", "{path} should route to a parser");
+    }
+}
+
+#[test]
 fn fake_parser_registry_wraps_registry_selection_for_tests() {
     let registry = FakeParserRegistry::new().with_parser(
         parser("fake_markdown")

--- a/crates/axon-parse/src/parser_tests.rs
+++ b/crates/axon-parse/src/parser_tests.rs
@@ -268,7 +268,7 @@ fn production_registry_runs_real_parser_families() {
     assert!(
         env.facts
             .iter()
-            .any(|fact| fact.fact_kind == "env_var" && fact.name == "QDRANT_URL")
+            .any(|fact| fact.fact_kind == "environment_variable" && fact.name == "QDRANT_URL")
     );
     assert!(
         env.facts

--- a/crates/axon-parse/src/parser_tests.rs
+++ b/crates/axon-parse/src/parser_tests.rs
@@ -246,6 +246,35 @@ fn production_registry_runs_real_parser_families() {
     )));
     assert_eq!(markdown.parser_id, "markdown_headings");
     assert_eq!(markdown.facts[0].fact_kind, "markdown_heading");
+
+    let docker = registry.parse(&input(source_doc(
+        ContentKind::PlainText,
+        Some("Dockerfile"),
+        None,
+        "FROM qdrant/qdrant:v1.13.1\nEXPOSE 6333\n",
+    )));
+    assert_eq!(docker.parser_id, "docker_manifest");
+    assert!(docker.facts.iter().any(|fact| {
+        fact.fact_kind == "docker_base_image" && fact.name == "qdrant/qdrant:v1.13.1"
+    }));
+
+    let env = registry.parse(&input(source_doc(
+        ContentKind::PlainText,
+        Some(".env.example"),
+        None,
+        "QDRANT_URL=http://localhost:6333\nOPENAI_API_KEY=\n",
+    )));
+    assert_eq!(env.parser_id, "env_example");
+    assert!(
+        env.facts
+            .iter()
+            .any(|fact| fact.fact_kind == "env_var" && fact.name == "QDRANT_URL")
+    );
+    assert!(
+        env.facts
+            .iter()
+            .any(|fact| { fact.fact_kind == "secret_reference" && fact.name == "OPENAI_API_KEY" })
+    );
 }
 
 #[test]

--- a/crates/axon-parse/src/tool.rs
+++ b/crates/axon-parse/src/tool.rs
@@ -57,13 +57,29 @@ pub fn tool_parse_items(input: &ParseInput) -> ToolParseItems {
             ));
             continue;
         }
-        let Some(tool) = value
-            .get("tool")
-            .or_else(|| value.get("tool_name"))
-            .and_then(Value::as_str)
-        else {
+        let Some(record) = ToolRecord::from_value(&value) else {
             continue;
         };
+        push_tool_record(input, &value, &record, line_no, &mut parsed);
+    }
+
+    parsed
+}
+
+struct ToolRecord<'a> {
+    tool: &'a str,
+    action: Option<&'a str>,
+    name: String,
+    output_kind: &'static str,
+    side_effect_class: &'a str,
+}
+
+impl<'a> ToolRecord<'a> {
+    fn from_value(value: &'a Value) -> Option<Self> {
+        let tool = value
+            .get("tool")
+            .or_else(|| value.get("tool_name"))
+            .and_then(Value::as_str)?;
         let action = value
             .get("action")
             .or_else(|| value.get("name"))
@@ -71,149 +87,208 @@ pub fn tool_parse_items(input: &ParseInput) -> ToolParseItems {
         let name = action
             .map(|action| format!("{tool}.{action}"))
             .unwrap_or_else(|| tool.to_string());
-        let output_kind = value.get("output").map(json_kind).unwrap_or("missing");
-        let side_effect_class = value
-            .get("side_effect_class")
-            .and_then(Value::as_str)
-            .unwrap_or("read");
+        Some(Self {
+            tool,
+            action,
+            name,
+            output_kind: value.get("output").map(json_kind).unwrap_or("missing"),
+            side_effect_class: value
+                .get("side_effect_class")
+                .and_then(Value::as_str)
+                .unwrap_or("read"),
+        })
+    }
+}
 
+fn push_tool_record(
+    input: &ParseInput,
+    value: &Value,
+    record: &ToolRecord<'_>,
+    line_no: u32,
+    parsed: &mut ToolParseItems,
+) {
+    push_observed_tool_claim(input, value, record, line_no, parsed);
+    push_redacted_field_reports(input, value, record, line_no, parsed);
+    push_artifact_reference(input, value, record, line_no, parsed);
+    push_external_resources(input, value, record, line_no, parsed);
+}
+
+fn push_observed_tool_claim(
+    input: &ParseInput,
+    value: &Value,
+    record: &ToolRecord<'_>,
+    line_no: u32,
+    parsed: &mut ToolParseItems,
+) {
+    parsed.facts.push(source_fact(
+        input,
+        "tool_output_jsonl",
+        "jsonl",
+        "tool_observed_claim",
+        &record.name,
+        json!({
+            "tool": record.tool,
+            "action": record.action,
+            "status": value.get("status").and_then(Value::as_str).unwrap_or("unknown"),
+            "output_kind": record.output_kind,
+            "observed_execution_requested": value.get("execution_requested").and_then(Value::as_bool),
+            "observed_execution_allowed_claim": value.get("execution_allowed").and_then(Value::as_bool),
+            "trusted_policy": false,
+            "side_effect_class": record.side_effect_class,
+            "argv": "[redacted]",
+            "env": "[redacted]",
+            "stdout": "[redacted]",
+            "stderr": "[redacted]",
+        }),
+        Some(line_no),
+    ));
+    parsed.graph_candidates.push(candidate_edge(
+        input,
+        "tool_output_jsonl",
+        "tool_call_event",
+        "tool_call",
+        &tool_call_key(input, &record.name, line_no),
+        "tool",
+        &format!("tool:{}", record.tool),
+        "tool_call_uses_tool",
+        "tool_call_event",
+        Some(line_no),
+        Some(format!("{} [redacted]", record.name)),
+    ));
+}
+
+fn push_redacted_field_reports(
+    input: &ParseInput,
+    value: &Value,
+    record: &ToolRecord<'_>,
+    line_no: u32,
+    parsed: &mut ToolParseItems,
+) {
+    for path in redacted_paths(value)
+        .into_iter()
+        .take(MAX_TOOL_REDACTED_FIELDS)
+    {
         parsed.facts.push(source_fact(
             input,
             "tool_output_jsonl",
-            "jsonl",
-            "tool_observed_claim",
-            &name,
+            "jsonl_heuristic",
+            "tool_redacted_field",
+            path.clone(),
             json!({
-                "tool": tool,
-                "action": action,
-                "status": value.get("status").and_then(Value::as_str).unwrap_or("unknown"),
-                "output_kind": output_kind,
-                "observed_execution_requested": value.get("execution_requested").and_then(Value::as_bool),
-                "observed_execution_allowed_claim": value.get("execution_allowed").and_then(Value::as_bool),
-                "trusted_policy": false,
-                "side_effect_class": side_effect_class,
-                "argv": "[redacted]",
-                "env": "[redacted]",
-                "stdout": "[redacted]",
-                "stderr": "[redacted]",
+                "tool": record.tool,
+                "action": record.action,
+                "path": path,
             }),
             Some(line_no),
         ));
-        parsed.graph_candidates.push(candidate_edge(
+        parsed.warnings.push(warning(
             input,
-            "tool_output_jsonl",
-            "tool_call_event",
-            "tool_call",
-            &tool_call_key(input, &name, line_no),
-            "tool",
-            &format!("tool:{tool}"),
-            "tool_call_uses_tool",
-            "tool_call_event",
-            Some(line_no),
-            Some(format!("{name} [redacted]")),
+            "tool.redacted_field",
+            format!("tool output contains redacted field at {path}"),
         ));
-
-        for path in redacted_paths(&value)
-            .into_iter()
-            .take(MAX_TOOL_REDACTED_FIELDS)
-        {
-            parsed.facts.push(source_fact(
-                input,
-                "tool_output_jsonl",
-                "jsonl_heuristic",
-                "tool_redacted_field",
-                path.clone(),
-                json!({
-                    "tool": tool,
-                    "action": action,
-                    "path": path,
-                }),
-                Some(line_no),
-            ));
-            parsed.warnings.push(warning(
-                input,
-                "tool.redacted_field",
-                format!("tool output contains redacted field at {path}"),
-            ));
-        }
-
-        if let Some(artifact) = output_artifact(&value) {
-            let artifact_id = artifact.artifact_id.clone();
-            parsed.facts.push(source_fact(
-                input,
-                "tool_output_jsonl",
-                "jsonl_heuristic",
-                "tool_artifact_ref",
-                artifact_id.clone(),
-                json!({
-                    "tool": tool,
-                    "action": action,
-                    "artifact_id": artifact_id,
-                    "uri": artifact.uri,
-                    "size_bytes": artifact.size_bytes,
-                    "reason": artifact.reason,
-                }),
-                Some(line_no),
-            ));
-            parsed.graph_candidates.push(candidate_edge(
-                input,
-                "tool_output_jsonl",
-                "tool_result_event",
-                "tool_call",
-                &tool_call_key(input, &name, line_no),
-                "artifact",
-                &format!("artifact:{artifact_id}"),
-                "tool_call_produced_artifact",
-                "tool_result_event",
-                Some(line_no),
-                Some(format!("artifact:{artifact_id}")),
-            ));
-            parsed.warnings.push(warning(
-                input,
-                "tool.output_artifact",
-                "tool output was stored as an artifact reference".to_string(),
-            ));
-        }
-
-        for uri in external_resources(&value)
-            .into_iter()
-            .take(MAX_TOOL_RESOURCES_PER_RECORD)
-        {
-            parsed.facts.push(source_fact(
-                input,
-                "tool_output_jsonl",
-                "jsonl_heuristic",
-                "external_resource",
-                uri.clone(),
-                json!({
-                    "tool": tool,
-                    "action": action,
-                    "uri": uri,
-                    "side_effect_class": side_effect_class,
-                }),
-                Some(line_no),
-            ));
-            parsed.graph_candidates.push(candidate_edge(
-                input,
-                "tool_output_jsonl",
-                "tool_call_event",
-                "tool_call",
-                &tool_call_key(input, &name, line_no),
-                "external_resource",
-                &format!("external:{uri}"),
-                if mutating_side_effect(side_effect_class) {
-                    "tool_call_mutated_resource"
-                } else {
-                    "tool_call_read_resource"
-                },
-                "tool_call_event",
-                Some(line_no),
-                Some(uri),
-            ));
-        }
     }
+}
 
-    parsed
+fn push_artifact_reference(
+    input: &ParseInput,
+    value: &Value,
+    record: &ToolRecord<'_>,
+    line_no: u32,
+    parsed: &mut ToolParseItems,
+) {
+    let Some(artifact) = output_artifact(value) else {
+        return;
+    };
+    let artifact_id = artifact.artifact_id.clone();
+    parsed.facts.push(source_fact(
+        input,
+        "tool_output_jsonl",
+        "jsonl_heuristic",
+        "tool_artifact_ref",
+        artifact_id.clone(),
+        json!({
+            "tool": record.tool,
+            "action": record.action,
+            "artifact_id": artifact_id,
+            "uri": artifact.uri,
+            "size_bytes": artifact.size_bytes,
+            "reason": artifact.reason,
+        }),
+        Some(line_no),
+    ));
+    parsed.graph_candidates.push(candidate_edge(
+        input,
+        "tool_output_jsonl",
+        "tool_result_event",
+        "tool_call",
+        &tool_call_key(input, &record.name, line_no),
+        "artifact",
+        &format!("artifact:{artifact_id}"),
+        "tool_call_produced_artifact",
+        "tool_result_event",
+        Some(line_no),
+        Some(format!("artifact:{artifact_id}")),
+    ));
+    parsed.warnings.push(warning(
+        input,
+        "tool.output_artifact",
+        "tool output was stored as an artifact reference".to_string(),
+    ));
+}
+
+fn push_external_resources(
+    input: &ParseInput,
+    value: &Value,
+    record: &ToolRecord<'_>,
+    line_no: u32,
+    parsed: &mut ToolParseItems,
+) {
+    for uri in external_resources(value)
+        .into_iter()
+        .take(MAX_TOOL_RESOURCES_PER_RECORD)
+    {
+        push_external_resource(input, record, line_no, parsed, redact_resource_uri(&uri));
+    }
+}
+
+fn push_external_resource(
+    input: &ParseInput,
+    record: &ToolRecord<'_>,
+    line_no: u32,
+    parsed: &mut ToolParseItems,
+    safe_uri: String,
+) {
+    parsed.facts.push(source_fact(
+        input,
+        "tool_output_jsonl",
+        "jsonl_heuristic",
+        "external_resource",
+        safe_uri.clone(),
+        json!({
+            "tool": record.tool,
+            "action": record.action,
+            "uri": safe_uri,
+            "side_effect_class": record.side_effect_class,
+        }),
+        Some(line_no),
+    ));
+    parsed.graph_candidates.push(candidate_edge(
+        input,
+        "tool_output_jsonl",
+        "tool_call_event",
+        "tool_call",
+        &tool_call_key(input, &record.name, line_no),
+        "external_resource",
+        &format!("external:{safe_uri}"),
+        if mutating_side_effect(record.side_effect_class) {
+            "tool_call_mutated_resource"
+        } else {
+            "tool_call_read_resource"
+        },
+        "tool_call_event",
+        Some(line_no),
+        Some(safe_uri),
+    ));
 }
 
 pub fn tool_parse_result(input: &ParseInput) -> ParseResult {
@@ -369,6 +444,59 @@ fn external_resources(value: &Value) -> Vec<String> {
         .filter_map(|resource| resource.get("uri").and_then(Value::as_str))
         .filter(|uri| !uri.is_empty())
         .map(str::to_string)
+        .collect()
+}
+
+fn redact_resource_uri(uri: &str) -> String {
+    let mut redacted = redact_authority_userinfo(uri);
+    if let Some(query_start) = redacted.find('?') {
+        let fragment = redacted[query_start..]
+            .find('#')
+            .map(|offset| redacted[query_start + offset..].to_string());
+        redacted.truncate(query_start);
+        redacted.push_str("?[REDACTED]");
+        if let Some(fragment) = fragment {
+            redacted.push_str(&fragment);
+        }
+    }
+    redact_secret_tokens(&redacted)
+}
+
+fn redact_authority_userinfo(uri: &str) -> String {
+    let Some(scheme_end) = uri.find("://") else {
+        return uri.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let authority_len = uri[authority_start..]
+        .find(['/', '?', '#'])
+        .unwrap_or(uri.len() - authority_start);
+    let authority_end = authority_start + authority_len;
+    let Some(at_offset) = uri[authority_start..authority_end].rfind('@') else {
+        return uri.to_string();
+    };
+    let at = authority_start + at_offset;
+    format!("{}[REDACTED]{}", &uri[..authority_start], &uri[at..])
+}
+
+fn redact_secret_tokens(text: &str) -> String {
+    text.split_inclusive(|ch: char| ch.is_ascii_whitespace() || matches!(ch, '&' | ';' | ','))
+        .map(|part| {
+            let lower = part.to_ascii_lowercase();
+            if lower.contains("authorization:")
+                || lower.contains("authorization=")
+                || lower.contains("api_key=")
+                || lower.contains("apikey=")
+                || lower.contains("token=")
+                || lower.contains("secret=")
+                || lower.contains("password=")
+                || lower.contains("sk-")
+                || lower.contains("ghp_")
+            {
+                "[REDACTED]".to_string()
+            } else {
+                part.to_string()
+            }
+        })
         .collect()
 }
 

--- a/crates/axon-parse/src/tool.rs
+++ b/crates/axon-parse/src/tool.rs
@@ -1,14 +1,23 @@
-use axon_api::source::{LifecycleStatus, Severity, SourceParseFacts, SourceWarning};
+use axon_api::source::{
+    GraphCandidate, LifecycleStatus, Severity, SourceParseFacts, SourceWarning,
+};
 use serde_json::{Value, json};
 
 use crate::facts::{inline_text, source_fact};
+use crate::graph_candidate::candidate_edge;
 use crate::parser::{ParseInput, ParseResult, stage_header};
 
 pub const MODULE_NAME: &str = "tool";
+pub const MAX_TOOL_JSONL_LINE_BYTES: usize = 256 * 1024;
+pub const MAX_TOOL_JSON_DEPTH: usize = 32;
+pub const MAX_TOOL_JSON_ENTRIES: usize = 4_096;
+pub const MAX_TOOL_REDACTED_FIELDS: usize = 512;
+pub const MAX_TOOL_RESOURCES_PER_RECORD: usize = 128;
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ToolParseItems {
     pub facts: Vec<SourceParseFacts>,
+    pub graph_candidates: Vec<GraphCandidate>,
     pub warnings: Vec<SourceWarning>,
 }
 
@@ -19,6 +28,14 @@ pub fn tool_parse_items(input: &ParseInput) -> ToolParseItems {
         let line_no = idx as u32 + 1;
         let trimmed = line.trim();
         if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.len() > MAX_TOOL_JSONL_LINE_BYTES {
+            parsed.warnings.push(warning(
+                input,
+                "tool.jsonl.line_too_large",
+                format!("tool JSONL line {line_no} exceeds maximum byte length"),
+            ));
             continue;
         }
         let value = match serde_json::from_str::<Value>(trimmed) {
@@ -32,6 +49,14 @@ pub fn tool_parse_items(input: &ParseInput) -> ToolParseItems {
                 continue;
             }
         };
+        if !json_within_caps(&value) {
+            parsed.warnings.push(warning(
+                input,
+                "tool.jsonl.bounds_exceeded",
+                format!("tool JSONL line {line_no} exceeds structural limits"),
+            ));
+            continue;
+        }
         let Some(tool) = value
             .get("tool")
             .or_else(|| value.get("tool_name"))
@@ -47,23 +72,51 @@ pub fn tool_parse_items(input: &ParseInput) -> ToolParseItems {
             .map(|action| format!("{tool}.{action}"))
             .unwrap_or_else(|| tool.to_string());
         let output_kind = value.get("output").map(json_kind).unwrap_or("missing");
+        let side_effect_class = value
+            .get("side_effect_class")
+            .and_then(Value::as_str)
+            .unwrap_or("read");
 
         parsed.facts.push(source_fact(
             input,
             "tool_output_jsonl",
             "jsonl",
-            "tool_output",
-            name,
+            "tool_observed_claim",
+            &name,
             json!({
                 "tool": tool,
                 "action": action,
                 "status": value.get("status").and_then(Value::as_str).unwrap_or("unknown"),
                 "output_kind": output_kind,
+                "observed_execution_requested": value.get("execution_requested").and_then(Value::as_bool),
+                "observed_execution_allowed_claim": value.get("execution_allowed").and_then(Value::as_bool),
+                "trusted_policy": false,
+                "side_effect_class": side_effect_class,
+                "argv": "[redacted]",
+                "env": "[redacted]",
+                "stdout": "[redacted]",
+                "stderr": "[redacted]",
             }),
             Some(line_no),
         ));
+        parsed.graph_candidates.push(candidate_edge(
+            input,
+            "tool_output_jsonl",
+            "tool_call_event",
+            "tool_call",
+            &tool_call_key(input, &name, line_no),
+            "tool",
+            &format!("tool:{tool}"),
+            "tool_call_uses_tool",
+            "tool_call_event",
+            Some(line_no),
+            Some(format!("{name} [redacted]")),
+        ));
 
-        for path in redacted_paths(&value) {
+        for path in redacted_paths(&value)
+            .into_iter()
+            .take(MAX_TOOL_REDACTED_FIELDS)
+        {
             parsed.facts.push(source_fact(
                 input,
                 "tool_output_jsonl",
@@ -85,26 +138,77 @@ pub fn tool_parse_items(input: &ParseInput) -> ToolParseItems {
         }
 
         if let Some(artifact) = output_artifact(&value) {
+            let artifact_id = artifact.artifact_id.clone();
             parsed.facts.push(source_fact(
                 input,
                 "tool_output_jsonl",
                 "jsonl_heuristic",
                 "tool_artifact_ref",
-                artifact.artifact_id.clone(),
+                artifact_id.clone(),
                 json!({
                     "tool": tool,
                     "action": action,
-                    "artifact_id": artifact.artifact_id,
+                    "artifact_id": artifact_id,
                     "uri": artifact.uri,
                     "size_bytes": artifact.size_bytes,
                     "reason": artifact.reason,
                 }),
                 Some(line_no),
             ));
+            parsed.graph_candidates.push(candidate_edge(
+                input,
+                "tool_output_jsonl",
+                "tool_result_event",
+                "tool_call",
+                &tool_call_key(input, &name, line_no),
+                "artifact",
+                &format!("artifact:{artifact_id}"),
+                "tool_call_produced_artifact",
+                "tool_result_event",
+                Some(line_no),
+                Some(format!("artifact:{artifact_id}")),
+            ));
             parsed.warnings.push(warning(
                 input,
                 "tool.output_artifact",
                 "tool output was stored as an artifact reference".to_string(),
+            ));
+        }
+
+        for uri in external_resources(&value)
+            .into_iter()
+            .take(MAX_TOOL_RESOURCES_PER_RECORD)
+        {
+            parsed.facts.push(source_fact(
+                input,
+                "tool_output_jsonl",
+                "jsonl_heuristic",
+                "external_resource",
+                uri.clone(),
+                json!({
+                    "tool": tool,
+                    "action": action,
+                    "uri": uri,
+                    "side_effect_class": side_effect_class,
+                }),
+                Some(line_no),
+            ));
+            parsed.graph_candidates.push(candidate_edge(
+                input,
+                "tool_output_jsonl",
+                "tool_call_event",
+                "tool_call",
+                &tool_call_key(input, &name, line_no),
+                "external_resource",
+                &format!("external:{uri}"),
+                if mutating_side_effect(side_effect_class) {
+                    "tool_call_mutated_resource"
+                } else {
+                    "tool_call_read_resource"
+                },
+                "tool_call_event",
+                Some(line_no),
+                Some(uri),
             ));
         }
     }
@@ -123,7 +227,7 @@ pub fn tool_parse_result(input: &ParseInput) -> ParseResult {
         header: stage_header(input, status, parsed.warnings.clone(), None),
         document_id: input.document.document_id.clone(),
         facts: parsed.facts,
-        graph_candidates: Vec::new(),
+        graph_candidates: parsed.graph_candidates,
         parser_id: "tool_output_jsonl".to_string(),
         parser_version: crate::facts::PARSER_VERSION.to_string(),
         warnings: parsed.warnings,
@@ -169,6 +273,34 @@ fn collect_redacted_paths(value: &Value, path: &str, paths: &mut Vec<String>) {
         }
         _ => {}
     }
+}
+
+fn json_within_caps(value: &Value) -> bool {
+    let mut stack = vec![(value, 1usize)];
+    let mut entries = 0usize;
+    while let Some((value, depth)) = stack.pop() {
+        if depth > MAX_TOOL_JSON_DEPTH {
+            return false;
+        }
+        match value {
+            Value::Array(items) => {
+                entries += items.len();
+                if entries > MAX_TOOL_JSON_ENTRIES {
+                    return false;
+                }
+                stack.extend(items.iter().map(|item| (item, depth + 1)));
+            }
+            Value::Object(object) => {
+                entries += object.len();
+                if entries > MAX_TOOL_JSON_ENTRIES {
+                    return false;
+                }
+                stack.extend(object.values().map(|item| (item, depth + 1)));
+            }
+            _ => {}
+        }
+    }
+    true
 }
 
 fn is_redacted(text: &str) -> bool {
@@ -226,6 +358,32 @@ fn string_field(value: &Value, keys: &[&str]) -> Option<String> {
         .filter_map(|key| value.get(*key).and_then(Value::as_str))
         .find(|text| !text.is_empty())
         .map(str::to_string)
+}
+
+fn external_resources(value: &Value) -> Vec<String> {
+    let Some(resources) = value.get("resources").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    resources
+        .iter()
+        .filter_map(|resource| resource.get("uri").and_then(Value::as_str))
+        .filter(|uri| !uri.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn mutating_side_effect(side_effect_class: &str) -> bool {
+    matches!(
+        side_effect_class,
+        "write" | "mutate" | "delete" | "network_write"
+    )
+}
+
+fn tool_call_key(input: &ParseInput, name: &str, line_no: u32) -> String {
+    format!(
+        "tool_call:{}:{}:{line_no}",
+        input.document.source_item_key.0, name
+    )
 }
 
 fn warning(input: &ParseInput, code: &str, message: String) -> SourceWarning {

--- a/crates/axon-parse/src/tool_tests.rs
+++ b/crates/axon-parse/src/tool_tests.rs
@@ -2,7 +2,7 @@ use axon_api::source::*;
 use uuid::Uuid;
 
 use crate::parser::ParseInput;
-use crate::tool::{tool_parse_items, tool_parse_result};
+use crate::tool::{MAX_TOOL_JSONL_LINE_BYTES, tool_parse_items, tool_parse_result};
 
 fn input(text: &str) -> ParseInput {
     ParseInput {
@@ -31,6 +31,63 @@ fn input(text: &str) -> ParseInput {
     }
 }
 
+fn parse_fixture(_path: &str, text: &str) -> crate::parser::ParseResult {
+    tool_parse_result(&input(text))
+}
+
+fn has_fact(result: &crate::parser::ParseResult, fact_kind: &str, name: &str) -> bool {
+    result
+        .facts
+        .iter()
+        .any(|fact| fact.fact_kind == fact_kind && fact.name == name)
+}
+
+#[test]
+fn tool_output_parser_defaults_to_metadata_only_and_redacts_io() {
+    let result = parse_fixture(
+        "tool-output.jsonl",
+        r#"{"tool":"shell","action":"exec","execution_requested":true,"execution_allowed":false,"side_effect_class":"read","argv":["curl","-H","Authorization: Bearer abc","https://api.example.com"],"env":{"OPENAI_API_KEY":"sk-proj-secret","PATH":"/usr/bin"},"stdout":"token=ghp_secret","stderr":"password=secret","output":{"artifact_id":"art_1","size_bytes":70000,"reason":"oversized stdout"},"resources":[{"kind":"github_issue","uri":"https://github.com/jmagar/axon/issues/298"}]}"#,
+    );
+
+    assert!(has_fact(&result, "tool_observed_claim", "shell.exec"));
+    assert!(has_fact(&result, "tool_artifact_ref", "art_1"));
+    assert!(has_fact(
+        &result,
+        "external_resource",
+        "https://github.com/jmagar/axon/issues/298"
+    ));
+    let serialized = serde_json::to_string(&result).expect("serialize parse result");
+    assert!(!serialized.contains("sk-proj-secret"));
+    assert!(!serialized.contains("Bearer abc"));
+    assert!(!serialized.contains("ghp_secret"));
+    assert!(!serialized.contains("password=secret"));
+    assert!(
+        result
+            .graph_candidates
+            .iter()
+            .all(|candidate| axon_graph::candidate::validate_candidate(candidate).is_ok())
+    );
+}
+
+#[test]
+fn tool_output_parser_degrades_oversized_jsonl_before_parsing() {
+    let huge = format!(
+        "{{\"tool\":\"mcp\",\"output\":\"{}\"}}",
+        "x".repeat(MAX_TOOL_JSONL_LINE_BYTES + 1)
+    );
+    let result = parse_fixture("tool-output.jsonl", &huge);
+
+    assert_eq!(result.header.status, LifecycleStatus::CompletedDegraded);
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "tool.jsonl.line_too_large")
+    );
+    assert!(result.facts.is_empty());
+    assert!(result.graph_candidates.is_empty());
+}
+
 #[test]
 fn extracts_tool_call_and_output_facts() {
     let parsed = tool_parse_items(&input(
@@ -39,7 +96,7 @@ fn extracts_tool_call_and_output_facts() {
 
     let facts = parsed.facts;
     assert_eq!(facts.len(), 1);
-    assert_eq!(facts[0].fact_kind, "tool_output");
+    assert_eq!(facts[0].fact_kind, "tool_observed_claim");
     assert_eq!(facts[0].name, "axon.search");
     assert_eq!(facts[0].value["status"], "ok");
     assert_eq!(facts[0].value["output_kind"], "object");

--- a/crates/axon-parse/src/tool_tests.rs
+++ b/crates/axon-parse/src/tool_tests.rs
@@ -61,6 +61,7 @@ fn tool_output_parser_defaults_to_metadata_only_and_redacts_io() {
     assert!(!serialized.contains("Bearer abc"));
     assert!(!serialized.contains("ghp_secret"));
     assert!(!serialized.contains("password=secret"));
+    assert!(!result.graph_candidates.is_empty());
     assert!(
         result
             .graph_candidates
@@ -150,4 +151,21 @@ fn extracts_artifact_reference_for_oversized_output() {
         "artifact://tool-output/artifact_123"
     );
     assert_eq!(artifact_fact.value["size_bytes"], 90000);
+}
+
+#[test]
+fn redacts_secret_bearing_external_resource_uris() {
+    let result = parse_fixture(
+        "tool-output.jsonl",
+        r#"{"tool":"http","action":"get","resources":[{"uri":"https://user:secret@example.com/path?token=ghp_secret&ok=1"}]}"#,
+    );
+
+    assert!(has_fact(
+        &result,
+        "external_resource",
+        "https://[REDACTED]@example.com/path?[REDACTED]"
+    ));
+    let serialized = serde_json::to_string(&result).expect("serialize parse result");
+    assert!(!serialized.contains("ghp_secret"));
+    assert!(!serialized.contains("user:secret"));
 }

--- a/crates/axon-services/Cargo.toml
+++ b/crates/axon-services/Cargo.toml
@@ -11,7 +11,6 @@ axon-core = { path = "../axon-core" }
 axon-error = { path = "../axon-error" }
 axon-llm = { path = "../axon-llm" }
 axon-api = { path = "../axon-api" }
-axon-error = { path = "../axon-error" }
 axon-crawl = { path = "../axon-crawl" }
 axon-vector = { path = "../axon-vector" }
 axon-ingest = { path = "../axon-ingest" }

--- a/crates/axon-services/Cargo.toml
+++ b/crates/axon-services/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 
 [dependencies]
 axon-core = { path = "../axon-core" }
+axon-error = { path = "../axon-error" }
 axon-llm = { path = "../axon-llm" }
 axon-api = { path = "../axon-api" }
 axon-error = { path = "../axon-error" }

--- a/crates/axon-services/src/source.rs
+++ b/crates/axon-services/src/source.rs
@@ -26,6 +26,7 @@ pub mod graph;
 pub mod prune;
 pub mod result_map;
 pub mod routing;
+pub mod tool_policy;
 
 use axon_api::source::{
     AdapterRef, JobId, LedgerSummary, LifecycleStatus, SourceCounts, SourceGenerationId, SourceId,

--- a/crates/axon-services/src/source/tool_policy.rs
+++ b/crates/axon-services/src/source/tool_policy.rs
@@ -1,0 +1,105 @@
+use std::collections::BTreeMap;
+
+use axon_api::source::{ApiError, SourceKind};
+use axon_error::ErrorStage;
+
+pub struct ToolExecutionAuditSnapshot {
+    pub policy_id: String,
+    pub side_effect_class: String,
+    pub command_allowlist: Vec<String>,
+    pub env_allowlist: Vec<String>,
+    pub shell_expansion_allowed: bool,
+}
+
+pub struct ToolSourceExecutionRequest {
+    pub source_kind: SourceKind,
+    pub execution_requested: bool,
+    pub command: Vec<String>,
+    pub env: BTreeMap<String, String>,
+    pub timeout_ms: Option<u64>,
+    pub output_cap_bytes: Option<u64>,
+    pub audit_snapshot: Option<ToolExecutionAuditSnapshot>,
+}
+
+pub fn validate_tool_source_execution(
+    request: &ToolSourceExecutionRequest,
+) -> Result<(), ApiError> {
+    if !request.execution_requested {
+        return Ok(());
+    }
+
+    let Some(snapshot) = request.audit_snapshot.as_ref() else {
+        return Err(policy_error(
+            "tool.execution_policy_missing",
+            "trusted tool execution audit snapshot is required",
+        ));
+    };
+    let Some(command) = request.command.first() else {
+        return Err(policy_error(
+            "tool.command_missing",
+            "tool execution requires an argv command",
+        ));
+    };
+    if !matches!(
+        request.source_kind,
+        SourceKind::CliTool | SourceKind::McpTool
+    ) {
+        return Err(policy_error(
+            "tool.source_kind_invalid",
+            "tool execution is only valid for CLI or MCP tool sources",
+        ));
+    }
+    if !snapshot
+        .command_allowlist
+        .iter()
+        .any(|allowed| allowed == command)
+    {
+        return Err(policy_error(
+            "tool.command_not_allowlisted",
+            "tool execution command is not allowlisted by trusted policy",
+        ));
+    }
+    if !snapshot.shell_expansion_allowed && command_requires_shell_expansion(&request.command) {
+        return Err(policy_error(
+            "tool.shell_expansion_denied",
+            "tool execution policy denies shell expansion",
+        ));
+    }
+    for key in request.env.keys() {
+        if !snapshot.env_allowlist.iter().any(|allowed| allowed == key) {
+            return Err(policy_error(
+                "tool.env_not_allowlisted",
+                "tool execution environment contains a non-allowlisted key",
+            ));
+        }
+    }
+    if request.timeout_ms.unwrap_or(0) == 0 {
+        return Err(policy_error(
+            "tool.timeout_required",
+            "tool execution requires a nonzero timeout",
+        ));
+    }
+    if request.output_cap_bytes.unwrap_or(0) == 0 {
+        return Err(policy_error(
+            "tool.output_cap_required",
+            "tool execution requires a nonzero output cap",
+        ));
+    }
+
+    Ok(())
+}
+
+fn command_requires_shell_expansion(command: &[String]) -> bool {
+    command
+        .first()
+        .is_some_and(|cmd| matches!(cmd.as_str(), "sh" | "bash" | "zsh" | "cmd" | "powershell"))
+        || command.iter().any(|arg| arg == "-c" || arg == "/c")
+}
+
+fn policy_error(code: &'static str, message: &'static str) -> ApiError {
+    ApiError::new(code, ErrorStage::Authorizing, message)
+}
+
+#[cfg(test)]
+#[path = "tool_policy_tests.rs"]
+mod tests;

--- a/crates/axon-services/src/source/tool_policy_tests.rs
+++ b/crates/axon-services/src/source/tool_policy_tests.rs
@@ -1,0 +1,45 @@
+use std::collections::BTreeMap;
+
+use axon_api::source::SourceKind;
+
+use super::{
+    ToolExecutionAuditSnapshot, ToolSourceExecutionRequest, validate_tool_source_execution,
+};
+
+#[test]
+fn tool_source_execution_requires_trusted_policy_snapshot() {
+    let request = ToolSourceExecutionRequest {
+        source_kind: SourceKind::CliTool,
+        execution_requested: true,
+        command: vec!["sh".to_string(), "-c".to_string(), "echo hi".to_string()],
+        env: BTreeMap::from([("OPENAI_API_KEY".to_string(), "sk-proj-secret".to_string())]),
+        timeout_ms: None,
+        output_cap_bytes: None,
+        audit_snapshot: None,
+    };
+
+    let err =
+        validate_tool_source_execution(&request).expect_err("trusted audit snapshot is required");
+    assert_eq!(err.code.to_string(), "tool.execution_policy_missing");
+}
+
+#[test]
+fn tool_source_execution_accepts_explicit_no_shell_allowlisted_policy() {
+    let request = ToolSourceExecutionRequest {
+        source_kind: SourceKind::McpTool,
+        execution_requested: true,
+        command: vec!["mcp-call".to_string(), "server.tool".to_string()],
+        env: BTreeMap::from([("PATH".to_string(), "/usr/bin".to_string())]),
+        timeout_ms: Some(30_000),
+        output_cap_bytes: Some(64 * 1024),
+        audit_snapshot: Some(ToolExecutionAuditSnapshot {
+            policy_id: "policy_tool_read".to_string(),
+            side_effect_class: "read".to_string(),
+            command_allowlist: vec!["mcp-call".to_string()],
+            env_allowlist: vec!["PATH".to_string()],
+            shell_expansion_allowed: false,
+        }),
+    };
+
+    validate_tool_source_execution(&request).expect("trusted policy accepted");
+}

--- a/crates/axon-vectors/src/payload_families.rs
+++ b/crates/axon-vectors/src/payload_families.rs
@@ -5,7 +5,8 @@
 //! source families land.
 
 pub const VECTOR_SOURCE_FAMILIES: &[&str] = &[
-    "code", "web", "package", "session", "graph", "memory", "feed", "social", "media",
+    "code", "web", "package", "session", "graph", "memory", "feed", "social", "media", "local",
+    "tool", "docker", "env",
 ];
 
 pub const VECTOR_SOURCE_FAMILY_FIELDS: &[(&str, &[&str])] = &[
@@ -98,4 +99,32 @@ pub const VECTOR_SOURCE_FAMILY_FIELDS: &[(&str, &[&str])] = &[
         "memory",
         &["memory_id", "memory_importance", "memory_status"],
     ),
+    (
+        "local",
+        &[
+            "local_checkout",
+            "local_path_key",
+            "local_git_remote",
+            "local_git_commit",
+        ],
+    ),
+    (
+        "tool",
+        &[
+            "tool_name",
+            "tool_action",
+            "tool_side_effect_class",
+            "tool_output_artifact_id",
+        ],
+    ),
+    (
+        "docker",
+        &[
+            "docker_image",
+            "docker_service",
+            "docker_port",
+            "docker_volume",
+        ],
+    ),
+    ("env", &["env_key", "env_secret_reference"]),
 ];

--- a/crates/axon-vectors/src/payload_tests.rs
+++ b/crates/axon-vectors/src/payload_tests.rs
@@ -110,6 +110,30 @@ fn initial_source_specific_registry_allows_only_declared_family_fields() {
 }
 
 #[test]
+fn source_family_registry_covers_phase_7_emitted_fields() {
+    for (family, field) in [
+        ("code", "code_language"),
+        ("graph", "graph_node_ids"),
+        ("local", "local_checkout"),
+        ("tool", "tool_name"),
+        ("tool", "tool_action"),
+        ("tool", "tool_side_effect_class"),
+        ("tool", "tool_output_artifact_id"),
+        ("docker", "docker_image"),
+        ("docker", "docker_service"),
+        ("docker", "docker_port"),
+        ("docker", "docker_volume"),
+        ("env", "env_key"),
+        ("env", "env_secret_reference"),
+    ] {
+        assert!(
+            source_family_allows_field(family, field),
+            "missing metadata registry for {family}.{field}"
+        );
+    }
+}
+
+#[test]
 fn invalid_payload_fixtures_report_the_expected_validation_error() {
     let cases = [
         (

--- a/crates/axon-vectors/src/redactor_tests.rs
+++ b/crates/axon-vectors/src/redactor_tests.rs
@@ -120,6 +120,16 @@ fn classify_field_bands() {
 }
 
 #[test]
+fn unknown_adapter_metadata_defaults_to_internal() {
+    let redactor = DefaultRedactor::new();
+
+    assert_eq!(
+        redactor.classify_field("adapter_blob", &json!({ "raw": "not classified" })),
+        Visibility::Internal
+    );
+}
+
+#[test]
 fn redact_text_scrubs_secrets_and_local_paths() {
     let r = DefaultRedactor::new();
     let c = ctx();

--- a/docs/reference/sources/vector-payload.md
+++ b/docs/reference/sources/vector-payload.md
@@ -16,7 +16,7 @@ See the family contract for declared output paths.
 |---|---|
 | `crates/axon-api/src/source/vector.rs` | `sha256:97c767a15c9f88a3a7278ac32c6b7b1a4fce722223e9dd3c5f59079fee69b9ac` |
 | `crates/axon-vectors/src/payload.rs` | `sha256:f937be4f83651ef06d4a28ce6a1b9e104f3405542337abceeb406e28089cc967` |
-| `crates/axon-vectors/src/payload_families.rs` | `sha256:fef4a0c55bf2a025c4326e2cc82ca13657024df7bbdb37c80637dde86090a466` |
+| `crates/axon-vectors/src/payload_families.rs` | `sha256:935c16dcd58bac358bcb78eb1e72634941709135d7148adcb8cbe3c09e6e7808` |
 | `crates/axon-vectors/src/point.rs` | `sha256:506dbcd5fc7edafa752b990da56f6177cb68810a74b59c6b2b3ddb937ce4d112` |
 | `crates/axon-vectors/src/schema_registry.rs` | `sha256:039aed1c85daf7da804f6f3a79d0482c39e435122f7a24177d703a9b9f63768a` |
 | `docs/pipeline-unification/schemas/vector-payload-schema.md` | `sha256:ef84517d66acc0e35fe0b432df3cee52fc07e6643006003eca0ec0c29a5cde7f` |

--- a/docs/reference/sources/vector-payload.md
+++ b/docs/reference/sources/vector-payload.md
@@ -16,6 +16,7 @@ See the family contract for declared output paths.
 |---|---|
 | `crates/axon-api/src/source/vector.rs` | `sha256:97c767a15c9f88a3a7278ac32c6b7b1a4fce722223e9dd3c5f59079fee69b9ac` |
 | `crates/axon-vectors/src/payload.rs` | `sha256:f937be4f83651ef06d4a28ce6a1b9e104f3405542337abceeb406e28089cc967` |
+| `crates/axon-vectors/src/payload_families.rs` | `sha256:fef4a0c55bf2a025c4326e2cc82ca13657024df7bbdb37c80637dde86090a466` |
 | `crates/axon-vectors/src/point.rs` | `sha256:506dbcd5fc7edafa752b990da56f6177cb68810a74b59c6b2b3ddb937ce4d112` |
 | `crates/axon-vectors/src/schema_registry.rs` | `sha256:039aed1c85daf7da804f6f3a79d0482c39e435122f7a24177d703a9b9f63768a` |
 | `docs/pipeline-unification/schemas/vector-payload-schema.md` | `sha256:ef84517d66acc0e35fe0b432df3cee52fc07e6643006003eca0ec0c29a5cde7f` |

--- a/docs/reference/sources/vector-payload.md
+++ b/docs/reference/sources/vector-payload.md
@@ -39,7 +39,7 @@ See `docs/reference/sources/vector-payload.schema.json`.
 | `collection` | `string; minLength=1` |
 | `vector_point_id` | `string; minLength=1` |
 | `vector_namespace` | `string; minLength=1` |
-| `source_family` | `string; enum=code|web|package|session|graph|memory|feed|social|media; minLength=1` |
+| `source_family` | `string; enum=code|web|package|session|graph|memory|feed|social|media|local|tool|docker|env; minLength=1` |
 | `source_kind` | `string; minLength=1` |
 | `source_adapter` | `string; minLength=1` |
 | `source_scope` | `string; minLength=1` |
@@ -105,6 +105,10 @@ Payload validation rejects secret field fragments and secret value fragments bef
 | `session` | `session_id`, `session_turn_index`, `session_tool_name`, `session_skill_name` |
 | `graph` | `graph_node_ids`, `graph_edge_ids`, `graph_confidence` |
 | `memory` | `memory_id`, `memory_importance`, `memory_status` |
+| `local` | `local_checkout`, `local_path_key`, `local_git_remote`, `local_git_commit` |
+| `tool` | `tool_name`, `tool_action`, `tool_side_effect_class`, `tool_output_artifact_id` |
+| `docker` | `docker_image`, `docker_service`, `docker_port`, `docker_volume` |
+| `env` | `env_key`, `env_secret_reference` |
 
 ## Indexable Payload Fields
 

--- a/docs/reference/sources/vector-payload.schema.json
+++ b/docs/reference/sources/vector-payload.schema.json
@@ -7101,6 +7101,11 @@
         "path": "crates/axon-vectors/src/payload.rs"
       },
       {
+        "checksum": "sha256:fef4a0c55bf2a025c4326e2cc82ca13657024df7bbdb37c80637dde86090a466",
+        "kind": "rust_module",
+        "path": "crates/axon-vectors/src/payload_families.rs"
+      },
+      {
         "checksum": "sha256:506dbcd5fc7edafa752b990da56f6177cb68810a74b59c6b2b3ddb937ce4d112",
         "kind": "rust_module",
         "path": "crates/axon-vectors/src/point.rs"

--- a/docs/reference/sources/vector-payload.schema.json
+++ b/docs/reference/sources/vector-payload.schema.json
@@ -3986,6 +3986,11 @@
             },
             {
               "required": [
+                "structured_parse_error"
+              ]
+            },
+            {
+              "required": [
                 "reddit_author"
               ]
             },
@@ -4350,6 +4355,11 @@
             {
               "required": [
                 "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "structured_parse_error"
               ]
             },
             {
@@ -4722,6 +4732,11 @@
             },
             {
               "required": [
+                "structured_parse_error"
+              ]
+            },
+            {
+              "required": [
                 "reddit_author"
               ]
             },
@@ -5086,6 +5101,11 @@
             {
               "required": [
                 "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "structured_parse_error"
               ]
             },
             {
@@ -7101,7 +7121,7 @@
         "path": "crates/axon-vectors/src/payload.rs"
       },
       {
-        "checksum": "sha256:fef4a0c55bf2a025c4326e2cc82ca13657024df7bbdb37c80637dde86090a466",
+        "checksum": "sha256:935c16dcd58bac358bcb78eb1e72634941709135d7148adcb8cbe3c09e6e7808",
         "kind": "rust_module",
         "path": "crates/axon-vectors/src/payload_families.rs"
       },

--- a/docs/reference/sources/vector-payload.schema.json
+++ b/docs/reference/sources/vector-payload.schema.json
@@ -926,6 +926,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -1214,6 +1284,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -1472,6 +1612,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -1724,6 +1934,76 @@
             {
               "required": [
                 "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
               ]
             }
           ]
@@ -2027,6 +2307,76 @@
             {
               "required": [
                 "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
               ]
             }
           ]
@@ -2336,6 +2686,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -2638,6 +3058,76 @@
             {
               "required": [
                 "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
               ]
             }
           ]
@@ -2947,6 +3437,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -3255,6 +3815,1558 @@
               "required": [
                 "graph_confidence"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_family": {
+            "const": "local"
+          }
+        },
+        "required": [
+          "source_family"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "code_language"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_name"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_kind"
+              ]
+            },
+            {
+              "required": [
+                "code_file_type"
+              ]
+            },
+            {
+              "required": [
+                "manifest"
+              ]
+            },
+            {
+              "required": [
+                "git_provider"
+              ]
+            },
+            {
+              "required": [
+                "git_host"
+              ]
+            },
+            {
+              "required": [
+                "git_repo"
+              ]
+            },
+            {
+              "required": [
+                "git_owner"
+              ]
+            },
+            {
+              "required": [
+                "git_web_url"
+              ]
+            },
+            {
+              "required": [
+                "feed_title"
+              ]
+            },
+            {
+              "required": [
+                "feed_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_id"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_published"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_created_utc"
+              ]
+            },
+            {
+              "required": [
+                "reddit_score"
+              ]
+            },
+            {
+              "required": [
+                "reddit_num_comments"
+              ]
+            },
+            {
+              "required": [
+                "reddit_upvote_ratio"
+              ]
+            },
+            {
+              "required": [
+                "reddit_subreddit"
+              ]
+            },
+            {
+              "required": [
+                "reddit_domain"
+              ]
+            },
+            {
+              "required": [
+                "reddit_is_video"
+              ]
+            },
+            {
+              "required": [
+                "reddit_distinguished"
+              ]
+            },
+            {
+              "required": [
+                "reddit_gilded"
+              ]
+            },
+            {
+              "required": [
+                "reddit_flair"
+              ]
+            },
+            {
+              "required": [
+                "reddit_permalink"
+              ]
+            },
+            {
+              "required": [
+                "reddit_kind"
+              ]
+            },
+            {
+              "required": [
+                "video_id"
+              ]
+            },
+            {
+              "required": [
+                "title"
+              ]
+            },
+            {
+              "required": [
+                "url"
+              ]
+            },
+            {
+              "required": [
+                "channel"
+              ]
+            },
+            {
+              "required": [
+                "channel_url"
+              ]
+            },
+            {
+              "required": [
+                "yt_uploader_id"
+              ]
+            },
+            {
+              "required": [
+                "yt_upload_date"
+              ]
+            },
+            {
+              "required": [
+                "yt_duration"
+              ]
+            },
+            {
+              "required": [
+                "yt_view_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_like_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_tags"
+              ]
+            },
+            {
+              "required": [
+                "yt_categories"
+              ]
+            },
+            {
+              "required": [
+                "yt_thumbnail"
+              ]
+            },
+            {
+              "required": [
+                "segment_kind"
+              ]
+            },
+            {
+              "required": [
+                "web_title"
+              ]
+            },
+            {
+              "required": [
+                "web_domain"
+              ]
+            },
+            {
+              "required": [
+                "web_status_code"
+              ]
+            },
+            {
+              "required": [
+                "web_depth"
+              ]
+            },
+            {
+              "required": [
+                "package_ecosystem"
+              ]
+            },
+            {
+              "required": [
+                "package_name"
+              ]
+            },
+            {
+              "required": [
+                "package_version"
+              ]
+            },
+            {
+              "required": [
+                "session_id"
+              ]
+            },
+            {
+              "required": [
+                "session_turn_index"
+              ]
+            },
+            {
+              "required": [
+                "session_tool_name"
+              ]
+            },
+            {
+              "required": [
+                "session_skill_name"
+              ]
+            },
+            {
+              "required": [
+                "graph_node_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_edge_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_confidence"
+              ]
+            },
+            {
+              "required": [
+                "memory_id"
+              ]
+            },
+            {
+              "required": [
+                "memory_importance"
+              ]
+            },
+            {
+              "required": [
+                "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_family": {
+            "const": "tool"
+          }
+        },
+        "required": [
+          "source_family"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "code_language"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_name"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_kind"
+              ]
+            },
+            {
+              "required": [
+                "code_file_type"
+              ]
+            },
+            {
+              "required": [
+                "manifest"
+              ]
+            },
+            {
+              "required": [
+                "git_provider"
+              ]
+            },
+            {
+              "required": [
+                "git_host"
+              ]
+            },
+            {
+              "required": [
+                "git_repo"
+              ]
+            },
+            {
+              "required": [
+                "git_owner"
+              ]
+            },
+            {
+              "required": [
+                "git_web_url"
+              ]
+            },
+            {
+              "required": [
+                "feed_title"
+              ]
+            },
+            {
+              "required": [
+                "feed_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_id"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_published"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_created_utc"
+              ]
+            },
+            {
+              "required": [
+                "reddit_score"
+              ]
+            },
+            {
+              "required": [
+                "reddit_num_comments"
+              ]
+            },
+            {
+              "required": [
+                "reddit_upvote_ratio"
+              ]
+            },
+            {
+              "required": [
+                "reddit_subreddit"
+              ]
+            },
+            {
+              "required": [
+                "reddit_domain"
+              ]
+            },
+            {
+              "required": [
+                "reddit_is_video"
+              ]
+            },
+            {
+              "required": [
+                "reddit_distinguished"
+              ]
+            },
+            {
+              "required": [
+                "reddit_gilded"
+              ]
+            },
+            {
+              "required": [
+                "reddit_flair"
+              ]
+            },
+            {
+              "required": [
+                "reddit_permalink"
+              ]
+            },
+            {
+              "required": [
+                "reddit_kind"
+              ]
+            },
+            {
+              "required": [
+                "video_id"
+              ]
+            },
+            {
+              "required": [
+                "title"
+              ]
+            },
+            {
+              "required": [
+                "url"
+              ]
+            },
+            {
+              "required": [
+                "channel"
+              ]
+            },
+            {
+              "required": [
+                "channel_url"
+              ]
+            },
+            {
+              "required": [
+                "yt_uploader_id"
+              ]
+            },
+            {
+              "required": [
+                "yt_upload_date"
+              ]
+            },
+            {
+              "required": [
+                "yt_duration"
+              ]
+            },
+            {
+              "required": [
+                "yt_view_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_like_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_tags"
+              ]
+            },
+            {
+              "required": [
+                "yt_categories"
+              ]
+            },
+            {
+              "required": [
+                "yt_thumbnail"
+              ]
+            },
+            {
+              "required": [
+                "segment_kind"
+              ]
+            },
+            {
+              "required": [
+                "web_title"
+              ]
+            },
+            {
+              "required": [
+                "web_domain"
+              ]
+            },
+            {
+              "required": [
+                "web_status_code"
+              ]
+            },
+            {
+              "required": [
+                "web_depth"
+              ]
+            },
+            {
+              "required": [
+                "package_ecosystem"
+              ]
+            },
+            {
+              "required": [
+                "package_name"
+              ]
+            },
+            {
+              "required": [
+                "package_version"
+              ]
+            },
+            {
+              "required": [
+                "session_id"
+              ]
+            },
+            {
+              "required": [
+                "session_turn_index"
+              ]
+            },
+            {
+              "required": [
+                "session_tool_name"
+              ]
+            },
+            {
+              "required": [
+                "session_skill_name"
+              ]
+            },
+            {
+              "required": [
+                "graph_node_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_edge_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_confidence"
+              ]
+            },
+            {
+              "required": [
+                "memory_id"
+              ]
+            },
+            {
+              "required": [
+                "memory_importance"
+              ]
+            },
+            {
+              "required": [
+                "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_family": {
+            "const": "docker"
+          }
+        },
+        "required": [
+          "source_family"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "code_language"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_name"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_kind"
+              ]
+            },
+            {
+              "required": [
+                "code_file_type"
+              ]
+            },
+            {
+              "required": [
+                "manifest"
+              ]
+            },
+            {
+              "required": [
+                "git_provider"
+              ]
+            },
+            {
+              "required": [
+                "git_host"
+              ]
+            },
+            {
+              "required": [
+                "git_repo"
+              ]
+            },
+            {
+              "required": [
+                "git_owner"
+              ]
+            },
+            {
+              "required": [
+                "git_web_url"
+              ]
+            },
+            {
+              "required": [
+                "feed_title"
+              ]
+            },
+            {
+              "required": [
+                "feed_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_id"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_published"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_created_utc"
+              ]
+            },
+            {
+              "required": [
+                "reddit_score"
+              ]
+            },
+            {
+              "required": [
+                "reddit_num_comments"
+              ]
+            },
+            {
+              "required": [
+                "reddit_upvote_ratio"
+              ]
+            },
+            {
+              "required": [
+                "reddit_subreddit"
+              ]
+            },
+            {
+              "required": [
+                "reddit_domain"
+              ]
+            },
+            {
+              "required": [
+                "reddit_is_video"
+              ]
+            },
+            {
+              "required": [
+                "reddit_distinguished"
+              ]
+            },
+            {
+              "required": [
+                "reddit_gilded"
+              ]
+            },
+            {
+              "required": [
+                "reddit_flair"
+              ]
+            },
+            {
+              "required": [
+                "reddit_permalink"
+              ]
+            },
+            {
+              "required": [
+                "reddit_kind"
+              ]
+            },
+            {
+              "required": [
+                "video_id"
+              ]
+            },
+            {
+              "required": [
+                "title"
+              ]
+            },
+            {
+              "required": [
+                "url"
+              ]
+            },
+            {
+              "required": [
+                "channel"
+              ]
+            },
+            {
+              "required": [
+                "channel_url"
+              ]
+            },
+            {
+              "required": [
+                "yt_uploader_id"
+              ]
+            },
+            {
+              "required": [
+                "yt_upload_date"
+              ]
+            },
+            {
+              "required": [
+                "yt_duration"
+              ]
+            },
+            {
+              "required": [
+                "yt_view_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_like_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_tags"
+              ]
+            },
+            {
+              "required": [
+                "yt_categories"
+              ]
+            },
+            {
+              "required": [
+                "yt_thumbnail"
+              ]
+            },
+            {
+              "required": [
+                "segment_kind"
+              ]
+            },
+            {
+              "required": [
+                "web_title"
+              ]
+            },
+            {
+              "required": [
+                "web_domain"
+              ]
+            },
+            {
+              "required": [
+                "web_status_code"
+              ]
+            },
+            {
+              "required": [
+                "web_depth"
+              ]
+            },
+            {
+              "required": [
+                "package_ecosystem"
+              ]
+            },
+            {
+              "required": [
+                "package_name"
+              ]
+            },
+            {
+              "required": [
+                "package_version"
+              ]
+            },
+            {
+              "required": [
+                "session_id"
+              ]
+            },
+            {
+              "required": [
+                "session_turn_index"
+              ]
+            },
+            {
+              "required": [
+                "session_tool_name"
+              ]
+            },
+            {
+              "required": [
+                "session_skill_name"
+              ]
+            },
+            {
+              "required": [
+                "graph_node_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_edge_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_confidence"
+              ]
+            },
+            {
+              "required": [
+                "memory_id"
+              ]
+            },
+            {
+              "required": [
+                "memory_importance"
+              ]
+            },
+            {
+              "required": [
+                "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_family": {
+            "const": "env"
+          }
+        },
+        "required": [
+          "source_family"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "code_language"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_name"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_kind"
+              ]
+            },
+            {
+              "required": [
+                "code_file_type"
+              ]
+            },
+            {
+              "required": [
+                "manifest"
+              ]
+            },
+            {
+              "required": [
+                "git_provider"
+              ]
+            },
+            {
+              "required": [
+                "git_host"
+              ]
+            },
+            {
+              "required": [
+                "git_repo"
+              ]
+            },
+            {
+              "required": [
+                "git_owner"
+              ]
+            },
+            {
+              "required": [
+                "git_web_url"
+              ]
+            },
+            {
+              "required": [
+                "feed_title"
+              ]
+            },
+            {
+              "required": [
+                "feed_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_id"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_published"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_created_utc"
+              ]
+            },
+            {
+              "required": [
+                "reddit_score"
+              ]
+            },
+            {
+              "required": [
+                "reddit_num_comments"
+              ]
+            },
+            {
+              "required": [
+                "reddit_upvote_ratio"
+              ]
+            },
+            {
+              "required": [
+                "reddit_subreddit"
+              ]
+            },
+            {
+              "required": [
+                "reddit_domain"
+              ]
+            },
+            {
+              "required": [
+                "reddit_is_video"
+              ]
+            },
+            {
+              "required": [
+                "reddit_distinguished"
+              ]
+            },
+            {
+              "required": [
+                "reddit_gilded"
+              ]
+            },
+            {
+              "required": [
+                "reddit_flair"
+              ]
+            },
+            {
+              "required": [
+                "reddit_permalink"
+              ]
+            },
+            {
+              "required": [
+                "reddit_kind"
+              ]
+            },
+            {
+              "required": [
+                "video_id"
+              ]
+            },
+            {
+              "required": [
+                "title"
+              ]
+            },
+            {
+              "required": [
+                "url"
+              ]
+            },
+            {
+              "required": [
+                "channel"
+              ]
+            },
+            {
+              "required": [
+                "channel_url"
+              ]
+            },
+            {
+              "required": [
+                "yt_uploader_id"
+              ]
+            },
+            {
+              "required": [
+                "yt_upload_date"
+              ]
+            },
+            {
+              "required": [
+                "yt_duration"
+              ]
+            },
+            {
+              "required": [
+                "yt_view_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_like_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_tags"
+              ]
+            },
+            {
+              "required": [
+                "yt_categories"
+              ]
+            },
+            {
+              "required": [
+                "yt_thumbnail"
+              ]
+            },
+            {
+              "required": [
+                "segment_kind"
+              ]
+            },
+            {
+              "required": [
+                "web_title"
+              ]
+            },
+            {
+              "required": [
+                "web_domain"
+              ]
+            },
+            {
+              "required": [
+                "web_status_code"
+              ]
+            },
+            {
+              "required": [
+                "web_depth"
+              ]
+            },
+            {
+              "required": [
+                "package_ecosystem"
+              ]
+            },
+            {
+              "required": [
+                "package_name"
+              ]
+            },
+            {
+              "required": [
+                "package_version"
+              ]
+            },
+            {
+              "required": [
+                "session_id"
+              ]
+            },
+            {
+              "required": [
+                "session_turn_index"
+              ]
+            },
+            {
+              "required": [
+                "session_tool_name"
+              ]
+            },
+            {
+              "required": [
+                "session_skill_name"
+              ]
+            },
+            {
+              "required": [
+                "graph_node_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_edge_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_confidence"
+              ]
+            },
+            {
+              "required": [
+                "memory_id"
+              ]
+            },
+            {
+              "required": [
+                "memory_importance"
+              ]
+            },
+            {
+              "required": [
+                "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
             }
           ]
         }
@@ -3337,6 +5449,18 @@
       "minLength": 1,
       "type": "string"
     },
+    "docker_image": {
+      "type": "string"
+    },
+    "docker_port": {
+      "type": "string"
+    },
+    "docker_service": {
+      "type": "string"
+    },
+    "docker_volume": {
+      "type": "string"
+    },
     "document_id": {
       "minLength": 1,
       "type": "string",
@@ -3376,6 +5500,12 @@
       "minLength": 1,
       "type": "string",
       "x-qdrant-index": "keyword"
+    },
+    "env_key": {
+      "type": "string"
+    },
+    "env_secret_reference": {
+      "type": "string"
     },
     "feed_entry_author": {
       "type": "string"
@@ -3433,6 +5563,18 @@
       "minLength": 1,
       "type": "string",
       "x-qdrant-index": "keyword"
+    },
+    "local_checkout": {
+      "type": "string"
+    },
+    "local_git_commit": {
+      "type": "string"
+    },
+    "local_git_remote": {
+      "type": "string"
+    },
+    "local_path_key": {
+      "type": "string"
     },
     "manifest": {
       "type": "boolean"
@@ -3542,7 +5684,11 @@
         "memory",
         "feed",
         "social",
-        "media"
+        "media",
+        "local",
+        "tool",
+        "docker",
+        "env"
       ],
       "minLength": 1,
       "type": "string",
@@ -3582,6 +5728,18 @@
       "type": "string"
     },
     "title": {
+      "type": "string"
+    },
+    "tool_action": {
+      "type": "string"
+    },
+    "tool_name": {
+      "type": "string"
+    },
+    "tool_output_artifact_id": {
+      "type": "string"
+    },
+    "tool_side_effect_class": {
       "type": "string"
     },
     "url": {
@@ -4452,6 +6610,324 @@
         "vector_namespace": "vector_namespace",
         "vector_point_id": "vector_point_id",
         "visibility": "internal"
+      },
+      {
+        "chunk_hash": "chunk_hash",
+        "chunk_id": "chunk-local-0",
+        "chunk_key": "local-chunk-key",
+        "chunk_locator": {
+          "canonical_uri": "https://example.com/local",
+          "heading_path": [
+            "local heading"
+          ],
+          "path": "/local",
+          "range": {
+            "byte_end": null,
+            "byte_start": null,
+            "char_end": null,
+            "char_start": null,
+            "csv_row": null,
+            "dom_selector": null,
+            "json_pointer": null,
+            "line_end": 4,
+            "line_start": 1,
+            "session_turn_id": null,
+            "time_end_ms": null,
+            "time_start_ms": null,
+            "turn_end": null,
+            "turn_start": null,
+            "xml_xpath": null,
+            "yaml_path": null
+          },
+          "symbol": null
+        },
+        "chunk_text": "chunk_text",
+        "collection": "axon",
+        "committed_generation": "uncommitted",
+        "content_hash": "sha256:localhash",
+        "content_kind": "content_kind",
+        "document_id": "doc-local",
+        "document_status": "prepared",
+        "embedded_at": "2026-06-30T00:00:00Z",
+        "embedding_dimensions": 768,
+        "embedding_model": "text-embedding-test",
+        "embedding_profile": "default",
+        "embedding_provider": "tei",
+        "item_canonical_uri": "item_canonical_uri",
+        "job_id": "job-local",
+        "local_checkout": "local_checkout",
+        "local_git_commit": "local_git_commit",
+        "local_git_remote": "local_git_remote",
+        "local_path_key": "local_path_key",
+        "payload_contract_version": "2026-07-01",
+        "redaction_status": "clean",
+        "source_adapter": "source_adapter",
+        "source_canonical_uri": "source_canonical_uri",
+        "source_family": "local",
+        "source_generation": "gen-local-7",
+        "source_id": "src-local",
+        "source_item_key": "local-item",
+        "source_kind": "source_kind",
+        "source_range": {
+          "byte_end": null,
+          "byte_start": null,
+          "char_end": null,
+          "char_start": null,
+          "csv_row": null,
+          "dom_selector": null,
+          "json_pointer": null,
+          "line_end": 4,
+          "line_start": 1,
+          "session_turn_id": null,
+          "time_end_ms": null,
+          "time_start_ms": null,
+          "turn_end": null,
+          "turn_start": null,
+          "xml_xpath": null,
+          "yaml_path": null
+        },
+        "source_scope": "source_scope",
+        "vector_namespace": "vector_namespace",
+        "vector_point_id": "vector_point_id",
+        "visibility": "internal"
+      },
+      {
+        "chunk_hash": "chunk_hash",
+        "chunk_id": "chunk-tool-0",
+        "chunk_key": "tool-chunk-key",
+        "chunk_locator": {
+          "canonical_uri": "https://example.com/tool",
+          "heading_path": [
+            "tool heading"
+          ],
+          "path": "/tool",
+          "range": {
+            "byte_end": null,
+            "byte_start": null,
+            "char_end": null,
+            "char_start": null,
+            "csv_row": null,
+            "dom_selector": null,
+            "json_pointer": null,
+            "line_end": 4,
+            "line_start": 1,
+            "session_turn_id": null,
+            "time_end_ms": null,
+            "time_start_ms": null,
+            "turn_end": null,
+            "turn_start": null,
+            "xml_xpath": null,
+            "yaml_path": null
+          },
+          "symbol": null
+        },
+        "chunk_text": "chunk_text",
+        "collection": "axon",
+        "committed_generation": "uncommitted",
+        "content_hash": "sha256:toolhash",
+        "content_kind": "content_kind",
+        "document_id": "doc-tool",
+        "document_status": "prepared",
+        "embedded_at": "2026-06-30T00:00:00Z",
+        "embedding_dimensions": 768,
+        "embedding_model": "text-embedding-test",
+        "embedding_profile": "default",
+        "embedding_provider": "tei",
+        "item_canonical_uri": "item_canonical_uri",
+        "job_id": "job-tool",
+        "payload_contract_version": "2026-07-01",
+        "redaction_status": "clean",
+        "source_adapter": "source_adapter",
+        "source_canonical_uri": "source_canonical_uri",
+        "source_family": "tool",
+        "source_generation": "gen-tool-7",
+        "source_id": "src-tool",
+        "source_item_key": "tool-item",
+        "source_kind": "source_kind",
+        "source_range": {
+          "byte_end": null,
+          "byte_start": null,
+          "char_end": null,
+          "char_start": null,
+          "csv_row": null,
+          "dom_selector": null,
+          "json_pointer": null,
+          "line_end": 4,
+          "line_start": 1,
+          "session_turn_id": null,
+          "time_end_ms": null,
+          "time_start_ms": null,
+          "turn_end": null,
+          "turn_start": null,
+          "xml_xpath": null,
+          "yaml_path": null
+        },
+        "source_scope": "source_scope",
+        "tool_action": "tool_action",
+        "tool_name": "tool_name",
+        "tool_output_artifact_id": "tool_output_artifact_id",
+        "tool_side_effect_class": "tool_side_effect_class",
+        "vector_namespace": "vector_namespace",
+        "vector_point_id": "vector_point_id",
+        "visibility": "internal"
+      },
+      {
+        "chunk_hash": "chunk_hash",
+        "chunk_id": "chunk-docker-0",
+        "chunk_key": "docker-chunk-key",
+        "chunk_locator": {
+          "canonical_uri": "https://example.com/docker",
+          "heading_path": [
+            "docker heading"
+          ],
+          "path": "/docker",
+          "range": {
+            "byte_end": null,
+            "byte_start": null,
+            "char_end": null,
+            "char_start": null,
+            "csv_row": null,
+            "dom_selector": null,
+            "json_pointer": null,
+            "line_end": 4,
+            "line_start": 1,
+            "session_turn_id": null,
+            "time_end_ms": null,
+            "time_start_ms": null,
+            "turn_end": null,
+            "turn_start": null,
+            "xml_xpath": null,
+            "yaml_path": null
+          },
+          "symbol": null
+        },
+        "chunk_text": "chunk_text",
+        "collection": "axon",
+        "committed_generation": "uncommitted",
+        "content_hash": "sha256:dockerhash",
+        "content_kind": "content_kind",
+        "docker_image": "docker_image",
+        "docker_port": "docker_port",
+        "docker_service": "docker_service",
+        "docker_volume": "docker_volume",
+        "document_id": "doc-docker",
+        "document_status": "prepared",
+        "embedded_at": "2026-06-30T00:00:00Z",
+        "embedding_dimensions": 768,
+        "embedding_model": "text-embedding-test",
+        "embedding_profile": "default",
+        "embedding_provider": "tei",
+        "item_canonical_uri": "item_canonical_uri",
+        "job_id": "job-docker",
+        "payload_contract_version": "2026-07-01",
+        "redaction_status": "clean",
+        "source_adapter": "source_adapter",
+        "source_canonical_uri": "source_canonical_uri",
+        "source_family": "docker",
+        "source_generation": "gen-docker-7",
+        "source_id": "src-docker",
+        "source_item_key": "docker-item",
+        "source_kind": "source_kind",
+        "source_range": {
+          "byte_end": null,
+          "byte_start": null,
+          "char_end": null,
+          "char_start": null,
+          "csv_row": null,
+          "dom_selector": null,
+          "json_pointer": null,
+          "line_end": 4,
+          "line_start": 1,
+          "session_turn_id": null,
+          "time_end_ms": null,
+          "time_start_ms": null,
+          "turn_end": null,
+          "turn_start": null,
+          "xml_xpath": null,
+          "yaml_path": null
+        },
+        "source_scope": "source_scope",
+        "vector_namespace": "vector_namespace",
+        "vector_point_id": "vector_point_id",
+        "visibility": "internal"
+      },
+      {
+        "chunk_hash": "chunk_hash",
+        "chunk_id": "chunk-env-0",
+        "chunk_key": "env-chunk-key",
+        "chunk_locator": {
+          "canonical_uri": "https://example.com/env",
+          "heading_path": [
+            "env heading"
+          ],
+          "path": "/env",
+          "range": {
+            "byte_end": null,
+            "byte_start": null,
+            "char_end": null,
+            "char_start": null,
+            "csv_row": null,
+            "dom_selector": null,
+            "json_pointer": null,
+            "line_end": 4,
+            "line_start": 1,
+            "session_turn_id": null,
+            "time_end_ms": null,
+            "time_start_ms": null,
+            "turn_end": null,
+            "turn_start": null,
+            "xml_xpath": null,
+            "yaml_path": null
+          },
+          "symbol": null
+        },
+        "chunk_text": "chunk_text",
+        "collection": "axon",
+        "committed_generation": "uncommitted",
+        "content_hash": "sha256:envhash",
+        "content_kind": "content_kind",
+        "document_id": "doc-env",
+        "document_status": "prepared",
+        "embedded_at": "2026-06-30T00:00:00Z",
+        "embedding_dimensions": 768,
+        "embedding_model": "text-embedding-test",
+        "embedding_profile": "default",
+        "embedding_provider": "tei",
+        "env_key": "env_key",
+        "env_secret_reference": "env_secret_reference",
+        "item_canonical_uri": "item_canonical_uri",
+        "job_id": "job-env",
+        "payload_contract_version": "2026-07-01",
+        "redaction_status": "clean",
+        "source_adapter": "source_adapter",
+        "source_canonical_uri": "source_canonical_uri",
+        "source_family": "env",
+        "source_generation": "gen-env-7",
+        "source_id": "src-env",
+        "source_item_key": "env-item",
+        "source_kind": "source_kind",
+        "source_range": {
+          "byte_end": null,
+          "byte_start": null,
+          "char_end": null,
+          "char_start": null,
+          "csv_row": null,
+          "dom_selector": null,
+          "json_pointer": null,
+          "line_end": 4,
+          "line_start": 1,
+          "session_turn_id": null,
+          "time_end_ms": null,
+          "time_start_ms": null,
+          "turn_end": null,
+          "turn_start": null,
+          "xml_xpath": null,
+          "yaml_path": null
+        },
+        "source_scope": "source_scope",
+        "vector_namespace": "vector_namespace",
+        "vector_point_id": "vector_point_id",
+        "visibility": "internal"
       }
     ],
     "generated_by": "cargo xtask schemas vector-payload",
@@ -4761,6 +7237,40 @@
           "memory_status"
         ],
         "source_family": "memory"
+      },
+      {
+        "fields": [
+          "local_checkout",
+          "local_path_key",
+          "local_git_remote",
+          "local_git_commit"
+        ],
+        "source_family": "local"
+      },
+      {
+        "fields": [
+          "tool_name",
+          "tool_action",
+          "tool_side_effect_class",
+          "tool_output_artifact_id"
+        ],
+        "source_family": "tool"
+      },
+      {
+        "fields": [
+          "docker_image",
+          "docker_service",
+          "docker_port",
+          "docker_volume"
+        ],
+        "source_family": "docker"
+      },
+      {
+        "fields": [
+          "env_key",
+          "env_secret_reference"
+        ],
+        "source_family": "env"
       }
     ]
   }

--- a/docs/sessions/2026-07-05-phase-7-parser-metadata-graph-pr369.md
+++ b/docs/sessions/2026-07-05-phase-7-parser-metadata-graph-pr369.md
@@ -1,0 +1,52 @@
+# Phase 7 Parser Metadata Graph PR #369
+
+Date: 2026-07-05
+
+Worktree: `/home/jmagar/workspace/axon/.worktrees/phase-7-parser-metadata-graph`
+
+Branch: `codex/phase-7-parser-metadata-graph`
+
+Base: `codex/phase-4-source-resolver-router` at `75daf47c1de6d98beac6bbf0bb4e866ffdc99125`
+
+PR: https://github.com/jmagar/axon/pull/369
+
+## Summary
+
+Executed Phase 7 parser/metadata/graph plan on top of Phase 4. The branch adds parser families for Docker/Compose, env examples, and observed tool output; carries parse facts and graph candidates into prepared documents; validates graph evidence source ranges; extends vector payload source families; and adds graph lineage fixtures and generated schema updates.
+
+Review remediation added URI redaction for tool external resources, hardened parser-family and graph-candidate tests, added Compose `env_file`/`secrets`/`depends_on` extraction, added vector payload source-input provenance for `payload_families.rs`, split monolith-sensitive parser/preparer code, and refreshed the generated vector payload snapshot.
+
+## Verification
+
+- `cargo test -p axon-parse --no-fail-fast` passed, 37 tests.
+- `cargo test -p axon-document --no-fail-fast` passed, 27 tests.
+- `cargo test -p axon-graph --no-fail-fast` passed, 52 tests.
+- `cargo test -p axon-extract --lib --no-fail-fast` passed, 153 tests.
+- `cargo test -p axon-vectors payload --no-fail-fast` passed, 35 tests, 84 filtered.
+- `cargo test -p axon-llm provider --no-fail-fast` passed, 7 tests, 128 filtered.
+- `cargo check -p axon-services --lib` passed with existing warnings.
+- `cargo test -p axon-services tool_policy --no-fail-fast` passed, 2 tests, 585 filtered.
+- `cargo xtask schemas vector-payload --check` passed.
+- `git diff --check` passed.
+- Contract scans for legacy `source_item`/`declares`/`source_line` and forbidden `candidate_with_edge`/`tool_execution_policy` returned no matches.
+- Pre-commit passed: structural checks, monolith, rustfmt.
+- Pre-push passed: structural checks.
+
+## Review Loop
+
+- Independent review agent found tool URI redaction, Compose coverage, graph evidence range validation, and vertical artifact wiring concerns.
+- Simplification pass 1 flagged dead/unwired tool policy, metadata-bound range validation, repeated Compose line scans, duplicate range construction, and duplicate secret/local helpers.
+- Simplification pass 2 flagged vacuous graph-candidate tests and oversized lineage fixture shape.
+- Simplification pass 3 flagged missing vector payload provenance for `payload_families.rs`.
+- PR-toolkit-equivalent review flagged generated schema source-input drift.
+- External PR comments were fetched with `gh-fetch-comments --pr 369 --output /tmp/phase7-pr-comments.json --no-beads`; only quota/skip notices were present.
+
+## PR Status
+
+PR #369 head is `474ef214f3d71d870e5f26ef3cfbb5a8c856a0c2` before this session-note commit. Base remains `codex/phase-4-source-resolver-router`. GitHub reports `UNSTABLE` because Cubic review is pending; CodeRabbit and GitGuardian passed, Claude review skipped, and no actionable review comments were present.
+
+## Residual Risks
+
+- `ScrapedDoc::parse_artifacts` is implemented and tested for GitHub repo verticals, but production web-source indexing does not yet carry the original `ScrapedDoc` through to `PrepareSourceDocumentRequest`; wiring that bridge is larger than the review-fix scope.
+- Compose service dependency edges use the closed `derived_from` edge kind because the current graph registry has no dedicated service-to-service dependency edge.
+- Existing unrelated warnings remain in `axon-services`, `axon-cli`, `xtask`, and one `axon-vectors` test import.

--- a/xtask/src/schemas/generated_contract_tests.rs
+++ b/xtask/src/schemas/generated_contract_tests.rs
@@ -371,6 +371,7 @@ fn generated_vector_payload_source_inputs_cover_builder_contract_and_api_vector_
 
     for path in [
         "crates/axon-vectors/src/payload.rs",
+        "crates/axon-vectors/src/payload_families.rs",
         "crates/axon-vectors/src/point.rs",
         "crates/axon-api/src/source/vector.rs",
         "docs/pipeline-unification/sources/metadata-payload.md",

--- a/xtask/src/schemas/vector_payload.rs
+++ b/xtask/src/schemas/vector_payload.rs
@@ -40,6 +40,7 @@ pub fn vector_payload_artifacts(root: &Path) -> Result<Vec<SchemaArtifact>> {
         &[
             "crates/axon-vectors/src/schema_registry.rs",
             "crates/axon-vectors/src/payload.rs",
+            "crates/axon-vectors/src/payload_families.rs",
             "crates/axon-vectors/src/point.rs",
             "crates/axon-api/src/source/vector.rs",
             "xtask/src/schemas/vector_payload_markdown.rs",

--- a/xtask/tests/fixtures/schemas/vector-payload/snapshots/vector-payload.schema.json
+++ b/xtask/tests/fixtures/schemas/vector-payload/snapshots/vector-payload.schema.json
@@ -7101,6 +7101,11 @@
         "path": "crates/axon-vectors/src/payload.rs"
       },
       {
+        "checksum": "sha256:fef4a0c55bf2a025c4326e2cc82ca13657024df7bbdb37c80637dde86090a466",
+        "kind": "rust_module",
+        "path": "crates/axon-vectors/src/payload_families.rs"
+      },
+      {
         "checksum": "sha256:506dbcd5fc7edafa752b990da56f6177cb68810a74b59c6b2b3ddb937ce4d112",
         "kind": "rust_module",
         "path": "crates/axon-vectors/src/point.rs"

--- a/xtask/tests/fixtures/schemas/vector-payload/snapshots/vector-payload.schema.json
+++ b/xtask/tests/fixtures/schemas/vector-payload/snapshots/vector-payload.schema.json
@@ -3986,6 +3986,11 @@
             },
             {
               "required": [
+                "structured_parse_error"
+              ]
+            },
+            {
+              "required": [
                 "reddit_author"
               ]
             },
@@ -4350,6 +4355,11 @@
             {
               "required": [
                 "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "structured_parse_error"
               ]
             },
             {
@@ -4722,6 +4732,11 @@
             },
             {
               "required": [
+                "structured_parse_error"
+              ]
+            },
+            {
+              "required": [
                 "reddit_author"
               ]
             },
@@ -5086,6 +5101,11 @@
             {
               "required": [
                 "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "structured_parse_error"
               ]
             },
             {
@@ -7101,7 +7121,7 @@
         "path": "crates/axon-vectors/src/payload.rs"
       },
       {
-        "checksum": "sha256:fef4a0c55bf2a025c4326e2cc82ca13657024df7bbdb37c80637dde86090a466",
+        "checksum": "sha256:935c16dcd58bac358bcb78eb1e72634941709135d7148adcb8cbe3c09e6e7808",
         "kind": "rust_module",
         "path": "crates/axon-vectors/src/payload_families.rs"
       },

--- a/xtask/tests/fixtures/schemas/vector-payload/snapshots/vector-payload.schema.json
+++ b/xtask/tests/fixtures/schemas/vector-payload/snapshots/vector-payload.schema.json
@@ -926,6 +926,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -1214,6 +1284,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -1472,6 +1612,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -1724,6 +1934,76 @@
             {
               "required": [
                 "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
               ]
             }
           ]
@@ -2027,6 +2307,76 @@
             {
               "required": [
                 "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
               ]
             }
           ]
@@ -2336,6 +2686,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -2638,6 +3058,76 @@
             {
               "required": [
                 "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
               ]
             }
           ]
@@ -2947,6 +3437,76 @@
               "required": [
                 "memory_status"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
             }
           ]
         }
@@ -3255,6 +3815,1558 @@
               "required": [
                 "graph_confidence"
               ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_family": {
+            "const": "local"
+          }
+        },
+        "required": [
+          "source_family"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "code_language"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_name"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_kind"
+              ]
+            },
+            {
+              "required": [
+                "code_file_type"
+              ]
+            },
+            {
+              "required": [
+                "manifest"
+              ]
+            },
+            {
+              "required": [
+                "git_provider"
+              ]
+            },
+            {
+              "required": [
+                "git_host"
+              ]
+            },
+            {
+              "required": [
+                "git_repo"
+              ]
+            },
+            {
+              "required": [
+                "git_owner"
+              ]
+            },
+            {
+              "required": [
+                "git_web_url"
+              ]
+            },
+            {
+              "required": [
+                "feed_title"
+              ]
+            },
+            {
+              "required": [
+                "feed_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_id"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_published"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_created_utc"
+              ]
+            },
+            {
+              "required": [
+                "reddit_score"
+              ]
+            },
+            {
+              "required": [
+                "reddit_num_comments"
+              ]
+            },
+            {
+              "required": [
+                "reddit_upvote_ratio"
+              ]
+            },
+            {
+              "required": [
+                "reddit_subreddit"
+              ]
+            },
+            {
+              "required": [
+                "reddit_domain"
+              ]
+            },
+            {
+              "required": [
+                "reddit_is_video"
+              ]
+            },
+            {
+              "required": [
+                "reddit_distinguished"
+              ]
+            },
+            {
+              "required": [
+                "reddit_gilded"
+              ]
+            },
+            {
+              "required": [
+                "reddit_flair"
+              ]
+            },
+            {
+              "required": [
+                "reddit_permalink"
+              ]
+            },
+            {
+              "required": [
+                "reddit_kind"
+              ]
+            },
+            {
+              "required": [
+                "video_id"
+              ]
+            },
+            {
+              "required": [
+                "title"
+              ]
+            },
+            {
+              "required": [
+                "url"
+              ]
+            },
+            {
+              "required": [
+                "channel"
+              ]
+            },
+            {
+              "required": [
+                "channel_url"
+              ]
+            },
+            {
+              "required": [
+                "yt_uploader_id"
+              ]
+            },
+            {
+              "required": [
+                "yt_upload_date"
+              ]
+            },
+            {
+              "required": [
+                "yt_duration"
+              ]
+            },
+            {
+              "required": [
+                "yt_view_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_like_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_tags"
+              ]
+            },
+            {
+              "required": [
+                "yt_categories"
+              ]
+            },
+            {
+              "required": [
+                "yt_thumbnail"
+              ]
+            },
+            {
+              "required": [
+                "segment_kind"
+              ]
+            },
+            {
+              "required": [
+                "web_title"
+              ]
+            },
+            {
+              "required": [
+                "web_domain"
+              ]
+            },
+            {
+              "required": [
+                "web_status_code"
+              ]
+            },
+            {
+              "required": [
+                "web_depth"
+              ]
+            },
+            {
+              "required": [
+                "package_ecosystem"
+              ]
+            },
+            {
+              "required": [
+                "package_name"
+              ]
+            },
+            {
+              "required": [
+                "package_version"
+              ]
+            },
+            {
+              "required": [
+                "session_id"
+              ]
+            },
+            {
+              "required": [
+                "session_turn_index"
+              ]
+            },
+            {
+              "required": [
+                "session_tool_name"
+              ]
+            },
+            {
+              "required": [
+                "session_skill_name"
+              ]
+            },
+            {
+              "required": [
+                "graph_node_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_edge_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_confidence"
+              ]
+            },
+            {
+              "required": [
+                "memory_id"
+              ]
+            },
+            {
+              "required": [
+                "memory_importance"
+              ]
+            },
+            {
+              "required": [
+                "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_family": {
+            "const": "tool"
+          }
+        },
+        "required": [
+          "source_family"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "code_language"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_name"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_kind"
+              ]
+            },
+            {
+              "required": [
+                "code_file_type"
+              ]
+            },
+            {
+              "required": [
+                "manifest"
+              ]
+            },
+            {
+              "required": [
+                "git_provider"
+              ]
+            },
+            {
+              "required": [
+                "git_host"
+              ]
+            },
+            {
+              "required": [
+                "git_repo"
+              ]
+            },
+            {
+              "required": [
+                "git_owner"
+              ]
+            },
+            {
+              "required": [
+                "git_web_url"
+              ]
+            },
+            {
+              "required": [
+                "feed_title"
+              ]
+            },
+            {
+              "required": [
+                "feed_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_id"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_published"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_created_utc"
+              ]
+            },
+            {
+              "required": [
+                "reddit_score"
+              ]
+            },
+            {
+              "required": [
+                "reddit_num_comments"
+              ]
+            },
+            {
+              "required": [
+                "reddit_upvote_ratio"
+              ]
+            },
+            {
+              "required": [
+                "reddit_subreddit"
+              ]
+            },
+            {
+              "required": [
+                "reddit_domain"
+              ]
+            },
+            {
+              "required": [
+                "reddit_is_video"
+              ]
+            },
+            {
+              "required": [
+                "reddit_distinguished"
+              ]
+            },
+            {
+              "required": [
+                "reddit_gilded"
+              ]
+            },
+            {
+              "required": [
+                "reddit_flair"
+              ]
+            },
+            {
+              "required": [
+                "reddit_permalink"
+              ]
+            },
+            {
+              "required": [
+                "reddit_kind"
+              ]
+            },
+            {
+              "required": [
+                "video_id"
+              ]
+            },
+            {
+              "required": [
+                "title"
+              ]
+            },
+            {
+              "required": [
+                "url"
+              ]
+            },
+            {
+              "required": [
+                "channel"
+              ]
+            },
+            {
+              "required": [
+                "channel_url"
+              ]
+            },
+            {
+              "required": [
+                "yt_uploader_id"
+              ]
+            },
+            {
+              "required": [
+                "yt_upload_date"
+              ]
+            },
+            {
+              "required": [
+                "yt_duration"
+              ]
+            },
+            {
+              "required": [
+                "yt_view_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_like_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_tags"
+              ]
+            },
+            {
+              "required": [
+                "yt_categories"
+              ]
+            },
+            {
+              "required": [
+                "yt_thumbnail"
+              ]
+            },
+            {
+              "required": [
+                "segment_kind"
+              ]
+            },
+            {
+              "required": [
+                "web_title"
+              ]
+            },
+            {
+              "required": [
+                "web_domain"
+              ]
+            },
+            {
+              "required": [
+                "web_status_code"
+              ]
+            },
+            {
+              "required": [
+                "web_depth"
+              ]
+            },
+            {
+              "required": [
+                "package_ecosystem"
+              ]
+            },
+            {
+              "required": [
+                "package_name"
+              ]
+            },
+            {
+              "required": [
+                "package_version"
+              ]
+            },
+            {
+              "required": [
+                "session_id"
+              ]
+            },
+            {
+              "required": [
+                "session_turn_index"
+              ]
+            },
+            {
+              "required": [
+                "session_tool_name"
+              ]
+            },
+            {
+              "required": [
+                "session_skill_name"
+              ]
+            },
+            {
+              "required": [
+                "graph_node_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_edge_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_confidence"
+              ]
+            },
+            {
+              "required": [
+                "memory_id"
+              ]
+            },
+            {
+              "required": [
+                "memory_importance"
+              ]
+            },
+            {
+              "required": [
+                "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_family": {
+            "const": "docker"
+          }
+        },
+        "required": [
+          "source_family"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "code_language"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_name"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_kind"
+              ]
+            },
+            {
+              "required": [
+                "code_file_type"
+              ]
+            },
+            {
+              "required": [
+                "manifest"
+              ]
+            },
+            {
+              "required": [
+                "git_provider"
+              ]
+            },
+            {
+              "required": [
+                "git_host"
+              ]
+            },
+            {
+              "required": [
+                "git_repo"
+              ]
+            },
+            {
+              "required": [
+                "git_owner"
+              ]
+            },
+            {
+              "required": [
+                "git_web_url"
+              ]
+            },
+            {
+              "required": [
+                "feed_title"
+              ]
+            },
+            {
+              "required": [
+                "feed_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_id"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_published"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_created_utc"
+              ]
+            },
+            {
+              "required": [
+                "reddit_score"
+              ]
+            },
+            {
+              "required": [
+                "reddit_num_comments"
+              ]
+            },
+            {
+              "required": [
+                "reddit_upvote_ratio"
+              ]
+            },
+            {
+              "required": [
+                "reddit_subreddit"
+              ]
+            },
+            {
+              "required": [
+                "reddit_domain"
+              ]
+            },
+            {
+              "required": [
+                "reddit_is_video"
+              ]
+            },
+            {
+              "required": [
+                "reddit_distinguished"
+              ]
+            },
+            {
+              "required": [
+                "reddit_gilded"
+              ]
+            },
+            {
+              "required": [
+                "reddit_flair"
+              ]
+            },
+            {
+              "required": [
+                "reddit_permalink"
+              ]
+            },
+            {
+              "required": [
+                "reddit_kind"
+              ]
+            },
+            {
+              "required": [
+                "video_id"
+              ]
+            },
+            {
+              "required": [
+                "title"
+              ]
+            },
+            {
+              "required": [
+                "url"
+              ]
+            },
+            {
+              "required": [
+                "channel"
+              ]
+            },
+            {
+              "required": [
+                "channel_url"
+              ]
+            },
+            {
+              "required": [
+                "yt_uploader_id"
+              ]
+            },
+            {
+              "required": [
+                "yt_upload_date"
+              ]
+            },
+            {
+              "required": [
+                "yt_duration"
+              ]
+            },
+            {
+              "required": [
+                "yt_view_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_like_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_tags"
+              ]
+            },
+            {
+              "required": [
+                "yt_categories"
+              ]
+            },
+            {
+              "required": [
+                "yt_thumbnail"
+              ]
+            },
+            {
+              "required": [
+                "segment_kind"
+              ]
+            },
+            {
+              "required": [
+                "web_title"
+              ]
+            },
+            {
+              "required": [
+                "web_domain"
+              ]
+            },
+            {
+              "required": [
+                "web_status_code"
+              ]
+            },
+            {
+              "required": [
+                "web_depth"
+              ]
+            },
+            {
+              "required": [
+                "package_ecosystem"
+              ]
+            },
+            {
+              "required": [
+                "package_name"
+              ]
+            },
+            {
+              "required": [
+                "package_version"
+              ]
+            },
+            {
+              "required": [
+                "session_id"
+              ]
+            },
+            {
+              "required": [
+                "session_turn_index"
+              ]
+            },
+            {
+              "required": [
+                "session_tool_name"
+              ]
+            },
+            {
+              "required": [
+                "session_skill_name"
+              ]
+            },
+            {
+              "required": [
+                "graph_node_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_edge_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_confidence"
+              ]
+            },
+            {
+              "required": [
+                "memory_id"
+              ]
+            },
+            {
+              "required": [
+                "memory_importance"
+              ]
+            },
+            {
+              "required": [
+                "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "env_key"
+              ]
+            },
+            {
+              "required": [
+                "env_secret_reference"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_family": {
+            "const": "env"
+          }
+        },
+        "required": [
+          "source_family"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "code_language"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_name"
+              ]
+            },
+            {
+              "required": [
+                "code_symbol_kind"
+              ]
+            },
+            {
+              "required": [
+                "code_file_type"
+              ]
+            },
+            {
+              "required": [
+                "manifest"
+              ]
+            },
+            {
+              "required": [
+                "git_provider"
+              ]
+            },
+            {
+              "required": [
+                "git_host"
+              ]
+            },
+            {
+              "required": [
+                "git_repo"
+              ]
+            },
+            {
+              "required": [
+                "git_owner"
+              ]
+            },
+            {
+              "required": [
+                "git_web_url"
+              ]
+            },
+            {
+              "required": [
+                "feed_title"
+              ]
+            },
+            {
+              "required": [
+                "feed_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_id"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_link"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_published"
+              ]
+            },
+            {
+              "required": [
+                "feed_entry_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_author"
+              ]
+            },
+            {
+              "required": [
+                "reddit_created_utc"
+              ]
+            },
+            {
+              "required": [
+                "reddit_score"
+              ]
+            },
+            {
+              "required": [
+                "reddit_num_comments"
+              ]
+            },
+            {
+              "required": [
+                "reddit_upvote_ratio"
+              ]
+            },
+            {
+              "required": [
+                "reddit_subreddit"
+              ]
+            },
+            {
+              "required": [
+                "reddit_domain"
+              ]
+            },
+            {
+              "required": [
+                "reddit_is_video"
+              ]
+            },
+            {
+              "required": [
+                "reddit_distinguished"
+              ]
+            },
+            {
+              "required": [
+                "reddit_gilded"
+              ]
+            },
+            {
+              "required": [
+                "reddit_flair"
+              ]
+            },
+            {
+              "required": [
+                "reddit_permalink"
+              ]
+            },
+            {
+              "required": [
+                "reddit_kind"
+              ]
+            },
+            {
+              "required": [
+                "video_id"
+              ]
+            },
+            {
+              "required": [
+                "title"
+              ]
+            },
+            {
+              "required": [
+                "url"
+              ]
+            },
+            {
+              "required": [
+                "channel"
+              ]
+            },
+            {
+              "required": [
+                "channel_url"
+              ]
+            },
+            {
+              "required": [
+                "yt_uploader_id"
+              ]
+            },
+            {
+              "required": [
+                "yt_upload_date"
+              ]
+            },
+            {
+              "required": [
+                "yt_duration"
+              ]
+            },
+            {
+              "required": [
+                "yt_view_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_like_count"
+              ]
+            },
+            {
+              "required": [
+                "yt_tags"
+              ]
+            },
+            {
+              "required": [
+                "yt_categories"
+              ]
+            },
+            {
+              "required": [
+                "yt_thumbnail"
+              ]
+            },
+            {
+              "required": [
+                "segment_kind"
+              ]
+            },
+            {
+              "required": [
+                "web_title"
+              ]
+            },
+            {
+              "required": [
+                "web_domain"
+              ]
+            },
+            {
+              "required": [
+                "web_status_code"
+              ]
+            },
+            {
+              "required": [
+                "web_depth"
+              ]
+            },
+            {
+              "required": [
+                "package_ecosystem"
+              ]
+            },
+            {
+              "required": [
+                "package_name"
+              ]
+            },
+            {
+              "required": [
+                "package_version"
+              ]
+            },
+            {
+              "required": [
+                "session_id"
+              ]
+            },
+            {
+              "required": [
+                "session_turn_index"
+              ]
+            },
+            {
+              "required": [
+                "session_tool_name"
+              ]
+            },
+            {
+              "required": [
+                "session_skill_name"
+              ]
+            },
+            {
+              "required": [
+                "graph_node_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_edge_ids"
+              ]
+            },
+            {
+              "required": [
+                "graph_confidence"
+              ]
+            },
+            {
+              "required": [
+                "memory_id"
+              ]
+            },
+            {
+              "required": [
+                "memory_importance"
+              ]
+            },
+            {
+              "required": [
+                "memory_status"
+              ]
+            },
+            {
+              "required": [
+                "local_checkout"
+              ]
+            },
+            {
+              "required": [
+                "local_path_key"
+              ]
+            },
+            {
+              "required": [
+                "local_git_remote"
+              ]
+            },
+            {
+              "required": [
+                "local_git_commit"
+              ]
+            },
+            {
+              "required": [
+                "tool_name"
+              ]
+            },
+            {
+              "required": [
+                "tool_action"
+              ]
+            },
+            {
+              "required": [
+                "tool_side_effect_class"
+              ]
+            },
+            {
+              "required": [
+                "tool_output_artifact_id"
+              ]
+            },
+            {
+              "required": [
+                "docker_image"
+              ]
+            },
+            {
+              "required": [
+                "docker_service"
+              ]
+            },
+            {
+              "required": [
+                "docker_port"
+              ]
+            },
+            {
+              "required": [
+                "docker_volume"
+              ]
             }
           ]
         }
@@ -3337,6 +5449,18 @@
       "minLength": 1,
       "type": "string"
     },
+    "docker_image": {
+      "type": "string"
+    },
+    "docker_port": {
+      "type": "string"
+    },
+    "docker_service": {
+      "type": "string"
+    },
+    "docker_volume": {
+      "type": "string"
+    },
     "document_id": {
       "minLength": 1,
       "type": "string",
@@ -3376,6 +5500,12 @@
       "minLength": 1,
       "type": "string",
       "x-qdrant-index": "keyword"
+    },
+    "env_key": {
+      "type": "string"
+    },
+    "env_secret_reference": {
+      "type": "string"
     },
     "feed_entry_author": {
       "type": "string"
@@ -3433,6 +5563,18 @@
       "minLength": 1,
       "type": "string",
       "x-qdrant-index": "keyword"
+    },
+    "local_checkout": {
+      "type": "string"
+    },
+    "local_git_commit": {
+      "type": "string"
+    },
+    "local_git_remote": {
+      "type": "string"
+    },
+    "local_path_key": {
+      "type": "string"
     },
     "manifest": {
       "type": "boolean"
@@ -3542,7 +5684,11 @@
         "memory",
         "feed",
         "social",
-        "media"
+        "media",
+        "local",
+        "tool",
+        "docker",
+        "env"
       ],
       "minLength": 1,
       "type": "string",
@@ -3582,6 +5728,18 @@
       "type": "string"
     },
     "title": {
+      "type": "string"
+    },
+    "tool_action": {
+      "type": "string"
+    },
+    "tool_name": {
+      "type": "string"
+    },
+    "tool_output_artifact_id": {
+      "type": "string"
+    },
+    "tool_side_effect_class": {
       "type": "string"
     },
     "url": {
@@ -4452,6 +6610,324 @@
         "vector_namespace": "vector_namespace",
         "vector_point_id": "vector_point_id",
         "visibility": "internal"
+      },
+      {
+        "chunk_hash": "chunk_hash",
+        "chunk_id": "chunk-local-0",
+        "chunk_key": "local-chunk-key",
+        "chunk_locator": {
+          "canonical_uri": "https://example.com/local",
+          "heading_path": [
+            "local heading"
+          ],
+          "path": "/local",
+          "range": {
+            "byte_end": null,
+            "byte_start": null,
+            "char_end": null,
+            "char_start": null,
+            "csv_row": null,
+            "dom_selector": null,
+            "json_pointer": null,
+            "line_end": 4,
+            "line_start": 1,
+            "session_turn_id": null,
+            "time_end_ms": null,
+            "time_start_ms": null,
+            "turn_end": null,
+            "turn_start": null,
+            "xml_xpath": null,
+            "yaml_path": null
+          },
+          "symbol": null
+        },
+        "chunk_text": "chunk_text",
+        "collection": "axon",
+        "committed_generation": "uncommitted",
+        "content_hash": "sha256:localhash",
+        "content_kind": "content_kind",
+        "document_id": "doc-local",
+        "document_status": "prepared",
+        "embedded_at": "2026-06-30T00:00:00Z",
+        "embedding_dimensions": 768,
+        "embedding_model": "text-embedding-test",
+        "embedding_profile": "default",
+        "embedding_provider": "tei",
+        "item_canonical_uri": "item_canonical_uri",
+        "job_id": "job-local",
+        "local_checkout": "local_checkout",
+        "local_git_commit": "local_git_commit",
+        "local_git_remote": "local_git_remote",
+        "local_path_key": "local_path_key",
+        "payload_contract_version": "2026-07-01",
+        "redaction_status": "clean",
+        "source_adapter": "source_adapter",
+        "source_canonical_uri": "source_canonical_uri",
+        "source_family": "local",
+        "source_generation": "gen-local-7",
+        "source_id": "src-local",
+        "source_item_key": "local-item",
+        "source_kind": "source_kind",
+        "source_range": {
+          "byte_end": null,
+          "byte_start": null,
+          "char_end": null,
+          "char_start": null,
+          "csv_row": null,
+          "dom_selector": null,
+          "json_pointer": null,
+          "line_end": 4,
+          "line_start": 1,
+          "session_turn_id": null,
+          "time_end_ms": null,
+          "time_start_ms": null,
+          "turn_end": null,
+          "turn_start": null,
+          "xml_xpath": null,
+          "yaml_path": null
+        },
+        "source_scope": "source_scope",
+        "vector_namespace": "vector_namespace",
+        "vector_point_id": "vector_point_id",
+        "visibility": "internal"
+      },
+      {
+        "chunk_hash": "chunk_hash",
+        "chunk_id": "chunk-tool-0",
+        "chunk_key": "tool-chunk-key",
+        "chunk_locator": {
+          "canonical_uri": "https://example.com/tool",
+          "heading_path": [
+            "tool heading"
+          ],
+          "path": "/tool",
+          "range": {
+            "byte_end": null,
+            "byte_start": null,
+            "char_end": null,
+            "char_start": null,
+            "csv_row": null,
+            "dom_selector": null,
+            "json_pointer": null,
+            "line_end": 4,
+            "line_start": 1,
+            "session_turn_id": null,
+            "time_end_ms": null,
+            "time_start_ms": null,
+            "turn_end": null,
+            "turn_start": null,
+            "xml_xpath": null,
+            "yaml_path": null
+          },
+          "symbol": null
+        },
+        "chunk_text": "chunk_text",
+        "collection": "axon",
+        "committed_generation": "uncommitted",
+        "content_hash": "sha256:toolhash",
+        "content_kind": "content_kind",
+        "document_id": "doc-tool",
+        "document_status": "prepared",
+        "embedded_at": "2026-06-30T00:00:00Z",
+        "embedding_dimensions": 768,
+        "embedding_model": "text-embedding-test",
+        "embedding_profile": "default",
+        "embedding_provider": "tei",
+        "item_canonical_uri": "item_canonical_uri",
+        "job_id": "job-tool",
+        "payload_contract_version": "2026-07-01",
+        "redaction_status": "clean",
+        "source_adapter": "source_adapter",
+        "source_canonical_uri": "source_canonical_uri",
+        "source_family": "tool",
+        "source_generation": "gen-tool-7",
+        "source_id": "src-tool",
+        "source_item_key": "tool-item",
+        "source_kind": "source_kind",
+        "source_range": {
+          "byte_end": null,
+          "byte_start": null,
+          "char_end": null,
+          "char_start": null,
+          "csv_row": null,
+          "dom_selector": null,
+          "json_pointer": null,
+          "line_end": 4,
+          "line_start": 1,
+          "session_turn_id": null,
+          "time_end_ms": null,
+          "time_start_ms": null,
+          "turn_end": null,
+          "turn_start": null,
+          "xml_xpath": null,
+          "yaml_path": null
+        },
+        "source_scope": "source_scope",
+        "tool_action": "tool_action",
+        "tool_name": "tool_name",
+        "tool_output_artifact_id": "tool_output_artifact_id",
+        "tool_side_effect_class": "tool_side_effect_class",
+        "vector_namespace": "vector_namespace",
+        "vector_point_id": "vector_point_id",
+        "visibility": "internal"
+      },
+      {
+        "chunk_hash": "chunk_hash",
+        "chunk_id": "chunk-docker-0",
+        "chunk_key": "docker-chunk-key",
+        "chunk_locator": {
+          "canonical_uri": "https://example.com/docker",
+          "heading_path": [
+            "docker heading"
+          ],
+          "path": "/docker",
+          "range": {
+            "byte_end": null,
+            "byte_start": null,
+            "char_end": null,
+            "char_start": null,
+            "csv_row": null,
+            "dom_selector": null,
+            "json_pointer": null,
+            "line_end": 4,
+            "line_start": 1,
+            "session_turn_id": null,
+            "time_end_ms": null,
+            "time_start_ms": null,
+            "turn_end": null,
+            "turn_start": null,
+            "xml_xpath": null,
+            "yaml_path": null
+          },
+          "symbol": null
+        },
+        "chunk_text": "chunk_text",
+        "collection": "axon",
+        "committed_generation": "uncommitted",
+        "content_hash": "sha256:dockerhash",
+        "content_kind": "content_kind",
+        "docker_image": "docker_image",
+        "docker_port": "docker_port",
+        "docker_service": "docker_service",
+        "docker_volume": "docker_volume",
+        "document_id": "doc-docker",
+        "document_status": "prepared",
+        "embedded_at": "2026-06-30T00:00:00Z",
+        "embedding_dimensions": 768,
+        "embedding_model": "text-embedding-test",
+        "embedding_profile": "default",
+        "embedding_provider": "tei",
+        "item_canonical_uri": "item_canonical_uri",
+        "job_id": "job-docker",
+        "payload_contract_version": "2026-07-01",
+        "redaction_status": "clean",
+        "source_adapter": "source_adapter",
+        "source_canonical_uri": "source_canonical_uri",
+        "source_family": "docker",
+        "source_generation": "gen-docker-7",
+        "source_id": "src-docker",
+        "source_item_key": "docker-item",
+        "source_kind": "source_kind",
+        "source_range": {
+          "byte_end": null,
+          "byte_start": null,
+          "char_end": null,
+          "char_start": null,
+          "csv_row": null,
+          "dom_selector": null,
+          "json_pointer": null,
+          "line_end": 4,
+          "line_start": 1,
+          "session_turn_id": null,
+          "time_end_ms": null,
+          "time_start_ms": null,
+          "turn_end": null,
+          "turn_start": null,
+          "xml_xpath": null,
+          "yaml_path": null
+        },
+        "source_scope": "source_scope",
+        "vector_namespace": "vector_namespace",
+        "vector_point_id": "vector_point_id",
+        "visibility": "internal"
+      },
+      {
+        "chunk_hash": "chunk_hash",
+        "chunk_id": "chunk-env-0",
+        "chunk_key": "env-chunk-key",
+        "chunk_locator": {
+          "canonical_uri": "https://example.com/env",
+          "heading_path": [
+            "env heading"
+          ],
+          "path": "/env",
+          "range": {
+            "byte_end": null,
+            "byte_start": null,
+            "char_end": null,
+            "char_start": null,
+            "csv_row": null,
+            "dom_selector": null,
+            "json_pointer": null,
+            "line_end": 4,
+            "line_start": 1,
+            "session_turn_id": null,
+            "time_end_ms": null,
+            "time_start_ms": null,
+            "turn_end": null,
+            "turn_start": null,
+            "xml_xpath": null,
+            "yaml_path": null
+          },
+          "symbol": null
+        },
+        "chunk_text": "chunk_text",
+        "collection": "axon",
+        "committed_generation": "uncommitted",
+        "content_hash": "sha256:envhash",
+        "content_kind": "content_kind",
+        "document_id": "doc-env",
+        "document_status": "prepared",
+        "embedded_at": "2026-06-30T00:00:00Z",
+        "embedding_dimensions": 768,
+        "embedding_model": "text-embedding-test",
+        "embedding_profile": "default",
+        "embedding_provider": "tei",
+        "env_key": "env_key",
+        "env_secret_reference": "env_secret_reference",
+        "item_canonical_uri": "item_canonical_uri",
+        "job_id": "job-env",
+        "payload_contract_version": "2026-07-01",
+        "redaction_status": "clean",
+        "source_adapter": "source_adapter",
+        "source_canonical_uri": "source_canonical_uri",
+        "source_family": "env",
+        "source_generation": "gen-env-7",
+        "source_id": "src-env",
+        "source_item_key": "env-item",
+        "source_kind": "source_kind",
+        "source_range": {
+          "byte_end": null,
+          "byte_start": null,
+          "char_end": null,
+          "char_start": null,
+          "csv_row": null,
+          "dom_selector": null,
+          "json_pointer": null,
+          "line_end": 4,
+          "line_start": 1,
+          "session_turn_id": null,
+          "time_end_ms": null,
+          "time_start_ms": null,
+          "turn_end": null,
+          "turn_start": null,
+          "xml_xpath": null,
+          "yaml_path": null
+        },
+        "source_scope": "source_scope",
+        "vector_namespace": "vector_namespace",
+        "vector_point_id": "vector_point_id",
+        "visibility": "internal"
       }
     ],
     "generated_by": "cargo xtask schemas vector-payload",
@@ -4761,6 +7237,40 @@
           "memory_status"
         ],
         "source_family": "memory"
+      },
+      {
+        "fields": [
+          "local_checkout",
+          "local_path_key",
+          "local_git_remote",
+          "local_git_commit"
+        ],
+        "source_family": "local"
+      },
+      {
+        "fields": [
+          "tool_name",
+          "tool_action",
+          "tool_side_effect_class",
+          "tool_output_artifact_id"
+        ],
+        "source_family": "tool"
+      },
+      {
+        "fields": [
+          "docker_image",
+          "docker_service",
+          "docker_port",
+          "docker_volume"
+        ],
+        "source_family": "docker"
+      },
+      {
+        "fields": [
+          "env_key",
+          "env_secret_reference"
+        ],
+        "source_family": "env"
       }
     ]
   }


### PR DESCRIPTION
## Summary

Implements Phase 7 parser/metadata/graph gap closure on top of Phase 4:

- registers Docker/env/tool/session/API/code parser coverage in the production parser registry
- emits bounded Docker/env/tool/vertical parse facts and source-graph candidates with closed graph node/edge/evidence kinds
- validates parser evidence/source ranges in graph/document paths and routes required chunk profiles
- registers Phase 7 vector payload family fields and refreshes generated vector payload docs/schema fixtures
- keeps trusted CLI/MCP tool execution policy in `axon-services`, with parsers only recording redacted observed claims
- adds ledger/vector/graph lineage fixture coverage and vertical extraction parse artifacts

Rebased on final Phase 4 head `75daf47c1de6d98beac6bbf0bb4e866ffdc99125`.

## Verification

Passed after rebase:

- `cargo test -p axon-parse --no-fail-fast`
- `cargo test -p axon-document --no-fail-fast`
- `cargo test -p axon-vectors payload --no-fail-fast`
- `cargo test -p axon-graph --no-fail-fast`
- `cargo test -p axon-llm provider --no-fail-fast`
- `cargo check -p axon-services --lib`
- `cargo xtask schemas vector-payload --check`
- `cargo test -p axon-services tool_policy --no-fail-fast`
- Contract scans for retired graph helper names and obsolete policy helper names returned no matches.

## Notes

- No durable job cutover, public surface deletion, reset/prune cutover, or issue #298 update is included.
- `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` were not edited.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes Phase 7 parser/metadata/graph gaps: adds Docker/Compose and env parsers, validates source ranges end-to-end, caps and sanitizes tool-output ingestion, and extends vector payload families. Hardens source-graph evidence and execution safety, and completes routing for env, tool, and session data.

- **New Features**
  - Register `docker_manifest` and `env_example` in `axon-parse`; router recognizes `.env.*` as StructuredRecords, `tool-output.jsonl` as ToolOutput, and `session.jsonl` as SessionTurns.
  - Dockerfile/Compose parsing: emits base images, services, ports, volumes, env/secret refs (incl. `env_file`, `secrets`, `depends_on`); bounded by file size/depth and per-document candidate caps.
  - Env example parsing: classifies secrets without emitting values; links env/secret declarations via source-graph candidates.
  - Tool output JSONL: bounded ingestion with redaction and external resource URI sanitization; emits `tool_observed_claim`, resources, and artifact refs; adds graph links from tool calls to tools, artifacts, and resources.
  - `axon-document`: normalizes document bounds and validates all chunk/parse-fact ranges; routes chunk profiles for tool, session, env.
  - `axon-extract`: GitHub repo vertical derives parse facts and source-graph candidates (homepage → repo).
  - `axon-vectors`: adds `local`, `tool`, `docker`, and `env` families and fields; regenerates docs and schema fixtures.

- **Bug Fixes**
  - Source-graph contract: enforce evidence kind registry and range ordering; parser helper now emits `repo_file → artifact` with `source_indexed_as` and retires legacy names.
  - Safer ingestion: reject invalid/oversized tool JSONL and out-of-bounds ranges; degrade stage on cap violations; default unknown adapter metadata to internal.
  - `axon-services`: add trusted CLI/MCP tool execution policy validator (allowlists, shell-expansion checks, timeout/output caps).
  - Tie vector/graph lineage fixtures to shared source generation for consistent tests.

<sup>Written for commit 49606800d1a6599bb0a946a6e193fdc5e556a0ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

