### PR TITLE
docs: save release-please session log

### DIFF
--- a/docs/sessions/2026-07-05-release-please-merge-closeout.md
+++ b/docs/sessions/2026-07-05-release-please-merge-closeout.md
@@ -1,0 +1,188 @@
+---
+date: 2026-07-05 01:26:30 EDT
+repo: git@github.com:jmagar/axon.git
+branch: main
+head: e43f97240
+plan: docs/superpowers/plans/2026-07-04-release-please-migration.md
+working directory: /home/jmagar/workspace/axon
+worktree: /home/jmagar/workspace/axon
+pr: "#365 Switch release flow toward release-please https://github.com/jmagar/axon/pull/365"
+beads: none
+---
+
+# Release-please merge closeout
+
+## User Request
+
+Create a release-please migration plan, review and revise it, implement the switch away from git-cliff plus xtask manual release tooling, confirm it covers Android, the Tauri palette, the CLI, and the Chrome extension, then merge it. After merge, save this session to markdown.
+
+## Session Overview
+
+The session moved Axon's release flow to release-please as the normal owner of version bumps, changelogs, tags, and GitHub Releases. PR #365 was merged into `main` at merge commit `e43f972406a2f7d1b8e251f956d32bfd0a56fece`, the release-please worktree was cleaned up, and the stale remote PR branch was deleted after merge.
+
+## Sequence of Events
+
+1. Created and worked from the existing release-please worktree on branch `codex/release-please-plan`.
+2. Used `superpowers:writing-plans` to produce the migration plan, then applied `lavra:lavra-eng-review` feedback and updated the plan.
+3. Expanded the plan and implementation so release-please covers the CLI, Android app, Tauri palette, and Chrome extension release surfaces.
+4. Reviewed release-please capabilities and repository release surfaces, then added release-please config, manifests, CI wiring, validation helpers, and artifact workflow changes.
+5. Removed git-cliff and manual xtask release-bump/changelog fallback tooling after the user clarified those paths should not exist.
+6. Verified the branch with targeted formatting, xtask release-version tests, release-version validation, workflow/config validation, Chrome packaging, docs link checks, and hooks.
+7. Merged PR #365, fast-forwarded local `main`, removed the release-please worktree and local branch, then deleted the lingering remote PR branch.
+
+## Key Findings
+
+- Release-please can own Axon's multi-component release flow through a manifest configuration, allowing separate release-please components for root CLI/Cargo, Android, Tauri palette, and Chrome extension packages.
+- GitHub Actions artifact jobs need to attach to releases created by release-please, not create independent releases.
+- `CLAUDE.md` had briefly described git-cliff/xtask as rollback tooling; that was corrected so git-cliff and manual xtask release paths are removed rather than preserved.
+- The merge command initially hit a worktree conflict because `main` was checked out in `/home/jmagar/workspace/axon`; rerunning the closeout from the primary checkout resolved the local sync path.
+
+## Technical Decisions
+
+- Use release-please manifest mode so component paths and package names are explicit in `release-please-config.json` and `.release-please-manifest.json`.
+- Keep xtask release-version validation, but make it validate release-please metadata and component path ownership instead of generating versions or changelogs.
+- Delete git-cliff config and cliff-specific tests to prevent old release machinery from silently reappearing as a fallback.
+- Dispatch existing artifact workflows from release-please-created releases so Android, Chrome extension, Tauri palette, and CLI assets still land on GitHub Releases.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `.github/workflows/android-release.yml` | - | Attach Android artifacts to release-please releases | merged PR diff |
+| modified | `.github/workflows/chrome-extension-release.yml` | - | Attach Chrome extension artifacts to release-please releases | merged PR diff |
+| modified | `.github/workflows/ci.yml` | - | Gate release-please after green CI | merged PR diff |
+| modified | `.github/workflows/palette-release.yml` | - | Attach Tauri palette artifacts to release-please releases | merged PR diff |
+| created | `.github/workflows/release-please.yml` | - | Add release-please workflow | merged PR diff |
+| modified | `.github/workflows/release.yml` | - | Align CLI release artifacts with release-please releases | merged PR diff |
+| created | `.release-please-manifest.json` | - | Seed component versions | merged PR diff |
+| modified | `CLAUDE.md` | - | Document release-please as the release source of truth | merged PR diff |
+| modified | `README.md` | - | Update release docs | merged PR diff |
+| modified | `apps/android/app/build.gradle.kts` | - | Align Android version surface | merged PR diff |
+| modified | `apps/chrome-extension/README.md` | - | Document Chrome extension release flow | merged PR diff |
+| deleted | `apps/chrome-extension/assets` | - | Replace placeholder/path collision with real assets directory | merged PR diff |
+| created | `apps/chrome-extension/assets/axon-glyph.svg` | - | Add extension source icon asset | merged PR diff |
+| created | `apps/chrome-extension/assets/png/axon-icon-128.png` | - | Add extension PNG asset | merged PR diff |
+| created | `apps/chrome-extension/assets/png/axon-icon-16.png` | - | Add extension PNG asset | merged PR diff |
+| created | `apps/chrome-extension/assets/png/axon-icon-32.png` | - | Add extension PNG asset | merged PR diff |
+| created | `apps/chrome-extension/assets/png/axon-icon-48.png` | - | Add extension PNG asset | merged PR diff |
+| modified | `apps/chrome-extension/package.sh` | - | Package assets from the extension package tree | merged PR diff |
+| deleted | `cliff.toml` | - | Remove git-cliff release configuration | merged PR diff |
+| created | `docs/sessions/2026-07-04-release-please-migration.md` | - | Save implementation-session log from the PR branch | merged PR diff |
+| created | `docs/superpowers/plans/2026-07-04-release-please-migration.md` | - | Save reviewed migration plan | merged PR diff |
+| created | `release-please-config.json` | - | Configure release-please manifest mode and components | merged PR diff |
+| modified | `release/components.toml` | - | Align release component metadata | merged PR diff |
+| modified | `xtask/src/checks/release_versions.rs` | - | Retarget release validation toward release-please | merged PR diff |
+| deleted | `xtask/src/checks/release_versions/cliff.rs` | - | Remove git-cliff integration | merged PR diff |
+| deleted | `xtask/src/checks/release_versions/cliff_tests.rs` | - | Remove cliff-specific tests | merged PR diff |
+| modified | `xtask/src/checks/release_versions/files.rs` | - | Remove manual writer helpers and route file checks | merged PR diff |
+| created | `xtask/src/checks/release_versions/files/readme.rs` | - | Add README-focused release validation support | merged PR diff |
+| modified | `xtask/src/checks/release_versions/git.rs` | - | Support release-please-aware git validation | merged PR diff |
+| modified | `xtask/src/checks/release_versions/manifest.rs` | - | Validate release-please manifest metadata | merged PR diff |
+| created | `xtask/src/checks/release_versions/release_please.rs` | - | Add release-please config validation | merged PR diff |
+| modified | `xtask/src/checks/release_versions_tests.rs` | - | Update release-version tests | merged PR diff |
+| modified | `xtask/src/main.rs` | - | Remove old release generation commands and wire validation commands | merged PR diff |
+| created | `docs/sessions/2026-07-05-release-please-merge-closeout.md` | - | Save this closeout session | this commit |
+
+## Beads Activity
+
+No bead activity observed for the release-please migration. A targeted bead search for `release-please`, `release please`, `git-cliff`, and `cliff` found only the older closed bead `axon_rust-qbvn` titled `git-cliff changelogs + auto-bump for release tooling`; no directly relevant open bead was created, edited, claimed, or closed in this session.
+
+## Repository Maintenance
+
+Plans: `docs/plans/` was listed and no release-please plan was present there. The active plan for this session is `docs/superpowers/plans/2026-07-04-release-please-migration.md`, so no `docs/plans` files were moved to `docs/plans/complete/`.
+
+Beads: no directly relevant open bead was observed. The old git-cliff bead was already closed, so no bead changes were made.
+
+Worktrees and branches: `git worktree list --porcelain` showed the primary `main` checkout plus unrelated long-lived or active worktrees. The release-please worktree was already removed from the registered list. Local branch `codex/release-please-plan` was absent; remote branch `origin/codex/release-please-plan` was present after merge and was deleted with `git push origin --delete codex/release-please-plan`.
+
+Stale docs: the release docs touched by the session were updated in the merged PR. No additional stale doc edits were made during this save step because `main` was clean and the PR had already removed the contradictory git-cliff/xtask rollback language.
+
+Transparency: branch deletion was limited to the merged PR head branch. Other worktrees and branches were left untouched because they were unrelated to this session or have unclear active ownership.
+
+## Tools and Skills Used
+
+- `superpowers:writing-plans`: created and revised the release-please migration plan.
+- `lavra:lavra-eng-review`: reviewed the plan and implementation direction for engineering risks.
+- `vibin:work-it`: used for implementation flow after the user clarified the existing worktree should be reused.
+- `vibin:save-to-md`: used for this final session artifact and commit/push closeout.
+- Shell and git commands: inspected status, worktrees, branches, PR state, diffs, and commit history; merged, pulled, pruned, deleted branches, staged, committed, and pushed.
+- GitHub CLI: created and merged PR #365 and inspected its final merged state.
+- File editing tools: applied scoped edits across workflows, release config, docs, assets, and xtask release validation.
+- Release-please documentation review: used to align repository configuration with release-please manifest capabilities.
+- External CLIs: `cargo`, `cargo xtask`, `jq`, `jsonschema`, `actionlint`, `gh`, `bd`, and `lefthook` were used for verification and closeout.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `gh pr view 365 --json number,title,url,state,mergedAt,mergeCommit,baseRefName,headRefName` | PR #365 was `MERGED`, merged at `2026-07-05T05:23:13Z`, merge commit `e43f972406a2f7d1b8e251f956d32bfd0a56fece`. |
+| `git pull --ff-only` | Fast-forwarded primary `main` to the PR merge commit. |
+| `git worktree remove /home/jmagar/workspace/axon/.worktrees/release-please-plan` | Removed the completed release-please worktree. |
+| `git branch -d codex/release-please-plan` | Deleted the local merged PR branch. |
+| `git push origin --delete codex/release-please-plan` | Deleted the stale remote PR branch; pre-push structural checks skipped because no files were pushed. |
+| `git diff --name-status e43f972406a2f7d1b8e251f956d32bfd0a56fece^1 e43f972406a2f7d1b8e251f956d32bfd0a56fece` | Listed the 33 files changed by the merged release-please PR. |
+| `bd list --all --json ...` | Found only old closed git-cliff bead `axon_rust-qbvn`; no relevant open release-please bead. |
+
+## Errors Encountered
+
+- `gh pr merge 365 --merge --delete-branch` initially failed from the release-please worktree because `main` was already checked out in `/home/jmagar/workspace/axon`. The closeout continued from the primary checkout, where `main` was fast-forwarded after the PR merged.
+- The first merge closeout did not delete the remote PR branch. A later `git push origin --delete codex/release-please-plan` removed it after confirming PR #365 was merged.
+- A broad `cargo xtask check` attempt during implementation was interrupted and generated unrelated `apps/web/openapi/axon.json` drift. That drift was restored and the passing verification set used targeted release/workflow/docs checks instead.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Release PRs | Manual git-cliff plus xtask bump/changelog tooling owned release preparation. | Release-please owns release PRs, version bumps, changelogs, tags, and GitHub Releases. |
+| CLI releases | CLI artifacts were tied to the old release workflow. | CLI release artifacts attach to release-please-created releases. |
+| Android releases | Android versioning and artifact release flow were not release-please-owned. | Android component metadata and workflow dispatch are part of the release-please flow. |
+| Tauri palette releases | Palette release workflow operated outside release-please release creation. | Palette artifacts attach to release-please-created releases. |
+| Chrome extension releases | Extension assets and package flow were not cleanly component-owned by release-please. | Extension assets live under the package tree and release artifacts attach to release-please-created releases. |
+| Git-cliff fallback | `cliff.toml` and xtask cliff paths existed. | Git-cliff config and xtask cliff/manual release paths are deleted. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo fmt --check` | Formatting passes | Passed on the PR branch | pass |
+| `cargo test -p xtask release_versions --no-fail-fast` | Release-version tests pass | Passed with 44 tests after removing cliff tests | pass |
+| `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr` | Release validation passes | Passed on the PR branch | pass |
+| `git diff --check` | No whitespace errors | Passed | pass |
+| `actionlint ...` | Workflow syntax validates | Passed during workflow review | pass |
+| `jq empty release-please-config.json .release-please-manifest.json` | Release-please JSON parses | Passed | pass |
+| Python `jsonschema` validation | Release-please config matches upstream schema | Passed | pass |
+| `./apps/chrome-extension/package.sh` | Extension package builds | Passed | pass |
+| `cargo xtask check-doc-links` | Documentation links validate | Passed | pass |
+| pre-commit and pre-push hooks | Hooks pass before merge/push | Passed; branch-delete push skipped structural file checks | pass |
+| `git status --short --branch` | Local `main` clean and tracking origin | `## main...origin/main` before this save artifact | pass |
+
+## Risks and Rollback
+
+The main risk is the first release-please cycle: component path mapping, generated release PR shape, or artifact attachment could still expose a workflow edge case. Rollback should be a normal git revert of the release-please migration commits or the merge commit, then rerun the previous release process only from history if absolutely needed; no git-cliff fallback remains in `main` by design.
+
+## Decisions Not Taken
+
+- Did not keep git-cliff or manual xtask release generation as rollback tooling, because the user explicitly clarified those paths should not exist anymore.
+- Did not move old active-looking `docs/plans` files during save cleanup, because they were not clearly completed by this session.
+- Did not delete unrelated worktrees or branches, because their ownership and activity were outside the release-please closeout.
+- Did not claim full `cargo xtask check` passed, because the broad run was interrupted and not part of the final verification set.
+
+## References
+
+- PR #365: https://github.com/jmagar/axon/pull/365
+- Release-please plan: `docs/superpowers/plans/2026-07-04-release-please-migration.md`
+- Prior session artifact from the implementation branch: `docs/sessions/2026-07-04-release-please-migration.md`
+- Release configuration: `release-please-config.json`
+- Release manifest: `.release-please-manifest.json`
+- Release workflow: `.github/workflows/release-please.yml`
+
+## Open Questions
+
+- The first release-please-generated PR after this merge should be inspected manually for correct component versions, changelog sections, tags, and release outputs.
+- Historical docs outside the touched release docs may still mention git-cliff or the removed manual xtask release commands.
+
+## Next Steps
+
+1. Watch the first release-please workflow run on `main` and inspect the generated release PR.
+2. Confirm artifact workflows upload to the expected release-please-created GitHub Releases for CLI, Android, Tauri palette, and Chrome extension.
+3. Search historical docs for old git-cliff/manual release command references and update or archive them if they are user-facing.


### PR DESCRIPTION
## Summary
- save the release-please merge closeout session log under docs/sessions

## Verification
- pre-commit structural checks passed during commit
- pre-push hook skipped file structural checks for docs-only branch push

This PR exists because direct push to protected main was rejected while required checks were pending.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Save the release-please merge closeout session log under docs/sessions, capturing decisions, steps, and verification from the migration to release-please (PR #365).
Docs-only change; no code, config, or workflow updates.

<sup>Written for commit d8a081fba957084f349a6d19a3000e6561ec80e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

