### PR TITLE
Add Phase 10 removed surface checker

### DIFF
--- a/xtask/src/schemas.rs
+++ b/xtask/src/schemas.rs
@@ -3,6 +3,7 @@ mod artifact_index;
 mod cross_check;
 mod families;
 pub mod registry;
+mod removed;
 mod report;
 mod schema_json;
 mod source_input;
@@ -176,9 +177,12 @@ fn run_families(root: &Path, families: Vec<SchemaFamily>, args: &SchemaGenerateA
         let validation_report =
             validate::validate_family(root, family, &artifact_index, validation_mode)?;
         let mut structural_drift = Vec::new();
-        if let Err(err) = registry::check_removed_surface_drift(&artifacts) {
-            structural_drift.push(err.to_string());
-        }
+        let removed_surface_report = removed::removed_surface_absence_report(&artifacts);
+        let structural_warnings =
+            match removed::assert_removed_surface_absent(&removed_surface_report) {
+                Ok(()) => Vec::new(),
+                Err(err) => err.to_string().lines().map(str::to_owned).collect(),
+            };
         if let Err(err) = registry::check_enum_projection_drift(&artifacts) {
             structural_drift.push(err.to_string());
         }
@@ -187,30 +191,30 @@ fn run_families(root: &Path, families: Vec<SchemaFamily>, args: &SchemaGenerateA
         }
         if args.print {
             print_artifacts(&artifacts)?;
-            reports.push(
-                FamilyReport::from_drift(family, artifacts.len(), structural_drift)
-                    .with_validation_counts(&validation_report),
-            );
+            let mut report = FamilyReport::from_drift(family, artifacts.len(), structural_drift)
+                .with_validation_counts(&validation_report);
+            report.warnings.extend(structural_warnings);
+            reports.push(report);
             continue;
         }
         if args.check {
             let mut drift = collect_drift(root, &artifacts)?;
             drift.extend(structural_drift);
-            reports.push(
-                FamilyReport::from_drift(family, artifacts.len(), drift)
-                    .with_validation_counts(&validation_report),
-            );
+            let mut report = FamilyReport::from_drift(family, artifacts.len(), drift)
+                .with_validation_counts(&validation_report);
+            report.warnings.extend(structural_warnings);
+            reports.push(report);
         } else if structural_drift.is_empty() {
             write_artifacts(root, &artifacts)?;
-            reports.push(
-                FamilyReport::ok(family, artifacts.len())
-                    .with_validation_counts(&validation_report),
-            );
+            let mut report = FamilyReport::ok(family, artifacts.len())
+                .with_validation_counts(&validation_report);
+            report.warnings.extend(structural_warnings);
+            reports.push(report);
         } else {
-            reports.push(
-                FamilyReport::from_drift(family, artifacts.len(), structural_drift)
-                    .with_validation_counts(&validation_report),
-            );
+            let mut report = FamilyReport::from_drift(family, artifacts.len(), structural_drift)
+                .with_validation_counts(&validation_report);
+            report.warnings.extend(structural_warnings);
+            reports.push(report);
         }
     }
 

--- a/xtask/src/schemas/removed.rs
+++ b/xtask/src/schemas/removed.rs
@@ -1,0 +1,522 @@
+use std::collections::BTreeSet;
+
+use anyhow::{Result, bail};
+
+use super::artifact::SchemaArtifact;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemovedRestRoute {
+    pub method: &'static str,
+    pub path: &'static str,
+    pub replacement: &'static str,
+    pub operation_id: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemovedDtoField {
+    pub dto: &'static str,
+    pub field: &'static str,
+    pub replacement: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemovedOperation {
+    pub name: &'static str,
+    pub replacement: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemovedSurfaceRegistry {
+    pub cli_commands: &'static [RemovedOperation],
+    pub mcp_actions: &'static [RemovedOperation],
+    pub rest_routes: &'static [RemovedRestRoute],
+    pub config_keys: &'static [RemovedOperation],
+    pub dto_fields: &'static [RemovedDtoField],
+    pub generated_clients: &'static [&'static str],
+    pub generated_client_operations: &'static [RemovedOperation],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemovedSurfaceFinding {
+    pub artifact_path: String,
+    pub category: &'static str,
+    pub surface: String,
+    pub replacement: &'static str,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RemovedSurfaceReport {
+    pub findings: Vec<RemovedSurfaceFinding>,
+}
+
+impl RemovedSurfaceReport {
+    pub fn is_clean(&self) -> bool {
+        self.findings.is_empty()
+    }
+
+    pub fn warning_messages(&self) -> Vec<String> {
+        self.findings
+            .iter()
+            .map(|finding| {
+                format!(
+                    "{} exposes removed {} {}; replacement: {}",
+                    finding.artifact_path, finding.category, finding.surface, finding.replacement
+                )
+            })
+            .collect()
+    }
+}
+
+const CLI_COMMANDS: &[RemovedOperation] = &[
+    op("embed", "axon <source>"),
+    op("ingest", "axon <source>"),
+    op("scrape", "axon <url> --scope page"),
+    op("crawl", "axon <url> --scope site"),
+    op(
+        "code-search",
+        "axon query <query> --content-kind code --freshness committed",
+    ),
+    op("code-search-watch", "axon watch <path>"),
+    op("purge", "axon prune ..."),
+    op("dedupe", "axon prune dedupe ..."),
+    op("refresh", "axon <source> --refresh"),
+    op("fresh", "axon watch ..."),
+];
+
+const MCP_ACTIONS: &[RemovedOperation] = &[
+    op("embed", "source"),
+    op("ingest", "source"),
+    op("scrape", "source with scope=page"),
+    op("crawl", "source with scope=site"),
+    op(
+        "code_search",
+        "query with code filters and committed freshness",
+    ),
+    op("code_search_watch", "watch"),
+    op("vertical_scrape", "adapter capabilities plus source"),
+    op("purge", "prune"),
+    op("dedupe", "prune"),
+];
+
+const REST_ROUTES: &[RemovedRestRoute] = &[
+    route("POST", "/v1/embed", "embed", "POST /v1/sources"),
+    route("POST", "/v1/ingest", "ingest", "POST /v1/sources"),
+    route("POST", "/v1/scrape", "scrape", "POST /v1/sources"),
+    route("POST", "/v1/crawl", "crawl", "POST /v1/sources"),
+    route("POST", "/v1/purge", "purge", "POST /v1/prune/purge"),
+    route("POST", "/v1/dedupe", "dedupe", "POST /v1/prune/dedupe"),
+    route(
+        "POST",
+        "/v1/watch/{id}/run",
+        "watch_run",
+        "POST /v1/watches/{watch_id}/exec",
+    ),
+];
+
+const CONFIG_KEYS: &[RemovedOperation] = &[
+    op("AXON_MCP_HTTP_HOST", "AXON_HTTP_HOST"),
+    op("AXON_MCP_HTTP_PORT", "AXON_HTTP_PORT"),
+    op("AXON_MCP_HTTP_TOKEN", "AXON_HTTP_TOKEN"),
+    op("AXON_MCP_AUTH_MODE", "AXON_AUTH_MODE"),
+    op("AXON_MCP_PUBLIC_URL", "AXON_PUBLIC_URL"),
+    op("AXON_MCP_GOOGLE_CLIENT_ID", "AXON_GOOGLE_CLIENT_ID"),
+    op("AXON_MCP_GOOGLE_CLIENT_SECRET", "AXON_GOOGLE_CLIENT_SECRET"),
+    op("AXON_MCP_AUTH_ADMIN_EMAIL", "AXON_AUTH_ADMIN_EMAIL"),
+    op(
+        "AXON_MCP_AUTH_ALLOWED_REDIRECT_URIS",
+        "AXON_ALLOWED_REDIRECT_URIS",
+    ),
+    op("AXON_MCP_ALLOWED_ORIGINS", "AXON_ALLOWED_ORIGINS"),
+    op(
+        "AXON_COLLECTION",
+        "server.default_collection in config.toml",
+    ),
+    op(
+        "AXON_HYBRID_CANDIDATES",
+        "retrieval.hybrid_candidates in config.toml",
+    ),
+    op(
+        "AXON_ASK_HYBRID_CANDIDATES",
+        "ask.hybrid_candidates in config.toml",
+    ),
+    op("AXON_INGEST_LANES", "pipeline.ingest_lanes in config.toml"),
+    op(
+        "AXON_EMBED_DOC_TIMEOUT_SECS",
+        "providers.embedding.doc_timeout_secs in config.toml",
+    ),
+    op("AXON_WATCH_TICK_SECS", "watch.tick_secs in config.toml"),
+    op("AXON_WATCH_LEASE_SECS", "watch.lease_secs in config.toml"),
+];
+
+const DTO_FIELDS: &[RemovedDtoField] = &[
+    dto("EmbedRequest", "input", "SourceRequest.source"),
+    dto(
+        "EmbedRequest",
+        "source_type",
+        "adapter-selected SourceKind / SourceScope",
+    ),
+    dto("IngestRequest", "target", "SourceRequest.source"),
+    dto(
+        "IngestRequest",
+        "source_type",
+        "adapter-selected SourceKind / SourceScope",
+    ),
+    dto(
+        "IngestRequest",
+        "include_source",
+        "SourceRequest.options.include_source when supported",
+    ),
+    dto(
+        "CrawlRequest",
+        "urls",
+        "SourceRequest.source plus multi-source submission",
+    ),
+    dto(
+        "ScrapeRequest",
+        "url",
+        "SourceRequest.source with scope=page",
+    ),
+    dto("PurgeRequest", "target", "PruneSelector"),
+    dto("PurgeRequest", "prefix", "PruneSelector scope/options"),
+    dto(
+        "CodeSearchRequest",
+        "cwd",
+        "QueryRequest.filters.source_id or local source filter",
+    ),
+    dto(
+        "CodeSearchRequest",
+        "path_prefix",
+        "QueryRequest.filters.path_prefix",
+    ),
+    dto(
+        "CodeSearchRequest",
+        "no_freshness",
+        "QueryRequest.freshness",
+    ),
+];
+
+const GENERATED_CLIENTS: &[&str] = &["web", "palette", "android", "chrome-extension"];
+
+const GENERATED_CLIENT_OPERATIONS: &[RemovedOperation] = &[
+    op("embed", "create_source"),
+    op("ingest", "create_source"),
+    op("scrape", "create_source"),
+    op("crawl", "create_source"),
+    op("purge", "prune_purge"),
+    op("dedupe", "prune_dedupe"),
+    op("watch_run", "exec_watch"),
+];
+
+pub fn removed_surface_registry() -> RemovedSurfaceRegistry {
+    RemovedSurfaceRegistry {
+        cli_commands: CLI_COMMANDS,
+        mcp_actions: MCP_ACTIONS,
+        rest_routes: REST_ROUTES,
+        config_keys: CONFIG_KEYS,
+        dto_fields: DTO_FIELDS,
+        generated_clients: GENERATED_CLIENTS,
+        generated_client_operations: GENERATED_CLIENT_OPERATIONS,
+    }
+}
+
+const fn op(name: &'static str, replacement: &'static str) -> RemovedOperation {
+    RemovedOperation { name, replacement }
+}
+
+const fn route(
+    method: &'static str,
+    path: &'static str,
+    operation_id: &'static str,
+    replacement: &'static str,
+) -> RemovedRestRoute {
+    RemovedRestRoute {
+        method,
+        path,
+        replacement,
+        operation_id,
+    }
+}
+
+const fn dto(dto: &'static str, field: &'static str, replacement: &'static str) -> RemovedDtoField {
+    RemovedDtoField {
+        dto,
+        field,
+        replacement,
+    }
+}
+
+pub fn removed_surface_absence_report(artifacts: &[SchemaArtifact]) -> RemovedSurfaceReport {
+    let registry = removed_surface_registry();
+    let mut report = RemovedSurfaceReport::default();
+
+    for artifact in artifacts {
+        if artifact.path.to_string_lossy().ends_with(".json") {
+            match serde_json::from_str::<serde_json::Value>(&artifact.content) {
+                Ok(json) => check_json_artifact(&registry, artifact, &json, &mut report),
+                Err(_) => continue,
+            }
+        }
+    }
+
+    report
+}
+
+pub fn assert_removed_surface_absent(report: &RemovedSurfaceReport) -> Result<()> {
+    if report.is_clean() {
+        return Ok(());
+    }
+    bail!("{}", report.warning_messages().join("\n"))
+}
+
+fn check_json_artifact(
+    registry: &RemovedSurfaceRegistry,
+    artifact: &SchemaArtifact,
+    json: &serde_json::Value,
+    report: &mut RemovedSurfaceReport,
+) {
+    check_cli_commands(registry, artifact, json, report);
+    check_mcp_actions(registry, artifact, json, report);
+    check_rest_routes(registry, artifact, json, report);
+    check_config_keys(registry, artifact, json, report);
+    check_api_dto_fields(registry, artifact, json, report);
+    check_generated_client_operations(registry, artifact, json, report);
+}
+
+fn check_cli_commands(
+    registry: &RemovedSurfaceRegistry,
+    artifact: &SchemaArtifact,
+    json: &serde_json::Value,
+    report: &mut RemovedSurfaceReport,
+) {
+    let Some(commands) = collect_string_field(json.get("commands"), "name") else {
+        return;
+    };
+    for removed in registry.cli_commands {
+        if commands.contains(removed.name) {
+            push_finding(
+                report,
+                artifact,
+                "CLI command",
+                removed.name,
+                removed.replacement,
+            );
+        }
+    }
+}
+
+fn check_mcp_actions(
+    registry: &RemovedSurfaceRegistry,
+    artifact: &SchemaArtifact,
+    json: &serde_json::Value,
+    report: &mut RemovedSurfaceReport,
+) {
+    let Some(actions) = collect_string_field(json.get("actions"), "action") else {
+        return;
+    };
+    for removed in registry.mcp_actions {
+        if actions.contains(removed.name) {
+            push_finding(
+                report,
+                artifact,
+                "MCP action",
+                removed.name,
+                removed.replacement,
+            );
+        }
+    }
+}
+
+fn check_rest_routes(
+    registry: &RemovedSurfaceRegistry,
+    artifact: &SchemaArtifact,
+    json: &serde_json::Value,
+    report: &mut RemovedSurfaceReport,
+) {
+    let Some(routes) = json.get("routes").and_then(|routes| routes.as_array()) else {
+        return;
+    };
+    let operation_ids =
+        collect_string_field(json.get("routes"), "operation_id").unwrap_or_else(|| BTreeSet::new());
+    for removed in registry.rest_routes {
+        let route_present = routes.iter().any(|route| {
+            route.get("method").and_then(|value| value.as_str()) == Some(removed.method)
+                && route.get("path").and_then(|value| value.as_str()) == Some(removed.path)
+        });
+        if route_present {
+            push_finding(
+                report,
+                artifact,
+                "REST route",
+                &format!("{} {}", removed.method, removed.path),
+                removed.replacement,
+            );
+        }
+        if operation_ids.contains(removed.operation_id) {
+            push_finding(
+                report,
+                artifact,
+                "REST operation",
+                removed.operation_id,
+                removed.replacement,
+            );
+        }
+    }
+}
+
+fn check_config_keys(
+    registry: &RemovedSurfaceRegistry,
+    artifact: &SchemaArtifact,
+    json: &serde_json::Value,
+    report: &mut RemovedSurfaceReport,
+) {
+    let Some(config_keys) = json.get("config_keys").and_then(|keys| keys.as_array()) else {
+        return;
+    };
+    for key in config_keys {
+        for removed in registry.config_keys {
+            let env_present =
+                key.get("env_key").and_then(|value| value.as_str()) == Some(removed.name);
+            let key_present = key.get("key").and_then(|value| value.as_str()) == Some(removed.name);
+            if env_present || key_present {
+                push_finding(
+                    report,
+                    artifact,
+                    "config key",
+                    removed.name,
+                    removed.replacement,
+                );
+            }
+        }
+    }
+}
+
+fn check_api_dto_fields(
+    registry: &RemovedSurfaceRegistry,
+    artifact: &SchemaArtifact,
+    json: &serde_json::Value,
+    report: &mut RemovedSurfaceReport,
+) {
+    let Some(defs) = json.get("$defs").and_then(|defs| defs.as_object()) else {
+        return;
+    };
+    let mut removed_dtos = BTreeSet::new();
+    for removed in registry.dto_fields {
+        removed_dtos.insert(removed.dto);
+    }
+
+    for dto in removed_dtos {
+        if defs.contains_key(dto) {
+            push_finding(
+                report,
+                artifact,
+                "DTO schema",
+                dto,
+                "SourceRequest, QueryRequest, or PruneSelector replacement DTO",
+            );
+        }
+    }
+
+    for removed in registry.dto_fields {
+        let Some(properties) = defs
+            .get(removed.dto)
+            .and_then(|schema| schema.get("properties"))
+            .and_then(|properties| properties.as_object())
+        else {
+            continue;
+        };
+        if properties.contains_key(removed.field) {
+            push_finding(
+                report,
+                artifact,
+                "DTO field",
+                &format!("{}.{}", removed.dto, removed.field),
+                removed.replacement,
+            );
+        }
+    }
+}
+
+fn check_generated_client_operations(
+    registry: &RemovedSurfaceRegistry,
+    artifact: &SchemaArtifact,
+    json: &serde_json::Value,
+    report: &mut RemovedSurfaceReport,
+) {
+    if !is_generated_client_artifact(artifact, json) {
+        return;
+    }
+
+    let mut operations = BTreeSet::new();
+    collect_operation_names(json, &mut operations);
+    for removed in registry.generated_client_operations {
+        if operations.contains(removed.name) {
+            push_finding(
+                report,
+                artifact,
+                "generated client operation",
+                removed.name,
+                removed.replacement,
+            );
+        }
+    }
+}
+
+fn collect_operation_names(value: &serde_json::Value, names: &mut BTreeSet<String>) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_operation_names(value, names);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for key in ["operation_id", "operationId", "operation", "method", "name"] {
+                if let Some(name) = map.get(key).and_then(|value| value.as_str()) {
+                    names.insert(name.to_owned());
+                }
+            }
+            for key in ["operations", "methods", "endpoints"] {
+                if let Some(value) = map.get(key) {
+                    collect_operation_names(value, names);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_string_field<'a>(
+    value: Option<&'a serde_json::Value>,
+    field: &str,
+) -> Option<BTreeSet<&'a str>> {
+    let values = value?.as_array()?;
+    Some(
+        values
+            .iter()
+            .filter_map(|item| item.get(field).and_then(|value| value.as_str()))
+            .collect(),
+    )
+}
+
+fn is_generated_client_artifact(artifact: &SchemaArtifact, json: &serde_json::Value) -> bool {
+    let path = artifact.path.to_string_lossy();
+    path.contains("generated")
+        || path.contains("client")
+        || path.contains("apps/web")
+        || json.get("client").is_some()
+        || json.get("operations").is_some()
+}
+
+fn push_finding(
+    report: &mut RemovedSurfaceReport,
+    artifact: &SchemaArtifact,
+    category: &'static str,
+    surface: &str,
+    replacement: &'static str,
+) {
+    report.findings.push(RemovedSurfaceFinding {
+        artifact_path: artifact.path.display().to_string(),
+        category,
+        surface: surface.to_owned(),
+        replacement,
+    });
+}

--- a/xtask/src/schemas/tests.rs
+++ b/xtask/src/schemas/tests.rs
@@ -565,27 +565,181 @@ fn targeted_family_checks_do_not_require_hidden_aggregate_generation() {
 }
 
 #[test]
-fn removed_surface_drift_fails_generation() {
-    for (path, token) in [
-        ("docs/reference/cli/commands.json", "\"embed\""),
-        ("docs/reference/cli/commands.json", "\"code-search\""),
-        ("docs/reference/mcp/tool-schema.json", "\"vertical_scrape\""),
-        ("docs/reference/mcp/tool-schema.json", "\"crawl\""),
-        ("docs/reference/rest/openapi.json", "\"/v1/embed\""),
-        ("docs/reference/rest/openapi.json", "\"/v1/scrape\""),
-        (
-            "docs/reference/config/env.schema.json",
-            "\"AXON_MCP_HTTP_TOKEN\"",
+fn removed_surface_registry_matches_contract() {
+    let registry = removed::removed_surface_registry();
+
+    assert!(
+        registry
+            .cli_commands
+            .iter()
+            .any(|command| command.name == "embed")
+    );
+    assert!(
+        registry
+            .cli_commands
+            .iter()
+            .any(|command| command.name == "code-search-watch")
+    );
+    assert!(
+        registry
+            .mcp_actions
+            .iter()
+            .any(|action| action.name == "vertical_scrape")
+    );
+    assert!(registry.rest_routes.iter().any(|route| {
+        route.method == "POST" && route.path == "/v1/embed" && route.operation_id == "embed"
+    }));
+    assert!(
+        registry
+            .config_keys
+            .iter()
+            .any(|key| key.name == "AXON_MCP_HTTP_TOKEN")
+    );
+    assert!(registry.generated_clients.contains(&"web"));
+    assert!(registry.generated_clients.contains(&"palette"));
+    assert!(registry.generated_clients.contains(&"android"));
+    assert!(registry.generated_clients.contains(&"chrome-extension"));
+}
+
+#[test]
+fn removed_surface_checker_reports_structural_findings() {
+    let artifacts = vec![
+        artifact::SchemaArtifact::new(
+            "docs/reference/cli/commands.json",
+            serde_json::json!({
+                "commands": [{"name": "embed"}, {"name": "query"}]
+            })
+            .to_string(),
         ),
-    ] {
-        let artifacts = vec![artifact::SchemaArtifact::new(
-            path,
-            format!("{{\"title\":{token}}}"),
-        )];
-        let err = registry::check_removed_surface_drift(&artifacts)
-            .expect_err("removed surface token should fail");
-        assert!(err.to_string().contains("removed public surface token"));
-    }
+        artifact::SchemaArtifact::new(
+            "docs/reference/mcp/tool-schema.json",
+            serde_json::json!({
+                "actions": [{"action": "vertical_scrape"}, {"action": "query"}]
+            })
+            .to_string(),
+        ),
+        artifact::SchemaArtifact::new(
+            "docs/reference/rest/openapi.json",
+            serde_json::json!({
+                "routes": [
+                    {"method": "POST", "path": "/v1/embed", "operation_id": "embed"},
+                    {"method": "POST", "path": "/v1/query", "operation_id": "query"}
+                ]
+            })
+            .to_string(),
+        ),
+        artifact::SchemaArtifact::new(
+            "docs/reference/config/env.schema.json",
+            serde_json::json!({
+                "config_keys": [{"env_key": "AXON_MCP_HTTP_TOKEN", "key": "auth.token"}]
+            })
+            .to_string(),
+        ),
+        artifact::SchemaArtifact::new(
+            "docs/reference/api/schemas.json",
+            serde_json::json!({
+                "$defs": {
+                    "CodeSearchRequest": {
+                        "properties": {
+                            "cwd": {"type": "string"}
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        ),
+        artifact::SchemaArtifact::new(
+            "apps/web/generated/client-operations.json",
+            serde_json::json!({
+                "client": "web",
+                "operations": [{"operation_id": "watch_run"}]
+            })
+            .to_string(),
+        ),
+    ];
+
+    let report = removed::removed_surface_absence_report(&artifacts);
+    let findings = report
+        .findings
+        .iter()
+        .map(|finding| (finding.category, finding.surface.as_str()))
+        .collect::<std::collections::BTreeSet<_>>();
+
+    assert!(findings.contains(&("CLI command", "embed")));
+    assert!(findings.contains(&("MCP action", "vertical_scrape")));
+    assert!(findings.contains(&("REST route", "POST /v1/embed")));
+    assert!(findings.contains(&("REST operation", "embed")));
+    assert!(findings.contains(&("config key", "AXON_MCP_HTTP_TOKEN")));
+    assert!(findings.contains(&("DTO schema", "CodeSearchRequest")));
+    assert!(findings.contains(&("DTO field", "CodeSearchRequest.cwd")));
+    assert!(findings.contains(&("generated client operation", "watch_run")));
+
+    let err = removed::assert_removed_surface_absent(&report)
+        .expect_err("present removed surfaces should be reported");
+    assert!(err.to_string().contains("replacement"));
+}
+
+#[test]
+fn removed_surface_checker_accepts_absent_canonical_artifacts() {
+    let artifacts = vec![
+        artifact::SchemaArtifact::new(
+            "docs/reference/cli/commands.json",
+            serde_json::json!({
+                "commands": [{"name": "source"}, {"name": "query"}]
+            })
+            .to_string(),
+        ),
+        artifact::SchemaArtifact::new(
+            "docs/reference/mcp/tool-schema.json",
+            serde_json::json!({
+                "actions": [{"action": "source"}, {"action": "query"}]
+            })
+            .to_string(),
+        ),
+        artifact::SchemaArtifact::new(
+            "docs/reference/rest/openapi.json",
+            serde_json::json!({
+                "routes": [
+                    {
+                        "method": "POST",
+                        "path": "/v1/sources",
+                        "operation_id": "create_source"
+                    },
+                    {
+                        "method": "POST",
+                        "path": "/v1/watches/{watch_id}/exec",
+                        "operation_id": "exec_watch"
+                    }
+                ]
+            })
+            .to_string(),
+        ),
+        artifact::SchemaArtifact::new(
+            "docs/reference/config/env.schema.json",
+            serde_json::json!({
+                "config_keys": [{"env_key": "AXON_HTTP_TOKEN", "key": "auth.token"}]
+            })
+            .to_string(),
+        ),
+        artifact::SchemaArtifact::new(
+            "docs/reference/api/schemas.json",
+            serde_json::json!({
+                "$defs": {
+                    "QueryRequest": {
+                        "properties": {
+                            "filters": {"type": "object"}
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        ),
+    ];
+
+    let report = removed::removed_surface_absence_report(&artifacts);
+
+    assert!(report.is_clean());
+    removed::assert_removed_surface_absent(&report).unwrap();
 }
 
 #[test]
@@ -1120,7 +1274,7 @@ fn cross_checks_detect_dangling_refs() {
 
 #[test]
 fn cross_checks_detect_removed_surface_drift() {
-    removed_surface_drift_fails_generation();
+    removed_surface_checker_reports_structural_findings();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a Phase 10 removed-surface registry for legacy CLI, MCP, REST, config, DTO, and generated-client surfaces
- add structural report-only absence checks over schema artifacts instead of broad token scanning
- cover present/absent checker behavior with focused xtask tests

## Verification
- cargo test -p xtask removed --no-fail-fast
- cargo xtask schemas generate --check
- git diff --check

## Notes
- This is checker-only preflight work. It does not delete CLI/MCP/REST surfaces or regenerate public/generated client artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Phase 10 removed-surface checker that verifies legacy CLI, MCP, REST, config, DTO, and generated-client surfaces are absent using structural JSON checks. It reports warnings only (no deletions or client regen).

- **New Features**
  - Added `removed` registry for legacy CLI commands, MCP actions, REST routes/operation IDs, config keys, DTO schemas/fields, and generated-client operations.
  - Implemented `removed_surface_absence_report` and `assert_removed_surface_absent` to detect removed surfaces via schema structure (not token scans).
  - Integrated warnings into `FamilyReport` across print/check/write flows in `xtask`.
  - Added focused tests for registry contract, structural findings, and clean canonical artifacts.

<sup>Written for commit 77f8ea184e40c29769fbdf1b1d2b6780592230dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema generation now reports removed or outdated surfaces as warnings instead of failing the stale-artifact drift check.
  * Removed commands, routes, config keys, fields, and generated client operations are now detected more consistently across schema outputs.

* **Tests**
  * Expanded coverage for removed-surface detection and for clean schema artifacts.
  * Updated validation checks to match the new warning-based behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->