### PR TITLE
Tighten Phase 9 source-family verification

### DIFF
--- a/apps/android/app/src/test/resources/openapi/android-route-contracts.json
+++ b/apps/android/app/src/test/resources/openapi/android-route-contracts.json
@@ -151,6 +151,56 @@
   },
   {
     "method": "GET",
+    "path": "/v1/jobs",
+    "requiresAuth": true
+  },
+  {
+    "method": "GET",
+    "path": "/v1/jobs/{id}",
+    "requiresAuth": true
+  },
+  {
+    "method": "GET",
+    "path": "/v1/jobs/{id}/events",
+    "requiresAuth": true
+  },
+  {
+    "method": "GET",
+    "path": "/v1/jobs/{id}/stream",
+    "requiresAuth": true
+  },
+  {
+    "method": "GET",
+    "path": "/v1/jobs/{id}/artifacts",
+    "requiresAuth": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/v1/jobs",
+    "requiresAuth": true
+  },
+  {
+    "method": "POST",
+    "path": "/v1/jobs/{id}/cancel",
+    "requiresAuth": true
+  },
+  {
+    "method": "POST",
+    "path": "/v1/jobs/{id}/retry",
+    "requiresAuth": true
+  },
+  {
+    "method": "POST",
+    "path": "/v1/jobs/recover",
+    "requiresAuth": true
+  },
+  {
+    "method": "POST",
+    "path": "/v1/jobs/cleanup",
+    "requiresAuth": true
+  },
+  {
+    "method": "GET",
     "path": "/v1/mobile/sessions",
     "requiresAuth": true
   },

--- a/apps/palette-tauri/src/lib/axon-api.d.ts
+++ b/apps/palette-tauri/src/lib/axon-api.d.ts
@@ -348,6 +348,150 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list_unified_jobs"];
+        put?: never;
+        post?: never;
+        delete: operations["clear_unified_jobs"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/jobs/cleanup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["cleanup_unified_jobs"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/jobs/recover": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["recover_unified_jobs"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/jobs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["unified_job_status"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/jobs/{id}/artifacts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["unified_job_artifacts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/jobs/{id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["cancel_unified_job"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/jobs/{id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["unified_job_events"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/jobs/{id}/retry": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["retry_unified_job"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/jobs/{id}/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["unified_job_stream"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/map": {
         parameters: {
             query?: never;
@@ -727,7 +871,18 @@ export interface components {
         };
         ArtifactId: string;
         /** @enum {string} */
+        ArtifactKind: "raw_content" | "normalized_content" | "manifest" | "report" | "screenshot" | "warc" | "provider_trace";
+        /** @enum {string} */
         ArtifactMode: "none" | "on_large_output" | "always";
+        ArtifactRef: {
+            artifact_id: components["schemas"]["ArtifactId"];
+            artifact_kind: components["schemas"]["ArtifactKind"];
+            content_hash?: string | null;
+            created_at: components["schemas"]["Timestamp"];
+            /** Format: int64 */
+            size_bytes?: number | null;
+            uri: string;
+        };
         AuthorityEvidence: {
             /** Format: float */
             confidence: number;
@@ -741,6 +896,8 @@ export interface components {
         };
         /** @enum {string} */
         AuthorityLevel: "official" | "verified" | "user_pinned" | "inferred" | "community" | "mirror" | "conflicting" | "unknown";
+        /** Format: uuid */
+        BatchId: string;
         BrandColor: {
             count: number;
             hex: string;
@@ -756,6 +913,8 @@ export interface components {
             og_image?: string | null;
             url: string;
         };
+        CheckpointId: string;
+        ChunkId: string;
         /** @enum {string} */
         ColorUsage: "primary" | "secondary" | "background" | "text" | "accent" | "unknown";
         ContentRef: {
@@ -807,6 +966,7 @@ export interface components {
             value: string;
             verified?: null | components["schemas"]["EndpointVerification"];
         };
+        DocumentId: string;
         /** @enum {string} */
         EndpointKind: "relative_path" | "absolute_url" | "graphql" | "websocket";
         EndpointReport: {
@@ -907,6 +1067,65 @@ export interface components {
             metadata: components["schemas"]["MetadataMap"];
             summary?: string | null;
         };
+        JobArtifactListResult: {
+            artifacts: components["schemas"]["ArtifactRef"][];
+            /** Format: int32 */
+            limit: number;
+            next_cursor?: string | null;
+        };
+        JobCancelRequest: {
+            /** Format: int64 */
+            force_after_ms?: number | null;
+            reason?: string | null;
+        };
+        JobCancelResult: {
+            canceled_at?: null | components["schemas"]["Timestamp"];
+            job_id: components["schemas"]["JobId"];
+            reason?: string | null;
+            status: components["schemas"]["LifecycleStatus"];
+        };
+        JobCleanupRequest: {
+            dry_run: boolean;
+            kind?: null | components["schemas"]["JobKind"];
+            /** Format: int32 */
+            limit?: number | null;
+            older_than?: null | components["schemas"]["Timestamp"];
+            status?: null | components["schemas"]["LifecycleStatus"];
+        };
+        JobCleanupResult: {
+            /** Format: int64 */
+            artifacts_pruned: number;
+            /** Format: int64 */
+            attempts_pruned: number;
+            /** Format: int64 */
+            deleted: number;
+            dry_run: boolean;
+            /** Format: int64 */
+            events_pruned: number;
+            /** Format: int64 */
+            heartbeats_pruned: number;
+            /** Format: int64 */
+            jobs_pruned: number;
+            /** Format: int64 */
+            matched: number;
+            /** Format: int64 */
+            reservations_pruned: number;
+            /** Format: int64 */
+            stages_pruned: number;
+            warnings: components["schemas"]["SourceWarning"][];
+        };
+        JobClearRequest: {
+            confirm: boolean;
+            kind?: null | components["schemas"]["JobKind"];
+            older_than?: null | components["schemas"]["Timestamp"];
+            status?: null | components["schemas"]["LifecycleStatus"];
+        };
+        JobClearResult: {
+            /** Format: int64 */
+            deleted: number;
+            status?: null | components["schemas"]["LifecycleStatus"];
+            warnings: components["schemas"]["SourceWarning"][];
+        };
         JobDescriptor: {
             cancel_url?: string | null;
             events_url: string;
@@ -917,6 +1136,30 @@ export interface components {
             retry_url?: string | null;
             status_url: string;
             stream_url: string;
+        };
+        JobEvent: {
+            /** Format: int32 */
+            attempt?: number;
+            details: components["schemas"]["MetadataMap"];
+            event_id: string;
+            job_id: components["schemas"]["JobId"];
+            message: string;
+            phase: components["schemas"]["PipelinePhase"];
+            /** Format: int64 */
+            sequence: number;
+            severity: components["schemas"]["Severity"];
+            stage_id?: null | components["schemas"]["StageId"];
+            status: components["schemas"]["LifecycleStatus"];
+            timestamp: components["schemas"]["Timestamp"];
+            visibility?: components["schemas"]["Visibility"];
+        };
+        JobEventPage: {
+            events: components["schemas"]["JobEvent"][];
+            /** Format: int64 */
+            last_sequence: number;
+            /** Format: int32 */
+            limit?: number;
+            next_cursor?: string | null;
         };
         /** @enum {string} */
         JobFamily: "embed" | "extract" | "ingest";
@@ -952,6 +1195,32 @@ export interface components {
             percent?: number | null;
             phase: components["schemas"]["JobPhase"];
         };
+        JobRecoveryRequest: {
+            kind?: null | components["schemas"]["JobKind"];
+            /** Format: int32 */
+            limit?: number | null;
+            stale_before?: null | components["schemas"]["Timestamp"];
+        };
+        JobRecoveryResult: {
+            job_ids: components["schemas"]["JobId"][];
+            /** Format: int64 */
+            recovered: number;
+            warnings: components["schemas"]["SourceWarning"][];
+        };
+        /** @enum {string} */
+        JobRetryMode: "same_config" | "with_overrides";
+        JobRetryRequest: {
+            from_phase?: null | components["schemas"]["PipelinePhase"];
+            idempotency_key?: string | null;
+            mode: components["schemas"]["JobRetryMode"];
+            overrides?: components["schemas"]["MetadataMap"];
+        };
+        JobRetryResult: {
+            /** Format: int32 */
+            attempt: number;
+            original_job_id: components["schemas"]["JobId"];
+            retry_job: components["schemas"]["JobDescriptor"];
+        };
         /**
          * @description Typed job-status envelope so the `{ job, progress }` wire shape is a
          *     registered OpenAPI schema (and thus reflected into the generated palette/
@@ -965,6 +1234,18 @@ export interface components {
              */
             job: unknown;
             progress?: null | components["schemas"]["JobProgress"];
+        };
+        JobSummary: {
+            counts?: null | components["schemas"]["StageCounts"];
+            created_at: components["schemas"]["Timestamp"];
+            job_id: components["schemas"]["JobId"];
+            kind: components["schemas"]["JobKind"];
+            last_error?: null | components["schemas"]["SourceError"];
+            phase: components["schemas"]["PipelinePhase"];
+            source_id?: null | components["schemas"]["SourceId"];
+            status: components["schemas"]["LifecycleStatus"];
+            updated_at: components["schemas"]["Timestamp"];
+            watch_id?: null | components["schemas"]["WatchId"];
         };
         LedgerSummary: {
             committed_generation?: null | components["schemas"]["SourceGenerationId"];
@@ -1068,6 +1349,33 @@ export interface components {
         PanelCollectionsResponse: {
             collections: string[];
         };
+        /** @enum {string} */
+        PipelinePhase: "queued" | "requested" | "resolving" | "routing" | "authorizing" | "planning" | "leasing" | "discovering" | "diffing" | "fetching" | "rendering" | "enriching" | "normalizing" | "parsing" | "graphing" | "preparing" | "batching" | "embedding" | "vectorizing" | "upserting" | "retrieving" | "synthesizing" | "evaluating" | "publishing" | "cleaning" | "complete" | "canceled";
+        ProgressCurrent: {
+            adapter?: string | null;
+            chunk_id?: null | components["schemas"]["ChunkId"];
+            document_id?: null | components["schemas"]["DocumentId"];
+            message?: string | null;
+            provider?: null | components["schemas"]["ProviderId"];
+            source_item_key?: null | components["schemas"]["SourceItemKey"];
+        };
+        ProgressThroughput: {
+            /** Format: double */
+            bytes_per_second?: number | null;
+            /** Format: double */
+            chunks_per_second?: number | null;
+            /** Format: double */
+            items_per_second?: number | null;
+        };
+        ProgressTiming: {
+            /** Format: int64 */
+            elapsed_ms: number;
+            /** Format: int64 */
+            eta_ms?: number | null;
+            started_at: components["schemas"]["Timestamp"];
+            updated_at: components["schemas"]["Timestamp"];
+        };
+        ProviderId: string;
         PurgeRequest: {
             collection?: string | null;
             /**
@@ -1109,6 +1417,7 @@ export interface components {
         };
         /** @enum {string} */
         RenderMode: "http" | "chrome" | "auto-switch";
+        ReservationId: string;
         /** @enum {string} */
         ResponseMode: "path" | "inline" | "both" | "auto_inline";
         RestAskRequest: {
@@ -1250,6 +1559,14 @@ export interface components {
             url?: string | null;
             urls?: string[] | null;
         };
+        RetryState: {
+            /** Format: int32 */
+            attempt: number;
+            /** Format: int32 */
+            max_attempts?: number | null;
+            next_retry_at?: null | components["schemas"]["Timestamp"];
+            reason: string;
+        };
         /**
          * @description Result of probing a discovered endpoint for JSON-RPC 2.0 / OpenRPC / MCP support.
          *
@@ -1318,6 +1635,15 @@ export interface components {
             /** Format: int64 */
             vector_points_total: number;
         };
+        SourceError: {
+            cause?: string | null;
+            code: string;
+            message: string;
+            provider_id?: null | components["schemas"]["ProviderId"];
+            retryable: boolean;
+            severity: components["schemas"]["Severity"];
+            source_item_key?: null | components["schemas"]["SourceItemKey"];
+        };
         SourceGenerationId: string;
         SourceId: string;
         /** @enum {string} */
@@ -1340,6 +1666,37 @@ export interface components {
             max_total_bytes?: number | null;
             /** Format: int64 */
             provider_timeout_ms?: number | null;
+        };
+        SourceProgressEvent: {
+            adapter?: null | components["schemas"]["AdapterRef"];
+            /** Format: int32 */
+            attempt?: number;
+            batch_id?: null | components["schemas"]["BatchId"];
+            canonical_uri?: string | null;
+            checkpoint_id?: null | components["schemas"]["CheckpointId"];
+            counts: components["schemas"]["StageCounts"];
+            current?: null | components["schemas"]["ProgressCurrent"];
+            dedupe_key?: string | null;
+            error?: null | components["schemas"]["ApiError"];
+            event_id: string;
+            generation?: null | components["schemas"]["SourceGenerationId"];
+            job_id: components["schemas"]["JobId"];
+            message: string;
+            phase: components["schemas"]["PipelinePhase"];
+            reservation_id?: null | components["schemas"]["ReservationId"];
+            retry?: null | components["schemas"]["RetryState"];
+            scope?: null | components["schemas"]["SourceScope"];
+            /** Format: int64 */
+            sequence: number;
+            severity: components["schemas"]["Severity"];
+            source_id?: null | components["schemas"]["SourceId"];
+            stage_id?: null | components["schemas"]["StageId"];
+            status: components["schemas"]["LifecycleStatus"];
+            throughput?: null | components["schemas"]["ProgressThroughput"];
+            timestamp: components["schemas"]["Timestamp"];
+            timing?: null | components["schemas"]["ProgressTiming"];
+            visibility: components["schemas"]["Visibility"];
+            warning?: null | components["schemas"]["SourceWarning"];
         };
         /** @enum {string} */
         SourceRefreshPolicy: "if_stale" | "force" | "never";
@@ -1376,6 +1733,11 @@ export interface components {
             warnings: components["schemas"]["SourceWarning"][];
             watch?: null | components["schemas"]["WatchResult"];
         };
+        SourceResultRef: {
+            job_id: components["schemas"]["JobId"];
+            source_id: components["schemas"]["SourceId"];
+            status: components["schemas"]["LifecycleStatus"];
+        };
         /** @enum {string} */
         SourceScope: "page" | "site" | "docs" | "repo" | "workspace" | "branch" | "org" | "package" | "version" | "feed" | "subreddit" | "thread" | "comment" | "video" | "playlist" | "channel" | "issue" | "pull_request" | "merge_request" | "release" | "wiki" | "file" | "directory" | "map" | "tool" | "script" | "api";
         SourceWarning: {
@@ -1387,6 +1749,45 @@ export interface components {
         };
         /** @enum {string} */
         SourceWatchPolicy: "disabled" | "ensure" | "enabled";
+        StageCounts: {
+            /** Format: int64 */
+            bytes_done: number;
+            /** Format: int64 */
+            bytes_total?: number | null;
+            /** Format: int64 */
+            chunks_done: number;
+            /** Format: int64 */
+            chunks_total?: number | null;
+            /** Format: int64 */
+            documents_done: number;
+            /** Format: int64 */
+            documents_total?: number | null;
+            /** Format: int64 */
+            items_done: number;
+            /** Format: int64 */
+            items_total?: number | null;
+        };
+        /** Format: uuid */
+        StageId: string;
+        StreamEvent: {
+            event: components["schemas"]["SourceProgressEvent"];
+            /** @enum {string} */
+            kind: "progress";
+        } | {
+            /** @enum {string} */
+            kind: "result";
+            result: components["schemas"]["SourceResultRef"];
+        } | {
+            error: components["schemas"]["ApiError"];
+            /** @enum {string} */
+            kind: "error";
+        } | {
+            /** @enum {string} */
+            kind: "heartbeat";
+            timestamp: components["schemas"]["Timestamp"];
+        };
+        /** Format: date-time */
+        Timestamp: string;
         TraceContext: {
             attributes: components["schemas"]["MetadataMap"];
             parent_span_id?: string | null;
@@ -1401,6 +1802,8 @@ export interface components {
             ok: boolean;
             session: components["schemas"]["MobileSession"];
         };
+        /** @enum {string} */
+        Visibility: "public" | "internal" | "sensitive" | "redacted" | "derived";
         WatchDefCreateRequest: {
             enabled?: boolean | null;
             /** Format: int64 */
@@ -2589,6 +2992,445 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    list_unified_jobs: {
+        parameters: {
+            query?: {
+                status?: components["schemas"]["LifecycleStatus"];
+                kind?: components["schemas"]["JobKind"];
+                limit?: number;
+                cursor?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unified jobs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobSummary"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    clear_unified_jobs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobClearRequest"];
+            };
+        };
+        responses: {
+            /** @description Unified job clear */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobClearResult"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    cleanup_unified_jobs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobCleanupRequest"];
+            };
+        };
+        responses: {
+            /** @description Unified job cleanup */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobCleanupResult"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    recover_unified_jobs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobRecoveryRequest"];
+            };
+        };
+        responses: {
+            /** @description Unified job recovery */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobRecoveryResult"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    unified_job_status: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unified job ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unified job status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobSummary"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Job not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorBody"];
+                };
+            };
+        };
+    };
+    unified_job_artifacts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unified job ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unified job artifacts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobArtifactListResult"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    cancel_unified_job: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unified job ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobCancelRequest"];
+            };
+        };
+        responses: {
+            /** @description Unified job cancellation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobCancelResult"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    unified_job_events: {
+        parameters: {
+            query?: {
+                after_sequence?: number;
+                since_sequence?: number;
+                limit?: number;
+                severity?: components["schemas"]["Severity"];
+                visibility?: components["schemas"]["Visibility"];
+                cursor?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Unified job ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unified job event page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobEventPage"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    retry_unified_job: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unified job ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobRetryRequest"];
+            };
+        };
+        responses: {
+            /** @description Unified job retry */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobRetryResult"];
+                };
+            };
+            /** @description Missing or invalid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Authenticated token lacks Axon access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    unified_job_stream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unified job ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unified job events streamed as server-sent events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": components["schemas"]["StreamEvent"];
                 };
             };
             /** @description Missing or invalid authentication */

--- a/apps/web/lib/generated/axon-api.ts
+++ b/apps/web/lib/generated/axon-api.ts
@@ -44,7 +44,16 @@ export type components = {
             "url"?: string | null;
         };
         "ArtifactId": string;
+        "ArtifactKind": "raw_content" | "normalized_content" | "manifest" | "report" | "screenshot" | "warc" | "provider_trace";
         "ArtifactMode": "none" | "on_large_output" | "always";
+        "ArtifactRef": {
+            "artifact_id": components['schemas']['ArtifactId'];
+            "artifact_kind": components['schemas']['ArtifactKind'];
+            "content_hash"?: string | null;
+            "created_at": components['schemas']['Timestamp'];
+            "size_bytes"?: number | null;
+            "uri": string;
+        };
         "AuthorityEvidence": {
             "confidence": number;
             "evidence_kind": string;
@@ -56,6 +65,7 @@ export type components = {
             "evidence": components['schemas']['AuthorityEvidence'][];
         };
         "AuthorityLevel": "official" | "verified" | "user_pinned" | "inferred" | "community" | "mirror" | "conflicting" | "unknown";
+        "BatchId": string;
         "BrandColor": {
             "count": number;
             "hex": string;
@@ -71,6 +81,8 @@ export type components = {
             "og_image"?: string | null;
             "url": string;
         };
+        "CheckpointId": string;
+        "ChunkId": string;
         "ColorUsage": "primary" | "secondary" | "background" | "text" | "accent" | "unknown";
         "ContentRef": {
             "kind": "inline_text";
@@ -114,6 +126,7 @@ export type components = {
             "value": string;
             "verified"?: null | components['schemas']['EndpointVerification'];
         };
+        "DocumentId": string;
         "EndpointKind": "relative_path" | "absolute_url" | "graphql" | "websocket";
         "EndpointReport": {
             "bundles_fetched": number;
@@ -186,6 +199,52 @@ export type components = {
             "metadata": components['schemas']['MetadataMap'];
             "summary"?: string | null;
         };
+        "JobArtifactListResult": {
+            "artifacts": components['schemas']['ArtifactRef'][];
+            "limit": number;
+            "next_cursor"?: string | null;
+        };
+        "JobCancelRequest": {
+            "force_after_ms"?: number | null;
+            "reason"?: string | null;
+        };
+        "JobCancelResult": {
+            "canceled_at"?: null | components['schemas']['Timestamp'];
+            "job_id": components['schemas']['JobId'];
+            "reason"?: string | null;
+            "status": components['schemas']['LifecycleStatus'];
+        };
+        "JobCleanupRequest": {
+            "dry_run": boolean;
+            "kind"?: null | components['schemas']['JobKind'];
+            "limit"?: number | null;
+            "older_than"?: null | components['schemas']['Timestamp'];
+            "status"?: null | components['schemas']['LifecycleStatus'];
+        };
+        "JobCleanupResult": {
+            "artifacts_pruned": number;
+            "attempts_pruned": number;
+            "deleted": number;
+            "dry_run": boolean;
+            "events_pruned": number;
+            "heartbeats_pruned": number;
+            "jobs_pruned": number;
+            "matched": number;
+            "reservations_pruned": number;
+            "stages_pruned": number;
+            "warnings": components['schemas']['SourceWarning'][];
+        };
+        "JobClearRequest": {
+            "confirm": boolean;
+            "kind"?: null | components['schemas']['JobKind'];
+            "older_than"?: null | components['schemas']['Timestamp'];
+            "status"?: null | components['schemas']['LifecycleStatus'];
+        };
+        "JobClearResult": {
+            "deleted": number;
+            "status"?: null | components['schemas']['LifecycleStatus'];
+            "warnings": components['schemas']['SourceWarning'][];
+        };
         "JobDescriptor": {
             "cancel_url"?: string | null;
             "events_url": string;
@@ -195,6 +254,26 @@ export type components = {
             "retry_url"?: string | null;
             "status_url": string;
             "stream_url": string;
+        };
+        "JobEvent": {
+            "attempt"?: number;
+            "details": components['schemas']['MetadataMap'];
+            "event_id": string;
+            "job_id": components['schemas']['JobId'];
+            "message": string;
+            "phase": components['schemas']['PipelinePhase'];
+            "sequence": number;
+            "severity": components['schemas']['Severity'];
+            "stage_id"?: null | components['schemas']['StageId'];
+            "status": components['schemas']['LifecycleStatus'];
+            "timestamp": components['schemas']['Timestamp'];
+            "visibility"?: components['schemas']['Visibility'];
+        };
+        "JobEventPage": {
+            "events": components['schemas']['JobEvent'][];
+            "last_sequence": number;
+            "limit"?: number;
+            "next_cursor"?: string | null;
         };
         "JobFamily": "embed" | "extract" | "ingest";
         "JobId": string;
@@ -212,9 +291,43 @@ export type components = {
             "percent"?: number | null;
             "phase": components['schemas']['JobPhase'];
         };
+        "JobRecoveryRequest": {
+            "kind"?: null | components['schemas']['JobKind'];
+            "limit"?: number | null;
+            "stale_before"?: null | components['schemas']['Timestamp'];
+        };
+        "JobRecoveryResult": {
+            "job_ids": components['schemas']['JobId'][];
+            "recovered": number;
+            "warnings": components['schemas']['SourceWarning'][];
+        };
+        "JobRetryMode": "same_config" | "with_overrides";
+        "JobRetryRequest": {
+            "from_phase"?: null | components['schemas']['PipelinePhase'];
+            "idempotency_key"?: string | null;
+            "mode": components['schemas']['JobRetryMode'];
+            "overrides"?: components['schemas']['MetadataMap'];
+        };
+        "JobRetryResult": {
+            "attempt": number;
+            "original_job_id": components['schemas']['JobId'];
+            "retry_job": components['schemas']['JobDescriptor'];
+        };
         "JobStatusResponse": {
             "job": unknown;
             "progress"?: null | components['schemas']['JobProgress'];
+        };
+        "JobSummary": {
+            "counts"?: null | components['schemas']['StageCounts'];
+            "created_at": components['schemas']['Timestamp'];
+            "job_id": components['schemas']['JobId'];
+            "kind": components['schemas']['JobKind'];
+            "last_error"?: null | components['schemas']['SourceError'];
+            "phase": components['schemas']['PipelinePhase'];
+            "source_id"?: null | components['schemas']['SourceId'];
+            "status": components['schemas']['LifecycleStatus'];
+            "updated_at": components['schemas']['Timestamp'];
+            "watch_id"?: null | components['schemas']['WatchId'];
         };
         "LedgerSummary": {
             "committed_generation"?: null | components['schemas']['SourceGenerationId'];
@@ -290,6 +403,27 @@ export type components = {
         "PanelCollectionsResponse": {
             "collections": string[];
         };
+        "PipelinePhase": "queued" | "requested" | "resolving" | "routing" | "authorizing" | "planning" | "leasing" | "discovering" | "diffing" | "fetching" | "rendering" | "enriching" | "normalizing" | "parsing" | "graphing" | "preparing" | "batching" | "embedding" | "vectorizing" | "upserting" | "retrieving" | "synthesizing" | "evaluating" | "publishing" | "cleaning" | "complete" | "canceled";
+        "ProgressCurrent": {
+            "adapter"?: string | null;
+            "chunk_id"?: null | components['schemas']['ChunkId'];
+            "document_id"?: null | components['schemas']['DocumentId'];
+            "message"?: string | null;
+            "provider"?: null | components['schemas']['ProviderId'];
+            "source_item_key"?: null | components['schemas']['SourceItemKey'];
+        };
+        "ProgressThroughput": {
+            "bytes_per_second"?: number | null;
+            "chunks_per_second"?: number | null;
+            "items_per_second"?: number | null;
+        };
+        "ProgressTiming": {
+            "elapsed_ms": number;
+            "eta_ms"?: number | null;
+            "started_at": components['schemas']['Timestamp'];
+            "updated_at": components['schemas']['Timestamp'];
+        };
+        "ProviderId": string;
         "PurgeRequest": {
             "collection"?: string | null;
             "dry_run"?: boolean | null;
@@ -313,6 +447,7 @@ export type components = {
             "tei": string;
         };
         "RenderMode": "http" | "chrome" | "auto-switch";
+        "ReservationId": string;
         "ResponseMode": "path" | "inline" | "both" | "auto_inline";
         "RestAskRequest": {
             "ask_authoritative_boost"?: number | null;
@@ -445,6 +580,12 @@ export type components = {
             "url"?: string | null;
             "urls"?: string[] | null;
         };
+        "RetryState": {
+            "attempt": number;
+            "max_attempts"?: number | null;
+            "next_retry_at"?: null | components['schemas']['Timestamp'];
+            "reason": string;
+        };
         "RpcProbeResult": {
             "methods"?: string[];
             "protocol"?: null | components['schemas']['RpcProtocol'];
@@ -478,6 +619,15 @@ export type components = {
             "items_total": number;
             "vector_points_total": number;
         };
+        "SourceError": {
+            "cause"?: string | null;
+            "code": string;
+            "message": string;
+            "provider_id"?: null | components['schemas']['ProviderId'];
+            "retryable": boolean;
+            "severity": components['schemas']['Severity'];
+            "source_item_key"?: null | components['schemas']['SourceItemKey'];
+        };
         "SourceGenerationId": string;
         "SourceId": string;
         "SourceIntent": "acquire" | "refresh" | "watch" | "map";
@@ -491,6 +641,35 @@ export type components = {
             "max_pages"?: number | null;
             "max_total_bytes"?: number | null;
             "provider_timeout_ms"?: number | null;
+        };
+        "SourceProgressEvent": {
+            "adapter"?: null | components['schemas']['AdapterRef'];
+            "attempt"?: number;
+            "batch_id"?: null | components['schemas']['BatchId'];
+            "canonical_uri"?: string | null;
+            "checkpoint_id"?: null | components['schemas']['CheckpointId'];
+            "counts": components['schemas']['StageCounts'];
+            "current"?: null | components['schemas']['ProgressCurrent'];
+            "dedupe_key"?: string | null;
+            "error"?: null | components['schemas']['ApiError'];
+            "event_id": string;
+            "generation"?: null | components['schemas']['SourceGenerationId'];
+            "job_id": components['schemas']['JobId'];
+            "message": string;
+            "phase": components['schemas']['PipelinePhase'];
+            "reservation_id"?: null | components['schemas']['ReservationId'];
+            "retry"?: null | components['schemas']['RetryState'];
+            "scope"?: null | components['schemas']['SourceScope'];
+            "sequence": number;
+            "severity": components['schemas']['Severity'];
+            "source_id"?: null | components['schemas']['SourceId'];
+            "stage_id"?: null | components['schemas']['StageId'];
+            "status": components['schemas']['LifecycleStatus'];
+            "throughput"?: null | components['schemas']['ProgressThroughput'];
+            "timestamp": components['schemas']['Timestamp'];
+            "timing"?: null | components['schemas']['ProgressTiming'];
+            "visibility": components['schemas']['Visibility'];
+            "warning"?: null | components['schemas']['SourceWarning'];
         };
         "SourceRefreshPolicy": "if_stale" | "force" | "never";
         "SourceRequest": {
@@ -526,6 +705,11 @@ export type components = {
             "warnings": components['schemas']['SourceWarning'][];
             "watch"?: null | components['schemas']['WatchResult'];
         };
+        "SourceResultRef": {
+            "job_id": components['schemas']['JobId'];
+            "source_id": components['schemas']['SourceId'];
+            "status": components['schemas']['LifecycleStatus'];
+        };
         "SourceScope": "page" | "site" | "docs" | "repo" | "workspace" | "branch" | "org" | "package" | "version" | "feed" | "subreddit" | "thread" | "comment" | "video" | "playlist" | "channel" | "issue" | "pull_request" | "merge_request" | "release" | "wiki" | "file" | "directory" | "map" | "tool" | "script" | "api";
         "SourceWarning": {
             "code": string;
@@ -535,6 +719,31 @@ export type components = {
             "source_item_key"?: null | components['schemas']['SourceItemKey'];
         };
         "SourceWatchPolicy": "disabled" | "ensure" | "enabled";
+        "StageCounts": {
+            "bytes_done": number;
+            "bytes_total"?: number | null;
+            "chunks_done": number;
+            "chunks_total"?: number | null;
+            "documents_done": number;
+            "documents_total"?: number | null;
+            "items_done": number;
+            "items_total"?: number | null;
+        };
+        "StageId": string;
+        "StreamEvent": {
+            "event": components['schemas']['SourceProgressEvent'];
+            "kind": "progress";
+        } | {
+            "kind": "result";
+            "result": components['schemas']['SourceResultRef'];
+        } | {
+            "error": components['schemas']['ApiError'];
+            "kind": "error";
+        } | {
+            "kind": "heartbeat";
+            "timestamp": components['schemas']['Timestamp'];
+        };
+        "Timestamp": string;
         "TraceContext": {
             "attributes": components['schemas']['MetadataMap'];
             "parent_span_id"?: string | null;
@@ -549,6 +758,7 @@ export type components = {
             "ok": boolean;
             "session": components['schemas']['MobileSession'];
         };
+        "Visibility": "public" | "internal" | "sensitive" | "redacted" | "derived";
         "WatchDefCreateRequest": {
             "enabled"?: boolean | null;
             "every_seconds": number;
@@ -600,6 +810,15 @@ export type paths = {
     "/v1/extract/recover": { post: operations["recover_extract_jobs"] };
     "/v1/extract/{id}": { get: operations["extract_job_status"] };
     "/v1/extract/{id}/cancel": { post: operations["cancel_extract_job"] };
+    "/v1/jobs": { get: operations["list_unified_jobs"]; delete: operations["clear_unified_jobs"] };
+    "/v1/jobs/cleanup": { post: operations["cleanup_unified_jobs"] };
+    "/v1/jobs/recover": { post: operations["recover_unified_jobs"] };
+    "/v1/jobs/{id}": { get: operations["unified_job_status"] };
+    "/v1/jobs/{id}/artifacts": { get: operations["unified_job_artifacts"] };
+    "/v1/jobs/{id}/cancel": { post: operations["cancel_unified_job"] };
+    "/v1/jobs/{id}/events": { get: operations["unified_job_events"] };
+    "/v1/jobs/{id}/retry": { post: operations["retry_unified_job"] };
+    "/v1/jobs/{id}/stream": { get: operations["unified_job_stream"] };
     "/v1/map": { post: operations["map"] };
     "/v1/memory": { post: operations["memory"] };
     "/v1/mobile/sessions": { get: operations["list_mobile_sessions"] };
@@ -645,6 +864,16 @@ export type operations = {
     "recover_extract_jobs": { method: "post"; path: "/v1/extract/recover"; operationId: "recover_extract_jobs"; parameters: { query: Record<string, never>; path: Record<string, never> }; requestBody: never; responses: { "200": unknown; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
     "extract_job_status": { method: "get"; path: "/v1/extract/{id}"; operationId: "extract_job_status"; parameters: { query: Record<string, never>; path: { "id": string } }; requestBody: never; responses: { "200": components['schemas']['JobStatusResponse']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope']; "404": components['schemas']['ErrorBody'] }; security: "bearerAuth" | "oauth2" };
     "cancel_extract_job": { method: "post"; path: "/v1/extract/{id}/cancel"; operationId: "cancel_extract_job"; parameters: { query: Record<string, never>; path: { "id": string } }; requestBody: never; responses: { "200": unknown; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "list_unified_jobs": { method: "get"; path: "/v1/jobs"; operationId: "list_unified_jobs"; parameters: { query: { "status"?: components['schemas']['LifecycleStatus']; "kind"?: components['schemas']['JobKind']; "limit"?: number; "cursor"?: string }; path: Record<string, never> }; requestBody: never; responses: { "200": components['schemas']['JobSummary']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "clear_unified_jobs": { method: "delete"; path: "/v1/jobs"; operationId: "clear_unified_jobs"; parameters: { query: Record<string, never>; path: Record<string, never> }; requestBody: components['schemas']['JobClearRequest']; responses: { "200": components['schemas']['JobClearResult']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "cleanup_unified_jobs": { method: "post"; path: "/v1/jobs/cleanup"; operationId: "cleanup_unified_jobs"; parameters: { query: Record<string, never>; path: Record<string, never> }; requestBody: components['schemas']['JobCleanupRequest']; responses: { "200": components['schemas']['JobCleanupResult']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "recover_unified_jobs": { method: "post"; path: "/v1/jobs/recover"; operationId: "recover_unified_jobs"; parameters: { query: Record<string, never>; path: Record<string, never> }; requestBody: components['schemas']['JobRecoveryRequest']; responses: { "200": components['schemas']['JobRecoveryResult']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "unified_job_status": { method: "get"; path: "/v1/jobs/{id}"; operationId: "unified_job_status"; parameters: { query: Record<string, never>; path: { "id": string } }; requestBody: never; responses: { "200": components['schemas']['JobSummary']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope']; "404": components['schemas']['ErrorBody'] }; security: "bearerAuth" | "oauth2" };
+    "unified_job_artifacts": { method: "get"; path: "/v1/jobs/{id}/artifacts"; operationId: "unified_job_artifacts"; parameters: { query: Record<string, never>; path: { "id": string } }; requestBody: never; responses: { "200": components['schemas']['JobArtifactListResult']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "cancel_unified_job": { method: "post"; path: "/v1/jobs/{id}/cancel"; operationId: "cancel_unified_job"; parameters: { query: Record<string, never>; path: { "id": string } }; requestBody: components['schemas']['JobCancelRequest']; responses: { "200": components['schemas']['JobCancelResult']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "unified_job_events": { method: "get"; path: "/v1/jobs/{id}/events"; operationId: "unified_job_events"; parameters: { query: { "after_sequence"?: number; "since_sequence"?: number; "limit"?: number; "severity"?: components['schemas']['Severity']; "visibility"?: components['schemas']['Visibility']; "cursor"?: string }; path: { "id": string } }; requestBody: never; responses: { "200": components['schemas']['JobEventPage']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "retry_unified_job": { method: "post"; path: "/v1/jobs/{id}/retry"; operationId: "retry_unified_job"; parameters: { query: Record<string, never>; path: { "id": string } }; requestBody: components['schemas']['JobRetryRequest']; responses: { "200": components['schemas']['JobRetryResult']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
+    "unified_job_stream": { method: "get"; path: "/v1/jobs/{id}/stream"; operationId: "unified_job_stream"; parameters: { query: Record<string, never>; path: { "id": string } }; requestBody: never; responses: { "200": components['schemas']['StreamEvent']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope'] }; security: "bearerAuth" | "oauth2" };
     "map": { method: "post"; path: "/v1/map"; operationId: "map"; parameters: { query: Record<string, never>; path: Record<string, never> }; requestBody: components['schemas']['RestMapRequest']; responses: { "200": unknown; "400": components['schemas']['ErrorBody']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope']; "502": components['schemas']['ErrorBody'] }; security: "bearerAuth" | "oauth2" };
     "memory": { method: "post"; path: "/v1/memory"; operationId: "memory"; parameters: { query: Record<string, never>; path: Record<string, never> }; requestBody: components['schemas']['RestMemoryRequest']; responses: { "200": unknown; "400": components['schemas']['ErrorBody']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope']; "502": components['schemas']['ErrorBody'] }; security: "bearerAuth" | "oauth2" };
     "list_mobile_sessions": { method: "get"; path: "/v1/mobile/sessions"; operationId: "list_mobile_sessions"; parameters: { query: Record<string, never>; path: Record<string, never> }; requestBody: never; responses: { "200": components['schemas']['MobileSessionListResponse']; "401": components['schemas']['ErrorEnvelope']; "403": components['schemas']['ErrorEnvelope']; "500": components['schemas']['ErrorBody'] }; security: "bearerAuth" | "oauth2" };

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -1695,6 +1695,776 @@
         ]
       }
     },
+    "/v1/jobs": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "list_unified_jobs",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/LifecycleStatus"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/JobKind"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unified jobs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobSummary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "clear_unified_jobs",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobClearRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Unified job clear",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobClearResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/jobs/cleanup": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "cleanup_unified_jobs",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobCleanupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Unified job cleanup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobCleanupResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/jobs/recover": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "recover_unified_jobs",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobRecoveryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Unified job recovery",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRecoveryResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/jobs/{id}": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "unified_job_status",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unified job ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unified job status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobSummary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/jobs/{id}/artifacts": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "unified_job_artifacts",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unified job ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unified job artifacts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobArtifactListResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/jobs/{id}/cancel": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "cancel_unified_job",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unified job ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobCancelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Unified job cancellation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobCancelResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/jobs/{id}/events": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "unified_job_events",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unified job ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "after_sequence",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "since_sequence",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "severity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Severity"
+            }
+          },
+          {
+            "name": "visibility",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Visibility"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unified job event page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobEventPage"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/jobs/{id}/retry": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "retry_unified_job",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unified job ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobRetryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Unified job retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRetryResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/jobs/{id}/stream": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "unified_job_stream",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unified job ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unified job events streamed as server-sent events",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamEvent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated token lacks Axon access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "oauth2": [
+              "axon:read"
+            ]
+          },
+          {
+            "oauth2": [
+              "axon:write"
+            ]
+          }
+        ]
+      }
+    },
     "/v1/map": {
       "post": {
         "tags": [
@@ -3757,6 +4527,18 @@
       "ArtifactId": {
         "type": "string"
       },
+      "ArtifactKind": {
+        "type": "string",
+        "enum": [
+          "raw_content",
+          "normalized_content",
+          "manifest",
+          "report",
+          "screenshot",
+          "warc",
+          "provider_trace"
+        ]
+      },
       "ArtifactMode": {
         "type": "string",
         "enum": [
@@ -3764,6 +4546,44 @@
           "on_large_output",
           "always"
         ]
+      },
+      "ArtifactRef": {
+        "type": "object",
+        "required": [
+          "artifact_id",
+          "artifact_kind",
+          "uri",
+          "created_at"
+        ],
+        "properties": {
+          "artifact_id": {
+            "$ref": "#/components/schemas/ArtifactId"
+          },
+          "artifact_kind": {
+            "$ref": "#/components/schemas/ArtifactKind"
+          },
+          "content_hash": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "size_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       },
       "AuthorityEvidence": {
         "type": "object",
@@ -3823,6 +4643,10 @@
           "conflicting",
           "unknown"
         ]
+      },
+      "BatchId": {
+        "type": "string",
+        "format": "uuid"
       },
       "BrandColor": {
         "type": "object",
@@ -3899,6 +4723,12 @@
             "type": "string"
           }
         }
+      },
+      "CheckpointId": {
+        "type": "string"
+      },
+      "ChunkId": {
+        "type": "string"
       },
       "ColorUsage": {
         "type": "string",
@@ -4133,6 +4963,9 @@
             ]
           }
         }
+      },
+      "DocumentId": {
+        "type": "string"
       },
       "EndpointKind": {
         "type": "string",
@@ -4564,6 +5397,281 @@
         },
         "additionalProperties": false
       },
+      "JobArtifactListResult": {
+        "type": "object",
+        "required": [
+          "artifacts",
+          "limit"
+        ],
+        "properties": {
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArtifactRef"
+            }
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobCancelRequest": {
+        "type": "object",
+        "properties": {
+          "force_after_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobCancelResult": {
+        "type": "object",
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "properties": {
+          "canceled_at": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            ]
+          },
+          "job_id": {
+            "$ref": "#/components/schemas/JobId"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/LifecycleStatus"
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobCleanupRequest": {
+        "type": "object",
+        "required": [
+          "dry_run"
+        ],
+        "properties": {
+          "dry_run": {
+            "type": "boolean"
+          },
+          "kind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/JobKind"
+              }
+            ]
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "older_than": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            ]
+          },
+          "status": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LifecycleStatus"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobCleanupResult": {
+        "type": "object",
+        "required": [
+          "matched",
+          "deleted",
+          "dry_run",
+          "warnings",
+          "jobs_pruned",
+          "events_pruned",
+          "heartbeats_pruned",
+          "attempts_pruned",
+          "stages_pruned",
+          "reservations_pruned",
+          "artifacts_pruned"
+        ],
+        "properties": {
+          "artifacts_pruned": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "attempts_pruned": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "deleted": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "dry_run": {
+            "type": "boolean"
+          },
+          "events_pruned": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "heartbeats_pruned": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "jobs_pruned": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "matched": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "reservations_pruned": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "stages_pruned": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SourceWarning"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobClearRequest": {
+        "type": "object",
+        "required": [
+          "confirm"
+        ],
+        "properties": {
+          "confirm": {
+            "type": "boolean"
+          },
+          "kind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/JobKind"
+              }
+            ]
+          },
+          "older_than": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            ]
+          },
+          "status": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LifecycleStatus"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobClearResult": {
+        "type": "object",
+        "required": [
+          "deleted",
+          "warnings"
+        ],
+        "properties": {
+          "deleted": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "status": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LifecycleStatus"
+              }
+            ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SourceWarning"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "JobDescriptor": {
         "type": "object",
         "required": [
@@ -4606,6 +5714,102 @@
           },
           "stream_url": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobEvent": {
+        "type": "object",
+        "required": [
+          "event_id",
+          "sequence",
+          "job_id",
+          "phase",
+          "status",
+          "severity",
+          "message",
+          "timestamp",
+          "details"
+        ],
+        "properties": {
+          "attempt": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "details": {
+            "$ref": "#/components/schemas/MetadataMap"
+          },
+          "event_id": {
+            "type": "string"
+          },
+          "job_id": {
+            "$ref": "#/components/schemas/JobId"
+          },
+          "message": {
+            "type": "string"
+          },
+          "phase": {
+            "$ref": "#/components/schemas/PipelinePhase"
+          },
+          "sequence": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "severity": {
+            "$ref": "#/components/schemas/Severity"
+          },
+          "stage_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/StageId"
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/LifecycleStatus"
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/Visibility"
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobEventPage": {
+        "type": "object",
+        "required": [
+          "events",
+          "last_sequence"
+        ],
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JobEvent"
+            }
+          },
+          "last_sequence": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "additionalProperties": false
@@ -4714,6 +5918,128 @@
           }
         }
       },
+      "JobRecoveryRequest": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/JobKind"
+              }
+            ]
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "stale_before": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobRecoveryResult": {
+        "type": "object",
+        "required": [
+          "recovered",
+          "job_ids",
+          "warnings"
+        ],
+        "properties": {
+          "job_ids": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JobId"
+            }
+          },
+          "recovered": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SourceWarning"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobRetryMode": {
+        "type": "string",
+        "enum": [
+          "same_config",
+          "with_overrides"
+        ]
+      },
+      "JobRetryRequest": {
+        "type": "object",
+        "required": [
+          "mode"
+        ],
+        "properties": {
+          "from_phase": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PipelinePhase"
+              }
+            ]
+          },
+          "idempotency_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mode": {
+            "$ref": "#/components/schemas/JobRetryMode"
+          },
+          "overrides": {
+            "$ref": "#/components/schemas/MetadataMap"
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobRetryResult": {
+        "type": "object",
+        "required": [
+          "original_job_id",
+          "retry_job",
+          "attempt"
+        ],
+        "properties": {
+          "attempt": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "original_job_id": {
+            "$ref": "#/components/schemas/JobId"
+          },
+          "retry_job": {
+            "$ref": "#/components/schemas/JobDescriptor"
+          }
+        },
+        "additionalProperties": false
+      },
       "JobStatusResponse": {
         "type": "object",
         "description": "Typed job-status envelope so the `{ job, progress }` wire shape is a\nregistered OpenAPI schema (and thus reflected into the generated palette/\nandroid clients) instead of an opaque `serde_json::Value`.",
@@ -4736,6 +6062,78 @@
             ]
           }
         }
+      },
+      "JobSummary": {
+        "type": "object",
+        "required": [
+          "job_id",
+          "kind",
+          "status",
+          "phase",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "counts": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/StageCounts"
+              }
+            ]
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "job_id": {
+            "$ref": "#/components/schemas/JobId"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/JobKind"
+          },
+          "last_error": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceError"
+              }
+            ]
+          },
+          "phase": {
+            "$ref": "#/components/schemas/PipelinePhase"
+          },
+          "source_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceId"
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/LifecycleStatus"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "watch_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WatchId"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
       },
       "LedgerSummary": {
         "type": "object",
@@ -5092,6 +6490,156 @@
           }
         }
       },
+      "PipelinePhase": {
+        "type": "string",
+        "enum": [
+          "queued",
+          "requested",
+          "resolving",
+          "routing",
+          "authorizing",
+          "planning",
+          "leasing",
+          "discovering",
+          "diffing",
+          "fetching",
+          "rendering",
+          "enriching",
+          "normalizing",
+          "parsing",
+          "graphing",
+          "preparing",
+          "batching",
+          "embedding",
+          "vectorizing",
+          "upserting",
+          "retrieving",
+          "synthesizing",
+          "evaluating",
+          "publishing",
+          "cleaning",
+          "complete",
+          "canceled"
+        ]
+      },
+      "ProgressCurrent": {
+        "type": "object",
+        "properties": {
+          "adapter": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "chunk_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChunkId"
+              }
+            ]
+          },
+          "document_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DocumentId"
+              }
+            ]
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ProviderId"
+              }
+            ]
+          },
+          "source_item_key": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceItemKey"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProgressThroughput": {
+        "type": "object",
+        "properties": {
+          "bytes_per_second": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "chunks_per_second": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "items_per_second": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProgressTiming": {
+        "type": "object",
+        "required": [
+          "started_at",
+          "updated_at",
+          "elapsed_ms"
+        ],
+        "properties": {
+          "elapsed_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "eta_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "started_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProviderId": {
+        "type": "string"
+      },
       "PurgeRequest": {
         "type": "object",
         "properties": {
@@ -5205,6 +6753,9 @@
           "chrome",
           "auto-switch"
         ]
+      },
+      "ReservationId": {
+        "type": "string"
       },
       "ResponseMode": {
         "type": "string",
@@ -5976,6 +7527,42 @@
         },
         "additionalProperties": false
       },
+      "RetryState": {
+        "type": "object",
+        "required": [
+          "attempt",
+          "reason"
+        ],
+        "properties": {
+          "attempt": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "max_attempts": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "next_retry_at": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            ]
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "RpcProbeResult": {
         "type": "object",
         "description": "Result of probing a discovered endpoint for JSON-RPC 2.0 / OpenRPC / MCP support.\n\nFields are populated according to the detected `protocol` and are otherwise\nleft empty: `server_name`/`server_version`/`tools` are MCP-only, `methods` is\nJSON-RPC/OpenRPC-only. The flat shape preserves the wire contract; the type\ndoes not statically prevent contradictory combinations.",
@@ -6174,6 +7761,56 @@
         },
         "additionalProperties": false
       },
+      "SourceError": {
+        "type": "object",
+        "required": [
+          "code",
+          "severity",
+          "message",
+          "retryable"
+        ],
+        "properties": {
+          "cause": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "provider_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ProviderId"
+              }
+            ]
+          },
+          "retryable": {
+            "type": "boolean"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/Severity"
+          },
+          "source_item_key": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceItemKey"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
       "SourceGenerationId": {
         "type": "string"
       },
@@ -6267,6 +7904,213 @@
             ],
             "format": "int64",
             "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "SourceProgressEvent": {
+        "type": "object",
+        "required": [
+          "event_id",
+          "sequence",
+          "job_id",
+          "phase",
+          "status",
+          "severity",
+          "visibility",
+          "message",
+          "timestamp",
+          "counts"
+        ],
+        "properties": {
+          "adapter": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AdapterRef"
+              }
+            ]
+          },
+          "attempt": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "batch_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BatchId"
+              }
+            ]
+          },
+          "canonical_uri": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "checkpoint_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CheckpointId"
+              }
+            ]
+          },
+          "counts": {
+            "$ref": "#/components/schemas/StageCounts"
+          },
+          "current": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ProgressCurrent"
+              }
+            ]
+          },
+          "dedupe_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "error": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ApiError"
+              }
+            ]
+          },
+          "event_id": {
+            "type": "string"
+          },
+          "generation": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceGenerationId"
+              }
+            ]
+          },
+          "job_id": {
+            "$ref": "#/components/schemas/JobId"
+          },
+          "message": {
+            "type": "string"
+          },
+          "phase": {
+            "$ref": "#/components/schemas/PipelinePhase"
+          },
+          "reservation_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReservationId"
+              }
+            ]
+          },
+          "retry": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RetryState"
+              }
+            ]
+          },
+          "scope": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceScope"
+              }
+            ]
+          },
+          "sequence": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "severity": {
+            "$ref": "#/components/schemas/Severity"
+          },
+          "source_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceId"
+              }
+            ]
+          },
+          "stage_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/StageId"
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/LifecycleStatus"
+          },
+          "throughput": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ProgressThroughput"
+              }
+            ]
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "timing": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ProgressTiming"
+              }
+            ]
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/Visibility"
+          },
+          "warning": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceWarning"
+              }
+            ]
           }
         },
         "additionalProperties": false
@@ -6441,6 +8285,26 @@
         },
         "additionalProperties": false
       },
+      "SourceResultRef": {
+        "type": "object",
+        "required": [
+          "job_id",
+          "source_id",
+          "status"
+        ],
+        "properties": {
+          "job_id": {
+            "$ref": "#/components/schemas/JobId"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/SourceId"
+          },
+          "status": {
+            "$ref": "#/components/schemas/LifecycleStatus"
+          }
+        },
+        "additionalProperties": false
+      },
       "SourceScope": {
         "type": "string",
         "enum": [
@@ -6515,6 +8379,154 @@
           "enabled"
         ]
       },
+      "StageCounts": {
+        "type": "object",
+        "required": [
+          "items_done",
+          "documents_done",
+          "chunks_done",
+          "bytes_done"
+        ],
+        "properties": {
+          "bytes_done": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "bytes_total": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "chunks_done": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "chunks_total": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "documents_done": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "documents_total": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "items_done": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "items_total": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "StageId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "StreamEvent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "event",
+              "kind"
+            ],
+            "properties": {
+              "event": {
+                "$ref": "#/components/schemas/SourceProgressEvent"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "progress"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "result",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "result"
+                ]
+              },
+              "result": {
+                "$ref": "#/components/schemas/SourceResultRef"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "error",
+              "kind"
+            ],
+            "properties": {
+              "error": {
+                "$ref": "#/components/schemas/ApiError"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "error"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "timestamp",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "heartbeat"
+                ]
+              },
+              "timestamp": {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            }
+          }
+        ]
+      },
+      "Timestamp": {
+        "type": "string",
+        "format": "date-time"
+      },
       "TraceContext": {
         "type": "object",
         "required": [
@@ -6572,6 +8584,16 @@
             "$ref": "#/components/schemas/MobileSession"
           }
         }
+      },
+      "Visibility": {
+        "type": "string",
+        "enum": [
+          "public",
+          "internal",
+          "sensitive",
+          "redacted",
+          "derived"
+        ]
       },
       "WatchDefCreateRequest": {
         "type": "object",

--- a/crates/axon-adapters/src/fixture_tests.rs
+++ b/crates/axon-adapters/src/fixture_tests.rs
@@ -63,7 +63,7 @@ const REQUIRED_VECTOR_PAYLOAD_FIELDS: &[&str] = &[
 ];
 
 #[test]
-fn fixture_packs_required_families_have_required_fixture_packs() {
+fn fixtures_required_families_have_required_fixture_packs() {
     for spec in source_family_matrix()
         .iter()
         .filter(|spec| spec.is_source_adapter)

--- a/crates/axon-services/src/feed_source_failure_tests.rs
+++ b/crates/axon-services/src/feed_source_failure_tests.rs
@@ -4,6 +4,8 @@ use axon_jobs::boundary::{FakeJobWatchStore, JobStore};
 use axon_ledger::store::FakeLedgerStore;
 use axon_vectors::store::{FakeVectorMode, FakeVectorStore};
 
+use crate::test_support::is_uncommitted_generation;
+
 use super::{FeedSourceIndexInput, index_feed_source, index_feed_source_with_job};
 
 const RSS_TWO_ITEMS: &str = r#"<?xml version="1.0"?>
@@ -272,7 +274,7 @@ async fn publish_generation_failure_reports_rollback_delete_failure() {
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str() != Some("uncommitted"))
+            .all(|point| !is_uncommitted_generation(&point.payload["committed_generation"]))
     );
 }
 
@@ -300,6 +302,6 @@ async fn vector_commit_marker_failure_leaves_vectors_uncommitted() {
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str() == Some("uncommitted"))
+            .all(|point| is_uncommitted_generation(&point.payload["committed_generation"]))
     );
 }

--- a/crates/axon-services/src/feed_source_tests.rs
+++ b/crates/axon-services/src/feed_source_tests.rs
@@ -6,6 +6,8 @@ use axon_ledger::store::{FakeLedgerStore, LedgerStore};
 use axon_vectors::store::FakeVectorStore;
 use std::sync::Arc;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{FeedSourceIndexInput, index_feed_source, index_feed_source_with_job};
 
 const RSS_TWO_ITEMS: &str = r#"<?xml version="1.0"?>
@@ -105,8 +107,8 @@ async fn feed_refresh_writes_vectors_then_commits_source_generation() {
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str()
-                == Some(output.generation.0.as_str()))
+            .all(|point| point.payload["committed_generation"]
+                == committed_generation_payload(&output.generation))
     );
     assert!(
         vectors

--- a/crates/axon-services/src/git_source/git_source_tests.rs
+++ b/crates/axon-services/src/git_source/git_source_tests.rs
@@ -9,6 +9,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{GitSourceIndexInput, git_source_id, index_git_source, index_git_source_with_job};
 
 const TARGET_URL: &str = "https://github.com/jmagar/fixture-repo";
@@ -102,8 +104,8 @@ async fn git_repo_index_writes_vectors_then_commits_source_generation() {
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str()
-                == Some(output.generation.0.as_str()))
+            .all(|point| point.payload["committed_generation"]
+                == committed_generation_payload(&output.generation))
     );
     assert!(
         vectors

--- a/crates/axon-services/src/local_source_failure_tests.rs
+++ b/crates/axon-services/src/local_source_failure_tests.rs
@@ -4,6 +4,8 @@ use axon_jobs::boundary::{FakeJobWatchStore, JobStore};
 use axon_ledger::store::FakeLedgerStore;
 use axon_vectors::store::{FakeVectorMode, FakeVectorStore};
 
+use crate::test_support::{committed_generation_payload, is_uncommitted_generation};
+
 use super::{
     LocalSourceIndexInput, LocalSourceSelectionPolicy, index_local_source,
     index_local_source_with_job,
@@ -351,7 +353,7 @@ async fn publish_generation_failure_reports_rollback_delete_failure() {
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str() != Some("uncommitted"))
+            .all(|point| !is_uncommitted_generation(&point.payload["committed_generation"]))
     );
 }
 
@@ -416,7 +418,7 @@ async fn partial_unchanged_vector_copy_failure_keeps_previous_generation_visible
         .collect::<Vec<_>>();
     assert!(!keep_points.is_empty());
     assert!(keep_points.iter().all(|point| {
-        point.payload["committed_generation"].as_str() == Some(first.generation.0.as_str())
+        point.payload["committed_generation"] == committed_generation_payload(&first.generation)
     }));
 }
 
@@ -447,6 +449,6 @@ async fn vector_commit_marker_failure_leaves_vectors_uncommitted() {
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str() == Some("uncommitted"))
+            .all(|point| is_uncommitted_generation(&point.payload["committed_generation"]))
     );
 }

--- a/crates/axon-services/src/local_source_tests.rs
+++ b/crates/axon-services/src/local_source_tests.rs
@@ -6,6 +6,8 @@ use axon_ledger::store::{FakeLedgerStore, LedgerStore};
 use axon_vectors::store::FakeVectorStore;
 use std::sync::Arc;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{
     LocalSourceIndexInput, LocalSourceSelectionPolicy, index_local_source,
     index_local_source_with_job,
@@ -89,8 +91,8 @@ async fn local_file_refresh_writes_vectors_then_commits_source_generation() {
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str()
-                == Some(output.generation.0.as_str()))
+            .all(|point| point.payload["committed_generation"]
+                == committed_generation_payload(&output.generation))
     );
     assert!(
         vectors

--- a/crates/axon-services/src/reddit_source_refresh_tests.rs
+++ b/crates/axon-services/src/reddit_source_refresh_tests.rs
@@ -3,6 +3,8 @@ use axon_embedding::fake::FakeEmbeddingProvider;
 use axon_ledger::store::{FakeLedgerStore, LedgerStore};
 use axon_vectors::store::FakeVectorStore;
 
+use crate::test_support::source_generation_payload;
+
 use super::{RedditSourceIndexInput, index_reddit_source};
 
 fn job_id() -> JobId {
@@ -168,8 +170,8 @@ async fn refresh_vectorizes_added_and_modified_posts_and_debts_removed_items() {
             .points("axon-test")
             .await
             .iter()
-            .any(|point| point.payload["source_generation"].as_str()
-                == Some(first.generation.0.as_str()))
+            .any(|point| point.payload["source_generation"]
+                == source_generation_payload(&first.generation))
     );
     let stable_points = vectors
         .points("axon-test")

--- a/crates/axon-services/src/reddit_source_tests.rs
+++ b/crates/axon-services/src/reddit_source_tests.rs
@@ -6,6 +6,8 @@ use axon_ledger::store::{FakeLedgerStore, LedgerStore};
 use axon_vectors::store::FakeVectorStore;
 use std::sync::Arc;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{RedditSourceIndexInput, index_reddit_source, index_reddit_source_with_job};
 
 fn job_id() -> JobId {
@@ -131,8 +133,8 @@ async fn reddit_subreddit_refresh_writes_vectors_then_commits_source_generation(
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str()
-                == Some(output.generation.0.as_str()))
+            .all(|point| point.payload["committed_generation"]
+                == committed_generation_payload(&output.generation))
     );
     assert!(
         vectors

--- a/crates/axon-services/src/registry_source_tests.rs
+++ b/crates/axon-services/src/registry_source_tests.rs
@@ -6,6 +6,8 @@ use axon_ledger::store::{FakeLedgerStore, LedgerStore};
 use axon_vectors::store::FakeVectorStore;
 use std::sync::Arc;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{RegistrySourceIndexInput, index_registry_source, index_registry_source_with_job};
 
 fn job_id() -> JobId {
@@ -120,8 +122,8 @@ async fn registry_source_refresh_writes_vectors_then_commits_source_generation()
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str()
-                == Some(output.generation.0.as_str()))
+            .all(|point| point.payload["committed_generation"]
+                == committed_generation_payload(&output.generation))
     );
     assert!(
         vectors

--- a/crates/axon-services/src/sessions_source_tests.rs
+++ b/crates/axon-services/src/sessions_source_tests.rs
@@ -6,6 +6,8 @@ use axon_ledger::store::{FakeLedgerStore, LedgerStore};
 use axon_vectors::store::FakeVectorStore;
 use std::sync::Arc;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{SessionsSourceIndexInput, index_sessions_source, index_sessions_source_with_job};
 
 fn job_id() -> JobId {
@@ -102,8 +104,8 @@ async fn sessions_refresh_writes_vectors_then_commits_source_generation() {
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str()
-                == Some(output.generation.0.as_str()))
+            .all(|point| point.payload["committed_generation"]
+                == committed_generation_payload(&output.generation))
     );
     assert!(
         vectors

--- a/crates/axon-services/src/test_support.rs
+++ b/crates/axon-services/src/test_support.rs
@@ -2,13 +2,34 @@ use std::collections::HashMap;
 use std::error::Error;
 
 use async_trait::async_trait;
+use axon_api::source::SourceGenerationId;
 use axon_jobs::backend::{BackendResult, JobKind, JobPayload};
 use axon_jobs::status::JobStatus;
+use axon_vectors::payload::generation_payload_i64;
+use serde_json::{Value, json};
 
 use crate::runtime::ServiceJobRuntime;
 
 #[derive(Default)]
 pub(crate) struct NoopServiceRuntime;
+
+pub(crate) fn committed_generation_payload(generation: &SourceGenerationId) -> Value {
+    json!(
+        generation_payload_i64(generation, "committed_generation")
+            .expect("test generation id is payload-encodable")
+    )
+}
+
+pub(crate) fn source_generation_payload(generation: &SourceGenerationId) -> Value {
+    json!(
+        generation_payload_i64(generation, "source_generation")
+            .expect("test generation id is payload-encodable")
+    )
+}
+
+pub(crate) fn is_uncommitted_generation(value: &Value) -> bool {
+    value.is_null()
+}
 
 #[async_trait]
 impl ServiceJobRuntime for NoopServiceRuntime {

--- a/crates/axon-services/src/web_source_failure_tests.rs
+++ b/crates/axon-services/src/web_source_failure_tests.rs
@@ -5,6 +5,8 @@ use axon_ledger::store::FakeLedgerStore;
 use axon_vectors::store::{FakeVectorMode, FakeVectorStore};
 use serde_json::json;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{WebSourceIndexInput, index_web_source};
 
 fn job_id() -> JobId {
@@ -173,7 +175,7 @@ async fn partial_unchanged_vector_copy_failure_keeps_previous_web_generation_vis
         .collect::<Vec<_>>();
     assert!(!api_points.is_empty());
     assert!(api_points.iter().all(|point| {
-        point.payload["committed_generation"].as_str() == Some(first.generation.0.as_str())
+        point.payload["committed_generation"] == committed_generation_payload(&first.generation)
     }));
 }
 

--- a/crates/axon-services/src/web_source_tests.rs
+++ b/crates/axon-services/src/web_source_tests.rs
@@ -4,6 +4,8 @@ use axon_ledger::store::FakeLedgerStore;
 use axon_vectors::store::FakeVectorStore;
 use serde_json::json;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{WebSourceIndexInput, index_web_source};
 
 fn job_id() -> JobId {
@@ -66,7 +68,8 @@ async fn web_source_refresh_writes_vectors_then_commits_generation() {
             && point.payload["web_domain"].as_str() == Some("example.com")
             && point.payload["visibility"].as_str() == Some("internal")
             && point.payload["redaction_status"].as_str() == Some("clean")
-            && point.payload["committed_generation"].as_str() == Some(output.generation.0.as_str())
+            && point.payload["committed_generation"]
+                == committed_generation_payload(&output.generation)
             && point.payload["document_status"].as_str() == Some("published")
     }));
 }
@@ -220,7 +223,7 @@ async fn mixed_web_refresh_carries_unchanged_vectors_into_new_generation() {
         })
         .collect::<Vec<_>>();
     assert!(api_points.iter().any(|point| {
-        point.payload["committed_generation"].as_str() == Some(second.generation.0.as_str())
+        point.payload["committed_generation"] == committed_generation_payload(&second.generation)
     }));
 }
 

--- a/crates/axon-services/src/youtube_source_tests.rs
+++ b/crates/axon-services/src/youtube_source_tests.rs
@@ -6,6 +6,8 @@ use axon_ledger::store::{FakeLedgerStore, LedgerStore};
 use axon_vectors::store::FakeVectorStore;
 use std::sync::Arc;
 
+use crate::test_support::committed_generation_payload;
+
 use super::{YoutubeSourceIndexInput, index_youtube_source, index_youtube_source_with_job};
 
 const TARGET_URL: &str = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
@@ -113,8 +115,8 @@ async fn youtube_source_refresh_writes_vectors_then_commits_source_generation() 
             .points("axon-test")
             .await
             .iter()
-            .all(|point| point.payload["committed_generation"].as_str()
-                == Some(output.generation.0.as_str()))
+            .all(|point| point.payload["committed_generation"]
+                == committed_generation_payload(&output.generation))
     );
     assert!(
         vectors

--- a/docs/pipeline-unification/plans/2026-07-04-phase-9-tool-source-families-matrix.md
+++ b/docs/pipeline-unification/plans/2026-07-04-phase-9-tool-source-families-matrix.md
@@ -1,6 +1,6 @@
 # Tool Source Families Matrix Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
 
 **Goal:** Finish Phase 9 by putting local, git, web, feed, YouTube, Reddit, sessions, registry/package, CLI tool/script, MCP tool/call, and shared memory-document integration behind the unified source-family matrix, adapter fixture contract, generated capability docs, and new-source onboarding checklist.
 
@@ -61,7 +61,7 @@ The Lavra engineering review found that the original plan could overreach into i
 **Interfaces:**
 - Produces: `SourceFamily`, `SourceAdapterSpec`, `SourceFamilyMatrix`, `source_family_matrix() -> &'static [SourceAdapterSpec]`.
 
-- [ ] **Step 1: Add failing matrix completeness test**
+- [x] **Step 1: Add failing matrix completeness test**
 
 ```rust
 #[test]
@@ -85,13 +85,13 @@ fn matrix_contains_required_source_families() {
 }
 ```
 
-- [ ] **Step 2: Run the failing test**
+- [x] **Step 2: Run the failing test**
 
 Run: `cargo test -p axon-adapters family_matrix --no-fail-fast`
 
 Expected: compile failure if `axon-adapters` or the matrix types are incomplete; otherwise failure for missing family rows.
 
-- [ ] **Step 3: Implement adapter spec shape**
+- [x] **Step 3: Implement adapter spec shape**
 
 Implement the contract fields:
 
@@ -122,11 +122,11 @@ pub struct SourceAdapterSpec {
 }
 ```
 
-- [ ] **Step 4: Add contract-complete initial rows**
+- [x] **Step 4: Add contract-complete initial rows**
 
 Populate one row per required family. Rows may declare unsupported scopes only when the contract says the family does not support them, but every row must have a stable adapter name/version or integration name/version, source kinds where applicable, schemes, default scope, metadata families, security capability flags, degraded modes, and graph fact declarations. `MemoryIntegration` must set `is_source_adapter=false` and must not appear in resolver public source choices.
 
-- [ ] **Step 5: Run matrix tests**
+- [x] **Step 5: Run matrix tests**
 
 Run: `cargo test -p axon-adapters family_matrix --no-fail-fast`
 
@@ -145,7 +145,7 @@ Expected: matrix rows validate and every required family exists.
 - Consumes: `SourceAdapterSpec`.
 - Produces: `SourceOnboardingStatus` with rows matching `sources/new-source-contract.md`.
 
-- [ ] **Step 1: Add failing onboarding row test**
+- [x] **Step 1: Add failing onboarding row test**
 
 ```rust
 #[test]
@@ -171,17 +171,17 @@ fn required_families_have_all_onboarding_rows() {
 }
 ```
 
-- [ ] **Step 2: Run the failing test**
+- [x] **Step 2: Run the failing test**
 
 Run: `cargo test -p axon-adapters onboarding --no-fail-fast`
 
 Expected: required families without complete rows fail.
 
-- [ ] **Step 3: Implement status derivation**
+- [x] **Step 3: Implement status derivation**
 
 Derive onboarding status from adapter specs, fixture presence, metadata registry entries, graph declarations, parser family declarations, auth/security flags, and generated capability docs.
 
-- [ ] **Step 4: Record implementation-variant exceptions only**
+- [x] **Step 4: Record implementation-variant exceptions only**
 
 Create machine-readable exceptions only for provider-specific variants beyond the minimal required family fixture:
 
@@ -196,7 +196,7 @@ Create machine-readable exceptions only for provider-specific variants beyond th
 
 Exceptions are not allowed for the issue #298 Phase 9 checklist rows themselves. Security fixtures for SSRF, local path containment, tool execution, and redaction are mandatory for any family accepted by the public router.
 
-- [ ] **Step 5: Run onboarding tests**
+- [x] **Step 5: Run onboarding tests**
 
 Run: `cargo test -p axon-adapters onboarding --no-fail-fast`
 
@@ -219,7 +219,7 @@ Expected: every required family is complete; optional provider variants have exp
 - Consumes: adapter specs and testing contract fixture layout.
 - Produces: fixture validation for every required source adapter family.
 
-- [ ] **Step 1: Add fixture presence test**
+- [x] **Step 1: Add fixture presence test**
 
 ```rust
 #[test]
@@ -240,13 +240,13 @@ fn required_families_have_required_fixture_packs() {
 }
 ```
 
-- [ ] **Step 2: Run test**
+- [x] **Step 2: Run test**
 
 Run: `cargo test -p axon-adapters fixture_packs --no-fail-fast`
 
 Expected: missing fixture packs fail.
 
-- [ ] **Step 3: Add fixtures for every required source adapter family**
+- [x] **Step 3: Add fixtures for every required source adapter family**
 
 For each source adapter family, add:
 
@@ -265,13 +265,13 @@ metadata/public-fields.valid.json
 metadata/unknown-fields.internal.json
 ```
 
-- [ ] **Step 4: Validate fixture content**
+- [x] **Step 4: Validate fixture content**
 
 Each fixture must include source id, canonical URI, adapter name/version, source item key, item canonical URI, metadata family, graph declarations, redaction status, and expected degraded/error code where applicable.
 
 Source-job fixtures must include `job_id`, stage sequence, generation publish state, item/document/chunk/vector counts, cleanup debt behavior for removed items, and provider-degradation behavior.
 
-- [ ] **Step 5: Run fixture tests**
+- [x] **Step 5: Run fixture tests**
 
 Run: `cargo test -p axon-adapters fixtures --no-fail-fast`
 
@@ -291,7 +291,7 @@ Expected: all required fixture packs parse and validate.
 **Interfaces:**
 - Produces: bounded prepare/embed/vector/graph write batches for source-family ports.
 
-- [ ] **Step 1: Add failing batching test**
+- [x] **Step 1: Add failing batching test**
 
 ```rust
 #[tokio::test]
@@ -305,17 +305,17 @@ async fn source_pipeline_batches_prepare_embed_vector_and_graph_writes() {
 }
 ```
 
-- [ ] **Step 2: Run batching test**
+- [x] **Step 2: Run batching test**
 
 Run: `cargo test -p axon-services source_batch --no-fail-fast`
 
 Expected: test fails if item-by-item writes remain in required/public source ports.
 
-- [ ] **Step 3: Implement batch boundaries**
+- [x] **Step 3: Implement batch boundaries**
 
 Source adapters emit item streams; the service layer chunks them into bounded batches before preparing, embedding, vector upsert, and graph write. Batch events include batch id, item counts, chunk counts, byte counts, provider reservation ids, and elapsed time.
 
-- [ ] **Step 4: Run batching tests**
+- [x] **Step 4: Run batching tests**
 
 Run: `cargo test -p axon-services source_batch --no-fail-fast`
 
@@ -336,7 +336,7 @@ Expected: required/public source paths use bounded batches.
 - Consumes: `SecurityPolicy`, `AuthSnapshot`.
 - Produces: SSRF/local policy parity for web/feed/video/registry and local sources.
 
-- [ ] **Step 1: Add failing security fixture tests**
+- [x] **Step 1: Add failing security fixture tests**
 
 ```rust
 #[tokio::test]
@@ -354,21 +354,21 @@ async fn local_source_denies_secret_paths_without_local_scope() {
 }
 ```
 
-- [ ] **Step 2: Run security tests**
+- [x] **Step 2: Run security tests**
 
 Run: `cargo test -p axon-services source_security --no-fail-fast`
 
 Expected: failures identify missing SSRF or local policy enforcement.
 
-- [ ] **Step 3: Add required fixtures**
+- [x] **Step 3: Add required fixtures**
 
 Network fixtures cover private IPs, redirects, DNS rebinding, loopback, link-local, `file:` schemes, and Chrome/render-provider parity. Local fixtures cover `axon:local`, symlink-resolved containment, default denies for `.env`, SSH/cloud/Codex/Gemini/browser-profile paths, and absolute-path redaction.
 
-- [ ] **Step 4: Enforce before side effects**
+- [x] **Step 4: Enforce before side effects**
 
 Run security policy before fetch, render, local read, tool execution, artifact write, vector write, graph write, or job child creation.
 
-- [ ] **Step 5: Run policy tests**
+- [x] **Step 5: Run policy tests**
 
 Run: `cargo test -p axon-services source_security --no-fail-fast`
 
@@ -387,7 +387,7 @@ Expected: fixtures pass and no denied fixture produces side effects.
 **Interfaces:**
 - Produces: metadata-only/no-exec default and explicit execution path for CLI tool/script sources.
 
-- [ ] **Step 1: Add failing CLI tool adapter tests**
+- [x] **Step 1: Add failing CLI tool adapter tests**
 
 ```rust
 #[tokio::test]
@@ -406,17 +406,17 @@ async fn cli_tool_exec_requires_execute_scope_and_allowlist() {
 }
 ```
 
-- [ ] **Step 2: Run tool tests**
+- [x] **Step 2: Run tool tests**
 
 Run: `cargo test -p axon-adapters tool --no-fail-fast`
 
 Expected: missing adapter or policy behavior fails.
 
-- [ ] **Step 3: Implement adapter behavior**
+- [x] **Step 3: Implement adapter behavior**
 
 The adapter stores command, argv, env allowlist, side-effect class, timeout, output cap, redacted stdout/stderr artifact refs, and audit metadata. It never stores shell-expanded strings as authority; shell scripts require an explicit shell-script source class.
 
-- [ ] **Step 4: Run tool adapter tests**
+- [x] **Step 4: Run tool adapter tests**
 
 Run: `cargo test -p axon-adapters tool --no-fail-fast`
 
@@ -435,7 +435,7 @@ Expected: metadata-only and explicit execution policy tests pass.
 **Interfaces:**
 - Produces: MCP server/tool schema and optional tool-call source behavior.
 
-- [ ] **Step 1: Add failing MCP adapter tests**
+- [x] **Step 1: Add failing MCP adapter tests**
 
 ```rust
 #[tokio::test]
@@ -453,17 +453,17 @@ async fn mcp_tool_call_requires_execute_scope_and_redacts_output() {
 }
 ```
 
-- [ ] **Step 2: Run MCP adapter tests**
+- [x] **Step 2: Run MCP adapter tests**
 
 Run: `cargo test -p axon-adapters mcp --no-fail-fast`
 
 Expected: missing adapter or redaction behavior fails.
 
-- [ ] **Step 3: Implement adapter behavior**
+- [x] **Step 3: Implement adapter behavior**
 
 MCP adapter supports server schema discovery, tool metadata, optional tool call execution with explicit opt-in, auth snapshot enforcement, output cap, artifact refs, redacted stdout/stderr-equivalent payloads, and external-resource graph nodes.
 
-- [ ] **Step 4: Run MCP adapter tests**
+- [x] **Step 4: Run MCP adapter tests**
 
 Run: `cargo test -p axon-adapters mcp --no-fail-fast`
 
@@ -484,15 +484,15 @@ Expected: metadata-only, explicit execution, and redaction tests pass.
 **Interfaces:**
 - Produces: proof that memory is not a source adapter but uses shared preparation, payload, graph, and retrieval rules where memory documents overlap with source processing.
 
-- [ ] **Step 1: Add memory integration matrix test**
+- [x] **Step 1: Add memory integration matrix test**
 
 Assert the matrix includes `MemoryIntegration` with `is_source_adapter=false`, no resolver schemes, `vector_namespace=memory`, memory-specific metadata families, graph fact declarations, and no adapter acquisition scopes.
 
-- [ ] **Step 2: Add shared-pipeline memory fixture**
+- [x] **Step 2: Add shared-pipeline memory fixture**
 
 Create a memory document fixture that flows through `DocumentPreparer`, vector payload validation, graph candidate validation, and retrieval namespace filtering without creating a `SourceAdapter` row or source ledger generation.
 
-- [ ] **Step 3: Run memory integration tests**
+- [x] **Step 3: Run memory integration tests**
 
 Run:
 
@@ -516,7 +516,7 @@ Expected: memory uses shared preparation/payload/graph/retrieval rules where app
 - Consumes: adapter matrix and onboarding status.
 - Produces: regenerated CLI/MCP/REST capability docs and schemas.
 
-- [ ] **Step 1: Add generated capability drift test**
+- [x] **Step 1: Add generated capability drift test**
 
 ```rust
 #[test]
@@ -529,13 +529,13 @@ fn generated_capabilities_include_source_family_matrix() {
 }
 ```
 
-- [ ] **Step 2: Run generator checks**
+- [x] **Step 2: Run generator checks**
 
 Run: `cargo xtask schemas generate`
 
 Expected: generator writes updated artifacts if stale.
 
-- [ ] **Step 3: Run final Phase 9 checks**
+- [x] **Step 3: Run final Phase 9 checks**
 
 Run:
 


### PR DESCRIPTION
## Summary

- make the Phase 9 `cargo test -p axon-adapters fixtures` filter exercise both fixture-pack presence and fixture field validation
- update source-family tests to assert vector generation payloads through the shared numeric/null contract instead of stale string IDs
- add test helpers for committed/source generation payload values and uncommitted/null vector payload assertions

## Verification

- `cargo test -p axon-adapters family_matrix --no-fail-fast`
- `cargo test -p axon-adapters onboarding --no-fail-fast`
- `cargo test -p axon-adapters fixtures --no-fail-fast`
- `cargo test -p axon-adapters tool --no-fail-fast`
- `cargo test -p axon-adapters mcp --no-fail-fast`
- `cargo test -p axon-services source_batch --no-fail-fast`
- `cargo test -p axon-services source_security --no-fail-fast`
- `cargo test -p axon-memory shared_pipeline --no-fail-fast`
- `cargo test -p axon-retrieval memory --no-fail-fast`
- `cargo xtask schemas generate --check`
- `cargo test -p axon-services source --no-fail-fast`
- `cargo test -p xtask generated_adapter_capability_artifact_contains_tool_and_memory_contracts --no-fail-fast`
- `cargo test -p axon-adapters --no-fail-fast`
- `git diff --check`

## Scope Notes

- Based on live issue #298 and `docs/pipeline-unification/plans/2026-07-04-phase-9-tool-source-families-matrix.md`, this PR stays in Phase 9 verification/source-family behavior.
- Phase 10 removed-surface deletion and Phase 11 reset/preflight work are intentionally left untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens Phase 9 source-family verification by moving tests to the shared numeric/null generation payload contract and clarifying assertions across adapters. Also refreshes OpenAPI and generated clients to reflect unified job APIs; aligns with issue #298 without touching Phase 10/11.

- **Refactors**
  - Tests now assert `committed_generation`/`source_generation` via numeric payloads; uncommitted is `null`.
  - Added `axon-services` helpers: `committed_generation_payload`, `source_generation_payload`, `is_uncommitted_generation`; adapter tests updated to use them. Minor fixture test rename and validation now checks both pack presence and required fields.

- **Dependencies**
  - Regenerated OpenAPI and clients (Android, Palette Tauri `.d.ts`, Web client) to include unified job endpoints: list/status/events/artifacts/retry/cancel/cleanup/recover/stream.

<sup>Written for commit 0b26f19955987310776d970144b52c97a11c3542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in how generation state is validated across refresh and failure flows.
  * Strengthened checks around committed vs. uncommitted vector payloads, reducing the chance of mismatched state handling.
  * Added shared validation helpers to keep generation-related behavior aligned across different sources and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->