### PR TITLE
fix(deploy): axon native systemd on Incus, not nested-Docker; fix GPU passthrough gap

### DIFF
--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -1,15 +1,40 @@
-# Axon Incus deployment — nested Docker-in-Incus
+# Axon Incus deployment — nested Docker for qdrant/tei/chrome, native axon
 
-One Incus system container (`axon-container-profile`) runs a full Docker
-Engine + Compose internally, using `docker-compose.prod.yaml` largely
-unchanged. See `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md`
-for the (retained, harmless) Incus 6.3+/Zabbly upgrade this deployment builds
-on, and `axon_rust-4m749` (beads epic) for the full architecture history —
-including the same-day pivot to native Incus OCI containers and revert back
-to nested Docker, after native OCI's GPU-compute path was found genuinely
-broken (`CUDA_ERROR_OUT_OF_MEMORY` during TEI warmup) on this host/Incus
-version. See bead `axon_rust-4m749.2`'s comments for the full diagnostic
-trail if you're wondering why this isn't native OCI.
+One Incus system container (`axon-container-profile`) runs:
+
+- **qdrant (default mode only)/tei/chrome as nested Docker containers**, via
+  a full Docker Engine + Compose internally, using `docker-compose.prod.yaml`
+  largely unchanged.
+- **axon itself as a native binary managed by systemd** (`axon-native.service`),
+  built directly inside the container from the repo's own Dockerfile
+  builder/runtime stages, *not* as another nested-Docker service — see
+  "Why axon is native, not nested-Docker" below.
+
+See `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md` for the
+(retained, harmless) Incus 6.3+/Zabbly upgrade this deployment builds on, and
+`axon_rust-4m749` (beads epic) for the full architecture history — including
+the same-day pivot to native Incus OCI containers and revert back to nested
+Docker for qdrant/tei/chrome, after native OCI's GPU-compute path was found
+genuinely broken (`CUDA_ERROR_OUT_OF_MEMORY` during TEI warmup) on this
+host/Incus version. See bead `axon_rust-4m749.2`'s comments for the full
+diagnostic trail if you're wondering why qdrant/tei/chrome aren't native OCI.
+
+## Why axon is native, not nested-Docker
+
+Confirmed in production 2026-07-08 (bead `axon_rust-4m749.3`): a
+containerized axon reaching qdrant/tei/chrome over the nested "jakenet"
+bridge works fine, but publishing axon's *own* port back out to the host (for
+SWAG/Cloudflare to reach) requires an extra Docker port-proxy NAT hop —
+docker-proxy accepted external TCP connections and forwarded bytes to the
+container, but the connection was reset mid-relay, specifically for axon
+(qdrant/tei/chrome's identical docker-proxy-published ports worked
+correctly the entire time, ruling out a general nested-networking bug).
+Running axon as a native binary via systemd sidesteps that hop entirely — it
+binds directly in the Incus container's own network namespace, and reaches
+qdrant/tei/chrome over their already-published `127.0.0.1` ports like any
+other client would. `bootstrap.sh` builds the binary via `docker build
+--target runtime` (same Dockerfile stage production images use) and installs
+`axon-native.service`.
 
 ## Profile
 
@@ -116,3 +141,31 @@ incus config device add <container> nvidia-procfs disk \
 
 This is a required boot-time step in `bootstrap.sh` (bead `.5`), not a
 one-time fix — see that bead for the automated version.
+
+### Required — nvidia-container-toolkit inside the container
+
+The nested Docker Engine needs its own `nvidia-container-toolkit` + CDI
+registration to expose the GPU to `docker run --gpus all` — the outer
+`nvidia.runtime` profile setting only gives the *outer* container GPU
+visibility (`nvidia-smi` works directly in it), not the nested Docker Engine
+automatically. Confirmed missing from a from-scratch container build
+2026-07-08: `docker run --gpus all ...` failed with `failed to discover GPU
+vendor from CDI: no known GPU vendor found` even though the outer
+container's own `nvidia-smi` worked fine. A prior working deployment had this
+installed by hand outside any script; that state does not survive a
+container recreate. `bootstrap.sh` now installs it and regenerates the CDI
+spec on every run (the spec embeds nvidia-procfs device paths, which also
+don't survive a restart — see above).
+
+### Optional — exposing axon's port to the host
+
+`bootstrap.sh` manages an Incus `proxy` device (`mcp-publish`) that forwards
+a host-side address to axon's `127.0.0.1:8001` inside the container, when
+`AXON_INCUS_PUBLISH_LISTEN` is set (e.g. `100.88.16.79:40090`, dookie's
+Tailscale IP — matching what SWAG's `axon.subdomain.conf` proxies to).
+**Scope this to a specific interface address, never `0.0.0.0`** — the point
+is to expose axon only on the address the reverse proxy actually reaches,
+not every interface on the shared host. This device does not survive a
+container recreate; losing it (recreating the container without setting the
+env var again) is exactly what took `axon.tootie.tv` down with a 502 after a
+2026-07-08 redeploy — SWAG had nothing left to reach.

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -1,21 +1,49 @@
 #!/usr/bin/env bash
-# Idempotent bootstrap for axon's nested-Docker-in-Incus deployment.
+# Idempotent bootstrap for axon's Incus deployment.
+#
+# Split model (confirmed in production 2026-07-08, bead axon_rust-4m749.3):
+#   - qdrant (default mode only)/tei/chrome run as NESTED DOCKER containers
+#     inside the Incus container — they need the GPU-passthrough Docker
+#     Engine setup this script builds.
+#   - axon itself runs as a NATIVE BINARY via systemd directly inside the
+#     Incus container, NOT as a nested-Docker service. A containerized axon
+#     talking to nested-Docker qdrant/tei/chrome over the "jakenet" bridge
+#     needs no NAT hairpin of its own, but publishing axon's port back out to
+#     the host (for SWAG/Cloudflare) requires an extra NAT hop through
+#     Docker's own port-proxy for every single request; that hop was found to
+#     silently reset connections in this environment (TCP handshake
+#     completes, backend byte relay resets) while every OTHER nested service
+#     on the same bridge/docker-proxy mechanism worked fine — i.e. axon
+#     specifically, not nested Docker networking in general. Native + systemd
+#     sidesteps that hop entirely: axon binds directly to the Incus
+#     container's own network namespace, and only reads from
+#     qdrant/tei/chrome over their already-published localhost ports.
 #
 # Usage:
 #   deploy/incus/bootstrap.sh [default|external-qdrant]
 #
-# default mode:          bundled qdrant starts alongside axon/tei/chrome.
+# default mode:          bundled qdrant starts alongside tei/chrome.
 # external-qdrant mode:  requires AXON_EXTERNAL_QDRANT_URL; bundled qdrant is
 #                        not started, axon points at the external instance.
 #
-# Safe to re-run at any time (idempotent). Also the intended entry point for
-# the companion systemd unit (axon-incus-bootstrap.service) that re-runs this
-# on every host boot, since boot.autostart=true alone does not re-apply the
-# known-fragile nvidia-procfs device or re-verify GPU access.
+# Optional: set AXON_INCUS_PUBLISH_LISTEN (e.g. "100.88.16.79:40090") to have
+# this script manage the Incus `proxy` device that exposes axon's HTTP port
+# to the host for SWAG/Cloudflare. Scope this to a specific interface
+# address, never 0.0.0.0 — the whole point is to expose axon only on the
+# Tailscale-reachable address SWAG proxies to, not every interface on the
+# shared host. If unset, no proxy device is created/updated here; manage
+# host-side exposure yourself.
+#
+# Safe to re-run at any time (idempotent) — including to redeploy a new axon
+# binary build after a code change. Also the intended entry point for the
+# companion systemd unit (axon-incus-bootstrap.service) that re-runs this on
+# every host boot, since boot.autostart=true alone does not re-apply the
+# known-fragile nvidia-procfs device, re-verify GPU access, or restart the
+# native axon service.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-CONTAINER_NAME="${AXON_INCUS_CONTAINER:-axon-bootstrap-temp}"
+CONTAINER_NAME="${AXON_INCUS_CONTAINER:-axon}"
 PROFILE_NAME="axon-container-profile"
 GPU_PCI_ADDRESS="${AXON_GPU_PCI_ADDRESS:-0000:03:00.0}"
 DEPLOY_PATH="/opt/axon-deploy"
@@ -69,7 +97,9 @@ for _ in $(seq 1 30); do
 done
 [ "$ready" = "1" ] || fatal "container did not become exec-ready within 60s"
 
-### 5. Install Docker inside the container if missing (idempotent).
+### 5. Install Docker inside the container if missing (idempotent). Needed
+### for the nested qdrant/tei/chrome services (and to build axon's own
+### binary via the repo's Dockerfile builder stage — see step 15).
 if ! incus exec "$CONTAINER_NAME" -- sh -c 'command -v docker' >/dev/null 2>&1; then
   log "Docker not found inside container, installing..."
   incus exec "$CONTAINER_NAME" -- sh -c '
@@ -90,7 +120,43 @@ else
   log "Docker already present inside container"
 fi
 
-### 6. Re-apply the nvidia-procfs device. REQUIRED ON EVERY RUN — confirmed
+### 6. Install nvidia-container-toolkit inside the container (idempotent).
+### REQUIRED for the nested Docker Engine to expose the GPU to containers via
+### `docker run --gpus all` — confirmed missing from a from-scratch container
+### build 2026-07-08: without it, `docker run --gpus all ...` fails with
+### "failed to discover GPU vendor from CDI: no known GPU vendor found" even
+### though the outer Incus container's own `nvidia-smi` works fine (the
+### `nvidia.runtime` profile setting gives the OUTER container GPU access;
+### the NESTED Docker Engine needs its own toolkit + CDI registration on top
+### of that). A prior working deployment had this set up manually, outside
+### this script — that state does not survive a container recreate, hence
+### this step.
+if ! incus exec "$CONTAINER_NAME" -- sh -c 'command -v nvidia-ctk' >/dev/null 2>&1; then
+  log "nvidia-container-toolkit not found inside container, installing..."
+  incus exec "$CONTAINER_NAME" -- sh -c '
+    set -e
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+      | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+      | sed "s#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g" \
+      > /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    apt-get update -qq
+    apt-get install -y -qq nvidia-container-toolkit
+    nvidia-ctk runtime configure --runtime=docker
+    systemctl restart docker
+  '
+else
+  log "nvidia-container-toolkit already present inside container"
+fi
+# The CDI spec must be (re)generated on every run, not just at install time —
+# it embeds the current nvidia-procfs GPU device paths, which step 7 below
+# re-applies on every run because they do not reliably survive a container
+# stop/start cycle. A stale CDI spec from a previous boot would silently
+# reference now-invalid device paths.
+log "regenerating NVIDIA CDI spec"
+incus exec "$CONTAINER_NAME" -- nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml >/dev/null 2>&1 || true
+
+### 7. Re-apply the nvidia-procfs device. REQUIRED ON EVERY RUN — confirmed
 ### (bead axon_rust-4m749.2) this does not reliably survive a container
 ### stop/start cycle, silently breaking nested-Docker GPU passthrough until
 ### removed and re-added.
@@ -100,7 +166,7 @@ incus config device add "$CONTAINER_NAME" nvidia-procfs disk \
   "source=/proc/driver/nvidia/gpus/${GPU_PCI_ADDRESS}" \
   "path=/proc/driver/nvidia/gpus/${GPU_PCI_ADDRESS}" >/dev/null
 
-### 7. Fail-closed GPU verification BEFORE anything GPU-dependent starts.
+### 8. Fail-closed GPU verification BEFORE anything GPU-dependent starts.
 ### Do not start TEI in a broken/CPU-fallback state — refuse and exit instead.
 ### Pull the verification image once, outside the retry loop — otherwise a
 ### cold image cache turns each retry into a registry pull-and-run, which
@@ -122,19 +188,21 @@ for _ in 1 2 3; do
 done
 [ "$gpu_ok" = "1" ] || fatal "GPU verification failed after 3 attempts — refusing to start TEI in a broken state. Check the nvidia-procfs device and host NVIDIA driver."
 
-### Resolve the env file now — needed by both the network-name lookup (9)
-### and the actual push (12).
+### Resolve the env file now — needed by the network-name lookup (10), the
+### axon-native systemd unit (16), and the actual push (13).
 env_file_on_host="${AXON_ENV_FILE:-$HOME/.axon/.env}"
 [ -f "$env_file_on_host" ] || fatal "env file not found at $env_file_on_host"
 
-### 8. Sync deploy artifacts (compose files + config/) into the container.
+### 9. Sync deploy artifacts (compose files + config/) into the container.
+### Only used for the nested qdrant/tei/chrome services now — axon itself is
+### built from the full repo tree separately in step 15.
 log "syncing compose files + config into ${DEPLOY_PATH}"
 incus exec "$CONTAINER_NAME" -- mkdir -p "$DEPLOY_PATH"
 incus file push "$REPO_ROOT/docker-compose.prod.yaml" "$CONTAINER_NAME$DEPLOY_PATH/docker-compose.prod.yaml"
 incus file push "$REPO_ROOT/docker-compose.external-qdrant.yaml" "$CONTAINER_NAME$DEPLOY_PATH/docker-compose.external-qdrant.yaml"
 incus file push -r "$REPO_ROOT/config" "$CONTAINER_NAME$DEPLOY_PATH/"
 
-### 9. Ensure the external Docker network exists (idempotent — compose
+### 10. Ensure the external Docker network exists (idempotent — compose
 ### requires this to pre-exist since docker-compose.prod.yaml declares it
 ### `external: true`). The real network name comes from DOCKER_NETWORK in the
 ### env file (defaults to "axon") — must match compose's own resolution
@@ -162,19 +230,6 @@ log "ensuring Docker network '$docker_network_name' exists"
 incus exec "$CONTAINER_NAME" -- docker network inspect "$docker_network_name" >/dev/null 2>&1 \
   || incus exec "$CONTAINER_NAME" -- docker network create "$docker_network_name" >/dev/null
 
-### 10. [removed] A prior version of this step computed a checksum of the
-### files this same script had just pushed in step 8 and compared it against
-### the last run's checksum — which can never differ, since step 8
-### unconditionally overwrites the container's copy with the host's current
-### copy on every run. That made it a no-op that logged a reassuring message
-### without ever being able to detect anything, which is worse than no check
-### at all (a future reader could mistake it for real drift detection). The
-### memory-headroom check in step 11 is this script's actual fail-closed
-### gate; if genuine tamper-evidence for the deployed config is needed later,
-### it needs to compare a HOST-side hash (computed before step 8's push, from
-### a value stored outside this script's own write path) — not container-side
-### state this script itself just wrote.
-
 ### 11. Memory-headroom check before starting bundled qdrant. This is the
 ### mandatory gate — dookie has a real, documented qdrant OOM-crashloop
 ### history; a config-integrity checksum alone would not have caught it.
@@ -187,71 +242,46 @@ if [ "$MODE" = "default" ]; then
   log "memory headroom check passed (${avail_gb}GB available)"
 fi
 
-### 12. Push the env-file and start the stack — --env-file is ALWAYS explicit,
-### no reliance on Compose's implicit .env-in-cwd behavior. Push with
-### --mode 0600 directly (not push-then-chmod as a separate step) — the
-### latter leaves the secrets file at incus file push's default mode for the
-### window between the two commands, readable by anything else in the same
-### container in the meantime.
+### 12. Push the env-file(s) — --env-file is ALWAYS explicit, no reliance on
+### Compose's implicit .env-in-cwd behavior. Push with --mode 0600 directly
+### (not push-then-chmod as a separate step) — the latter leaves the secrets
+### file at incus file push's default mode for the window between the two
+### commands, readable by anything else in the same container in the
+### meantime. Two copies are needed: $DEPLOY_PATH/.env for the nested-Docker
+### compose services, and /mnt/axon-data/.env for the native axon-native
+### systemd unit (step 16) — same secrets file, two paths each consumer reads
+### it from.
 incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME$DEPLOY_PATH/.env"
-# The axon service's own `env_file:` directive (compose, not the CLI flag
-# above) reads from ${AXON_HOME}/.env — which resolves to /mnt/axon-data/.env
-# once AXON_HOME is overridden below. Keep that copy in sync too (same
-# secrets file, two paths compose needs it at — see README for why the
-# split exists).
 incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME/mnt/axon-data/.env"
 
-# The shared ~/.axon/.env carries host-native paths meant for bare-host/
-# local-dev use (e.g. AXON_HOME=/home/jmagar/.axon, GEMINI_HOME resolving off
-# a bare-host $HOME) and may set AXON_IMAGE for a manually-tagged local build.
-# None of that is valid *inside* this Incus container, where data actually
-# lives at the mounted /mnt/axon-data and /mnt/axon-gemini — force the
-# correct values explicitly rather than trust whatever's in the shared file.
-# (Also: `incus exec` runs as root by default, so an unset $HOME-relative
-# default would resolve against /root, not /home/axon — another reason these
-# must be explicit, not left to the compose file's own fallback.)
-#
-# Passed via `incus exec --env`/`--cwd` flags, not interpolated into an
-# `sh -c` string — these values (AXON_INCUS_IMAGE, AXON_EXTERNAL_QDRANT_URL)
-# come from a trusted operator-authored env file today, but string
-# interpolation into a root-executed shell command is a shape worth avoiding
-# even when the current threat model doesn't require it: a stray single
-# quote in either value would otherwise splice arbitrary content into the
-# command.
-axon_incus_image="${AXON_INCUS_IMAGE:-ghcr.io/jmagar/axon:latest}"
-
+### 13. Bring up ONLY the nested-Docker services — qdrant (default mode)/tei/
+### chrome, never axon itself (see split-model rationale at the top of this
+### file). Explicit service names, not a bare `up -d`, so this stays correct
+### even if docker-compose.prod.yaml's `axon` service definition changes
+### later.
 if [ "$MODE" = "default" ]; then
   log "=== bundled qdrant IS starting locally (default mode) ==="
   incus exec "$CONTAINER_NAME" \
     --cwd "$DEPLOY_PATH" \
-    --env AXON_HOME=/mnt/axon-data \
-    --env GEMINI_HOME=/mnt/axon-gemini \
-    --env "AXON_IMAGE=${axon_incus_image}" \
-    -- docker compose --env-file .env -f docker-compose.prod.yaml up -d
+    -- docker compose --env-file .env -f docker-compose.prod.yaml up -d axon-qdrant axon-tei axon-chrome
 else
   log "=== bundled qdrant is NOT starting, using external QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL} ==="
   incus exec "$CONTAINER_NAME" \
     --cwd "$DEPLOY_PATH" \
-    --env AXON_HOME=/mnt/axon-data \
-    --env GEMINI_HOME=/mnt/axon-gemini \
-    --env "AXON_IMAGE=${axon_incus_image}" \
-    --env "AXON_EXTERNAL_QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL}" \
-    -- docker compose --env-file .env -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d
+    -- docker compose --env-file .env -f docker-compose.prod.yaml up -d axon-tei axon-chrome
 fi
 
-### 13. Health-check polling — EXPLICIT bounded timeout/retry (36 * 10s =
-### 360s max), sized against axon's own 180s start_period plus margin. No
-### open-ended "wait until ready" loop.
-### Assumes every service in docker-compose.prod.yaml defines a healthcheck
-### (true today for axon/axon-tei/axon-chrome/axon-qdrant) — a service added
-### later without one reports an empty .Health, which correctly fails this
-### check rather than being silently ignored, but will spin the full 360s
-### every time until it gets a healthcheck of its own.
-log "polling for all services healthy (bounded: up to 360s)"
+### 14. Health-check polling for the nested-Docker services — EXPLICIT
+### bounded timeout/retry (36 * 10s = 360s max). No open-ended "wait until
+### ready" loop. Assumes axon-tei/axon-chrome(/axon-qdrant) define
+### healthchecks (true today).
+log "polling for nested-Docker services healthy (bounded: up to 360s)"
+docker_services="axon-tei axon-chrome"
+[ "$MODE" = "default" ] && docker_services="axon-qdrant $docker_services"
 healthy=0
 for _ in $(seq 1 36); do
   statuses="$(incus exec "$CONTAINER_NAME" -- sh -c \
-    "cd $DEPLOY_PATH && docker compose -f docker-compose.prod.yaml ps --format '{{.Service}}:{{.Health}}'" 2>/dev/null || true)"
+    "cd $DEPLOY_PATH && docker compose -f docker-compose.prod.yaml ps ${docker_services} --format '{{.Service}}:{{.Health}}'" 2>/dev/null || true)"
   if [ -n "$statuses" ] && ! printf '%s\n' "$statuses" | grep -qv "healthy$"; then
     healthy=1
     break
@@ -259,21 +289,116 @@ for _ in $(seq 1 36); do
   sleep 10
 done
 if [ "$healthy" != "1" ]; then
-  # Fail closed here, not just warn — this is the one signal the systemd
-  # unit's Restart=no is designed to surface (a failed unit after boot means
-  # "check systemctl status", per axon-incus-bootstrap.service). Falling
-  # through to "bootstrap complete" with exit 0 would silently swallow the
-  # most common real-world failure mode (slow model load, transient GPU
-  # flake) exactly where the fail-closed design matters most. Services that
-  # did start are left running, not torn down — inspect 'docker compose ps'
-  # inside the container to see what's actually up.
-  fatal "not all services reported healthy within the bounded window (360s) — inspect 'docker compose ps' inside $CONTAINER_NAME"
+  fatal "not all nested-Docker services reported healthy within the bounded window (360s) — inspect 'docker compose ps' inside $CONTAINER_NAME"
 fi
 
-### 14. Enable Incus-level autostart. The companion systemd unit
+### 15. Build axon's own binary directly inside the container, using the
+### repo's own Dockerfile builder+runtime stages (matches production exactly
+### — same rust:1.94.0-bookworm toolchain, same feature flags, no ad hoc
+### `cargo build` invocation to keep in sync separately). Fed via a tar
+### stream on stdin rather than pushing the whole repo tree to a persistent
+### path first — avoids managing a stale source checkout inside the
+### container between runs. This is genuinely slow on a cold nested-Docker
+### build-cache (large workspace, no sccache inside the container) — expect
+### several minutes on the very first run; subsequent runs reuse Docker's
+### layer/BuildKit cache as long as the container itself isn't recreated.
+log "building axon runtime image inside the container (this can take a while on a cold cache)"
+tar cf - -C "$REPO_ROOT" \
+    --exclude=target --exclude=.git --exclude=node_modules \
+    --exclude=.worktrees --exclude='apps/*/node_modules' . \
+  | incus exec "$CONTAINER_NAME" -- docker build -q -f config/Dockerfile --target runtime -t axon-native:runtime - \
+  > /dev/null
+
+log "extracting axon binary from the built image"
+incus exec "$CONTAINER_NAME" -- sh -c '
+  set -e
+  cid="$(docker create axon-native:runtime)"
+  docker cp "$cid:/usr/local/bin/axon" /usr/local/bin/axon
+  docker rm "$cid" >/dev/null
+  chmod 755 /usr/local/bin/axon
+'
+
+### 16. Install/refresh the axon-native systemd unit and (re)start it — always
+### restart, even if the unit already existed, so a re-run of this script
+### picks up a freshly built binary. AXON_HOME/AXON_DATA_DIR are forced to
+### the Incus-internal mount path (the shared env file's own values are
+### bare-host paths, not valid inside this container — same reasoning as the
+### compose AXON_HOME override this replaced). AXON_HTTP_HOST is forced to
+### 0.0.0.0 unconditionally: the shared env file was found (2026-07-08)
+### carrying the pre-rename AXON_MCP_HTTP_HOST key, which the current binary
+### does not recognize, silently falling back to its 127.0.0.1 default and
+### making the whole deployment unreachable from outside the container with
+### no error at all. Forcing it here is correct for this deployment target
+### in every case — a native axon-native unit inside this container always
+### needs to listen on all interfaces to be reachable from the host/SWAG.
+log "installing axon-native systemd unit"
+cat > /tmp/axon-native.service <<'UNIT'
+[Unit]
+Description=Axon unified server (native binary, Incus-hosted)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/mnt/axon-data/.env
+Environment=AXON_HOME=/mnt/axon-data
+Environment=AXON_DATA_DIR=/mnt/axon-data
+Environment=AXON_HTTP_HOST=0.0.0.0
+WorkingDirectory=/mnt/axon-data
+ExecStart=/usr/local/bin/axon serve
+Restart=always
+RestartSec=5
+User=root
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+incus file push /tmp/axon-native.service "$CONTAINER_NAME/etc/systemd/system/axon-native.service"
+rm -f /tmp/axon-native.service
+incus exec "$CONTAINER_NAME" -- systemctl daemon-reload
+incus exec "$CONTAINER_NAME" -- systemctl enable axon-native.service >/dev/null 2>&1 || true
+incus exec "$CONTAINER_NAME" -- systemctl restart axon-native.service
+
+### 17. Health-check polling for the native axon service — same bounded
+### pattern as step 14 (36 * 10s = 360s max).
+log "polling for axon-native healthy (bounded: up to 360s)"
+axon_healthy=0
+for _ in $(seq 1 36); do
+  if incus exec "$CONTAINER_NAME" -- curl -fsS --max-time 4 http://127.0.0.1:8001/healthz >/dev/null 2>&1; then
+    axon_healthy=1
+    break
+  fi
+  sleep 10
+done
+if [ "$axon_healthy" != "1" ]; then
+  fatal "axon-native did not become healthy within the bounded window (360s) — inspect 'systemctl status axon-native' and 'journalctl -u axon-native' inside $CONTAINER_NAME"
+fi
+
+### 18. Optional: manage the Incus `proxy` device that exposes axon's HTTP
+### port to the host (for SWAG/Cloudflare to reach). Only touched when
+### AXON_INCUS_PUBLISH_LISTEN is set — deliberately scoped to a specific
+### interface address (e.g. the host's Tailscale IP), never 0.0.0.0, since
+### the point is to expose axon only on the address the reverse proxy
+### actually uses, not every interface on the shared host. This device does
+### not survive a container recreate (confirmed 2026-07-08 — the prior
+### working deployment had it added by hand, outside any script, and losing
+### it was the reason "axon.tootie.tv" 502'd after a redeploy), hence
+### managing it here on every run.
+if [ -n "${AXON_INCUS_PUBLISH_LISTEN:-}" ]; then
+  log "ensuring proxy device forwards ${AXON_INCUS_PUBLISH_LISTEN} -> 127.0.0.1:8001"
+  incus config device remove "$CONTAINER_NAME" mcp-publish >/dev/null 2>&1 || true
+  incus config device add "$CONTAINER_NAME" mcp-publish proxy \
+    "listen=tcp:${AXON_INCUS_PUBLISH_LISTEN}" \
+    "connect=tcp:127.0.0.1:8001" >/dev/null
+else
+  log "AXON_INCUS_PUBLISH_LISTEN not set — not managing host port exposure for axon"
+fi
+
+### 19. Enable Incus-level autostart. The companion systemd unit
 ### (axon-incus-bootstrap.service) is what actually re-runs THIS script after
 ### a host reboot — boot.autostart alone would restart the container but
-### skip the nvidia-procfs re-application and GPU re-verification above.
+### skip the nvidia-procfs re-application, GPU re-verification, and
+### axon-native restart above.
 incus config set "$CONTAINER_NAME" boot.autostart true
 
 log "bootstrap complete (mode: $MODE)"


### PR DESCRIPTION
## Summary

Redeploying axon on dookie's Incus container today (2026-07-08) surfaced three real, distinct bugs, all fixed here:

1. **`nvidia-container-toolkit` was never installed by `bootstrap.sh`** — a from-scratch container build failed nested-Docker GPU verification (`failed to discover GPU vendor from CDI`) even though the outer container's own `nvidia-smi` worked. A prior working deployment had this set up by hand outside any script; that state doesn't survive a container recreate. Now installed + CDI spec regenerated on every run.
2. **Axon should not run as a nested-Docker service.** A containerized axon reaching qdrant/tei/chrome over the nested bridge worked fine, but publishing axon's own port back to the host went through Docker's port-proxy and silently reset every connection mid-relay — specifically for axon (qdrant/tei/chrome's identically-published ports worked the whole time, ruling out a general nested-networking bug). Axon now runs as a native binary via a new `axon-native.service` systemd unit, built inside the container via `docker build --target runtime` against the repo's own Dockerfile stage.
3. **The persisted `.env` had the pre-rename `AXON_MCP_HTTP_HOST` key** instead of the current `AXON_HTTP_HOST`, so axon silently bound to `127.0.0.1` only — unreachable from outside the container, no error. `axon-native.service` now forces `AXON_HTTP_HOST=0.0.0.0` unconditionally.

Also adds optional `AXON_INCUS_PUBLISH_LISTEN`-driven management of the Incus `proxy` device that exposes axon's port to the host for SWAG/Cloudflare — this was previously added by hand and didn't survive the container recreate that surfaced bug #2, which is what actually took `axon.tootie.tv` down with a 502.

## Test plan

- [x] Verified end-to-end on dookie's live `axon` Incus container: qdrant(stopped, unused — real config points at tootie's external Qdrant)/tei/chrome via nested Docker, axon via `axon-native.service`, all healthy.
- [x] `axon.tootie.tv/healthz` → `200`, `/mcp` → `401` (correct, needs auth), `/.well-known/oauth-authorization-server` → valid discovery doc.
- [x] `bash -n deploy/incus/bootstrap.sh` clean.
- [ ] Full from-scratch redeploy of this exact script version not re-run end-to-end in this PR (the live host already reflects the equivalent manual steps) — recommend a dry run before the next real redeploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run axon as a native systemd service on Incus instead of nested Docker to stop docker-proxy connection resets and ensure reachability. Fix GPU passthrough by installing `nvidia-container-toolkit` and regenerating the NVIDIA CDI spec on each run; also force `AXON_HTTP_HOST=0.0.0.0`, with optional Incus `proxy` management for host publishing.

- **Bug Fixes**
  - Install `nvidia-container-toolkit` inside the container and regenerate the NVIDIA CDI spec every run; re-apply the `nvidia-procfs` device and fail-closed GPU verification before starting TEI.
  - Replace the nested axon container with a native `axon-native.service`; build the binary via `docker build --target runtime` inside the container to fix docker-proxy TCP resets.
  - Force `AXON_HTTP_HOST=0.0.0.0` in the systemd unit to avoid accidental localhost binding from stale env keys.

- **Migration**
  - Rerun `deploy/incus/bootstrap.sh` with your mode; it builds the axon binary, installs/starts `axon-native.service`, and brings up only qdrant/tei/chrome via Docker.
  - Set `AXON_INCUS_PUBLISH_LISTEN` (e.g. `100.88.x.x:40090`) to create the Incus `proxy` forwarding to `127.0.0.1:8001`; never use `0.0.0.0`.

<sup>Written for commit 23e4499bb18529d22c7ffb35d8e3efd444356c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a split deployment setup where core services run in containers and the main app runs as a native service inside the deployment environment.
  * Added optional host port exposure for the app through a configurable proxy setting.

* **Bug Fixes**
  * Improved GPU setup reliability during restarts and rebuilds.
  * Added stronger startup checks so deployments fail fast if required GPU support is unavailable.
  * Made service health checks more reliable and scoped to the selected deployment mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->