### PR TITLE
fix(ci): switch OpenWiki to local openai-compatible proxy

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -36,13 +36,10 @@ jobs:
       - name: Run OpenWiki
         run: openwiki --update --print
         env:
-          OPENWIKI_PROVIDER: ${{ secrets.OPENWIKI_PROVIDER }}
-          OPENWIKI_MODEL_ID: ${{ secrets.OPENWIKI_MODEL_ID }}
-          ANTHROPIC_API_KEY: ${{ secrets.OPENWIKI_ANTHROPIC_API_KEY }}
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENWIKI_ANTHROPIC_BASE_URL }}
-          LANGSMITH_API_KEY: ${{ secrets.OPENWIKI_LANGSMITH_API_KEY }}
-          LANGCHAIN_PROJECT: openwiki
-          LANGCHAIN_TRACING_V2: "true"
+          OPENWIKI_PROVIDER: openai-compatible
+          OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+          OPENAI_COMPATIBLE_BASE_URL: https://cli-api.tootie.tv/v1
+          OPENWIKI_MODEL_ID: gpt-5.3-codex-spark
 
       - name: Create OpenWiki update pull request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
The z.ai Anthropic-compatible endpoint was hitting its 5-hour usage-window rate limit. Switch to the self-hosted openai-compatible proxy at cli-api.tootie.tv (gpt-5.3-codex-spark), simplifying the secrets indirection down to a single `OPENAI_COMPATIBLE_API_KEY`.

Part of the fleet-wide OpenWiki proxy rollout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the OpenWiki CI job to our self-hosted OpenAI-compatible proxy at https://cli-api.tootie.tv/v1 using `gpt-5.3-codex-spark` to avoid z.ai rate-limit windows. Simplifies config to `OPENWIKI_PROVIDER=openai-compatible` with a single `OPENAI_COMPATIBLE_API_KEY`.

- **Migration**
  - Add repo/org secret `OPENAI_COMPATIBLE_API_KEY`.
  - Optional: remove unused secrets `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, `OPENWIKI_ANTHROPIC_API_KEY`, `OPENWIKI_ANTHROPIC_BASE_URL`, `OPENWIKI_LANGSMITH_API_KEY`.

<sup>Written for commit b6fe0170eb684cba9d5ff84e4f0e5064f307fe9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

