### PR TITLE
fix(deploy): correct Incus deployment docs/script to match live native-axon setup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -376,9 +376,14 @@ qdrant-down:
     docker compose --env-file "${AXON_ENV_FILE:-$HOME/.axon/.env}" -f docker-compose.yaml --profile local-qdrant rm -f axon-qdrant
 
 # Production stack (docker-compose.prod.yaml), bundled qdrant mode — the default.
-# Every invocation guarantees --env-file so TEI's env-driven config (e.g.
-# TEI_MAX_CONCURRENT_REQUESTS) can never silently fall back to its built-in
-# default the way it would with a bare `docker compose up`.
+# Every invocation guarantees --env-file so .env's values actually reach
+# Compose interpolation (a bare `docker compose up` from the wrong cwd can
+# miss the file entirely). Note this guarantees .env is READ, not that no
+# default-drift is possible: docker-compose.prod.yaml's own
+# TEI_MAX_CONCURRENT_REQUESTS:-512 fallback is a separate value from TEI's own
+# built-in default — this repo has hit that exact two-layer drift before
+# (32 vs 256 permits) and --env-file alone doesn't prevent a repeat if the
+# YAML's own fallback and .env's intended value ever diverge again.
 prod-up:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/Justfile
+++ b/Justfile
@@ -375,6 +375,50 @@ qdrant-down:
     docker compose --env-file "${AXON_ENV_FILE:-$HOME/.axon/.env}" -f docker-compose.yaml --profile local-qdrant stop axon-qdrant
     docker compose --env-file "${AXON_ENV_FILE:-$HOME/.axon/.env}" -f docker-compose.yaml --profile local-qdrant rm -f axon-qdrant
 
+# Production stack (docker-compose.prod.yaml), bundled qdrant mode — the default.
+# Every invocation guarantees --env-file so TEI's env-driven config (e.g.
+# TEI_MAX_CONCURRENT_REQUESTS) can never silently fall back to its built-in
+# default the way it would with a bare `docker compose up`.
+prod-up:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/lib/axon-env.sh
+    repo="$(pwd)"
+    env_file="$(resolve_axon_env_file "$repo")"
+    if [ -f "$env_file" ]; then
+      perm=$(stat -c '%a' "$env_file")
+      if [ "${perm: -2}" != "00" ]; then
+        echo "warn: $env_file is group/world-readable (mode $perm) — tighten with chmod 600" >&2
+      fi
+    fi
+    echo "=== bundled qdrant IS starting locally (default mode) ==="
+    docker compose --env-file "$env_file" -f docker-compose.prod.yaml up -d
+
+prod-down:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/lib/axon-env.sh
+    env_file="$(resolve_axon_env_file "$(pwd)")"
+    docker compose --env-file "$env_file" -f docker-compose.prod.yaml down
+
+# Production stack, external-qdrant override — this deployment's mode (qdrant
+# lives on tootie). Requires AXON_EXTERNAL_QDRANT_URL; fails loudly if unset.
+prod-up-external-qdrant:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/lib/axon-env.sh
+    repo="$(pwd)"
+    env_file="$(resolve_axon_env_file "$repo")"
+    echo "=== bundled qdrant is NOT starting, using external QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL:?AXON_EXTERNAL_QDRANT_URL must be set} ==="
+    docker compose --env-file "$env_file" -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d
+
+prod-down-external-qdrant:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/lib/axon-env.sh
+    env_file="$(resolve_axon_env_file "$(pwd)")"
+    docker compose --env-file "$env_file" -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml down
+
 # Backward-compatible aliases used by setup/docs for local infra.
 test-infra-up:
     just services-up

--- a/crates/axon-authz/src/http.rs
+++ b/crates/axon-authz/src/http.rs
@@ -293,24 +293,35 @@ pub async fn build_auth_policy(
             .filter(|s| !s.trim().is_empty())
             .unwrap_or_default();
 
+        // lab-auth's AuthConfigBuilder is configured below with
+        // .env_prefix("AXON_MCP"), so every key pushed here must carry that
+        // prefix (e.g. AXON_MCP_AUTH_MODE, AXON_MCP_PUBLIC_URL) even though
+        // the real, user-facing env vars we read from above are unprefixed
+        // (AXON_AUTH_MODE, AXON_PUBLIC_URL, per .env.example) — these two
+        // naming schemes are unrelated; this vars Vec is an internal,
+        // synthetic source for the builder, not the real environment.
         let mut vars: Vec<(String, String)> = Vec::with_capacity(16);
-        push_var(&mut vars, "AXON_AUTH_MODE", "oauth");
+        push_var(&mut vars, "AXON_MCP_AUTH_MODE", "oauth");
         if let Some(url) = public_url.as_deref() {
-            push_var(&mut vars, "AXON_PUBLIC_URL", url);
+            push_var(&mut vars, "AXON_MCP_PUBLIC_URL", url);
         }
         if let Some(id) = google_client_id.as_deref() {
-            push_var(&mut vars, "AXON_GOOGLE_CLIENT_ID", id);
+            push_var(&mut vars, "AXON_MCP_GOOGLE_CLIENT_ID", id);
         }
         if let Some(secret) = google_client_secret.as_deref() {
-            push_var(&mut vars, "AXON_GOOGLE_CLIENT_SECRET", secret);
+            push_var(&mut vars, "AXON_MCP_GOOGLE_CLIENT_SECRET", secret);
         }
         if !admin_email.is_empty() {
-            push_var(&mut vars, "AXON_AUTH_ADMIN_EMAIL", &admin_email);
+            push_var(&mut vars, "AXON_MCP_AUTH_ADMIN_EMAIL", &admin_email);
         }
         // Pass allowed redirect URIs; always include claude.ai as a default.
         let allowed_uris = build_allowed_redirect_uris();
         if !allowed_uris.is_empty() {
-            push_var(&mut vars, "AXON_ALLOWED_REDIRECT_URIS", &allowed_uris);
+            push_var(
+                &mut vars,
+                "AXON_MCP_AUTH_ALLOWED_REDIRECT_URIS",
+                &allowed_uris,
+            );
         }
 
         let auth_config = build_oauth_auth_config_from_sources(vars)?;

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -1,0 +1,118 @@
+# Axon Incus deployment — nested Docker-in-Incus
+
+One Incus system container (`axon-container-profile`) runs a full Docker
+Engine + Compose internally, using `docker-compose.prod.yaml` largely
+unchanged. See `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md`
+for the (retained, harmless) Incus 6.3+/Zabbly upgrade this deployment builds
+on, and `axon_rust-4m749` (beads epic) for the full architecture history —
+including the same-day pivot to native Incus OCI containers and revert back
+to nested Docker, after native OCI's GPU-compute path was found genuinely
+broken (`CUDA_ERROR_OUT_OF_MEMORY` during TEI warmup) on this host/Incus
+version. See bead `axon_rust-4m749.2`'s comments for the full diagnostic
+trail if you're wondering why this isn't native OCI.
+
+## Profile
+
+`profile.yaml` in this directory is exported directly from the live,
+validated Incus profile (`incus profile show axon-container-profile`),
+minus the live-only `used_by` field. To apply it fresh:
+
+```bash
+incus profile create axon-container-profile
+incus profile edit axon-container-profile < deploy/incus/profile.yaml
+```
+
+Key config, and why:
+
+- `limits.memory: 24GiB` (hard) — derived as 16GiB qdrant (its own existing
+  production cap, justified by its own OOM history) + 2GiB TEI + 2GiB chrome
+  + 1GiB axon + 1GiB dockerd overhead, +~14% headroom. Re-verify this still
+  matches dookie's actual available headroom before relying on it — it was
+  derived once, not continuously monitored.
+- `nvidia.runtime: "true"` + `nvidia.driver.capabilities: all` — gives the
+  OUTER Incus container GPU/driver visibility (`nvidia-smi` works directly
+  in it). The GPU-compute workload (TEI) runs in a NESTED Docker container
+  inside this one, and gets its own GPU access via the nested dockerd's own
+  `nvidia-container-toolkit` — this is a real, working double-hop, confirmed
+  end-to-end with the actual production TEI image (bead `.2`).
+- `security.nesting: "true"`, `security.privileged: "false"`,
+  `security.syscalls.intercept.{mknod,setxattr}: "true"` — required for the
+  nested Docker Engine to function inside an unprivileged Incus container.
+- `security.idmap.isolated: "true"` — per-container isolated UID/GID range,
+  not a privileged or shared idmap. Container UID 1000 (what axon's Docker
+  images run as) maps to a host UID that's stable per-container-instance but
+  **not guaranteed identical across a fresh container recreate** — always
+  read it back via `incus config get <name> volatile.idmap.current` after
+  creating a container, never hardcode the number.
+- `gpu` device (bare, no extra options) — whole-GPU passthrough to the outer
+  container.
+
+## Storage
+
+`~/.axon` (the real host appdata root used by today's bare-host / local-dev
+deployment) is **NOT** shared directly with this Incus container. A real
+attempt to `raw.idmap` the container's UID 1000 onto the real host UID 1000
+(jmagar) fails: `/etc/subuid` deliberately excludes real system UIDs like
+1000 from root's delegation range (`newuidmap: uid range [1000-1001) ->
+[1000-1001) not allowed` — intentional Linux security policy, not a bug to
+work around).
+
+The resolution: two **separate**, dedicated host directories, chowned to
+whatever host UID the container's isolated idmap currently shifts container
+UID 1000 to:
+
+| Host path | Container path | Purpose |
+|---|---|---|
+| `~/.axon-incus` | `/mnt/axon-data` | jobs.db, config.toml, .env, qdrant storage, TEI cache, artifacts, logs, screenshots — everything `docker-compose.prod.yaml` expects under `${AXON_HOME}` |
+| `~/.axon-incus-gemini` | `/mnt/axon-gemini` (read-only) | Gemini CLI auth (`oauth_creds.json`, `gemini-credentials.json`, etc.) |
+
+**This is a deliberate, permanent fork from `~/.axon`, not a temporary
+workaround.** Host-native CLI commands (`axon doctor`, `axon stats` run
+directly on the bare host, outside any Incus instance) will **not** see this
+deployment's data, and vice versa. If you're debugging and see stale/empty
+results, check which tree you're actually looking at before assuming
+something is broken.
+
+Both paths live under `/home/jmagar` (ZFS dataset `rpool/USERDATA/home_hon64g`),
+so they're automatically covered by whatever snapshot/replication policy
+already covers this host's home dataset — no new backup-side configuration
+needed.
+
+### Verified 2026-07-07 (real command output, not description)
+
+- Mount visibility: `incus exec axon-bootstrap-temp -- ls -la /mnt/axon-data
+  /mnt/axon-gemini` shows all files/dirs correctly owned by UID 1000 *as seen
+  from inside the container* (idmap-shifted; the same files show as UID
+  `1066536` from the host side).
+- UID 1000 read/write: `docker run --rm --user 1000:1000 -v
+  /mnt/axon-data:/data alpine sh -c 'touch /data/test.txt'` succeeds; the
+  resulting file lands on the host owned by `1066536:1066536`, not root.
+- Adversarial path-traversal test: `docker run --rm --user 1000:1000 -v
+  /mnt/axon-data:/data alpine sh -c 'touch /data/../escape.txt'` →
+  `Permission denied` (the bind mount is its own boundary; `..` doesn't
+  escape it).
+- Adversarial outer-container test: attempting to `touch
+  /home/jmagar/escape-test.txt` from inside the outer Incus container (as
+  root) → `No such file or directory` — the outer container's rootfs simply
+  has no visibility into the host filesystem outside its declared disk
+  devices at all.
+
+### Known fragility — nvidia-procfs device
+
+A third device, `nvidia-procfs` (bind-mounting
+`/proc/driver/nvidia/gpus/<pci-address>` from host to the same path in the
+container), is required for nested-Docker GPU passthrough specifically — and
+does **not** reliably survive a container stop/start cycle. If nested Docker
+GPU access breaks after a restart with `nvidia-container-cli: mount error:
+stat failed: /proc/driver/nvidia/gpus/...: no such file or directory`,
+remove and re-add this device:
+
+```bash
+incus config device remove <container> nvidia-procfs
+incus config device add <container> nvidia-procfs disk \
+  source=/proc/driver/nvidia/gpus/0000:03:00.0 \
+  path=/proc/driver/nvidia/gpus/0000:03:00.0
+```
+
+This is a required boot-time step in `bootstrap.sh` (bead `.5`), not a
+one-time fix — see that bead for the automated version.

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -1,15 +1,60 @@
-# Axon Incus deployment — nested Docker-in-Incus
+# Axon Incus deployment — native axon + nested Docker sidecars
 
-One Incus system container (`axon-container-profile`) runs a full Docker
-Engine + Compose internally, using `docker-compose.prod.yaml` largely
-unchanged. See `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md`
+One Incus system container (`axon-container-profile`) hosts the whole axon
+stack, but it is **not** all-Docker. Two distinct process models run side by
+side inside the same container:
+
+- **axon itself** runs as a **native systemd service**
+  (`axon-native.service`, `/usr/local/bin/axon serve`) — built in place with
+  `cargo build --release` (Debian x86_64, same OS/arch as dookie — no
+  cross-compilation, no image to build or publish for axon).
+- **axon-tei, axon-chrome, and (default mode) axon-qdrant** run as **nested
+  Docker containers** via `docker compose`, using `docker-compose.prod.yaml`
+  largely unchanged (that file still defines an `axon` service too, but
+  `bootstrap.sh` deliberately excludes it from the Incus `up -d` invocation —
+  that definition exists for bare-host/non-Incus deployments).
+
+Why the split: axon is a single native binary that already runs correctly on
+the container's own OS — building/shipping a Docker image for it is pure
+overhead with no upside. TEI, chrome, and qdrant genuinely benefit from their
+own containerized runtimes/images (GPU toolkit layering, headless-browser
+deps, upstream-maintained images), so those stay on nested Docker.
+
+See `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md`
 for the (retained, harmless) Incus 6.3+/Zabbly upgrade this deployment builds
 on, and `axon_rust-4m749` (beads epic) for the full architecture history —
 including the same-day pivot to native Incus OCI containers and revert back
-to nested Docker, after native OCI's GPU-compute path was found genuinely
-broken (`CUDA_ERROR_OUT_OF_MEMORY` during TEI warmup) on this host/Incus
-version. See bead `axon_rust-4m749.2`'s comments for the full diagnostic
-trail if you're wondering why this isn't native OCI.
+to nested Docker for the sidecars, after native OCI's GPU-compute path was
+found genuinely broken (`CUDA_ERROR_OUT_OF_MEMORY` during TEI warmup) on this
+host/Incus version. See bead `axon_rust-4m749.2`'s comments for the full
+diagnostic trail if you're wondering why the sidecars aren't native OCI.
+
+## Axon process model (native systemd)
+
+`axon-native.service` (`deploy/incus/axon-native.service`, pushed and enabled
+by `bootstrap.sh`) runs `/usr/local/bin/axon serve` directly as root inside
+the Incus container, reading `EnvironmentFile=/mnt/axon-data/.env` for
+config/secrets — the same `.env` the Docker sidecars use, just consumed via
+systemd's own env-file mechanism instead of Compose's.
+
+`bootstrap.sh` builds the binary in place on every run where the installed
+`axon --version` doesn't match the checkout's `Cargo.toml` version (or when
+`AXON_FORCE_REBUILD=1` is set): it ships the source as a `git archive HEAD`
+tarball (never a full git clone, so the container never needs its own git
+credentials), builds with `cargo build --release --bin axon` under a
+container-local Rust toolchain (installed via `rustup` on first run), and
+installs the resulting binary to `/usr/local/bin/axon`. A version match skips
+the rebuild — this keeps idempotent re-runs (including the post-reboot
+systemd re-run) fast; only an actual version bump or an explicit force
+triggers a real rebuild.
+
+Check axon's own health with `systemctl status axon-native` / `journalctl -u
+axon-native` inside the container — **not** `docker ps`/`docker compose ps`,
+which will correctly show no `axon` entry at all. The service is reachable
+from the host through the Incus proxy device declared in the profile (see
+`incus config show <container>` for the current `listen`/`connect` mapping —
+it forwards a host-side address, not `localhost:8001` on the Incus host
+itself, to the container's `127.0.0.1:8001`).
 
 ## Profile
 
@@ -26,9 +71,10 @@ Key config, and why:
 
 - `limits.memory: 24GiB` (hard) — derived as 16GiB qdrant (its own existing
   production cap, justified by its own OOM history) + 2GiB TEI + 2GiB chrome
-  + 1GiB axon + 1GiB dockerd overhead, +~14% headroom. Re-verify this still
-  matches dookie's actual available headroom before relying on it — it was
-  derived once, not continuously monitored.
+  + 1GiB axon (native process, not a container, but still budgeted the same)
+  + 1GiB dockerd overhead, +~14% headroom. Re-verify this still matches
+  dookie's actual available headroom before relying on it — it was derived
+  once, not continuously monitored.
 - `nvidia.runtime: "true"` + `nvidia.driver.capabilities: all` — gives the
   OUTER Incus container GPU/driver visibility (`nvidia-smi` works directly
   in it). The GPU-compute workload (TEI) runs in a NESTED Docker container
@@ -46,6 +92,16 @@ Key config, and why:
   creating a container, never hardcode the number.
 - `gpu` device (bare, no extra options) — whole-GPU passthrough to the outer
   container.
+
+Not in the shared profile (deployment-specific, managed per-container by
+`bootstrap.sh`):
+
+- `mcp-publish` proxy device — forwards a host-side address (e.g. dookie's
+  Tailscale IP, a stable port) to the container's `127.0.0.1:8001`, where
+  `axon-native.service` listens. Set `AXON_HTTP_PUBLISH_LISTEN` (e.g.
+  `100.88.16.79:40090`) before running `bootstrap.sh` for it to manage this
+  device idempotently; check the live mapping any time with `incus config
+  show <container>`.
 
 ## Storage
 

--- a/deploy/incus/axon-incus-bootstrap.env.example
+++ b/deploy/incus/axon-incus-bootstrap.env.example
@@ -1,0 +1,9 @@
+# Copy to /etc/axon-incus-bootstrap.env (root-owned, mode 600 — contains no
+# secrets itself, but keep it tight since it's read by a root-run systemd unit).
+#
+# Required for external-qdrant mode (this deployment's mode on dookie):
+AXON_EXTERNAL_QDRANT_URL=http://100.120.242.29:53333
+
+# Optional — defaults to $HOME/.axon/.env if unset. Set explicitly here since
+# systemd services don't have a shell $HOME by default.
+AXON_ENV_FILE=/home/jmagar/.axon/.env

--- a/deploy/incus/axon-incus-bootstrap.service
+++ b/deploy/incus/axon-incus-bootstrap.service
@@ -10,7 +10,13 @@ Type=oneshot
 # external-qdrant override, since qdrant lives on tootie for RAM reasons.
 # AXON_EXTERNAL_QDRANT_URL and AXON_ENV_FILE are read from the environment
 # file below rather than hardcoded here.
-EnvironmentFile=-/etc/axon-incus-bootstrap.env
+# No leading "-": this file is required, not optional. external-qdrant mode
+# hard-requires AXON_EXTERNAL_QDRANT_URL, which only comes from here — a
+# missing file should fail loudly and distinctly at the systemd level
+# ("condition failed: EnvironmentFile does not exist"), not silently proceed
+# into bootstrap.sh's own more generic "AXON_EXTERNAL_QDRANT_URL must be set"
+# error, which would conflate "file missing" with "file present but empty".
+EnvironmentFile=/etc/axon-incus-bootstrap.env
 ExecStart=/home/jmagar/workspace/axon/deploy/incus/bootstrap.sh external-qdrant
 # Fail closed and stay failed (do not retry silently) — a discoverable
 # `systemctl status axon-incus-bootstrap` failure is the intended signal for

--- a/deploy/incus/axon-incus-bootstrap.service
+++ b/deploy/incus/axon-incus-bootstrap.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Re-run axon's Incus nested-Docker bootstrap after boot
+After=incus.service network-online.target
+Wants=network-online.target
+Requires=incus.service
+
+[Service]
+Type=oneshot
+# Mode is fixed at install time — this deployment (dookie) always uses the
+# external-qdrant override, since qdrant lives on tootie for RAM reasons.
+# AXON_EXTERNAL_QDRANT_URL and AXON_ENV_FILE are read from the environment
+# file below rather than hardcoded here.
+EnvironmentFile=-/etc/axon-incus-bootstrap.env
+ExecStart=/home/jmagar/workspace/axon/deploy/incus/bootstrap.sh external-qdrant
+# Fail closed and stay failed (do not retry silently) — a discoverable
+# `systemctl status axon-incus-bootstrap` failure is the intended signal for
+# an operator investigating "why didn't the stack come back after reboot".
+Restart=no
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/incus/axon-native.service
+++ b/deploy/incus/axon-native.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Axon unified server (native binary, Incus-hosted)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/mnt/axon-data/.env
+Environment=AXON_HOME=/mnt/axon-data
+Environment=AXON_DATA_DIR=/mnt/axon-data
+WorkingDirectory=/mnt/axon-data
+ExecStart=/usr/local/bin/axon serve
+Restart=always
+RestartSec=5
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -107,7 +107,9 @@ incus config device add "$CONTAINER_NAME" nvidia-procfs disk \
 ### conflates "GPU/nvidia-procfs isn't ready yet" with "registry is slow,"
 ### and 3s between retries isn't enough time for a fresh pull anyway.
 GPU_VERIFY_IMAGE="nvidia/cuda:12.6.0-base-ubuntu24.04"
-incus exec "$CONTAINER_NAME" -- docker pull "$GPU_VERIFY_IMAGE" >/dev/null 2>&1 || true
+if ! incus exec "$CONTAINER_NAME" -- docker pull "$GPU_VERIFY_IMAGE" >/dev/null 2>&1; then
+  log "warn: could not pre-pull ${GPU_VERIFY_IMAGE} (registry/network issue?) — if GPU verification below fails, check network/registry access first, not just the GPU/driver"
+fi
 log "verifying nested-Docker GPU access (fail-closed if this doesn't work)"
 gpu_ok=0
 for _ in 1 2 3; do
@@ -142,11 +144,20 @@ incus file push -r "$REPO_ROOT/config" "$CONTAINER_NAME$DEPLOY_PATH/"
 ### correctly) instead of a one-off grep, in a subshell so it doesn't leak
 ### the whole env file into this script's environment.
 # shellcheck source=/dev/null
+docker_network_load_err="$(mktemp)"
 docker_network_name="$(
   source "$REPO_ROOT/scripts/lib/axon-env.sh"
-  AXON_ENV_FILE="$env_file_on_host" load_axon_env_file "$REPO_ROOT" 2>/dev/null || true
+  AXON_ENV_FILE="$env_file_on_host" load_axon_env_file "$REPO_ROOT" 2>"$docker_network_load_err"
   printf '%s' "${DOCKER_NETWORK:-axon}"
 )"
+# This deployment specifically relies on a non-default DOCKER_NETWORK value
+# (dookie's ~/.axon/.env sets jakenet) — a silently-swallowed parse failure
+# here would fall through to the "axon" default and misroute the whole stack
+# onto the wrong bridge with no visible error. Surface it instead.
+if [ -s "$docker_network_load_err" ]; then
+  log "warn: error loading ${env_file_on_host} while resolving DOCKER_NETWORK: $(cat "$docker_network_load_err")"
+fi
+rm -f "$docker_network_load_err"
 log "ensuring Docker network '$docker_network_name' exists"
 incus exec "$CONTAINER_NAME" -- docker network inspect "$docker_network_name" >/dev/null 2>&1 \
   || incus exec "$CONTAINER_NAME" -- docker network create "$docker_network_name" >/dev/null

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -1,17 +1,30 @@
 #!/usr/bin/env bash
-# Idempotent bootstrap for axon's nested-Docker-in-Incus deployment.
+# Idempotent bootstrap for axon's Incus deployment.
+#
+# Architecture: HYBRID, not all-Docker. Only axon-tei, axon-chrome, and
+# (default mode) axon-qdrant run as nested-Docker containers inside the Incus
+# container. The axon binary itself runs natively via systemd
+# (axon-native.service) directly on the Incus container's own OS — no
+# container image is built or shipped for axon. This avoids the build/publish
+# overhead of a Docker image for a binary that already runs fine as a native
+# process on the same OS family as the Incus container (Debian, x86_64,
+# matching dookie's host arch — no cross-compilation needed). See
+# deploy/incus/README.md for the full rationale.
 #
 # Usage:
 #   deploy/incus/bootstrap.sh [default|external-qdrant]
 #
-# default mode:          bundled qdrant starts alongside axon/tei/chrome.
+# default mode:          bundled qdrant starts alongside tei/chrome; axon
+#                        (native) points at the bundled qdrant.
 # external-qdrant mode:  requires AXON_EXTERNAL_QDRANT_URL; bundled qdrant is
-#                        not started, axon points at the external instance.
+#                        not started, axon (native) points at the external
+#                        instance instead.
 #
 # Safe to re-run at any time (idempotent). Also the intended entry point for
 # the companion systemd unit (axon-incus-bootstrap.service) that re-runs this
 # on every host boot, since boot.autostart=true alone does not re-apply the
-# known-fragile nvidia-procfs device or re-verify GPU access.
+# known-fragile nvidia-procfs device, re-verify GPU access, or rebuild/restart
+# the native axon binary.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -89,6 +102,43 @@ if ! incus exec "$CONTAINER_NAME" -- sh -c 'command -v docker' >/dev/null 2>&1; 
 else
   log "Docker already present inside container"
 fi
+
+### 5b. Install the Rust toolchain natively inside the container (idempotent)
+### — needed to build the axon binary in place, matching the container's own
+### OS/arch (Debian x86_64, same as dookie — no cross-compilation).
+if ! incus exec "$CONTAINER_NAME" -- sh -c 'command -v /root/.cargo/bin/cargo' >/dev/null 2>&1; then
+  log "Rust toolchain not found inside container, installing via rustup..."
+  incus exec "$CONTAINER_NAME" -- sh -c \
+    'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable'
+else
+  log "Rust toolchain already present inside container"
+fi
+
+### 5c. Build + install the axon binary natively — skip the rebuild if a
+### binary already installed reports the same version as this checkout's
+### Cargo.toml (keeps re-runs fast; a version bump or explicit force forces
+### a rebuild). Source is shipped as a plain archive (git archive, not a full
+### clone) so the container never needs its own git credentials.
+axon_repo_version="$(awk -F'"' '/^version = /{print $2; exit}' "$REPO_ROOT/Cargo.toml")"
+installed_version="$(incus exec "$CONTAINER_NAME" -- sh -c '/usr/local/bin/axon --version 2>/dev/null' | awk '{print $2}' || true)"
+if [ "$installed_version" = "$axon_repo_version" ] && [ "${AXON_FORCE_REBUILD:-0}" != "1" ]; then
+  log "axon binary already at v${installed_version}, skipping native build (set AXON_FORCE_REBUILD=1 to force)"
+else
+  log "building axon v${axon_repo_version} natively inside container (was: ${installed_version:-none}) — this can take several minutes"
+  incus exec "$CONTAINER_NAME" -- rm -rf /root/axon-src
+  incus exec "$CONTAINER_NAME" -- mkdir -p /root/axon-src
+  git -C "$REPO_ROOT" archive HEAD | incus exec "$CONTAINER_NAME" -- tar -x -C /root/axon-src
+  incus exec "$CONTAINER_NAME" --cwd /root/axon-src --env "PATH=/root/.cargo/bin:/usr/bin:/bin" \
+    -- cargo build --release --bin axon
+  incus exec "$CONTAINER_NAME" -- install -m 0755 /root/axon-src/target/release/axon /usr/local/bin/axon
+fi
+
+### 5d. Install + enable the axon-native systemd unit (idempotent — re-copying
+### and re-enabling an already-enabled unit is a no-op).
+incus file push "$REPO_ROOT/deploy/incus/axon-native.service" \
+  "$CONTAINER_NAME/etc/systemd/system/axon-native.service"
+incus exec "$CONTAINER_NAME" -- systemctl daemon-reload
+incus exec "$CONTAINER_NAME" -- systemctl enable axon-native.service >/dev/null 2>&1 || true
 
 ### 6. Re-apply the nvidia-procfs device. REQUIRED ON EVERY RUN — confirmed
 ### (bead axon_rust-4m749.2) this does not reliably survive a container
@@ -212,47 +262,63 @@ incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME/mnt/axon-data/.
 # must be explicit, not left to the compose file's own fallback.)
 #
 # Passed via `incus exec --env`/`--cwd` flags, not interpolated into an
-# `sh -c` string — these values (AXON_INCUS_IMAGE, AXON_EXTERNAL_QDRANT_URL)
-# come from a trusted operator-authored env file today, but string
-# interpolation into a root-executed shell command is a shape worth avoiding
-# even when the current threat model doesn't require it: a stray single
-# quote in either value would otherwise splice arbitrary content into the
-# command.
-axon_incus_image="${AXON_INCUS_IMAGE:-ghcr.io/jmagar/axon:latest}"
+# `sh -c` string — this value (AXON_EXTERNAL_QDRANT_URL) comes from a
+# trusted operator-authored env file today, but string interpolation into a
+# root-executed shell command is a shape worth avoiding even when the current
+# threat model doesn't require it: a stray single quote would otherwise
+# splice arbitrary content into the command.
 
+### Only the sidecar services run via docker compose here — axon itself runs
+### natively (step 5c/5d above), so it is deliberately excluded from the `up
+### -d` service list even though docker-compose.prod.yaml still defines an
+### `axon` service (that definition is for bare-host/non-Incus deployments).
+### AXON_HOME is still needed here: axon-tei and axon-qdrant's volume mounts
+### resolve off it. GEMINI_HOME/AXON_IMAGE are not — those only apply to the
+### now-excluded `axon` service definition.
 if [ "$MODE" = "default" ]; then
   log "=== bundled qdrant IS starting locally (default mode) ==="
   incus exec "$CONTAINER_NAME" \
     --cwd "$DEPLOY_PATH" \
     --env AXON_HOME=/mnt/axon-data \
-    --env GEMINI_HOME=/mnt/axon-gemini \
-    --env "AXON_IMAGE=${axon_incus_image}" \
-    -- docker compose --env-file .env -f docker-compose.prod.yaml up -d
+    -- docker compose --env-file .env -f docker-compose.prod.yaml up -d axon-tei axon-chrome axon-qdrant
 else
   log "=== bundled qdrant is NOT starting, using external QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL} ==="
   incus exec "$CONTAINER_NAME" \
     --cwd "$DEPLOY_PATH" \
     --env AXON_HOME=/mnt/axon-data \
-    --env GEMINI_HOME=/mnt/axon-gemini \
-    --env "AXON_IMAGE=${axon_incus_image}" \
     --env "AXON_EXTERNAL_QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL}" \
-    -- docker compose --env-file .env -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d
+    -- docker compose --env-file .env -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d axon-tei axon-chrome
 fi
+
+### Restart the native axon service now that its .env/config is in place and
+### its dependent sidecars are up — `systemctl restart` is safe even on the
+### very first run (a not-yet-started unit just starts).
+log "restarting axon-native.service"
+incus exec "$CONTAINER_NAME" -- systemctl restart axon-native.service
 
 ### 13. Health-check polling — EXPLICIT bounded timeout/retry (36 * 10s =
 ### 360s max), sized against axon's own 180s start_period plus margin. No
 ### open-ended "wait until ready" loop.
-### Assumes every service in docker-compose.prod.yaml defines a healthcheck
-### (true today for axon/axon-tei/axon-chrome/axon-qdrant) — a service added
-### later without one reports an empty .Health, which correctly fails this
-### check rather than being silently ignored, but will spin the full 360s
-### every time until it gets a healthcheck of its own.
-log "polling for all services healthy (bounded: up to 360s)"
+### Checks two independent things: (a) the Docker sidecars started in step 12
+### (tei/chrome, +qdrant in default mode) report healthy, and (b) the native
+### axon-native.service is active AND its own /healthz responds — a Docker
+### sidecar going healthy says nothing about the native axon process, and
+### vice versa.
+log "polling for sidecars + native axon healthy (bounded: up to 360s)"
 healthy=0
 for _ in $(seq 1 36); do
   statuses="$(incus exec "$CONTAINER_NAME" -- sh -c \
     "cd $DEPLOY_PATH && docker compose -f docker-compose.prod.yaml ps --format '{{.Service}}:{{.Health}}'" 2>/dev/null || true)"
+  sidecars_ok=0
   if [ -n "$statuses" ] && ! printf '%s\n' "$statuses" | grep -qv "healthy$"; then
+    sidecars_ok=1
+  fi
+  axon_ok=0
+  if incus exec "$CONTAINER_NAME" -- systemctl is-active --quiet axon-native.service \
+      && incus exec "$CONTAINER_NAME" -- curl -fsS --max-time 4 http://127.0.0.1:8001/healthz >/dev/null 2>&1; then
+    axon_ok=1
+  fi
+  if [ "$sidecars_ok" = "1" ] && [ "$axon_ok" = "1" ]; then
     healthy=1
     break
   fi
@@ -266,8 +332,25 @@ if [ "$healthy" != "1" ]; then
   # most common real-world failure mode (slow model load, transient GPU
   # flake) exactly where the fail-closed design matters most. Services that
   # did start are left running, not torn down — inspect 'docker compose ps'
-  # inside the container to see what's actually up.
-  fatal "not all services reported healthy within the bounded window (360s) — inspect 'docker compose ps' inside $CONTAINER_NAME"
+  # and 'systemctl status axon-native' inside the container to see what's
+  # actually up.
+  fatal "not all services reported healthy within the bounded window (360s) — inspect 'docker compose ps' and 'systemctl status axon-native' inside $CONTAINER_NAME"
+fi
+
+### 13b. Ensure the axon HTTP proxy device exists (host address -> the native
+### axon-native.service's 127.0.0.1:8001 inside the container). Not part of
+### the shared profile.yaml since the host-side listen address is
+### deployment-specific (e.g. a Tailscale IP:port). Idempotent — only added
+### if AXON_HTTP_PUBLISH_LISTEN is set AND the device doesn't already exist;
+### an existing device (created manually or by a prior run) is left as-is.
+if [ -n "${AXON_HTTP_PUBLISH_LISTEN:-}" ]; then
+  if ! incus config device show "$CONTAINER_NAME" 2>/dev/null | grep -q '^mcp-publish:'; then
+    log "adding mcp-publish proxy device (listen=${AXON_HTTP_PUBLISH_LISTEN} -> 127.0.0.1:8001)"
+    incus config device add "$CONTAINER_NAME" mcp-publish proxy \
+      "listen=tcp:${AXON_HTTP_PUBLISH_LISTEN}" "connect=tcp:127.0.0.1:8001"
+  fi
+else
+  log "AXON_HTTP_PUBLISH_LISTEN not set — skipping proxy device management (set it, e.g. 100.88.16.79:40090, for bootstrap.sh to manage the host-facing port idempotently)"
 fi
 
 ### 14. Enable Incus-level autostart. The companion systemd unit

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Idempotent bootstrap for axon's nested-Docker-in-Incus deployment.
+#
+# Usage:
+#   deploy/incus/bootstrap.sh [default|external-qdrant]
+#
+# default mode:          bundled qdrant starts alongside axon/tei/chrome.
+# external-qdrant mode:  requires AXON_EXTERNAL_QDRANT_URL; bundled qdrant is
+#                        not started, axon points at the external instance.
+#
+# Safe to re-run at any time (idempotent). Also the intended entry point for
+# the companion systemd unit (axon-incus-bootstrap.service) that re-runs this
+# on every host boot, since boot.autostart=true alone does not re-apply the
+# known-fragile nvidia-procfs device or re-verify GPU access.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTAINER_NAME="${AXON_INCUS_CONTAINER:-axon-bootstrap-temp}"
+PROFILE_NAME="axon-container-profile"
+GPU_PCI_ADDRESS="${AXON_GPU_PCI_ADDRESS:-0000:03:00.0}"
+DEPLOY_PATH="/opt/axon-deploy"
+MODE="${1:-default}"
+
+log() { echo "[bootstrap] $*"; }
+fatal() { echo "[bootstrap] FATAL: $*" >&2; exit 1; }
+
+case "$MODE" in
+  default|external-qdrant) ;;
+  *) fatal "unknown mode '$MODE' (expected 'default' or 'external-qdrant')" ;;
+esac
+if [ "$MODE" = "external-qdrant" ] && [ -z "${AXON_EXTERNAL_QDRANT_URL:-}" ]; then
+  fatal "AXON_EXTERNAL_QDRANT_URL must be set for external-qdrant mode"
+fi
+
+### 1. Profile: create from the committed definition if missing. Never
+### overwrite an existing profile — live edits during development are
+### intentional and this script must not clobber them.
+if ! incus profile show "$PROFILE_NAME" >/dev/null 2>&1; then
+  log "creating profile $PROFILE_NAME from deploy/incus/profile.yaml"
+  incus profile create "$PROFILE_NAME"
+  incus profile edit "$PROFILE_NAME" < "$REPO_ROOT/deploy/incus/profile.yaml"
+else
+  log "profile $PROFILE_NAME already exists, leaving as-is"
+fi
+
+### 2. Container: create if missing.
+if ! incus info "$CONTAINER_NAME" >/dev/null 2>&1; then
+  log "creating container $CONTAINER_NAME"
+  incus launch images:debian/bookworm "$CONTAINER_NAME" -p default -p "$PROFILE_NAME"
+else
+  log "container $CONTAINER_NAME already exists"
+fi
+
+### 3. Ensure running.
+state="$(incus list "$CONTAINER_NAME" --format csv -c s 2>/dev/null || echo "")"
+if [ "$state" != "RUNNING" ]; then
+  log "starting container (was: ${state:-absent})"
+  incus start "$CONTAINER_NAME"
+fi
+
+### 4. Wait for exec-readiness — bounded (30 attempts * 2s = 60s max).
+ready=0
+for _ in $(seq 1 30); do
+  if incus exec "$CONTAINER_NAME" -- true >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 2
+done
+[ "$ready" = "1" ] || fatal "container did not become exec-ready within 60s"
+
+### 5. Install Docker inside the container if missing (idempotent).
+if ! incus exec "$CONTAINER_NAME" -- sh -c 'command -v docker' >/dev/null 2>&1; then
+  log "Docker not found inside container, installing..."
+  incus exec "$CONTAINER_NAME" -- sh -c '
+    set -e
+    apt-get update
+    apt-get install -y ca-certificates curl gnupg
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+    codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+    arch="$(dpkg --print-architecture)"
+    echo "deb [arch=${arch} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${codename} stable" \
+      > /etc/apt/sources.list.d/docker.list
+    apt-get update
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  '
+else
+  log "Docker already present inside container"
+fi
+
+### 6. Re-apply the nvidia-procfs device. REQUIRED ON EVERY RUN — confirmed
+### (bead axon_rust-4m749.2) this does not reliably survive a container
+### stop/start cycle, silently breaking nested-Docker GPU passthrough until
+### removed and re-added.
+log "re-applying nvidia-procfs device (known fragility across restarts)"
+incus config device remove "$CONTAINER_NAME" nvidia-procfs >/dev/null 2>&1 || true
+incus config device add "$CONTAINER_NAME" nvidia-procfs disk \
+  "source=/proc/driver/nvidia/gpus/${GPU_PCI_ADDRESS}" \
+  "path=/proc/driver/nvidia/gpus/${GPU_PCI_ADDRESS}" >/dev/null
+
+### 7. Fail-closed GPU verification BEFORE anything GPU-dependent starts.
+### Do not start TEI in a broken/CPU-fallback state — refuse and exit instead.
+log "verifying nested-Docker GPU access (fail-closed if this doesn't work)"
+gpu_ok=0
+for _ in 1 2 3; do
+  if incus exec "$CONTAINER_NAME" -- docker run --rm --gpus all \
+       nvidia/cuda:12.6.0-base-ubuntu24.04 nvidia-smi >/dev/null 2>&1; then
+    gpu_ok=1
+    break
+  fi
+  sleep 3
+done
+[ "$gpu_ok" = "1" ] || fatal "GPU verification failed after 3 attempts — refusing to start TEI in a broken state. Check the nvidia-procfs device and host NVIDIA driver."
+
+### Resolve the env file now — needed by both the network-name lookup (9)
+### and the actual push (12).
+env_file_on_host="${AXON_ENV_FILE:-$HOME/.axon/.env}"
+[ -f "$env_file_on_host" ] || fatal "env file not found at $env_file_on_host"
+
+### 8. Sync deploy artifacts (compose files + config/) into the container.
+log "syncing compose files + config into ${DEPLOY_PATH}"
+incus exec "$CONTAINER_NAME" -- mkdir -p "$DEPLOY_PATH"
+incus file push "$REPO_ROOT/docker-compose.prod.yaml" "$CONTAINER_NAME$DEPLOY_PATH/docker-compose.prod.yaml"
+incus file push "$REPO_ROOT/docker-compose.external-qdrant.yaml" "$CONTAINER_NAME$DEPLOY_PATH/docker-compose.external-qdrant.yaml"
+incus file push -r "$REPO_ROOT/config" "$CONTAINER_NAME$DEPLOY_PATH/"
+
+### 9. Ensure the external Docker network exists (idempotent — compose
+### requires this to pre-exist since docker-compose.prod.yaml declares it
+### `external: true`). The real network name comes from DOCKER_NETWORK in the
+### env file (defaults to "axon") — must match compose's own resolution
+### exactly, not be hardcoded, since a deployment can override it (e.g.
+### dookie's existing ~/.axon/.env sets DOCKER_NETWORK=jakenet).
+docker_network_name="$(grep -E '^DOCKER_NETWORK=' "$env_file_on_host" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
+docker_network_name="${docker_network_name:-axon}"
+log "ensuring Docker network '$docker_network_name' exists"
+incus exec "$CONTAINER_NAME" -- docker network inspect "$docker_network_name" >/dev/null 2>&1 \
+  || incus exec "$CONTAINER_NAME" -- docker network create "$docker_network_name" >/dev/null
+
+### 10. Config-integrity check. A single combined checksum over the deploy
+### artifacts, recorded as "last known good" after every successful run.
+### Detects drift/corruption between runs; does not gate startup on first
+### run (nothing to compare against yet).
+checksum_file="$DEPLOY_PATH/.last-known-good.sha256"
+current_checksum="$(incus exec "$CONTAINER_NAME" -- sh -c \
+  "sha256sum $DEPLOY_PATH/docker-compose.prod.yaml $DEPLOY_PATH/docker-compose.external-qdrant.yaml | sha256sum" \
+  | awk '{print $1}')"
+stored_checksum="$(incus exec "$CONTAINER_NAME" -- cat "$checksum_file" 2>/dev/null || true)"
+if [ -n "$stored_checksum" ] && [ "$stored_checksum" != "$current_checksum" ]; then
+  log "deploy artifacts changed since the last successful bootstrap (expected after an intentional edit) — recording new checksum"
+fi
+incus exec "$CONTAINER_NAME" -- sh -c "printf '%s' '$current_checksum' > $checksum_file"
+
+### 11. Memory-headroom check before starting bundled qdrant. This is the
+### mandatory gate — dookie has a real, documented qdrant OOM-crashloop
+### history; a config-integrity checksum alone would not have caught it.
+if [ "$MODE" = "default" ]; then
+  avail_kb="$(incus exec "$CONTAINER_NAME" -- awk '/MemAvailable/{print $2}' /proc/meminfo)"
+  avail_gb=$(( avail_kb / 1024 / 1024 ))
+  if [ "$avail_gb" -lt 18 ]; then
+    fatal "insufficient memory headroom for bundled qdrant (${avail_gb}GB available inside container, need ~18GB) — refusing to start qdrant. Use external-qdrant mode instead, or free memory first."
+  fi
+  log "memory headroom check passed (${avail_gb}GB available)"
+fi
+
+### 12. Push the env-file and start the stack — --env-file is ALWAYS explicit,
+### no reliance on Compose's implicit .env-in-cwd behavior.
+incus file push "$env_file_on_host" "$CONTAINER_NAME$DEPLOY_PATH/.env"
+incus exec "$CONTAINER_NAME" -- chmod 600 "$DEPLOY_PATH/.env"
+# The axon service's own `env_file:` directive (compose, not the CLI flag
+# above) reads from ${AXON_HOME}/.env — which resolves to /mnt/axon-data/.env
+# once AXON_HOME is overridden below. Keep that copy in sync too.
+incus file push "$env_file_on_host" "$CONTAINER_NAME/mnt/axon-data/.env"
+incus exec "$CONTAINER_NAME" -- chmod 600 /mnt/axon-data/.env
+
+# The shared ~/.axon/.env carries host-native paths meant for bare-host/
+# local-dev use (e.g. AXON_HOME=/home/jmagar/.axon, GEMINI_HOME resolving off
+# a bare-host $HOME) and may set AXON_IMAGE for a manually-tagged local build.
+# None of that is valid *inside* this Incus container, where data actually
+# lives at the mounted /mnt/axon-data and /mnt/axon-gemini — force the
+# correct values explicitly rather than trust whatever's in the shared file.
+# (Also: `incus exec` runs as root by default, so an unset $HOME-relative
+# default would resolve against /root, not /home/axon — another reason these
+# must be explicit, not left to the compose file's own fallback.)
+axon_incus_image="${AXON_INCUS_IMAGE:-ghcr.io/jmagar/axon:latest}"
+incus_env_overrides="AXON_HOME=/mnt/axon-data GEMINI_HOME=/mnt/axon-gemini AXON_IMAGE='${axon_incus_image}'"
+
+if [ "$MODE" = "default" ]; then
+  log "=== bundled qdrant IS starting locally (default mode) ==="
+  incus exec "$CONTAINER_NAME" -- sh -c \
+    "cd $DEPLOY_PATH && ${incus_env_overrides} docker compose --env-file .env -f docker-compose.prod.yaml up -d"
+else
+  log "=== bundled qdrant is NOT starting, using external QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL} ==="
+  incus exec "$CONTAINER_NAME" -- sh -c \
+    "cd $DEPLOY_PATH && ${incus_env_overrides} AXON_EXTERNAL_QDRANT_URL='${AXON_EXTERNAL_QDRANT_URL}' docker compose --env-file .env -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d"
+fi
+
+### 13. Health-check polling — EXPLICIT bounded timeout/retry (36 * 10s =
+### 360s max), sized against axon's own 180s start_period plus margin. No
+### open-ended "wait until ready" loop.
+log "polling for all services healthy (bounded: up to 360s)"
+healthy=0
+for _ in $(seq 1 36); do
+  statuses="$(incus exec "$CONTAINER_NAME" -- sh -c \
+    "cd $DEPLOY_PATH && docker compose -f docker-compose.prod.yaml ps --format '{{.Service}}:{{.Health}}'" 2>/dev/null || true)"
+  if [ -n "$statuses" ] && ! printf '%s\n' "$statuses" | grep -qv "healthy$"; then
+    healthy=1
+    break
+  fi
+  sleep 10
+done
+if [ "$healthy" != "1" ]; then
+  log "WARNING: not all services reported healthy within the bounded window. Partial-failure behavior: services that DID start remain running, nothing is torn down automatically — inspect 'docker compose ps' inside the container before relying on this deployment."
+fi
+
+### 14. Enable Incus-level autostart. The companion systemd unit
+### (axon-incus-bootstrap.service) is what actually re-runs THIS script after
+### a host reboot — boot.autostart alone would restart the container but
+### skip the nvidia-procfs re-application and GPU re-verification above.
+incus config set "$CONTAINER_NAME" boot.autostart true
+
+log "bootstrap complete (mode: $MODE)"

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -102,11 +102,17 @@ incus config device add "$CONTAINER_NAME" nvidia-procfs disk \
 
 ### 7. Fail-closed GPU verification BEFORE anything GPU-dependent starts.
 ### Do not start TEI in a broken/CPU-fallback state — refuse and exit instead.
+### Pull the verification image once, outside the retry loop — otherwise a
+### cold image cache turns each retry into a registry pull-and-run, which
+### conflates "GPU/nvidia-procfs isn't ready yet" with "registry is slow,"
+### and 3s between retries isn't enough time for a fresh pull anyway.
+GPU_VERIFY_IMAGE="nvidia/cuda:12.6.0-base-ubuntu24.04"
+incus exec "$CONTAINER_NAME" -- docker pull "$GPU_VERIFY_IMAGE" >/dev/null 2>&1 || true
 log "verifying nested-Docker GPU access (fail-closed if this doesn't work)"
 gpu_ok=0
 for _ in 1 2 3; do
   if incus exec "$CONTAINER_NAME" -- docker run --rm --gpus all \
-       nvidia/cuda:12.6.0-base-ubuntu24.04 nvidia-smi >/dev/null 2>&1; then
+       "$GPU_VERIFY_IMAGE" nvidia-smi >/dev/null 2>&1; then
     gpu_ok=1
     break
   fi
@@ -131,26 +137,32 @@ incus file push -r "$REPO_ROOT/config" "$CONTAINER_NAME$DEPLOY_PATH/"
 ### `external: true`). The real network name comes from DOCKER_NETWORK in the
 ### env file (defaults to "axon") — must match compose's own resolution
 ### exactly, not be hardcoded, since a deployment can override it (e.g.
-### dookie's existing ~/.axon/.env sets DOCKER_NETWORK=jakenet).
-docker_network_name="$(grep -E '^DOCKER_NETWORK=' "$env_file_on_host" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
-docker_network_name="${docker_network_name:-axon}"
+### dookie's existing ~/.axon/.env sets DOCKER_NETWORK=jakenet). Reuse the
+### repo's own env-file parser (handles quoting/comments/export prefix
+### correctly) instead of a one-off grep, in a subshell so it doesn't leak
+### the whole env file into this script's environment.
+# shellcheck source=/dev/null
+docker_network_name="$(
+  source "$REPO_ROOT/scripts/lib/axon-env.sh"
+  AXON_ENV_FILE="$env_file_on_host" load_axon_env_file "$REPO_ROOT" 2>/dev/null || true
+  printf '%s' "${DOCKER_NETWORK:-axon}"
+)"
 log "ensuring Docker network '$docker_network_name' exists"
 incus exec "$CONTAINER_NAME" -- docker network inspect "$docker_network_name" >/dev/null 2>&1 \
   || incus exec "$CONTAINER_NAME" -- docker network create "$docker_network_name" >/dev/null
 
-### 10. Config-integrity check. A single combined checksum over the deploy
-### artifacts, recorded as "last known good" after every successful run.
-### Detects drift/corruption between runs; does not gate startup on first
-### run (nothing to compare against yet).
-checksum_file="$DEPLOY_PATH/.last-known-good.sha256"
-current_checksum="$(incus exec "$CONTAINER_NAME" -- sh -c \
-  "sha256sum $DEPLOY_PATH/docker-compose.prod.yaml $DEPLOY_PATH/docker-compose.external-qdrant.yaml | sha256sum" \
-  | awk '{print $1}')"
-stored_checksum="$(incus exec "$CONTAINER_NAME" -- cat "$checksum_file" 2>/dev/null || true)"
-if [ -n "$stored_checksum" ] && [ "$stored_checksum" != "$current_checksum" ]; then
-  log "deploy artifacts changed since the last successful bootstrap (expected after an intentional edit) — recording new checksum"
-fi
-incus exec "$CONTAINER_NAME" -- sh -c "printf '%s' '$current_checksum' > $checksum_file"
+### 10. [removed] A prior version of this step computed a checksum of the
+### files this same script had just pushed in step 8 and compared it against
+### the last run's checksum — which can never differ, since step 8
+### unconditionally overwrites the container's copy with the host's current
+### copy on every run. That made it a no-op that logged a reassuring message
+### without ever being able to detect anything, which is worse than no check
+### at all (a future reader could mistake it for real drift detection). The
+### memory-headroom check in step 11 is this script's actual fail-closed
+### gate; if genuine tamper-evidence for the deployed config is needed later,
+### it needs to compare a HOST-side hash (computed before step 8's push, from
+### a value stored outside this script's own write path) — not container-side
+### state this script itself just wrote.
 
 ### 11. Memory-headroom check before starting bundled qdrant. This is the
 ### mandatory gate — dookie has a real, documented qdrant OOM-crashloop
@@ -165,14 +177,18 @@ if [ "$MODE" = "default" ]; then
 fi
 
 ### 12. Push the env-file and start the stack — --env-file is ALWAYS explicit,
-### no reliance on Compose's implicit .env-in-cwd behavior.
-incus file push "$env_file_on_host" "$CONTAINER_NAME$DEPLOY_PATH/.env"
-incus exec "$CONTAINER_NAME" -- chmod 600 "$DEPLOY_PATH/.env"
+### no reliance on Compose's implicit .env-in-cwd behavior. Push with
+### --mode 0600 directly (not push-then-chmod as a separate step) — the
+### latter leaves the secrets file at incus file push's default mode for the
+### window between the two commands, readable by anything else in the same
+### container in the meantime.
+incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME$DEPLOY_PATH/.env"
 # The axon service's own `env_file:` directive (compose, not the CLI flag
 # above) reads from ${AXON_HOME}/.env — which resolves to /mnt/axon-data/.env
-# once AXON_HOME is overridden below. Keep that copy in sync too.
-incus file push "$env_file_on_host" "$CONTAINER_NAME/mnt/axon-data/.env"
-incus exec "$CONTAINER_NAME" -- chmod 600 /mnt/axon-data/.env
+# once AXON_HOME is overridden below. Keep that copy in sync too (same
+# secrets file, two paths compose needs it at — see README for why the
+# split exists).
+incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME/mnt/axon-data/.env"
 
 # The shared ~/.axon/.env carries host-native paths meant for bare-host/
 # local-dev use (e.g. AXON_HOME=/home/jmagar/.axon, GEMINI_HOME resolving off
@@ -183,22 +199,43 @@ incus exec "$CONTAINER_NAME" -- chmod 600 /mnt/axon-data/.env
 # (Also: `incus exec` runs as root by default, so an unset $HOME-relative
 # default would resolve against /root, not /home/axon — another reason these
 # must be explicit, not left to the compose file's own fallback.)
+#
+# Passed via `incus exec --env`/`--cwd` flags, not interpolated into an
+# `sh -c` string — these values (AXON_INCUS_IMAGE, AXON_EXTERNAL_QDRANT_URL)
+# come from a trusted operator-authored env file today, but string
+# interpolation into a root-executed shell command is a shape worth avoiding
+# even when the current threat model doesn't require it: a stray single
+# quote in either value would otherwise splice arbitrary content into the
+# command.
 axon_incus_image="${AXON_INCUS_IMAGE:-ghcr.io/jmagar/axon:latest}"
-incus_env_overrides="AXON_HOME=/mnt/axon-data GEMINI_HOME=/mnt/axon-gemini AXON_IMAGE='${axon_incus_image}'"
 
 if [ "$MODE" = "default" ]; then
   log "=== bundled qdrant IS starting locally (default mode) ==="
-  incus exec "$CONTAINER_NAME" -- sh -c \
-    "cd $DEPLOY_PATH && ${incus_env_overrides} docker compose --env-file .env -f docker-compose.prod.yaml up -d"
+  incus exec "$CONTAINER_NAME" \
+    --cwd "$DEPLOY_PATH" \
+    --env AXON_HOME=/mnt/axon-data \
+    --env GEMINI_HOME=/mnt/axon-gemini \
+    --env "AXON_IMAGE=${axon_incus_image}" \
+    -- docker compose --env-file .env -f docker-compose.prod.yaml up -d
 else
   log "=== bundled qdrant is NOT starting, using external QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL} ==="
-  incus exec "$CONTAINER_NAME" -- sh -c \
-    "cd $DEPLOY_PATH && ${incus_env_overrides} AXON_EXTERNAL_QDRANT_URL='${AXON_EXTERNAL_QDRANT_URL}' docker compose --env-file .env -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d"
+  incus exec "$CONTAINER_NAME" \
+    --cwd "$DEPLOY_PATH" \
+    --env AXON_HOME=/mnt/axon-data \
+    --env GEMINI_HOME=/mnt/axon-gemini \
+    --env "AXON_IMAGE=${axon_incus_image}" \
+    --env "AXON_EXTERNAL_QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL}" \
+    -- docker compose --env-file .env -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d
 fi
 
 ### 13. Health-check polling — EXPLICIT bounded timeout/retry (36 * 10s =
 ### 360s max), sized against axon's own 180s start_period plus margin. No
 ### open-ended "wait until ready" loop.
+### Assumes every service in docker-compose.prod.yaml defines a healthcheck
+### (true today for axon/axon-tei/axon-chrome/axon-qdrant) — a service added
+### later without one reports an empty .Health, which correctly fails this
+### check rather than being silently ignored, but will spin the full 360s
+### every time until it gets a healthcheck of its own.
 log "polling for all services healthy (bounded: up to 360s)"
 healthy=0
 for _ in $(seq 1 36); do
@@ -211,7 +248,15 @@ for _ in $(seq 1 36); do
   sleep 10
 done
 if [ "$healthy" != "1" ]; then
-  log "WARNING: not all services reported healthy within the bounded window. Partial-failure behavior: services that DID start remain running, nothing is torn down automatically — inspect 'docker compose ps' inside the container before relying on this deployment."
+  # Fail closed here, not just warn — this is the one signal the systemd
+  # unit's Restart=no is designed to surface (a failed unit after boot means
+  # "check systemctl status", per axon-incus-bootstrap.service). Falling
+  # through to "bootstrap complete" with exit 0 would silently swallow the
+  # most common real-world failure mode (slow model load, transient GPU
+  # flake) exactly where the fail-closed design matters most. Services that
+  # did start are left running, not torn down — inspect 'docker compose ps'
+  # inside the container to see what's actually up.
+  fatal "not all services reported healthy within the bounded window (360s) — inspect 'docker compose ps' inside $CONTAINER_NAME"
 fi
 
 ### 14. Enable Incus-level autostart. The companion systemd unit

--- a/deploy/incus/profile.yaml
+++ b/deploy/incus/profile.yaml
@@ -1,0 +1,32 @@
+config:
+  limits.cpu: "4"
+  limits.memory: 24GiB
+  limits.memory.enforce: hard
+  limits.processes: "4096"
+  linux.kernel_modules: overlay,br_netfilter,nf_nat,ip_tables,ip6_tables
+  nvidia.driver.capabilities: all
+  nvidia.runtime: "true"
+  security.idmap.isolated: "true"
+  security.nesting: "true"
+  security.privileged: "false"
+  security.syscalls.intercept.mknod: "true"
+  security.syscalls.intercept.setxattr: "true"
+description: Incus profile for the Axon single-container (nested Docker) deployment
+devices:
+  axon-data:
+    path: /mnt/axon-data
+    source: /home/jmagar/.axon-incus
+    type: disk
+  axon-gemini:
+    path: /mnt/axon-gemini
+    readonly: "true"
+    source: /home/jmagar/.axon-incus-gemini
+    type: disk
+  eth0:
+    name: eth0
+    network: incusbr0
+    type: nic
+  gpu:
+    type: gpu
+name: axon-container-profile
+project: default

--- a/docker-compose.external-qdrant.yaml
+++ b/docker-compose.external-qdrant.yaml
@@ -1,0 +1,26 @@
+name: axon
+
+# Override for deployments that point axon at an existing EXTERNAL qdrant
+# instance (this homelab: tootie, kept off dookie for RAM reasons) instead of
+# running the bundled axon-qdrant service from docker-compose.prod.yaml.
+# qdrant ships mandatory in the base file — this override is an explicit,
+# visible opt-out for this specific deployment, not a default.
+#
+# Apply alongside docker-compose.prod.yaml (not standalone):
+#   docker compose --env-file ~/.axon/.env \
+#     -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d
+#
+# Requires AXON_EXTERNAL_QDRANT_URL to be set — fails loudly (compose refuses
+# to start) if it isn't, rather than silently falling back to anything.
+
+services:
+  # Compose only starts a profiled service if its profile is explicitly
+  # requested or it's depended on by an active service. axon has no depends_on
+  # for axon-qdrant, so giving it a profile here removes it from the default
+  # `up -d` set without requiring a --profile flag anywhere.
+  axon-qdrant:
+    profiles: ["external-qdrant-disabled"]
+
+  axon:
+    environment:
+      QDRANT_URL: ${AXON_EXTERNAL_QDRANT_URL:?AXON_EXTERNAL_QDRANT_URL must be set when applying docker-compose.external-qdrant.yaml}

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,10 +1,14 @@
 name: axon
 
-# Full axon stack: axon (HTTP), tei, chrome, plus an optional qdrant service.
-# Production on dookie uses Qdrant on tootie by default to keep the large vector
-# working set off the dev box. Override AXON_QDRANT_URL to point elsewhere, or
-# start the optional axon-qdrant service explicitly when running all infra local.
+# Full axon stack: axon (HTTP), tei, chrome, and a mandatory bundled qdrant
+# service — qdrant is NOT optional in this file; every `up -d` starts all 4.
 #   docker compose --env-file ~/.axon/.env -f docker-compose.prod.yaml up -d
+# For this deployment's specific override (qdrant lives on tootie for RAM
+# reasons, not dookie), apply docker-compose.external-qdrant.yaml on top:
+#   docker compose --env-file ~/.axon/.env \
+#     -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d
+# That override skips starting the bundled axon-qdrant container and points
+# AXON_QDRANT_URL at the external instance instead — see that file's comments.
 # ~/.axon is the canonical host appdata root. Override AXON_HOME only when
 # relocating the full Axon appdata tree to another absolute path.
 
@@ -51,10 +55,10 @@ services:
       AXON_HOME: /home/axon/.axon
       AXON_DATA_DIR: /home/axon/.axon
       # Pin service URLs so the axon container does not inherit host-loopback
-      # values from ~/.axon/.env. Qdrant defaults to tootie's Tailscale IP to
-      # keep the memory-heavy vector store off dookie; use AXON_QDRANT_URL to
-      # override, e.g. http://axon-qdrant:6333 for an all-local compose stack.
-      QDRANT_URL: ${AXON_QDRANT_URL:-http://100.120.242.29:53333}
+      # values from ~/.axon/.env. Bundled qdrant is the default (mandatory,
+      # always started below); docker-compose.external-qdrant.yaml overrides
+      # this to point at an external instance (e.g. tootie) instead.
+      QDRANT_URL: ${AXON_QDRANT_URL:-http://axon-qdrant:6333}
       TEI_URL: http://axon-tei:80
       AXON_CHROME_REMOTE_URL: http://axon-chrome:6000
       # AXON_SERVER_URL is a client-side switch. The shared ~/.axon/.env may
@@ -119,7 +123,6 @@ services:
     <<: *common-service
     image: qdrant/qdrant:v1.18.2
     container_name: axon-qdrant
-    profiles: ["local-qdrant"]
     # Shield the vector DB from the kernel's *global* OOM killer: under host
     # memory pressure (concurrent cargo builds + optimizer churn) qdrant is the
     # largest RSS on the box and got picked twice in 10 minutes (dmesg

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -7,8 +7,9 @@ name: axon
 # reasons, not dookie), apply docker-compose.external-qdrant.yaml on top:
 #   docker compose --env-file ~/.axon/.env \
 #     -f docker-compose.prod.yaml -f docker-compose.external-qdrant.yaml up -d
-# That override skips starting the bundled axon-qdrant container and points
-# AXON_QDRANT_URL at the external instance instead — see that file's comments.
+# That override skips starting the bundled axon-qdrant container and sets
+# QDRANT_URL directly from AXON_EXTERNAL_QDRANT_URL instead (overriding this
+# file's own AXON_QDRANT_URL-based default) — see that file's comments.
 # ~/.axon is the canonical host appdata root. Override AXON_HOME only when
 # relocating the full Axon appdata tree to another absolute path.
 

--- a/docs/sessions/2026-07-08-incus-nested-docker-deployment.md
+++ b/docs/sessions/2026-07-08-incus-nested-docker-deployment.md
@@ -1,0 +1,166 @@
+---
+date: 2026-07-08 02:43:04 EST
+repo: git@github.com:jmagar/axon.git
+branch: claude/unruffled-goldberg-07a585
+head: 8fb787f56e660dfb1abe3d937a66dd264154ea48
+working directory: /home/jmagar/workspace/axon/.claude/worktrees/unruffled-goldberg-07a585
+worktree: /home/jmagar/workspace/axon/.claude/worktrees/unruffled-goldberg-07a585
+pr: #383 "Incus nested-Docker deployment: qdrant mandatory, GPU passthrough validated, bootstrap script" — https://github.com/jmagar/axon/pull/383 (merged)
+beads: axon_rust-4m749 (epic), axon_rust-4m749.1 through .8
+---
+
+## User Request
+
+Deploy axon's full stack (axon + TEI + qdrant + chrome) inside an Incus container on dookie so the whole stack ships as "one Incus profile + bootstrap script." Explore Incus OCI-native containers as an alternative to nested Docker-in-Incus, evaluate feasibility including GPU passthrough, then fully implement, review, and merge whichever architecture actually works — the user explicitly directed working the entire epic to completion ("YES YOU NEED TO LAVRA-WORK THE ENTIRE FUCKING EPIC"), not just a single bead.
+
+## Session Overview
+
+Explored, prototyped, and pivoted twice on the deployment architecture before landing on a fully validated, merged solution: nested Docker-in-Incus (one Incus system container running a full Docker Engine internally, hosting axon/TEI/chrome/qdrant via the existing `docker-compose.prod.yaml`). Along the way: upgraded dookie's Incus from distro 6.0.5 LTS to Zabbly's 7.2 feature channel to unlock native OCI containers, prototyped native OCI GPU passthrough, found it genuinely broken (`CUDA_ERROR_OUT_OF_MEMORY` during TEI warmup) after extensive debugging, and reverted to the original nested-Docker design with real evidence instead of assumption. Fixed a separate, real bug in `axon-authz`'s OAuth env-var key prefix. Ran two independent multi-agent review passes (`lavra-review`, `/review-pr`) and applied all findings. Recovered from a git worktree/branch mismatch (commits initially landed on a stale, diverged local `main`) without losing work. Merged PR #383 into `main`. Confirmed the deployment is live and healthy on dookie. One epic item remains open: a real host-reboot validation (bead `.7`), deliberately not attempted without explicit authorization since dookie also hosts the production Labby MCP gateway.
+
+## Sequence of Events
+
+1. **Research phase.** Searched Incus docs and the repo/worktrees for prior work on an Incus-based axon deployment; found the epic groundwork already partially scoped.
+2. **Architecture question raised.** User asked about switching to Incus's native OCI application-container support (landed as a monthly-feature-release capability, not in the LTS channel) instead of nested Docker-in-Incus, for simpler single-hop GPU passthrough.
+3. **Mechanics review.** Explained how OCI-native Incus containers work (skopeo/umoci image unpacking, no nested dockerd) and confirmed "deploy everything at once" was still achievable under that model.
+4. **Rejected an alternative shipping mechanism.** Evaluated distrobuilder's `ubuntu.yaml` example as a single-artifact build path; determined it doesn't fit the OCI-native model.
+5. **Engineering review + plan.** Ran `/lavra-eng-review` (4-agent parallel review: architecture, simplicity, security, performance) against the pivot plan, applied all findings, then used `/writing-plans` to produce a detailed implementation plan for the first gated bead (`.8`, the Zabbly/Incus upgrade).
+6. **Zabbly upgrade executed.** Baseline capture, GPG key verification, rollback dry-run, repo pinning, then the live `apt-get install incus` upgrade from 6.0.5 → 7.2 on dookie — a host also running the production `labby` container — after explicit user confirmation before the live-mutation step. Verified all pre-existing containers/profiles survived.
+7. **Native OCI GPU prototype.** Built the OCI-native profile/container path (`nvidia.runtime=true`, `nvidia.driver.capabilities`) and attempted a real TEI GPU workload.
+8. **Native OCI GPU failure diagnosed.** `CUDA_ERROR_OUT_OF_MEMORY` during TEI model warmup, reproduced 3x. Ruled out real VRAM exhaustion, cgroup memory limits, driver/kernel mismatch, and the RLIMIT_MEMLOCK containerized-CUDA gotcha. Per explicit user direction, also stopped bare-host `axon-tei`, checked live GPU memory usage, and searched Incus community/docs for this exact failure signature — root cause not resolved.
+9. **Nested-Docker re-validated.** Re-tested nested Docker-in-Incus on the pre-existing `axon-bootstrap-temp` container with the real TEI image and real GPU: reached "Ready", served a real embedding request successfully.
+10. **Architecture decision: revert.** User chose to revert the whole epic to nested-Docker-in-Incus given native OCI GPU was proven broken and nested-Docker was proven working, end-to-end, on real hardware.
+11. **Compose changes.** Made `axon-qdrant` mandatory by default in `docker-compose.prod.yaml`; added `docker-compose.external-qdrant.yaml` override for dookie's real topology (qdrant lives on tootie for RAM reasons); added `just prod-up`/`prod-down` targets with an env-file permission warning.
+12. **Storage + profile work.** Exported and committed the validated `axon-container-profile` (`deploy/incus/profile.yaml`) and documented the `~/.axon-incus` vs `~/.axon` storage-mapping rationale (`deploy/incus/README.md`), driven by a real `/etc/subuid` limitation preventing shared UID mapping.
+13. **Bootstrap script + systemd unit.** Wrote `deploy/incus/bootstrap.sh` (idempotent 14-step bootstrap: profile/container create-if-missing, Docker install, `nvidia-procfs` device re-application, fail-closed GPU verification, artifact sync, Docker network resolution, env-file push, compose up, health-check polling, autostart enable) and `deploy/incus/axon-incus-bootstrap.service` (systemd unit to re-run bootstrap on host boot).
+14. **Separate bug found and fixed.** While validating the real `axon` service inside the deployment, discovered `crates/axon-authz/src/http.rs` built its OAuth vars-list with unprefixed env-var keys (`AXON_AUTH_MODE`) when the `lab-auth` builder expected `AXON_MCP_`-prefixed keys — silently forcing bearer-auth fallback. Fixed by renaming the six `push_var` keys.
+15. **Git worktree/branch recovery.** Discovered commits had landed on the main checkout's local `main`, which was ~2997 commits diverged from real `origin/main` (a past history rewrite). Verified all touched files were byte-identical between `origin/main` and the stale base, then rebuilt the working branch on `origin/main` and cherry-picked the commits cleanly.
+16. **PR created.** Opened PR #383 against `main` with the 4 substantive commits (compose changes, Incus profile/docs, authz fix, bootstrap script + systemd).
+17. **Two independent review passes.** Ran `/lavra-review` (5 agents: architecture, security, performance, simplicity, pattern-recognition) and `/review-pr` (3 agents: code-reviewer, comment-analyzer, silent-failure-hunter) against the PR, applying every finding between passes — removed a non-functional "config-integrity checksum," hardened a fail-closed health-check gate, fixed a `.env` push permission race, fixed fragile Docker-network-name parsing, added a GPU pre-pull step, hardened shell interpolation via `incus exec --env`/`--cwd`, and corrected a comment describing the wrong override variable name.
+18. **CI wait and merge.** Waited for required checks (`ci-gate`, `codeql-gate`, `compose-smoke-gate`) to go green, then merged PR #383 into `main`.
+19. **Bare-host container investigation deferred.** Found bare-host `axon-tei` had disappeared entirely with no forensic explanation (docker events retention exhausted); per user direction, did not investigate or recreate it — launched the validated Incus deployment as the real production stack instead.
+20. **Deployment launched for real.** Ran `bootstrap.sh external-qdrant` against `axon-bootstrap-temp`; `axon doctor` confirmed all backends green (sqlite, tei, qdrant → tootie, chrome, gemini_headless); `boot.autostart=true` confirmed set.
+21. **Bead cleanup.** Discovered bead `.5` was still marked open despite its work being fully merged; closed it with a fact comment.
+22. **Live-state re-verification (this session).** Re-checked `incus list axon-bootstrap-temp` and `docker compose ps` inside the container directly — confirmed `axon`, `axon-tei`, `axon-chrome` all `Up ~1 hour (healthy)`.
+23. **Reboot question answered.** User asked whether closing the epic requires a real dookie reboot. Explained the distinction between tested (`incus stop`/`start` cycles) and untested (real host reboot proving `axon-incus-bootstrap.service` + `boot.autostart` survive a cold Incus daemon restart) — and flagged the blast radius (dookie also hosts the live `labby` MCP gateway). Awaiting user decision on whether/when to run that test.
+
+## Key Findings
+
+- `crates/axon-authz/src/http.rs`: `build_auth_policy()`'s `push_var()` calls used unprefixed keys (`AXON_AUTH_MODE`, `AXON_PUBLIC_URL`, etc.) when `lab_auth::config::AuthConfigBuilder` was configured with `.env_prefix("AXON_MCP")`, so its internal lookups expected `AXON_MCP_AUTH_MODE` etc. Real, user-facing env vars (confirmed via `.env.example`) are correctly unprefixed — only the internal vars-list construction was wrong. This silently forced `AuthMode::Bearer` even when `AXON_AUTH_MODE=oauth` was set.
+- `docker-compose.prod.yaml`: `axon-qdrant` previously had `profiles: ["local-qdrant"]`, making it optional; changed to mandatory-by-default with `axon`'s `QDRANT_URL` defaulting to the bundled service (`http://axon-qdrant:6333`) instead of a hardcoded tootie IP.
+- `nvidia-procfs` Incus disk device (`source=/proc/driver/nvidia/gpus/<pci-address>`) does not reliably survive a container stop/start cycle — must be removed and re-added on every bootstrap run (baked into `bootstrap.sh` permanently, not a one-time fix).
+- Native Incus OCI (`nvidia.runtime=true`) GPU passthrough is genuinely broken for real inference workloads on this host/Incus 7.2 combination — `CUDA_ERROR_OUT_OF_MEMORY` during TEI warmup, not caused by real VRAM exhaustion, cgroup limits, driver mismatch, or RLIMIT_MEMLOCK.
+- `ghcr.io/jmagar/axon:latest` (and all published tags) are built from the Dockerfile's `dev-runtime` stage instead of `runtime` — confirmed via `docker image inspect` entrypoint mismatch. This is a separate, real CI/release-pipeline bug, out of scope for this epic; worked around locally by building `ghcr.io/jmagar/axon:local-runtime` via `git archive HEAD | docker build --target runtime`.
+- Main checkout's local `main` branch was ~2997 commits diverged from real `origin/main` due to a past history rewrite/squash-merge — required verifying byte-identical file state before rebuilding the branch and cherry-picking.
+
+## Technical Decisions
+
+- **Reverted native-OCI pivot back to nested-Docker-in-Incus.** Decision driven by empirical, reproducible hardware testing (native OCI GPU broken, nested-Docker GPU proven working end-to-end), not assumption or a priori preference. The Incus 7.2 upgrade itself was kept since it was harmless and separately beneficial.
+- **Qdrant made mandatory in the shared compose file**, with a separate `docker-compose.external-qdrant.yaml` override for dookie's specific topology (qdrant on tootie for RAM headroom reasons), rather than keeping qdrant permanently optional behind a profile flag — makes the default `up -d` behavior correct for new/other deployments while preserving dookie's existing external-qdrant setup via explicit override.
+- **Storage split (`~/.axon` vs `~/.axon-incus`/`~/.axon-incus-gemini`)** instead of trying to share host UID 1000 into the Incus container's idmap-shifted namespace — driven by a real `/etc/subuid` Linux limitation, not a workaround of choice.
+- **Removed a fake "config-integrity checksum"** step from `bootstrap.sh` (flagged during `/review-pr`) — it hashed files the same script had just pushed and compared against the prior run's hash, which could never detect real drift since both comparison inputs were derived from the script's own immediately-prior write.
+- **Health-check timeout escalated to `fatal()`** instead of a warn-only log (flagged during `lavra-review`) — a warn-only timeout undermined the systemd unit's intentional `Restart=no` fail-closed design.
+
+## Files Changed
+
+| status | path | purpose | evidence |
+|---|---|---|---|
+| modified | `docker-compose.prod.yaml` | Make `axon-qdrant` mandatory by default; default `QDRANT_URL` to bundled service instead of hardcoded tootie IP | commit `a2ad54e92` |
+| created | `docker-compose.external-qdrant.yaml` | Override to disable bundled qdrant and point at an external instance (tootie) | commit `a2ad54e92` |
+| modified | `Justfile` | Added `prod-up`/`prod-down`/`prod-up-external-qdrant`/`prod-down-external-qdrant` targets with env-file permission warning | commits `a2ad54e92`, `8fb787f56` |
+| created | `deploy/incus/profile.yaml` | Validated, live-exported Incus container profile (GPU, nesting, idmap isolation, disk mounts) | commit `70d43b006` |
+| created | `deploy/incus/README.md` | Storage-mapping rationale + adversarial test results + `nvidia-procfs` fragility notes | commit `70d43b006` |
+| modified | `crates/axon-authz/src/http.rs` | Fixed OAuth vars-list key prefix mismatch (`AXON_AUTH_MODE` → `AXON_MCP_AUTH_MODE` etc.) | commit `30801d3cc` |
+| created | `deploy/incus/bootstrap.sh` | Idempotent 14-step nested-Docker-in-Incus bootstrap script | commits `47dfd665b`, `0fdbd4b1d`, `8fb787f56` |
+| created | `deploy/incus/axon-incus-bootstrap.service` | systemd unit re-running bootstrap on host boot | commits `47dfd665b`, `8fb787f56` |
+| created | `deploy/incus/axon-incus-bootstrap.env.example` | Template env file for the systemd unit | commit `47dfd665b` |
+| created | `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md` | Implementation plan for bead `.8` (Zabbly/Incus upgrade) | written via `/writing-plans`, executed |
+| created | `docs/sessions/2026-07-08-incus-nested-docker-deployment.md` | This session log | this commit |
+
+## Beads Activity
+
+- `axon_rust-4m749` (epic) — rewritten multiple times to reflect the OCI-native pivot and the same-day revert, with an "ARCHITECTURE HISTORY" section and an "AUDIT FINDING" section documenting a recurring "closed but artifact never persisted" pattern. Still open (parent of `.7`).
+- `axon_rust-4m749.1` — closed (historical/superseded groundwork).
+- `axon_rust-4m749.2` — closed (nested-Docker GPU re-validation; contains the full native-OCI GPU diagnostic trail in comments).
+- `axon_rust-4m749.3` — closed (compose changes; commits `a2ad54e92`, `6b0325f08`).
+- `axon_rust-4m749.4` — closed (storage re-verification; commits `70d43b006`, `632aa50c0`).
+- `axon_rust-4m749.5` — closed this session (bootstrap script + systemd unit; work was merged via PR #383 but the bead had not been closed — fixed with a fact comment + `bd update ... -s closed`).
+- `axon_rust-4m749.7` — **still open**. Formal end-to-end validation across a real host reboot. Not yet attempted; user asked about it this session and a decision is pending (see Next Steps).
+- `axon_rust-4m749.8` — closed (Zabbly/Incus 7.2 upgrade, executed via the `/writing-plans` output plan, validated harmless).
+
+## Repository Maintenance
+
+- **Plans**: `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md` covers bead `.8`, which is closed and fully executed. Not moved to `docs/plans/complete/` — it lives in a separate `docs/superpowers/plans/` directory (a different convention used by the `superpowers:writing-plans` skill), not `docs/plans/`, so it's out of scope for this session's plan-migration pass. No other plans under `docs/plans/` were touched or completed by this session's work.
+- **Beads**: `axon_rust-4m749.5` was found open despite merged work and closed with a fact comment (see Beads Activity). All other epic children were already in correct state. Epic itself correctly remains open pending `.7`.
+- **Worktrees and branches**: This session's worktree (`unruffled-goldberg-07a585`, branch `claude/unruffled-goldberg-07a585`) is clean and in sync with `origin`. The repo has ~60+ other worktrees/branches from unrelated parallel work (pipeline-unification phases, palette tools, etc.) — none were inspected or touched; ownership and in-progress status are unclear for all of them, so cleanup is explicitly out of scope for this session.
+- **Stale docs**: None identified as contradicted by this session's changes. `deploy/incus/README.md` and the root `CLAUDE.md`'s Incus references are current as of the merge.
+- **Transparency**: No cleanup items were skipped due to uncertainty beyond the two explicitly noted above (plan-directory convention mismatch, unrelated worktree sprawl).
+
+## Tools and Skills Used
+
+- **Shell (Bash)**: `incus` CLI (profile/container management, `exec`, `file push`), `docker`/`docker compose`, `git` (branch recovery, cherry-pick, worktree inspection), `gh` (PR creation, CI status, merge), `bd` (beads tracker), `apt`/`dpkg` (Zabbly repo + Incus upgrade), `cargo` (build/check for the authz fix).
+- **Skills**: `lavra:lavra-eng-review` (4-agent plan review), `superpowers:writing-plans` (Zabbly upgrade plan), `superpowers:executing-plans` (Tasks 1–4 of that plan), `lavra:lavra-work` (epic dispatch), `lavra:lavra-review` (5-agent PR review), `pr-review-toolkit:review-pr` (3-agent PR review), `vibin:save-to-md` (this log).
+- **Agents/subagents**: architecture-strategist, security-sentinel, performance-oracle, code-simplicity-reviewer (eng-review + lavra-review passes), pattern-recognition-specialist (lavra-review), code-reviewer, comment-analyzer, silent-failure-hunter (review-pr pass). All completed successfully; no failures or degraded runs observed.
+- **Web/docs research**: Searched Incus documentation and community forum threads for OCI GPU passthrough behavior and the `CUDA_ERROR_OUT_OF_MEMORY` failure signature — informed the diagnosis but did not itself resolve the root cause (resolved instead by reverting architecture).
+- **No issues encountered** with tool availability this session; one `Monitor`-tracked background task (`bqaog9ahn`, a stale CI-poll loop) had to be stopped via `TaskStop` because its exit condition never triggered due to a permanently-pending non-required check.
+
+## Commands Executed
+
+- `incus list axon-bootstrap-temp` / `incus exec axon-bootstrap-temp -- sh -c 'cd /opt/axon-deploy && docker compose -f docker-compose.prod.yaml ps'` — confirmed `axon`, `axon-tei`, `axon-chrome` all `Up ~1 hour (healthy)` (this session, re-verification).
+- `incus exec axon-bootstrap-temp -- curl -sf http://localhost:8001/healthz` — returned exit 56 (connection reset), attributed to running curl from the Incus container's own netns rather than the axon container's netns/published port; compose's own healthcheck (executed from inside the `axon` container) is the authoritative signal and reports healthy.
+- `bd show axon_rust-4m749 --json`, `bd list --parent axon_rust-4m749 --json` — confirmed only `.7` remains open.
+- `git status --short --branch` — clean, in sync with `origin/claude/unruffled-goldberg-07a585`.
+- `gh pr view 383 --json state,mergedAt,mergeStateStatus` — `state: MERGED`, `mergedAt: 2026-07-08T03:09:14Z`.
+- `gh repo view --json defaultBranchRef` → `main`; `git symbolic-ref --short refs/remotes/origin/HEAD` → `origin/main`.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Production axon deployment (dookie) | Bare-host Docker Compose stack (with an unexplained missing `axon-tei` container by session's end) | Nested Docker-in-Incus: one Incus system container (`axon-bootstrap-temp`) running the full compose stack, `boot.autostart=true`, systemd-managed re-bootstrap on host boot |
+| `docker-compose.prod.yaml` qdrant | Optional, behind `profiles: ["local-qdrant"]` | Mandatory by default; external override via `docker-compose.external-qdrant.yaml` |
+| dookie Incus version | 6.0.5 (Ubuntu distro LTS package) | 7.2 (Zabbly feature channel) |
+| `crates/axon-authz` OAuth mode | Silently fell back to `AuthMode::Bearer` even when `AXON_AUTH_MODE=oauth` was set | OAuth mode activates correctly; vars-list keys match the `lab-auth` builder's expected `AXON_MCP_`-prefixed internal keys |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `incus list axon-bootstrap-temp` | Container RUNNING | RUNNING | pass |
+| `docker compose ... ps` (inside container) | axon/axon-tei/axon-chrome healthy | All three `Up ~1h (healthy)` | pass |
+| `axon doctor` (from earlier in session, prior to compaction) | All backends reachable | sqlite/tei/qdrant/chrome/gemini_headless all green | pass |
+| `gh pr view 383` | Merged into `main` | `state: MERGED`, `mergedAt` set | pass |
+| Required CI checks (`ci-gate`, `codeql-gate`, `compose-smoke-gate`) | Green before merge | Confirmed green prior to merge (earlier in session) | pass |
+| `curl` to `localhost:8001/healthz` from inside the Incus container's own shell | Reachable | Connection reset (exit 56) — believed to be a netns/routing artifact of curling from the wrong network namespace, not a real health issue, since compose's own in-container healthcheck reports healthy | warn (unresolved minor discrepancy) |
+
+## Risks and Rollback
+
+- The `nvidia-procfs` Incus device is fragile across container restarts by design of the current fix (must be re-applied every boot by `bootstrap.sh`) — if `bootstrap.sh` or the systemd unit is ever bypassed, GPU access inside the container will silently fail on the next restart.
+- dookie also hosts the live production `labby` MCP gateway under the same Incus daemon — any future Incus-level changes (including the still-pending real-reboot test for bead `.7`) carry a shared blast radius with that gateway.
+- Rollback path if the nested-Docker-in-Incus deployment needs to be abandoned: bare-host `docker-compose.prod.yaml` remains fully functional and unmodified in its service definitions (only defaults changed); reverting to it requires only stopping the Incus container and re-running `docker compose up -d` on the host directly with an appropriate `.env`.
+- The known, unfixed `ghcr.io/jmagar/axon:latest` wrong-build-stage bug means any future deployment pulling that tag fresh (rather than reusing the locally-built `local-runtime` image) will get a broken `dev-runtime`-based image — flagged but not fixed this session.
+
+## Decisions Not Taken
+
+- **distrobuilder's `ubuntu.yaml` as a single-artifact shipping mechanism** — evaluated and rejected; doesn't fit the OCI-native container model (and OCI-native itself was later abandoned).
+- **Recreating bare-host `axon-tei` after it inexplicably disappeared** — user explicitly redirected to launching the Incus deployment instead of investigating/recreating the bare-host container.
+- **Stopping the redundant bare-host `axon-chrome` container** (still running alongside the new Incus deployment as of last check) — flagged but not actioned this session.
+- **Investigating the unrelated failing `openwiki-update.yml` CI workflow** — noticed during merge-readiness checks, flagged but out of scope.
+
+## References
+
+- PR #383: https://github.com/jmagar/axon/pull/383
+- Beads epic: `axon_rust-4m749` and children `.1`–`.8`
+- `deploy/incus/README.md` (storage mapping + adversarial test results)
+- `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md`
+
+## Open Questions
+
+- Whether/when to run the real dookie host-reboot test required to close bead `.7`, given it shares blast radius with the live `labby` MCP gateway — raised to the user this session, decision pending.
+- Why bare-host `axon-tei` disappeared entirely mid-epic (no forensic evidence found in available docker events retention) — unresolved, not going to be investigated further per user direction.
+- Whether the `curl` connection-reset seen when probing `localhost:8001/healthz` from inside the Incus container's own shell (vs. compose's in-container healthcheck reporting healthy) indicates any real routing issue worth a follow-up check, or is purely a netns-mismatch artifact of how the probe was issued.
+
+## Next Steps
+
+1. **Bead `.7` (real host-reboot validation)** is the only remaining open item in the epic. Immediate next action once the user decides: either (a) schedule/run an actual `sudo reboot` of dookie and verify `axon-incus-bootstrap.service` + `boot.autostart` bring the stack back automatically, or (b) close `.7` as validated-via-container-restarts-only with the real-reboot proof explicitly deferred/documented as a known gap.
+2. **Not yet started, flagged only:** stop the redundant bare-host `axon-chrome` container; investigate/fix the failing `openwiki-update.yml` workflow; fix the `ghcr.io/jmagar/axon:latest` image-publishing pipeline building from the wrong Dockerfile stage (`dev-runtime` instead of `runtime`) — all explicitly out of this epic's scope, candidates for separate follow-up beads.
+3. **Recommended immediate command** once a reboot decision is made: if proceeding, coordinate timing with the user (labby downtime window), then `sudo reboot` on dookie followed by `incus list` / `systemctl status axon-incus-bootstrap` / `axon doctor` post-boot verification.

--- a/docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md
+++ b/docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md
@@ -1,0 +1,425 @@
+# Incus Zabbly Feature-Channel Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch dookie's Incus install from Ubuntu-distro-packaged 6.0.5-8 (LTS, no OCI support) to Zabbly's `stable` (monthly feature) channel and upgrade to 6.3+, unlocking native OCI application-container support, without breaking the live production `labby` container or any other existing container/profile on the host.
+
+**Architecture:** This is a host operations task, not application code — there are no source files to create. Each task is a sequenced, verified shell operation: capture a baseline, verify the trust root, rehearse rollback, add the repo, upgrade, re-verify every pre-existing container/profile against the baseline, prove OCI actually works, then pin the repo against silent future drift. "Tests" in this plan are verification commands run against real host state, not unit tests against source code.
+
+**Tech Stack:** `incus`/`incusd` (LXC-based), `apt`/`dpkg`, Zabbly's `pkgs.zabbly.com` APT repository, `gpg`.
+
+## Global Constraints
+
+- Zabbly's repo GPG key fingerprint MUST match `4EFC 5906 96CB 15B8 7C73 A3AD 82CC 8797 C838 DCFD` before it is trusted — verify before every step that depends on the key, not just once.
+- `labby` (the production Labby MCP gateway, currently RUNNING) MUST still be running (or cleanly restartable) with unchanged config, MCP routing, and Tailscale identity after every mutating step.
+- No destructive recovery action (`incus delete`, storage pool recreation, forced re-init) may be taken without explicit user confirmation, per bead `axon_rust-4m749.8`'s locked decision — if anything breaks in a way that isn't cleanly fixable, STOP and report.
+- This bead produces no standalone doc file — all evidence for the close-gate lives in the final task's bd close-comment (a real, pasted command transcript), per the epic-wide close-gate: **no bead may be closed without citing a real command transcript / file path a reviewer can independently verify.**
+- Do not run any command that installs, removes, or reconfigures anything under `labby`, `labby-golden`, `incus-web*`, `agent-run-*`, or `axon-bootstrap-temp` directly — this plan only touches the host-level `incus`/`incusd` packages and the APT repo configuration.
+
+---
+
+### Task 1: Capture the pre-upgrade baseline
+
+**Files:**
+- Create: `/tmp/incus-upgrade-baseline/` (scratch directory, NOT committed to git — host-local evidence only, referenced in the close-comment)
+
+**Interfaces:**
+- Consumes: nothing (first task)
+- Produces: `/tmp/incus-upgrade-baseline/{incus-list.txt,profile-list.txt,profile-axon-container-profile.txt,profile-labby-gateway.txt,dpkg-incus.txt,incus-version.txt}` — every later task's "confirm unchanged" checks diff against these files
+
+- [ ] **Step 1: Create the scratch baseline directory**
+
+Run:
+```bash
+mkdir -p /tmp/incus-upgrade-baseline
+```
+Expected: no output, directory exists.
+
+- [ ] **Step 2: Capture full instance list, profile list, and current package/version state**
+
+Run:
+```bash
+incus list -a > /tmp/incus-upgrade-baseline/incus-list.txt
+incus profile list > /tmp/incus-upgrade-baseline/profile-list.txt
+incus profile show axon-container-profile > /tmp/incus-upgrade-baseline/profile-axon-container-profile.txt
+incus profile show labby-gateway > /tmp/incus-upgrade-baseline/profile-labby-gateway.txt
+incus config show labby --expanded > /tmp/incus-upgrade-baseline/config-labby.txt
+dpkg -l | grep -i incus > /tmp/incus-upgrade-baseline/dpkg-incus.txt
+incus version > /tmp/incus-upgrade-baseline/incus-version.txt
+cat /tmp/incus-upgrade-baseline/*.txt
+```
+Expected: `incus-list.txt` shows `labby` as RUNNING with its two IPs (`100.80.57.104` tailscale0, `10.47.200.10` eth0), plus the stopped containers (`labby-golden`, `incus-web`, `incus-web-agent-golden`, `agent-run-*`, `axon-bootstrap-temp`); `incus-version.txt` shows `Client version: 6.0.5` / `Server version: 6.0.5`; `dpkg-incus.txt` shows all `incus*` packages at `6.0.5-8`.
+
+- [ ] **Step 3: Confirm `labby`'s MCP gateway currently responds (pre-upgrade health baseline)**
+
+Run:
+```bash
+incus exec labby -- curl -fsS http://127.0.0.1:8765/ready
+```
+Expected: HTTP 200 / a ready response (per `lab`'s own `docs/runtime/INCUS.md` runbook pattern). Record the raw output in `/tmp/incus-upgrade-baseline/labby-ready-pre.txt`:
+```bash
+incus exec labby -- curl -fsS http://127.0.0.1:8765/ready | tee /tmp/incus-upgrade-baseline/labby-ready-pre.txt
+```
+
+- [ ] **Step 4: No commit needed — this is a read-only baseline capture step**
+
+This task creates no repo changes. Proceed directly to Task 2.
+
+---
+
+### Task 2: Verify Zabbly's GPG key fingerprint before trusting it
+
+**Files:**
+- Create: `/etc/apt/keyrings/zabbly.asc` (host file, not repo-tracked)
+
+**Interfaces:**
+- Consumes: none
+- Produces: a verified, saved GPG key at `/etc/apt/keyrings/zabbly.asc` that Task 3 references by path
+
+- [ ] **Step 1: Fetch and print the key's fingerprint**
+
+Run:
+```bash
+curl -fsSL https://pkgs.zabbly.com/key.asc | gpg --show-keys --fingerprint
+```
+Expected: output includes a fingerprint line matching exactly `4EFC 5906 96CB 15B8 7C73 A3AD 82CC 8797 C838 DCFD` (spacing may vary, digits must match).
+
+- [ ] **Step 2: STOP if the fingerprint does not match**
+
+If the printed fingerprint does not match `4EFC590696CB15B87C73A3AD82CC8797C838DCFD` (compare digit-by-digit, ignore whitespace), do not proceed to Step 3. Report back with the mismatched fingerprint instead of continuing.
+
+- [ ] **Step 3: Save the verified key**
+
+Run:
+```bash
+mkdir -p /etc/apt/keyrings/
+curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
+gpg --show-keys --fingerprint /etc/apt/keyrings/zabbly.asc
+```
+Expected: the fingerprint printed from the saved file matches the one verified in Step 1.
+
+- [ ] **Step 4: No commit needed — host-local key file, not repo-tracked**
+
+Proceed to Task 3.
+
+---
+
+### Task 3: Prepare and dry-run the rollback procedure BEFORE touching the live upgrade
+
+**Files:**
+- Create: `/tmp/incus-upgrade-baseline/rollback-procedure.txt` (scratch, referenced in close-comment)
+
+**Interfaces:**
+- Consumes: `dpkg-incus.txt` from Task 1 (the exact pre-upgrade package/version string to roll back to)
+- Produces: a verified-workable rollback command sequence, proven via `apt-get install --dry-run` (not actually executed) before any real upgrade happens
+
+- [ ] **Step 1: Confirm the exact pre-upgrade package versions to roll back to**
+
+Run:
+```bash
+cat /tmp/incus-upgrade-baseline/dpkg-incus.txt
+```
+Expected: all `incus*` packages at version `6.0.5-8` (matches Task 1's capture).
+
+- [ ] **Step 2: Dry-run the downgrade command (does NOT execute anything — proves the rollback path exists before you need it)**
+
+Run:
+```bash
+apt-get install --dry-run \
+  incus=6.0.5-8 incus-base=6.0.5-8 incus-client=6.0.5-8 incus-agent=6.0.5-8
+```
+Expected: apt reports a plan to install/downgrade to these exact versions (from the currently-configured Ubuntu universe repo, since Zabbly's repo isn't added yet at this point in the plan) with no errors about unavailable versions. If apt reports the exact versions are unavailable, note this — it means once Zabbly's repo is added in Task 4, the downgrade dry-run must be re-verified against Zabbly's own available version list (Ubuntu's universe repo may age out old point releases).
+
+- [ ] **Step 3: Record the rollback command sequence for real use if needed**
+
+Write the verified sequence to a scratch file:
+```bash
+cat > /tmp/incus-upgrade-baseline/rollback-procedure.txt <<'ROLLBACK'
+# Verified rollback procedure (dry-run tested 2026-07-07, before live upgrade)
+# Use ONLY if the Zabbly upgrade breaks labby or another existing container/profile
+# in a way that isn't cleanly fixable. Do NOT run without explicit confirmation.
+
+# 1. Downgrade packages back to the pre-upgrade baseline version:
+apt-get install incus=6.0.5-8 incus-base=6.0.5-8 incus-client=6.0.5-8 incus-agent=6.0.5-8
+
+# 2. Remove the Zabbly repo source so it can't be picked up again by a future apt upgrade:
+rm -f /etc/apt/sources.list.d/zabbly-incus-stable.sources
+apt-get update
+
+# 3. Verify labby comes back:
+incus exec labby -- curl -fsS http://127.0.0.1:8765/ready
+incus list -a
+ROLLBACK
+cat /tmp/incus-upgrade-baseline/rollback-procedure.txt
+```
+Expected: file is written and its contents match the heredoc above.
+
+- [ ] **Step 4: No commit needed — host-local scratch file, referenced (not committed) in the final close-comment**
+
+Proceed to Task 4.
+
+---
+
+### Task 4: Add and scope the Zabbly repo (does not upgrade anything yet)
+
+**Files:**
+- Create: `/etc/apt/sources.list.d/zabbly-incus-stable.sources` (host file, not repo-tracked)
+
+**Interfaces:**
+- Consumes: `/etc/apt/keyrings/zabbly.asc` from Task 2
+- Produces: an APT source pointed at Zabbly's `stable` (feature) channel, ready for Task 5's upgrade
+
+- [ ] **Step 1: Write the Zabbly stable-channel source file**
+
+Run (as root):
+```bash
+cat <<EOF > /etc/apt/sources.list.d/zabbly-incus-stable.sources
+Enabled: yes
+Types: deb
+URIs: https://pkgs.zabbly.com/incus/stable
+Suites: $(. /etc/os-release && echo ${VERSION_CODENAME})
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/zabbly.asc
+EOF
+cat /etc/apt/sources.list.d/zabbly-incus-stable.sources
+```
+Expected: file contains `Enabled: yes`, `URIs: https://pkgs.zabbly.com/incus/stable`, a `Suites:` line matching this host's actual Ubuntu codename (e.g. `noble` or `resolute` — whatever `/etc/os-release`'s `VERSION_CODENAME` reports), `Signed-By: /etc/apt/keyrings/zabbly.asc`.
+
+- [ ] **Step 2: Refresh apt and confirm the new repo is reachable and offers a newer Incus version**
+
+Run:
+```bash
+apt-get update
+apt-cache policy incus
+```
+Expected: `apt-get update` completes with no GPG or 404 errors for the Zabbly source; `apt-cache policy incus` now shows a candidate version ≥ 6.3 from `pkgs.zabbly.com`, alongside the currently-installed `6.0.5-8` from Ubuntu's universe repo.
+
+- [ ] **Step 3: No commit needed — host-local repo config file, not repo-tracked**
+
+Proceed to Task 5 (the actual upgrade).
+
+---
+
+### Task 5: Perform the upgrade and immediately re-verify `labby`
+
+**Files:**
+- Create: `/tmp/incus-upgrade-baseline/post-upgrade-labby-ready.txt` (scratch, referenced in close-comment)
+
+**Interfaces:**
+- Consumes: the baseline files from Task 1
+- Produces: an upgraded `incus`/`incusd` (6.3+) with `labby` verified still healthy — the precondition every later task assumes
+
+- [ ] **Step 1: Perform the upgrade**
+
+Run:
+```bash
+apt-get install incus incus-base incus-client incus-agent
+```
+Expected: apt installs a new version ≥ 6.3 for all four packages from the Zabbly source, restarting `incusd` as part of the package's postinst. Watch for any error output — if the command fails or reports broken dependencies, STOP here and do not proceed; report back rather than attempting an ad hoc fix.
+
+- [ ] **Step 2: Confirm the new version**
+
+Run:
+```bash
+incus version | tee /tmp/incus-upgrade-baseline/post-upgrade-incus-version.txt
+```
+Expected: `Client version:` and `Server version:` both show 6.3 or higher.
+
+- [ ] **Step 3: Immediately confirm `labby` is still running and its gateway responds**
+
+Run:
+```bash
+incus list labby
+incus exec labby -- curl -fsS http://127.0.0.1:8765/ready | tee /tmp/incus-upgrade-baseline/post-upgrade-labby-ready.txt
+```
+Expected: `incus list labby` shows `RUNNING`; the `/ready` curl returns the same successful response captured in Task 1 Step 3. If `labby` is not running, run `incus restart labby` once and re-check — if it still doesn't come up cleanly, STOP and report per the Global Constraints (no destructive recovery without confirmation).
+
+- [ ] **Step 4: No git commit for this step** — this is a live host state change, not a repo change. Evidence (the version + ready-check output) is captured in the scratch files above for the final task's close-comment.
+
+Proceed to Task 6.
+
+---
+
+### Task 6: Verify every pre-existing container and profile survived unchanged
+
+**Files:**
+- Create: `/tmp/incus-upgrade-baseline/post-upgrade-diff.txt`
+
+**Interfaces:**
+- Consumes: all baseline files from Task 1
+- Produces: a diff report proving no pre-existing container/profile config drifted — the evidence Task 8's close-comment cites for "all pre-existing containers/profiles/storage survive with unchanged config"
+
+- [ ] **Step 1: Re-capture the same state Task 1 captured, and diff against the baseline**
+
+Run:
+```bash
+incus list -a > /tmp/incus-upgrade-baseline/post-incus-list.txt
+incus profile list > /tmp/incus-upgrade-baseline/post-profile-list.txt
+incus profile show axon-container-profile > /tmp/incus-upgrade-baseline/post-profile-axon-container-profile.txt
+incus profile show labby-gateway > /tmp/incus-upgrade-baseline/post-profile-labby-gateway.txt
+incus config show labby --expanded > /tmp/incus-upgrade-baseline/post-config-labby.txt
+
+diff /tmp/incus-upgrade-baseline/profile-axon-container-profile.txt /tmp/incus-upgrade-baseline/post-profile-axon-container-profile.txt
+diff /tmp/incus-upgrade-baseline/profile-labby-gateway.txt /tmp/incus-upgrade-baseline/post-profile-labby-gateway.txt
+diff /tmp/incus-upgrade-baseline/config-labby.txt /tmp/incus-upgrade-baseline/post-config-labby.txt
+```
+Expected: all three `diff` commands produce **no output** (or only diffs in fields that are expected to change across a restart, such as `volatile.last_state.power` timestamps — inspect any non-empty diff line-by-line and confirm it is not a config/device/limits change). Save the full diff transcript:
+```bash
+{
+  echo "=== axon-container-profile diff ==="
+  diff /tmp/incus-upgrade-baseline/profile-axon-container-profile.txt /tmp/incus-upgrade-baseline/post-profile-axon-container-profile.txt
+  echo "=== labby-gateway profile diff ==="
+  diff /tmp/incus-upgrade-baseline/profile-labby-gateway.txt /tmp/incus-upgrade-baseline/post-profile-labby-gateway.txt
+  echo "=== labby config diff ==="
+  diff /tmp/incus-upgrade-baseline/config-labby.txt /tmp/incus-upgrade-baseline/post-config-labby.txt
+} > /tmp/incus-upgrade-baseline/post-upgrade-diff.txt
+cat /tmp/incus-upgrade-baseline/post-upgrade-diff.txt
+```
+
+- [ ] **Step 2: Confirm every container from the baseline list is still present with the same state**
+
+Run:
+```bash
+diff <(awk '{print $2, $4}' /tmp/incus-upgrade-baseline/incus-list.txt) \
+     <(awk '{print $2, $4}' /tmp/incus-upgrade-baseline/post-incus-list.txt)
+```
+Expected: no output — every container name + state (RUNNING/STOPPED) column matches between pre- and post-upgrade. (This awk-column comparison is approximate given `incus list`'s table formatting; if the diff is noisy, visually cross-check `post-incus-list.txt` against `incus-list.txt` line-by-line instead — the goal is confirming no container vanished and no RUNNING container became STOPPED unexpectedly.)
+
+- [ ] **Step 3: STOP if any unexpected diff is found**
+
+If any diff shows a real config/device/limits/state change (not just an expected timestamp/volatile field), STOP and report the specific diff rather than proceeding to Task 7. Do not attempt to silently "fix" a drifted profile.
+
+- [ ] **Step 4: No commit needed** — scratch evidence only.
+
+Proceed to Task 7.
+
+---
+
+### Task 7: Pin the Incus packages against silent future drift
+
+**Files:**
+- Modify: apt's package-hold state (not a file in this repo)
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces: a host where a routine `apt upgrade` cannot silently move Incus to a different version without an explicit `apt-mark unhold` first
+
+- [ ] **Step 1: Hold the four Incus packages at their newly-installed version**
+
+Run:
+```bash
+apt-mark hold incus incus-base incus-client incus-agent
+apt-mark showhold
+```
+Expected: `apt-mark showhold` lists all four package names.
+
+- [ ] **Step 2: Confirm a routine `apt upgrade` no longer touches Incus**
+
+Run:
+```bash
+apt-get upgrade --dry-run 2>&1 | grep -i incus
+```
+Expected: no output (or explicitly shows the held packages are excluded from the upgrade plan) — proving future unattended/routine upgrades won't silently move Incus versions.
+
+- [ ] **Step 3: No commit needed** — host package-manager state, not repo-tracked.
+
+Proceed to Task 8.
+
+---
+
+### Task 8: Minimal OCI smoke test, cleanup, and final close-comment evidence
+
+**Files:**
+- None created in the repo (per bead `.8`'s Files section: no standalone doc — evidence lives in the bd close-comment)
+
+**Interfaces:**
+- Consumes: the upgraded, verified, pinned Incus install from Tasks 5–7
+- Produces: proof the upgrade actually unlocked OCI support, satisfying `.8`'s Validation criteria — the final gate before this bead can close
+
+- [ ] **Step 1: Register the Docker Hub OCI remote**
+
+Run:
+```bash
+incus remote add docker https://docker.io --protocol=oci
+incus remote list
+```
+Expected: `incus remote list` shows a `docker` entry with protocol `oci`.
+
+- [ ] **Step 2: Launch a minimal, ephemeral OCI instance**
+
+Run:
+```bash
+incus launch docker:hello-world oci-smoke-test --ephemeral
+```
+Expected: the instance launches and (being an ephemeral, run-to-completion image) either exits and self-deletes, or runs briefly — confirm with:
+```bash
+incus list oci-smoke-test
+```
+Expected: either the instance is gone already (ephemeral cleanup happened) or shows as STOPPED/exited; this is normal for `hello-world`-style images. If the instance is still present, clean it up explicitly:
+```bash
+incus delete oci-smoke-test --force 2>/dev/null || true
+incus list oci-smoke-test
+```
+Expected final state: `incus list oci-smoke-test` returns no matching instance.
+
+- [ ] **Step 3: Confirm no orphaned instances/profiles remain from this entire task sequence**
+
+Run:
+```bash
+incus list -a
+incus profile list
+```
+Expected: identical to the post-upgrade baseline from Task 6 (Step 2's diff target), plus no `oci-smoke-test` instance and no new profiles created by this plan.
+
+- [ ] **Step 4: Assemble the close-comment evidence and update the bead**
+
+Run:
+```bash
+cd /home/jmagar/workspace/axon
+bd comments add axon_rust-4m749.8 "$(cat <<'EOF'
+FACT: Zabbly stable-channel upgrade completed and verified on dookie (2026-07-07). Evidence (full transcripts in /tmp/incus-upgrade-baseline/, host-local scratch — pasted key excerpts below per the epic's close-gate requiring a citable, independently-verifiable transcript, not just prose):
+
+$(cat /tmp/incus-upgrade-baseline/incus-version.txt)
+--- upgraded to ---
+$(cat /tmp/incus-upgrade-baseline/post-upgrade-incus-version.txt)
+
+labby post-upgrade health check:
+$(cat /tmp/incus-upgrade-baseline/post-upgrade-labby-ready.txt)
+
+Profile/config diff (pre vs post upgrade) — empty or timestamp-only, no config drift:
+$(cat /tmp/incus-upgrade-baseline/post-upgrade-diff.txt)
+
+Packages held at new version: $(apt-mark showhold | tr '\n' ' ')
+
+OCI smoke test: incus launch docker:hello-world succeeded, cleaned up, no orphaned instances/profiles remain (incus list -a / incus profile list checked against baseline).
+
+Rollback procedure verified via dry-run BEFORE the live upgrade (not needed, upgrade succeeded): see /tmp/incus-upgrade-baseline/rollback-procedure.txt on dookie.
+EOF
+)"
+bd update axon_rust-4m749.8 -s closed --notes "Closed per plan docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md, all 8 tasks completed and verified."
+```
+Expected: `bd comments add` succeeds; `bd update ... -s closed` reports the bead is now closed.
+
+- [ ] **Step 5: No git commit** — this task produced no repo file changes (per `.8`'s Files section: "None as a standalone deliverable"). The evidence lives in the bd comment (Step 4) and the host-local scratch directory `/tmp/incus-upgrade-baseline/` it quotes from. If you want a permanent record beyond bd + host scratch, that's `.7`'s consolidated doc's job later, not this bead's.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check against `axon_rust-4m749.8`'s locked decisions:**
+- GPG fingerprint verification → Task 2 ✓
+- Baseline snapshot before upgrade → Task 1 ✓
+- Rehearsed rollback prepared/dry-run BEFORE live upgrade → Task 3 ✓
+- Post-upgrade `labby` health/config verification → Tasks 5–6 ✓
+- Post-upgrade verification of all pre-existing containers/profiles → Task 6 ✓
+- Exact validated Incus version recorded → Tasks 5, 8 ✓
+- Stop-and-report (no silent rollback/destructive recovery) → stated as a Global Constraint and repeated at each risk point (Tasks 5, 6) ✓
+- Repo pinning against silent future drift → Task 7 ✓
+- Minimal OCI smoke test → Task 8 ✓
+- No standalone doc file; evidence via close-comment citing a real transcript → Task 8 Step 4 ✓
+- Epic-wide close-gate (citable commit/file path, not prose) → satisfied by quoting real captured file contents directly into the close-comment in Task 8 Step 4, not a paraphrased summary
+
+**Placeholder scan:** no TBD/TODO/"add error handling" language found — every step has a concrete command and expected output.
+
+**Type/name consistency:** the baseline directory path (`/tmp/incus-upgrade-baseline/`) and its exact filenames are introduced in Task 1 and referenced identically (same names) in every later task — no renamed variables.


### PR DESCRIPTION
## Summary
- The production dookie deployment quietly diverged from PR #383's design: axon itself runs as a native systemd service (`axon-native.service`) inside the Incus container, not as a Docker container — only TEI/chrome/qdrant stay on nested Docker. That change was made live on the host but never fed back into the repo.
- Adds `deploy/incus/axon-native.service` (captured from the live unit), updates `bootstrap.sh` to build/install the axon binary natively and manage the service + host-facing proxy device idempotently, and rewrites `deploy/incus/README.md` to describe the real hybrid architecture.

## Test plan
- [x] `bash -n deploy/incus/bootstrap.sh` — syntax OK
- [x] `shellcheck` — no new warnings vs. pre-existing baseline
- [ ] Next live bootstrap.sh run on dookie should be a no-op for the already-installed axon binary (version match skips rebuild) and should not disturb the currently-running `axon-native.service`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Incus deployment with production: `axon` now runs as a native systemd service inside the Incus container, while `axon-tei`, `axon-chrome`, and qdrant stay on nested Docker. Adds an idempotent bootstrap and external-Qdrant path to make the hybrid setup reproducible.

- **New Features**
  - Run `axon` natively via `deploy/incus/axon-native.service`; `deploy/incus/bootstrap.sh` builds/installs the binary in-container and manages the service.
  - Keep sidecars on nested Docker; add `docker-compose.external-qdrant.yaml` for external Qdrant, and make bundled Qdrant the default in `docker-compose.prod.yaml`.
  - Add `deploy/incus/profile.yaml` and a new `deploy/incus/README.md`; document storage mapping, GPU passthrough, and manage the `mcp-publish` proxy via `AXON_HTTP_PUBLISH_LISTEN`.
  - Add `deploy/incus/axon-incus-bootstrap.service` to re-run bootstrap on host boot; new `Justfile` tasks (`prod-up`, `prod-up-external-qdrant`) ensure correct env-file usage.

- **Bug Fixes**
  - Fix OAuth config key prefix in `crates/axon-authz/src/http.rs` by using `AXON_MCP_` keys so `AXON_AUTH_MODE=oauth` works as intended.

<sup>Written for commit d42a83db082841799f6c8d00fbb8bc6981520301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production start/stop commands for the app stack, including support for both bundled and external Qdrant setups.
  * Added Incus-based deployment support for running the app natively with nested container sidecars.
* **Bug Fixes**
  * Improved environment handling for OAuth settings and redirect URLs.
  * Added safer checks for required configuration and GPU/container readiness during startup.
* **Documentation**
  * Added deployment guides and setup examples for the new Incus workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->