### PR TITLE
docs(pipeline): plan remaining durable-job-cutover and phase 3b security work

### DIFF
--- a/docs/pipeline-unification/plans/2026-07-08-finish-job-cutover-and-security-completion.md
+++ b/docs/pipeline-unification/plans/2026-07-08-finish-job-cutover-and-security-completion.md
@@ -1,0 +1,928 @@
+# Finish Job Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining open items in Task 3A (`2026-07-04-full-durable-job-cutover.md`, Tasks 6 and 8) by cutting `Crawl`/`Embed`/`Ingest` job execution over to the unified `JobStore`, mirroring the already-shipped `Extract` cutover — while fixing the two defects an engineering review found in that shipped precedent (an unconditional `trusted_system` auth snapshot, and zero callers of the worker-wake notify) before tripling their surface area, and fixing the unified worker's serial-only claim loop before deleting the legacy per-family lane concurrency it currently provides.
+
+**Architecture:** `Extract` is already fully cut over (`crates/axon-services/src/extract.rs::extract_start_with_context` → `ExtractRunner` in `crates/axon-services/src/runtime/job_runners.rs` → `crates/axon-services/src/runtime/sqlite/extract_bridge.rs`). This plan repeats that pattern for `Crawl`, `Embed`, `Ingest`, one at a time, each fully verified before the next — but only after Task 0 fixes two cross-cutting gaps in the shared unified-worker infrastructure that every ported family would otherwise inherit silently: (1) `notify_unified()` has zero callers anywhere, so every job enqueued today waits a full poll interval instead of waking immediately; (2) the unified worker's claim loop runs each job inline/serially (`lanes = 1`, confirmed by its own log line), while the legacy `embed_worker`/`ingest_worker` it will replace run `embed_lanes`/`ingest_lanes`-way parallel (up to 32/16). Both gaps are pre-existing in the shipped Extract cutover — low-impact there because of Extract's low volume — but would become real regressions the moment Crawl/Embed/Ingest (the system's higher-volume job kinds) move onto the same infrastructure. This plan also corrects the shipped `extract_start_with_context`'s auth-snapshot handling to match the pattern the rest of the codebase's newer `*_source_job.rs` files already use (`Option<AuthSnapshot>` + `.unwrap_or_else(|| AuthSnapshot::trusted_system(...))`), rather than inventing a new pattern.
+
+Crawl has one apparent wrinkle Extract didn't — `crates/axon-jobs/src/workers.rs`'s existing comment claims crawl futures are `!Send`, requiring a dedicated single-lane worker. Evidence against this claim is strong (crawl already runs inside a plain `tokio::spawn`, which requires `Send`, today), so Task 2 leads with a compile-check to settle it empirically before choosing an implementation strategy, rather than assuming the comment is correct.
+
+**Split out of this plan, tracked separately (see the "Related Plans" section below):** provider-cooling wiring, redaction-boundary extension to CLI/artifacts/traces, and the REST memory route split — all architecturally independent of the job cutover, per engineering review. Reset's legacy-store confirmation gap stays in this plan (Task 5) since it's small, cheap, and unrelated in *code* but related in *theme* (another "don't silently trust legacy state" fix), and a security review found its originally-proposed fix (a `config.toml`-persistable flag) needed correcting anyway.
+
+**Tech Stack:** Rust 2024, Tokio, `sqlx` SQLite/WAL, `axon-api::source` job DTOs, `axon-jobs`, `axon-services`, `axon-cli`, `axon-mcp`, `axon-web`.
+
+## Global Constraints
+
+- Do not migrate or backfill legacy `axon_crawl_jobs`/`axon_embed_jobs`/`axon_ingest_jobs` rows into the unified tables. In-flight legacy jobs finish on the legacy path; new jobs enqueue on the unified path from the cutover commit forward.
+- Every job-backed operation still returns a `JobDescriptor`/`JobStartOutcome`; do not change the CLI/MCP/REST-facing shape of `crawl`/`embed`/`ingest` responses, only what backs them.
+- Preserve panic guard, cancellation, heartbeat, stale reclaim, and retry semantics through the cutover.
+- **Never construct `AuthSnapshot::trusted_system(...)` unconditionally in a function that has (or could have) a real caller identity available.** Accept `Option<AuthSnapshot>`, fall back to `trusted_system` only when genuinely absent (internal/system-triggered calls like watch/refresh), matching `crates/axon-services/src/web_source/web_source_job.rs`'s established pattern.
+- `axon:write` does not imply `axon:admin`, `axon:execute`, or `axon:local`.
+- Do not edit `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`.
+- Commit after each task's verification passes.
+- Follow the repo's sidecar test-file convention (`foo.rs` + `foo_tests.rs` declared via `#[path]`) and the ≤500-line monolith policy.
+
+---
+
+## Source-Of-Truth Contracts
+
+- `docs/pipeline-unification/plans/2026-07-04-full-durable-job-cutover.md` (Tasks 6 and 8)
+- `docs/pipeline-unification/runtime/job-contract.md`
+- `docs/pipeline-unification/runtime/auth-contract.md`
+- `docs/pipeline-unification/delivery/cutover-contract.md`
+
+## Related Plans (split out, do not implement here)
+
+- `2026-07-08-provider-cooling.md` — Phase 3B Task 3 gap
+- `2026-07-08-redaction-boundary-extension.md` — Phase 3B Task 4 gap
+- `2026-07-08-rest-memory-surface.md` — Phase 3B Task 9 gap
+
+## Current-State Anchors
+
+- Proven cutover template: `crates/axon-services/src/extract.rs::extract_start_with_context`, `crates/axon-services/src/runtime/job_runners.rs::{build_registry, ExtractRunner}`, `crates/axon-services/src/runtime/sqlite/extract_bridge.rs`, `crates/axon-services/src/runtime/sqlite.rs` (the `if kind == JobKind::Extract { ... }` bridge dispatch).
+- Established real auth-snapshot pattern to copy (NOT `extract.rs`'s unconditional `trusted_system`): `crates/axon-services/src/web_source/web_source_job.rs` — `input.auth_snapshot.clone().unwrap_or_else(|| AuthSnapshot::trusted_system("runtime"))`. Caller-context construction at the transport layer: `crates/axon-web/src/server/handlers/sources.rs::caller_context_from_auth(&AuthContext) -> CallerContext`, then `AuthSnapshot::from_caller(&caller, Visibility::Internal, policy_version)`.
+- Worker-wake gap: `crates/axon-jobs/src/workers.rs::notify_unified()` (zero callers anywhere). Poll fallback: `crates/axon-jobs/src/workers/unified.rs`'s `POLL_INTERVAL` in the `tokio::select!` at the top of `unified_worker_loop`.
+- Concurrency gap: `crates/axon-jobs/src/workers/unified.rs::unified_worker_loop`'s inner `while processed < WORKER_BATCH_LIMIT` loop calls `run_unified_claimed(...).await` inline before claiming the next job — fully serial. `crates/axon-jobs/src/workers/spawn_unified.rs` logs `lanes = 1` explicitly. Compare against legacy `embed_lanes`/`ingest_lanes`-driven `tokio::spawn` loops in `crates/axon-jobs/src/workers.rs::spawn_workers`.
+- Legacy dual-run spawn point: `crates/axon-jobs/src/workers.rs::spawn_workers` — spawns `crawl_worker` (single lane), `embed_worker` (multi-lane), `ingest_worker` (multi-lane) alongside `spawn_unified_worker`.
+- Legacy enqueue call sites: `crates/axon-services/src/crawl.rs::crawl_start_with_context`, `crates/axon-services/src/embed.rs::embed_start_with_context`, `crates/axon-services/src/ingest.rs::ingest_start_with_context` — all currently call `service_context.jobs.enqueue(JobPayload::{Crawl,Embed,Ingest} { .. })`.
+- Legacy active-runtime table readers: `crates/axon-jobs/src/backend.rs`, `crates/axon-jobs/src/query.rs`.
+- Crawl's disputed `!Send` claim: comment at `crates/axon-jobs/src/workers.rs` near the `crawl_worker` spawn. Contradicting evidence: `crates/axon-jobs/src/workers/runners/crawl.rs::run_crawl_job` already executes inside a plain `tokio::spawn` today.
+- Reset legacy-store handling: `crates/axon-services/src/reset.rs::execute_prepared_reset`, `crates/axon-services/src/reset/execution.rs` (wipes unconditionally today, writes an audit receipt after the fact — a deliberate but under-visible tradeoff, not an oversight).
+
+## File Structure
+
+- Modify: `crates/axon-jobs/src/workers/unified.rs` (bounded concurrent claim-and-run)
+- Modify: `crates/axon-core/src/config/types/config.rs` (add `unified_worker_concurrency`)
+- Modify: `crates/axon-services/src/extract.rs` (fix `trusted_system` → `Option<AuthSnapshot>`, add `notify_unified()` call)
+- Modify: `crates/axon-services/src/jobs.rs` (same fix, second unconditional `trusted_system` site)
+- Create: `crates/axon-services/src/runtime/sqlite/crawl_bridge.rs`, `embed_bridge.rs`, `ingest_bridge.rs`
+- Modify: `crates/axon-services/src/runtime/job_runners.rs` (add `CrawlRunner`, `EmbedRunner`, `IngestRunner`)
+- Modify: `crates/axon-services/src/crawl.rs`, `embed.rs`, `ingest.rs` (`*_start_with_context` → unified enqueue, real caller auth, notify)
+- Modify: `crates/axon-services/src/runtime/sqlite.rs` (bridge dispatch for `JobKind::{Crawl,Embed,Ingest}`)
+- Modify: `crates/axon-jobs/src/workers.rs` (remove legacy worker spawns once each family is ported)
+- Modify: `crates/axon-jobs/src/backend.rs`, `crates/axon-jobs/src/query.rs` (remove legacy table mappings)
+- Modify: `crates/axon-api/src/reset.rs`, `crates/axon-services/src/reset.rs`, `reset/execution.rs`, `reset/sqlite.rs` (legacy-store confirmation, CLI-flag-only)
+- Modify: `crates/axon-cli/src/**` (auth context threading into `*_start_with_context` call sites; `--confirm-legacy-wipe` CLI flag)
+- Create: `crates/axon-jobs/src/security_error_memory_e2e_tests.rs` additions (the jobs-crate slice only — MCP/web slices live in the split-out redaction/memory plans)
+
+---
+
+## Task 0: Fix The Shared Unified-Worker Infrastructure Before Porting Any Family
+
+**Files:**
+- Modify: `crates/axon-jobs/src/workers/unified.rs`
+- Modify: `crates/axon-core/src/config/types/config.rs`, `crates/axon-core/src/config/types/config_impls.rs`
+- Modify: `crates/axon-services/src/extract.rs`
+- Modify: `crates/axon-services/src/jobs.rs`
+- Test: `crates/axon-jobs/src/unified_tests.rs`
+- Test: `crates/axon-services/src/extract_tests.rs`
+
+**Interfaces:**
+- Consumes: `tokio::sync::Semaphore`, existing `JobRunnerRegistry`/`run_unified_claimed`.
+- Produces: `unified_worker_loop` claiming and running jobs concurrently up to a bounded limit; `notify_unified()` actually called on enqueue; `extract_start_with_context`/`crates/axon-services/src/jobs.rs`'s job-tracking helper both stop constructing `AuthSnapshot::trusted_system` unconditionally.
+
+This task exists because an engineering review found these two gaps in the *already-shipped* Extract cutover, and every subsequent task in this plan would otherwise silently inherit and triple them.
+
+- [ ] **Step 1: Write a failing prompt-wakeup latency test**
+
+Add to `crates/axon-jobs/src/unified_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn enqueued_job_is_claimed_within_one_wakeup_not_a_full_poll_interval() {
+    let (pool, notify, shutdown) = unified_test_harness().await;
+    let handle = tokio::spawn(crate::workers::unified::unified_worker_loop(
+        Arc::clone(&pool),
+        Arc::clone(&notify),
+        shutdown.clone(),
+        None,
+    ));
+    let store = crate::unified::SqliteUnifiedJobStore::new((*pool).clone());
+    let started = std::time::Instant::now();
+    let job = store.create(job_request_fixture("memory")).await.unwrap();
+    notify.notify_one();
+    let claimed_at = wait_for_status_change(&store, job.job_id, LifecycleStatus::Queued, std::time::Duration::from_millis(500))
+        .await
+        .expect("job should leave Queued well before a full poll interval");
+    assert!(
+        claimed_at.elapsed_since(started) < std::time::Duration::from_secs(1),
+        "job took a full poll interval to be claimed — notify_unified() is not being called"
+    );
+    shutdown.cancel();
+    let _ = handle.await;
+}
+```
+
+Add `unified_test_harness()` and `wait_for_status_change()` helpers next to whatever this file's existing unified-store test fixtures already use (reuse, don't duplicate — `unified_tests.rs` already has fixtures like `job_request_fixture` per the Task 3A cutover).
+
+- [ ] **Step 2: Write a failing concurrency test**
+
+Add:
+
+```rust
+#[tokio::test]
+async fn unified_worker_claims_and_runs_multiple_jobs_concurrently() {
+    let (pool, notify, shutdown) = unified_test_harness().await;
+    let concurrency_marker = Arc::new(tokio::sync::Semaphore::new(0));
+    let registry = registry_with_slow_concurrent_runner(Arc::clone(&concurrency_marker));
+    let handle = tokio::spawn(crate::workers::unified::unified_worker_loop(
+        Arc::clone(&pool),
+        Arc::clone(&notify),
+        shutdown.clone(),
+        Some(registry),
+    ));
+    let store = crate::unified::SqliteUnifiedJobStore::new((*pool).clone());
+    for _ in 0..4 {
+        store.create(job_request_fixture("memory")).await.unwrap();
+    }
+    notify.notify_one();
+    // The slow runner blocks until it observes >1 concurrently in-flight,
+    // proving the worker didn't serialize them.
+    let observed_concurrent = wait_for_concurrent_marker(&concurrency_marker, std::time::Duration::from_secs(2)).await;
+    assert!(observed_concurrent >= 2, "expected at least 2 jobs running concurrently, saw {observed_concurrent}");
+    shutdown.cancel();
+    let _ = handle.await;
+}
+```
+
+Add `registry_with_slow_concurrent_runner`/`wait_for_concurrent_marker` as small local test helpers — a fake `UnifiedJobRunner` whose `run()` increments a shared counter, awaits a short sleep, decrements, and returns `Ok(())`.
+
+- [ ] **Step 3: Run tests and confirm failure**
+
+Run: `cargo test -p axon-jobs enqueued_job_is_claimed_within_one_wakeup unified_worker_claims_and_runs_multiple_jobs_concurrently --no-fail-fast`
+
+Expected: both FAIL — the first because nothing calls `notify.notify_one()` from the production enqueue path (only the test does, proving the mechanism works when invoked, but nothing in `extract_start_with_context` invokes it), the second because `unified_worker_loop` awaits each claimed job inline.
+
+- [ ] **Step 4: Add `unified_worker_concurrency` config**
+
+Add `unified_worker_concurrency: usize` to `Config` (default `8` — a conservative middle ground between Extract's implicit `1` and legacy `embed_lanes`' ceiling of `32`; document in the field's doc comment that this is deliberately not auto-derived from `embed_lanes`/`ingest_lanes` because after Task 4 those fields stop being consumed for job execution and become dead config, which a later cleanup pass should remove). Wire it into `Config::default()`/`test_default()` and `~/.axon/config.toml` parsing per this repo's "Adding fields to `Config`" convention.
+
+- [ ] **Step 5: Bound the claim loop with a semaphore**
+
+In `crates/axon-jobs/src/workers/unified.rs::unified_worker_loop`, replace the inline `run_unified_claimed(&pool, &claimed, &shutdown, registry.as_deref()).await;` with a semaphore-permitted spawn:
+
+```rust
+let semaphore = Arc::new(tokio::sync::Semaphore::new(unified_worker_concurrency));
+// ... inside the claim loop:
+match claim_next_unified_job_unchecked(&pool).await {
+    Ok(Some(claimed)) => {
+        let permit = Arc::clone(&semaphore).acquire_owned().await.expect("semaphore not closed");
+        let pool = Arc::clone(&pool);
+        let shutdown = shutdown.clone();
+        let registry = registry.clone();
+        tokio::spawn(async move {
+            run_unified_claimed(&pool, &claimed, &shutdown, registry.as_deref()).await;
+            drop(permit);
+        });
+        processed += 1;
+    }
+    Ok(None) => break,
+    Err(error) => { /* unchanged */ }
+}
+```
+
+Thread `unified_worker_concurrency: usize` as a new parameter into `unified_worker_loop` and `spawn_unified_worker` (`crates/axon-jobs/src/workers/spawn_unified.rs`), sourced from `cfg.unified_worker_concurrency` at the `spawn_workers` call site. Update the `spawn_unified_worker` log line's hardcoded `lanes = 1` to log the real configured concurrency instead — it is actively misleading once this fix lands.
+
+- [ ] **Step 6: Wire `notify_unified()` into the enqueue path**
+
+`notify_unified()` (`crates/axon-jobs/src/workers.rs`) needs to be reachable from `axon-services`. Check whether `ServiceContext`/`WorkerHandles` already exposes a callable path (search for how `crawl_notify`/`embed_notify` are reached from `axon-services` today, since the legacy family enqueue functions already call their own family notify successfully — mirror that exact wiring for the unified notify handle instead of inventing a new plumbing path). Add `service_context.notify_unified()` (or the equivalent real method name found) as the last line of `extract_start_with_context`, right after `store.create(...)` succeeds.
+
+- [ ] **Step 7: Fix `extract_start_with_context`'s unconditional `trusted_system`**
+
+Change `extract_start_with_context`'s signature to accept `caller: Option<&AuthSnapshot>` (or thread through however `web_source_job.rs`'s `input.auth_snapshot: Option<AuthSnapshot>` field is populated — read that file's full struct definition first to match the established shape exactly, do not invent a divergent parameter shape). Replace:
+
+```rust
+auth_snapshot: AuthSnapshot::trusted_system("runtime"),
+```
+
+with:
+
+```rust
+auth_snapshot: caller
+    .cloned()
+    .unwrap_or_else(|| AuthSnapshot::trusted_system("runtime")),
+```
+
+Update `extract_start_with_context`'s three real callers (CLI `crates/axon-cli/src/commands/extract.rs`, MCP `crates/axon-mcp/src/server/handlers_extract.rs`, REST `crates/axon-web/src/server/handlers/{rest/,}async_jobs.rs` or wherever the real extract-start REST handler lives) to construct a real `CallerContext`/`AuthSnapshot` the same way `crates/axon-web/src/server/handlers/sources.rs::caller_context_from_auth` already does for the newer source pipeline, and pass it through. Where a transport genuinely has no authenticated caller available (e.g. an internal scheduler trigger), pass `None` explicitly rather than silently defaulting — the call site should make the "no real caller" case visible in the diff, not implicit.
+
+- [ ] **Step 8: Fix the second unconditional `trusted_system` site**
+
+`crates/axon-services/src/jobs.rs` (line ~201 per the review) has a second unconditional `AuthSnapshot::trusted_system("runtime")` construction in a job-tracking helper. Read its surrounding function to determine whether it has caller context available; apply the same `Option<AuthSnapshot>` fix if it does, or leave it as `trusted_system` with a `// no caller identity available at this call site — see docs/pipeline-unification/runtime/auth-contract.md` comment explaining why if it is genuinely an internal-only path (e.g. system-triggered watch/reclaim), so a future reader doesn't mistake it for an oversight.
+
+- [ ] **Step 9: Run tests**
+
+```bash
+cargo test -p axon-jobs unified --no-fail-fast
+cargo test -p axon-services extract --no-fail-fast
+```
+
+Expected: PASS, including both new tests from Steps 1-2.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/axon-jobs/src crates/axon-core/src/config crates/axon-services/src/extract.rs crates/axon-services/src/jobs.rs crates/axon-cli/src crates/axon-mcp/src crates/axon-web/src
+git commit -m "fix(jobs): bound unified worker concurrency, wire enqueue notify, fix unconditional trusted_system auth"
+```
+
+## Task 1: Port Embed (Simplest — No `!Send` Wrinkle)
+
+**Files:**
+- Create: `crates/axon-services/src/runtime/sqlite/embed_bridge.rs`
+- Modify: `crates/axon-services/src/runtime/job_runners.rs`
+- Modify: `crates/axon-services/src/embed.rs`
+- Modify: `crates/axon-services/src/runtime/sqlite.rs`
+- Test: `crates/axon-services/src/embed_tests.rs`
+- Test: `crates/axon-services/src/runtime/job_runners_tests.rs`
+
+**Interfaces:**
+- Consumes: `axon_jobs::boundary::JobStore::create`, `axon_api::source::{JobCreateRequest, JobKind as UnifiedJobKind, JobIntent, JobPriority, JobStagePlan, PipelinePhase, AuthSnapshot, MetadataMap}`, `crate::runtime::job_runners::{UnifiedJobRunner, UnifiedClaimedJob, SqliteUnifiedJobStore}`, Task 0's fixed `notify_unified()` wiring and real-caller-auth pattern.
+- Produces: `embed_start_with_context` enqueueing via the unified store with real caller auth and immediate wakeup; `EmbedRunner` executing embed jobs. Tasks 2-3 reuse this exact pattern.
+
+- [ ] **Step 1: Read the exact current embed enqueue/execute code**
+
+Read `crates/axon-services/src/embed.rs` in full, and whichever function `crates/axon-jobs/src/workers/runners/embed.rs`'s `embed_worker` calls to run a real embed job — that function's name/signature is what `EmbedRunner::run` must call.
+
+- [ ] **Step 2: Write failing test for unified enqueue with real auth and wakeup**
+
+Add to `crates/axon-services/src/embed_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn embed_start_with_context_enqueues_on_unified_job_store_with_caller_auth() {
+    let ctx = crate::testing::service_context_with_unified_jobs().await;
+    let cfg = axon_core::config::Config::test_default();
+    let caller = AuthSnapshot::from_caller(
+        &CallerContext {
+            actor: Some("user_1".to_string()),
+            transport: TransportKind::Cli,
+            scopes: vec![AuthScope::Read, AuthScope::Write],
+            visibility_ceiling: Visibility::Internal,
+        },
+        Visibility::Internal,
+        "test",
+    );
+    let outcome = embed_start_with_context(&cfg, "https://example.com", &ctx, None, None, Some(&caller))
+        .await
+        .expect("embed_start_with_context should enqueue");
+    let store = ctx.job_store().expect("unified job store must be attached");
+    let job = store
+        .get(axon_api::source::JobId(
+            uuid::Uuid::parse_str(&outcome.result.job_id).unwrap(),
+        ))
+        .await
+        .unwrap()
+        .expect("job row must exist");
+    assert_eq!(job.job_kind, axon_api::source::JobKind::Embed);
+    assert_eq!(job.auth_snapshot.caller_id.as_deref(), Some("user_1"));
+    assert_ne!(job.auth_snapshot.granted_scopes, vec![AuthScope::Admin]);
+}
+```
+
+If `crate::testing::service_context_with_unified_jobs` does not exist yet, reuse whatever helper `extract_tests.rs`'s own unified-store fixture already uses — do not write a second one.
+
+- [ ] **Step 3: Run test and confirm failure**
+
+Run: `cargo test -p axon-services embed_start_with_context_enqueues_on_unified_job_store_with_caller_auth --no-fail-fast`
+
+Expected: FAIL — `outcome` still comes from `JobPayload::Embed` on the legacy backend.
+
+- [ ] **Step 4: Implement `embed_start_with_context` unified enqueue**
+
+Add a `caller: Option<&AuthSnapshot>` parameter (matching Task 0 Step 7's `extract_start_with_context` shape exactly) and replace the legacy enqueue body:
+
+```rust
+pub async fn embed_start_with_context(
+    cfg: &Config,
+    input: &str,
+    service_context: &ServiceContext,
+    tx: Option<mpsc::Sender<ServiceEvent>>,
+    _source_type: Option<&str>,
+    caller: Option<&AuthSnapshot>,
+) -> Result<JobStartOutcome<EmbedStartResult>, Box<dyn Error>> {
+    let _ = tx;
+    let config_json = config_snapshot_json(cfg)?;
+    let store = service_context
+        .job_store()
+        .ok_or("unified job store is not available for this runtime")?;
+    let descriptor = store
+        .create(JobCreateRequest {
+            request_id: None,
+            job_kind: UnifiedJobKind::Embed,
+            job_intent: JobIntent::Run,
+            source_id: None,
+            watch_id: None,
+            parent_job_id: None,
+            root_job_id: None,
+            attempt: 1,
+            priority: JobPriority::Normal,
+            idempotency_key: None,
+            stage_plan: vec![JobStagePlan {
+                phase: PipelinePhase::Embedding,
+                required: true,
+                provider_requirements: Vec::new(),
+                estimated_items: None,
+            }],
+            request: Some(serde_json::json!({
+                "input": input,
+                "config_json": config_json,
+            })),
+            auth_snapshot: caller
+                .cloned()
+                .unwrap_or_else(|| AuthSnapshot::trusted_system("runtime")),
+            config_snapshot_id: None,
+            requirements: MetadataMap::new(),
+            result_schema: Some("embed_result".to_string()),
+            warnings: Vec::new(),
+            error: None,
+            metadata: MetadataMap::new(),
+        })
+        .await
+        .map_err(|e| -> Box<dyn Error> { e.message.into() })?;
+    service_context.notify_unified();
+    Ok(JobStartOutcome {
+        disposition: StartDisposition::Enqueued,
+        execution_mode: ExecutionMode::InProcess,
+        result: map_embed_start_result(descriptor.job_id.0.to_string()),
+    })
+}
+```
+
+Update every existing caller of `embed_start_with_context` (CLI/MCP/REST) to pass a real `Some(&caller_snapshot)` constructed the same way Task 0 Step 7 wired Extract's callers — do not leave them passing `None` out of laziness when a real caller identity is available at that call site.
+
+- [ ] **Step 5: Implement `EmbedRunner`**
+
+In `crates/axon-services/src/runtime/job_runners.rs`, mirror `ExtractRunner`'s heartbeat/cancellation/error-wrapping shape:
+
+```rust
+struct EmbedRunner {
+    cfg: Arc<Config>,
+}
+
+#[async_trait]
+impl UnifiedJobRunner for EmbedRunner {
+    async fn run(
+        &self,
+        claimed: &UnifiedClaimedJob,
+        store: &SqliteUnifiedJobStore,
+        shutdown: &CancellationToken,
+    ) -> Result<(), ApiError> {
+        heartbeat_running(store, claimed, PipelinePhase::Embedding).await;
+        if shutdown.is_cancelled() {
+            return Err(embed_error("embed canceled before running"));
+        }
+        let request = claimed
+            .request_json
+            .as_ref()
+            .ok_or_else(|| embed_error("embed job has no request payload"))?;
+        let input = request
+            .get("input")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| embed_error("embed job request is missing `input`"))?
+            .to_string();
+        let config_json = request
+            .get("config_json")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let effective_cfg = apply_config_snapshot(&self.cfg, config_json).map_err(|error| {
+            ApiError::new(
+                "job_runner.invalid_config_snapshot",
+                ErrorStage::Planning,
+                error.to_string(),
+            )
+        })?;
+        let embed_fut = crate::embed::embed_sync(&effective_cfg, &input);
+        tokio::select! {
+            _ = shutdown.cancelled() => Err(embed_error("embed canceled")),
+            result = embed_fut => result.map(|_summary| ()).map_err(|error| embed_error(error.to_string())),
+        }
+    }
+}
+
+fn embed_error(message: impl Into<String>) -> ApiError {
+    ApiError::new(
+        "job_runner.embed_failed",
+        ErrorStage::Embedding,
+        message.into(),
+    )
+}
+```
+
+Replace `crate::embed::embed_sync` with the real function name found in Step 1 if it differs. Register it in `build_registry`.
+
+- [ ] **Step 6: Add the embed bridge**
+
+Create `crates/axon-services/src/runtime/sqlite/embed_bridge.rs` by copying `extract_bridge.rs`, adapting the request-payload field extraction to Embed's `{"input": "...", "config_json": "..."}` shape.
+
+- [ ] **Step 7: Wire the bridge dispatch**
+
+In `crates/axon-services/src/runtime/sqlite.rs`, add `mod embed_bridge;` and `if kind == JobKind::Embed { ... }` branches mirroring the existing `JobKind::Extract` branches.
+
+- [ ] **Step 8: Run the enqueue test and confirm pass**
+
+Run: `cargo test -p axon-services embed_start_with_context_enqueues_on_unified_job_store_with_caller_auth --no-fail-fast`
+
+Expected: PASS.
+
+- [ ] **Step 9: Add and run an end-to-end embed execution test with a wakeup-latency assertion**
+
+Add to `crates/axon-services/src/embed_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn embed_job_runs_end_to_end_and_is_claimed_promptly() {
+    let ctx = crate::testing::service_context_with_unified_jobs_and_workers().await;
+    let cfg = axon_core::config::Config::test_default();
+    let started = std::time::Instant::now();
+    let outcome = embed_start_with_context(&cfg, "https://example.com", &ctx, None, None, None)
+        .await
+        .unwrap();
+    let job_id = uuid::Uuid::parse_str(&outcome.result.job_id).unwrap();
+    let job = crate::testing::wait_for_terminal_status(&ctx, job_id, std::time::Duration::from_secs(5))
+        .await
+        .expect("job should reach a terminal status");
+    assert!(matches!(
+        job.status,
+        axon_api::source::LifecycleStatus::Completed
+            | axon_api::source::LifecycleStatus::CompletedDegraded
+    ));
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(3),
+        "embed job took longer than a poll-interval-free path should — notify_unified() regression?"
+    );
+}
+```
+
+Reuse `extract_tests.rs`'s equivalent helpers if named differently.
+
+Run:
+
+```bash
+cargo test -p axon-services embed --no-fail-fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/axon-services/src/embed.rs crates/axon-services/src/embed_tests.rs crates/axon-services/src/runtime/job_runners.rs crates/axon-services/src/runtime/job_runners_tests.rs crates/axon-services/src/runtime/sqlite.rs crates/axon-services/src/runtime/sqlite/embed_bridge.rs crates/axon-cli/src crates/axon-mcp/src crates/axon-web/src
+git commit -m "feat(jobs): cut embed over to the unified job store"
+```
+
+## Task 2: Resolve The Crawl `!Send` Question, Then Port Crawl
+
+**Files:**
+- Modify: `crates/axon-services/src/runtime/job_runners.rs`
+- Modify: `crates/axon-services/src/crawl.rs`
+- Modify: `crates/axon-services/src/runtime/sqlite.rs`
+- Create: `crates/axon-services/src/runtime/sqlite/crawl_bridge.rs`
+- Test: `crates/axon-services/src/crawl_tests.rs`
+
+**Interfaces:**
+- Consumes: same unified-store primitives as Task 1.
+- Produces: `crawl_start_with_context` on the unified store; `CrawlRunner` executing crawl jobs.
+
+The `!Send` claim behind crawl's dedicated single-lane legacy worker is very likely stale: `run_crawl_job` already executes inside a plain `tokio::spawn` today (which requires `Send`), and neither `axon-crawl/src/engine.rs` nor the crawl job runner contains `Rc`/`RefCell`/`LocalSet`/`spawn_local` — the fingerprints of genuine `!Send` state held across an `.await`. **Default to the plain `ExtractRunner`-shaped implementation (Step 2 below). Only fall back to the thread-isolation design (Step 3) if Step 1's compile check fails with a concrete named `Send` violation** — do not write or use the thread-isolation code preemptively.
+
+- [ ] **Step 1: Prove or disprove `!Send` with a real compile check**
+
+Write the plain-shaped `CrawlRunner` from Step 2 below and run:
+
+```bash
+cargo check -p axon-services
+```
+
+If it compiles cleanly, the `!Send` claim is false — proceed with Step 2 as written and skip Step 3 entirely. If it fails with a `Send` bound error, read the error to identify the exact type that isn't `Send`, then use Step 3, scoping the thread-isolation boundary as tightly as possible around only that type's usage (not the whole crawl engine) if feasible.
+
+- [ ] **Step 2: Default path — plain `CrawlRunner` (use unless Step 1 proves otherwise)**
+
+```rust
+struct CrawlRunner {
+    cfg: Arc<Config>,
+}
+
+#[async_trait]
+impl UnifiedJobRunner for CrawlRunner {
+    async fn run(
+        &self,
+        claimed: &UnifiedClaimedJob,
+        store: &SqliteUnifiedJobStore,
+        shutdown: &CancellationToken,
+    ) -> Result<(), ApiError> {
+        heartbeat_running(store, claimed, PipelinePhase::Fetching).await;
+        if shutdown.is_cancelled() {
+            return Err(crawl_error("crawl canceled before running"));
+        }
+        let request = claimed
+            .request_json
+            .as_ref()
+            .ok_or_else(|| crawl_error("crawl job has no request payload"))?;
+        let urls: Vec<String> = request
+            .get("urls")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .ok_or_else(|| crawl_error("crawl job request is missing a `urls` array"))?;
+        let config_json = request
+            .get("config_json")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let effective_cfg = apply_config_snapshot(&self.cfg, config_json).map_err(|error| {
+            ApiError::new(
+                "job_runner.invalid_config_snapshot",
+                ErrorStage::Planning,
+                error.to_string(),
+            )
+        })?;
+        let crawl_fut = crate::crawl::run_crawl_for_unified_job(&effective_cfg, &urls);
+        tokio::select! {
+            _ = shutdown.cancelled() => Err(crawl_error("crawl canceled")),
+            result = crawl_fut => result.map(|_summary| ()).map_err(|error| crawl_error(error.to_string())),
+        }
+    }
+}
+
+fn crawl_error(message: impl Into<String>) -> ApiError {
+    ApiError::new(
+        "job_runner.crawl_failed",
+        ErrorStage::Fetching,
+        message.into(),
+    )
+}
+```
+
+Implement `crate::crawl::run_crawl_for_unified_job(cfg, urls) -> Result<Summary, Box<dyn Error>>` as a thin wrapper around whatever function the legacy `crawl_worker` (in `crates/axon-jobs/src/workers/runners/crawl.rs`) actually calls to execute a crawl — found by reading that file in Step 1.
+
+- [ ] **Step 3: Fallback path — dedicated-thread isolation (ONLY if Step 1's compile check genuinely fails)**
+
+If and only if Step 1 fails with a real `Send` error, isolate just the offending type behind a dedicated OS thread with a single-threaded runtime, racing the result against `shutdown` (not the unconditional `rx.await` an earlier draft of this plan used — that version had no way to observe cancellation):
+
+```rust
+struct CrawlRunner {
+    cfg: Arc<Config>,
+}
+
+#[async_trait]
+impl UnifiedJobRunner for CrawlRunner {
+    async fn run(
+        &self,
+        claimed: &UnifiedClaimedJob,
+        store: &SqliteUnifiedJobStore,
+        shutdown: &CancellationToken,
+    ) -> Result<(), ApiError> {
+        heartbeat_running(store, claimed, PipelinePhase::Fetching).await;
+        let request = claimed
+            .request_json
+            .as_ref()
+            .ok_or_else(|| crawl_error("crawl job has no request payload"))?
+            .clone();
+        let cfg = Arc::clone(&self.cfg);
+        let thread_shutdown = shutdown.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let join_handle = std::thread::spawn(move || {
+            let local = tokio::task::LocalSet::new();
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build crawl worker runtime");
+            let result = rt.block_on(local.run_until(async move {
+                run_crawl_request(&cfg, request, thread_shutdown).await
+            }));
+            let _ = tx.send(result);
+        });
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                // The thread observes the cloned `shutdown` token internally
+                // (run_crawl_request must poll it between batches) and is
+                // expected to exit; join it with a bounded grace period so
+                // we don't leak the OS thread even if it's slow to notice.
+                let _ = tokio::task::spawn_blocking(move || join_handle.join()).await;
+                Err(crawl_error("crawl canceled"))
+            }
+            result = rx => result
+                .map_err(|_| crawl_error("crawl worker thread panicked or dropped"))?
+                .map_err(|error| crawl_error(error.to_string())),
+        }
+    }
+}
+```
+
+`run_crawl_request(cfg, request_json, shutdown) -> Result<(), ApiError>` must poll `shutdown.is_cancelled()` between crawl page batches (not just once at the top) so the join in the `shutdown.cancelled()` branch above actually completes promptly instead of blocking for the full crawl duration.
+
+- [ ] **Step 4: Write failing enqueue test**
+
+Add to `crates/axon-services/src/crawl_tests.rs`, mirroring Task 1 Step 2's shape (real caller auth, `JobKind::Crawl`).
+
+- [ ] **Step 5: Run test and confirm failure**
+
+Run: `cargo test -p axon-services crawl_start_with_context_enqueues_on_unified_job_store_with_caller_auth --no-fail-fast`
+
+Expected: FAIL.
+
+- [ ] **Step 6: Implement `crawl_start_with_context` unified enqueue**
+
+Same pattern as Task 1 Step 4: add `caller: Option<&AuthSnapshot>`, `job_kind: UnifiedJobKind::Crawl`, `PipelinePhase::Fetching`, request payload `{"urls": urls, "config_json": config_json}` (keep the existing `apply_crawl_defaults(cfg)` call), call `service_context.notify_unified()` after enqueue.
+
+- [ ] **Step 7: Register `CrawlRunner`, add bridge, wire dispatch**
+
+Same as Task 1 Steps 6-7, for `Crawl`.
+
+- [ ] **Step 8: Run enqueue and end-to-end tests**
+
+```bash
+cargo test -p axon-services crawl --no-fail-fast
+```
+
+Expected: PASS, including an end-to-end test mirroring Task 1 Step 9.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/axon-services/src/crawl.rs crates/axon-services/src/crawl_tests.rs crates/axon-services/src/runtime/job_runners.rs crates/axon-services/src/runtime/sqlite.rs crates/axon-services/src/runtime/sqlite/crawl_bridge.rs
+git commit -m "feat(jobs): cut crawl over to the unified job store"
+```
+
+## Task 3: Port Ingest
+
+**Files:**
+- Modify: `crates/axon-services/src/runtime/job_runners.rs`
+- Modify: `crates/axon-services/src/ingest.rs`
+- Modify: `crates/axon-services/src/runtime/sqlite.rs`
+- Create: `crates/axon-services/src/runtime/sqlite/ingest_bridge.rs`
+- Test: `crates/axon-services/src/ingest_tests.rs`
+
+**Interfaces:**
+- Consumes: same unified-store primitives as Task 1.
+- Produces: `ingest_start_with_context` on the unified store; `IngestRunner` executing sessions/prepared-sessions ingest (the only `IngestSource` variants that still execute after the Phase 12 axon-ingest shrink — every other variant already returns a clean error at execution time per `crates/axon-jobs/src/workers/runners/ingest.rs::execute_ingest_source`).
+
+- [ ] **Step 1: Read the current ingest enqueue/execute code**
+
+Read `crates/axon-services/src/ingest.rs::ingest_start_with_context` and `crates/axon-jobs/src/workers/runners/ingest.rs::{run_ingest_job, execute_ingest_source, execute_prepared_sessions_ingest}` in full.
+
+- [ ] **Step 2: Write failing enqueue test**
+
+Add to `crates/axon-services/src/ingest_tests.rs`, mirroring Task 1 Step 2's shape, `job_kind: UnifiedJobKind::Ingest`, request payload `{"source": serde_json::to_value(&source)?}`.
+
+- [ ] **Step 3: Run test and confirm failure**
+
+Run: `cargo test -p axon-services ingest_start_with_context_enqueues_sessions_source_on_unified_job_store_with_caller_auth --no-fail-fast`
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement `ingest_start_with_context` unified enqueue**
+
+Add `caller: Option<&AuthSnapshot>`, `job_kind: UnifiedJobKind::Ingest`, `PipelinePhase::Parsing`, keep the existing `preflight_ingest_source(cfg, &source).await?;` call, call `service_context.notify_unified()` after enqueue.
+
+- [ ] **Step 5: Implement `IngestRunner`**
+
+Mirror `ExtractRunner`, deserializing the full `IngestSource` from `claimed.request_json["source"]` and calling the same dispatch `execute_ingest_source`/`execute_prepared_sessions_ingest` already implement.
+
+- [ ] **Step 6: Register `IngestRunner`, add bridge, wire dispatch**
+
+Same as Task 1 Steps 6-7, for `Ingest`.
+
+- [ ] **Step 7: Run enqueue and end-to-end tests**
+
+```bash
+cargo test -p axon-services ingest --no-fail-fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/axon-services/src/ingest.rs crates/axon-services/src/ingest_tests.rs crates/axon-services/src/runtime/job_runners.rs crates/axon-services/src/runtime/sqlite.rs crates/axon-services/src/runtime/sqlite/ingest_bridge.rs
+git commit -m "feat(jobs): cut ingest over to the unified job store"
+```
+
+## Task 4: Retire The Legacy Per-Family Workers And Table Readers
+
+**Files:**
+- Modify: `crates/axon-jobs/src/workers.rs`
+- Modify: `crates/axon-jobs/src/backend.rs`
+- Modify: `crates/axon-jobs/src/query.rs`
+- Delete: `crates/axon-jobs/src/workers/runners/crawl.rs`, `embed.rs`, `ingest.rs` (and their `_tests.rs` sidecars) once nothing references them
+- Test: `crates/axon-jobs/src/legacy_removal_tests.rs`
+
+**Interfaces:**
+- Consumes: Tasks 0-3.
+- Produces: no active-runtime reference to `axon_crawl_jobs`/`axon_embed_jobs`/`axon_ingest_jobs`.
+
+- [ ] **Step 1: Add the legacy-reference blocker test**
+
+```rust
+#[test]
+fn active_runtime_no_longer_names_legacy_family_tables() {
+    let source = include_str!("backend.rs").to_string()
+        + include_str!("query.rs")
+        + include_str!("workers.rs");
+    for table in ["axon_crawl_jobs", "axon_embed_jobs", "axon_ingest_jobs"] {
+        assert!(
+            !source.contains(table),
+            "legacy table {table} still referenced in active runtime"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test and confirm failure**
+
+Run: `cargo test -p axon-jobs active_runtime_no_longer_names_legacy_family_tables --no-fail-fast`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Remove the legacy worker spawns, resolving the reclaim question explicitly**
+
+In `spawn_workers`, delete the `crawl_worker`/`embed_worker`/`ingest_worker` spawn blocks and their `Notify` construction. **Decision, not a footnote: keep the watchdog's reclaim sweep wired to a lightweight legacy-table scan** (matching how `extract_notify` was kept wired into the watchdog's generic reclaim sweep during the Extract cutover) so any in-flight legacy row that existed at the moment of this deploy still gets a terminal status eventually, rather than stranding permanently. Do not add new legacy-row execution — only reclaim-to-failed, consistent with the "no migration/backfill" global constraint.
+
+- [ ] **Step 4: Remove legacy family table mappings**
+
+In `crates/axon-jobs/src/backend.rs`, remove the `JobKind::{Crawl,Embed,Ingest}` → table-name mapping arms. In `crates/axon-jobs/src/query.rs`, remove the list/count/cleanup/clear query functions targeting those three tables.
+
+- [ ] **Step 5: Fix fallout**
+
+Run `cargo check --workspace --all-targets` and fix every resulting compile error by routing through the unified bridges from Tasks 1-3.
+
+- [ ] **Step 6: Run the blocker test and full job-crate suite**
+
+```bash
+cargo test -p axon-jobs active_runtime_no_longer_names_legacy_family_tables --no-fail-fast
+cargo test -p axon-jobs --no-fail-fast
+cargo test -p axon-services --no-fail-fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Verify with the durable-job-cutover plan's own final check**
+
+```bash
+rg -n "axon_crawl_jobs|axon_embed_jobs|axon_extract_jobs|axon_ingest_jobs|JobKind::Crawl|JobKind::Embed|JobKind::Extract|JobKind::Ingest" crates/axon-jobs crates/axon-services crates/axon-cli crates/axon-mcp crates/axon-web
+```
+
+Expected: matches only in migration modules and bridge modules (which legitimately still route on `JobKind::Crawl`/etc. to select which bridge to call).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/axon-jobs/src crates/axon-services/src
+git commit -m "refactor(jobs): remove legacy crawl/embed/ingest job runtime"
+```
+
+## Task 5: Fix Reset's Legacy-Store Confirmation Gap (CLI-Flag-Only)
+
+**Files:**
+- Modify: `crates/axon-api/src/reset.rs`
+- Modify: `crates/axon-services/src/reset.rs`
+- Modify: `crates/axon-services/src/reset/execution.rs`
+- Modify: `crates/axon-cli/src/commands/reset.rs` (or wherever reset's clap args live)
+- Test: `crates/axon-services/src/reset_tests.rs`
+
+**Interfaces:**
+- Consumes: `axon_jobs::unified::{detect_incompatible_legacy_jobs, LegacyJobStoreBlocker}` (already exists).
+- Produces: `ResetPlan.blockers` genuinely populated; `reset()` refuses to execute when legacy rows are present unless a **per-invocation CLI flag** (not a persistable config field) confirms it.
+
+Today's behavior (`crates/axon-services/src/reset/execution.rs`) is a deliberate design choice — treating `axon reset --yes` as the "explicit admin reset receipt" the security contract requires — with a real visibility gap: `ResetPlan.blockers`/`ResetResult.blockers` are hardcoded to `Vec::new()`, so a caller inspecting the dry-run plan can't see legacy rows exist before they wipe them. A security review of an earlier draft of this task found the originally-proposed fix — a `reset_confirm_legacy_wipe: bool` field on `Config`, settable via `config.toml` — could be set once and permanently defeat the "distinct explicit confirmation" the task is trying to add. **This must be a CLI-flag-only value, explicitly rejected if it arrives via config file or environment variable**, so it can never become a standing footgun.
+
+- [ ] **Step 1: Write failing dry-run visibility test**
+
+```rust
+#[tokio::test]
+async fn dry_run_plan_surfaces_non_empty_legacy_job_tables_as_a_blocker() {
+    let cfg = test_config_with_legacy_crawl_job_row().await;
+    let result = reset(&cfg).await.unwrap();
+    assert!(result.dry_run);
+    assert!(
+        result.blockers.iter().any(|b| b.contains("axon_crawl_jobs")),
+        "expected a legacy-store blocker naming axon_crawl_jobs, got {:?}",
+        result.blockers
+    );
+}
+```
+
+- [ ] **Step 2: Write failing config-source rejection test**
+
+```rust
+#[tokio::test]
+async fn legacy_wipe_confirmation_sourced_from_config_file_is_rejected() {
+    let mut cfg = test_config_with_legacy_crawl_job_row().await;
+    cfg.yes = true;
+    cfg.reset_confirm_legacy_wipe = true;
+    cfg.reset_confirm_legacy_wipe_source = ConfigValueSource::TomlFile;
+    let err = reset(&cfg).await.unwrap_err();
+    assert!(
+        err.to_string().contains("--confirm-legacy-wipe must be passed as a CLI flag"),
+        "config-sourced confirmation must be rejected, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn legacy_wipe_confirmation_from_cli_flag_wipes_and_records_receipt() {
+    let mut cfg = test_config_with_legacy_crawl_job_row().await;
+    cfg.yes = true;
+    cfg.reset_confirm_legacy_wipe = true;
+    cfg.reset_confirm_legacy_wipe_source = ConfigValueSource::CliFlag;
+    let result = reset(&cfg).await.unwrap();
+    assert!(!result.dry_run);
+    assert!(result.audit_events.iter().any(|e| e.contains("legacy")));
+}
+```
+
+Add `test_config_with_legacy_crawl_job_row` as a helper mirroring however other reset tests in this file already build a scratch DB.
+
+- [ ] **Step 3: Run tests and confirm failure**
+
+Run: `cargo test -p axon-services reset --no-fail-fast`
+
+Expected: FAIL.
+
+- [ ] **Step 4: Add the confirmation flag with a source-tracking field**
+
+Add `reset_confirm_legacy_wipe: bool` (default `false`) and `reset_confirm_legacy_wipe_source: ConfigValueSource` (an enum `{ CliFlag, TomlFile, EnvVar, Unset }`, default `Unset`) to `Config`. Wire the CLI flag `--confirm-legacy-wipe` to set both `reset_confirm_legacy_wipe = true` and `reset_confirm_legacy_wipe_source = ConfigValueSource::CliFlag`. If this repo's config-parsing layer would otherwise also accept it from `config.toml`/env (check `crates/axon-core/src/config/parse/`), explicitly exclude `reset_confirm_legacy_wipe` from that parsing path — it must only ever be settable by the CLI flag.
+
+- [ ] **Step 5: Populate `blockers` and gate execution on CLI-sourced confirmation**
+
+In `prepare_reset`, when `wants_any_sqlite(&stores)`, call `sqlite::detect_legacy_jobs(&cfg.sqlite_path).await` and push a human-readable string into `ResetPlan.blockers`/`ResetResult.blockers` if it returns `Some`. Before `execute_prepared_reset` mutates anything, if a legacy blocker was detected and `!(cfg.reset_confirm_legacy_wipe && cfg.reset_confirm_legacy_wipe_source == ConfigValueSource::CliFlag)`, return an error whose message says `"--confirm-legacy-wipe must be passed as a CLI flag"` when the source is wrong, or names the table and required flag when it's simply missing.
+
+- [ ] **Step 6: Record the legacy wipe explicitly in the audit trail**
+
+In `reset/execution.rs`, when a legacy blocker was present and confirmed, push a `"reset.legacy_store_wiped"` entry into `audit_events` alongside the existing `record_legacy_reset_receipt` call.
+
+- [ ] **Step 7: Run reset tests**
+
+```bash
+cargo test -p axon-services reset --no-fail-fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/axon-core/src/config crates/axon-services/src/reset.rs crates/axon-services/src/reset/execution.rs crates/axon-services/src/reset_tests.rs crates/axon-cli/src
+git commit -m "fix(reset): require a CLI-flag-only confirmation before wiping non-empty legacy job tables"
+```
+
+## Task 6: Full Verification And Plan Closeout
+
+**Files:**
+- Modify: this plan file (check off completed tasks)
+- Modify: `docs/pipeline-unification/plans/2026-07-04-full-durable-job-cutover.md` (mark Tasks 6 and 8 done with evidence)
+
+**Interfaces:**
+- Consumes: Tasks 0-5.
+- Produces: closeout evidence.
+
+- [ ] **Step 1: Run the durable-job-cutover plan's own Task 9 verification**
+
+```bash
+cargo test -p axon-api source_job --no-fail-fast
+cargo test -p axon-jobs --no-fail-fast
+cargo test -p axon-services jobs --no-fail-fast
+cargo test -p axon-cli jobs --no-fail-fast
+cargo test -p axon-mcp jobs --no-fail-fast
+cargo test -p axon-web jobs --no-fail-fast
+rg -n "axon_crawl_jobs|axon_embed_jobs|axon_extract_jobs|axon_ingest_jobs|JobKind::Crawl|JobKind::Embed|JobKind::Extract|JobKind::Ingest" crates/axon-jobs crates/axon-services crates/axon-cli crates/axon-mcp crates/axon-web
+```
+
+Expected: PASS; `rg` matches only in migration/bridge modules.
+
+- [ ] **Step 2: Verify the concurrency and latency fixes hold under the full suite**
+
+```bash
+cargo test -p axon-jobs enqueued_job_is_claimed_within_one_wakeup_not_a_full_poll_interval unified_worker_claims_and_runs_multiple_jobs_concurrently --no-fail-fast
+cargo test -p axon-services embed_job_runs_end_to_end_and_is_claimed_promptly --no-fail-fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Full workspace gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets
+cargo test --workspace --no-fail-fast
+cargo xtask check-layering
+cargo xtask check-repo-structure
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Update the source plan doc**
+
+In `2026-07-04-full-durable-job-cutover.md`, check off Task 6 and Task 8's step boxes and add an evidence note pointing at this plan's commits.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/pipeline-unification/plans
+git commit -m "docs(pipeline): close out full durable job cutover Tasks 6 and 8"
+```
+
+## Self-Review
+
+- Spec coverage: durable-job-cutover Task 6 → Tasks 1-3; Task 8 → Task 4.
+- Engineering review findings applied: unconditional `trusted_system` auth fixed at its source (Task 0, both call sites) before being tripled by Tasks 1-3, not left as a copy-pasted regression; `notify_unified()` wired everywhere it was missing; unified worker concurrency bounded before Task 4 deletes the lane-based alternative; Task 2 restructured so the (likely unnecessary) thread-isolation design is a gated fallback, not the default; Task 4's legacy-reclaim question resolved as an explicit decision; Task 5's confirmation flag hardened to reject config/env sourcing.
+- Split out per review (architecturally independent, tracked separately): provider cooling, redaction boundary extension, REST memory surface — see `docs/pipeline-unification/plans/2026-07-08-provider-cooling.md`, `2026-07-08-redaction-boundary-extension.md`, `2026-07-08-rest-memory-surface.md`.
+- Placeholder scan: every step names exact files and function/type names cited from direct code reads, or explicitly instructs a read-first step where the exact current name could not be verified directly (crawl's real execution entry point, the `jobs.rs` `trusted_system` site's caller-availability, the config-parsing exclusion list) — these are read-first steps, not deferred-decision placeholders.
+- Type consistency: `JobKind`/`UnifiedJobKind`, `JobCreateRequest`, `JobStagePlan`, `PipelinePhase`, `AuthSnapshot`, `MetadataMap`, `UnifiedJobRunner`, `UnifiedClaimedJob`, `SqliteUnifiedJobStore` used identically across Tasks 1-3, matching the real `ExtractRunner`/`extract_bridge.rs`/`web_source_job.rs` precedents.

--- a/docs/pipeline-unification/plans/2026-07-08-provider-cooling.md
+++ b/docs/pipeline-unification/plans/2026-07-08-provider-cooling.md
@@ -1,0 +1,257 @@
+# Provider Cooling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close Phase 3B Task 3's remaining gap — wire the already-defined `ProviderCooling` type into job claim eligibility, so a saturated provider actually backs off instead of the job being re-claimed and re-failing in a hot loop.
+
+**Architecture:** `axon_error::cooling::ProviderCooling` and `ApiError::with_provider_cooling`/`provider_cooling()` already exist and are already consumed by `axon_observe::reservation::cooling_snapshot` — this is not net-new plumbing, only the missing link between "an error carries a cooling window" and "the unified job store's claim query respects it." No `cooldown_until` column exists yet; cooling data currently only round-trips through the serialized error JSON blob written on a terminal/waiting status update.
+
+**Tech Stack:** Rust 2024, `sqlx` SQLite, `axon-jobs`, `axon-error`.
+
+## Global Constraints
+
+- Split out of `2026-07-08-finish-job-cutover-and-security-completion.md` per engineering review: this work is independent of the crawl/embed/ingest job cutover and can land before, after, or in parallel with it.
+- `ProviderCooling.cooldown_until` must be bounded — clamp any incoming value to a maximum window (e.g. 1 hour) so a buggy or malicious far-future timestamp cannot permanently blacklist a job kind from ever being claimed again. This was flagged as a DoS-shaped risk in engineering review and must not ship unbounded.
+- `cooldown_until` must be cleared (`NULL`) on every transition to a non-`Waiting` status, not just left to expire — a job that cooled once and later completes must not retain a stale cooldown that silently blocks its next legitimate run.
+- The new claim-query predicate must stay covered by an index — do not add an unindexed filter to a query that runs on every worker poll.
+- Do not edit `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`.
+- Commit after each task's verification passes.
+
+---
+
+## Source-Of-Truth Contracts
+
+- `docs/pipeline-unification/plans/2026-07-04-phase-3b-security-error-memory-completion.md` (Task 3)
+- `docs/pipeline-unification/runtime/error-handling.md`
+
+## Current-State Anchors
+
+- `axon_error::cooling::ProviderCooling` — real type, already has consumers (`ApiError::with_provider_cooling`/`provider_cooling()`, `axon_observe::reservation::cooling_snapshot`). Read this file first to get the exact real field names/methods before writing any code against it — do not assume the illustrative names below are exact.
+- Claim query and its existing index: `crates/axon-jobs/src/workers/unified.rs::claim_next_unified_job_unchecked` (or wherever the real claim SQL lives), `idx_axon_jobs_claim` in the migration that created it (search `crates/axon-jobs/src/migrations/` for the partial index keyed on `status`).
+- Terminal/status-write path that must clear `cooldown_until`: `crates/axon-jobs/src/workers/unified.rs::mark_terminal` (or wherever the real terminal-status write function is).
+
+## File Structure
+
+- Modify: `crates/axon-jobs/src/migrations/` (new migration: `cooldown_until` column + covering index)
+- Modify: `crates/axon-jobs/src/unified/control.rs` (or wherever `update_status`/terminal-write logic lives)
+- Modify: `crates/axon-jobs/src/workers/unified.rs` (claim query predicate)
+- Modify: real provider-saturation error call site (found in Task 1 below)
+- Test: `crates/axon-jobs/src/provider_cooling_tests.rs`
+
+---
+
+## Task 1: Read The Real Cooling Type And Claim Query Before Writing Any Code
+
+**Files:**
+- Read only: `crates/axon-error/src/cooling.rs`, `crates/axon-error/src/api_error.rs`, `crates/axon-jobs/src/workers/unified.rs`, `crates/axon-jobs/src/migrations/`
+
+**Interfaces:**
+- Consumes: nothing — this is a research step.
+- Produces: confirmed real names for `ProviderCooling`'s fields, `ApiError`'s cooling accessor, the claim query's exact SQL and index, and the exact call site where a provider-saturation error is currently raised after local retries are exhausted (search `crates/axon-services`, `crates/axon-embedding`, `crates/axon-llm` for existing 429/rate-limit handling — the root `CLAUDE.md`'s "TEI retries" section documents the retry policy this sits downstream of).
+
+- [ ] **Step 1: Read and record the real API surface**
+
+Read the four files above in full. Write down (as a comment at the top of the new test file created in Task 2) the exact real signatures for: `ProviderCooling::new`/`with_provider`/`with_reason` (or whatever the real constructors are), `ApiError::with_provider_cooling`/`provider_cooling()`, the claim query's table/column names, and `idx_axon_jobs_claim`'s exact `WHERE`/column list.
+
+- [ ] **Step 2: Identify the real provider-saturation error call site**
+
+Find where this repo currently detects a provider is saturated after exhausting local retries (e.g. TEI 429 after `TEI_MAX_RETRIES` attempts). Confirm whether it already returns an `ApiError` at all, or a different error type that would need converting.
+
+## Task 2: Add `cooldown_until` Column And Covering Index
+
+**Files:**
+- Create: new migration under `crates/axon-jobs/src/migrations/`
+- Test: `crates/axon-jobs/src/provider_cooling_tests.rs`
+
+**Interfaces:**
+- Consumes: Task 1's confirmed real table/column names.
+- Produces: `cooldown_until INTEGER` (or the real timestamp representation this table already uses elsewhere — check whether other timestamp columns in this table are stored as epoch integers or RFC3339 strings and match that, since `ProviderCooling.cooldown_until` is a `DateTime<Utc>` and needs a consistent serialization on both the write and the claim-query read side) and an index covering the new claim predicate.
+
+- [ ] **Step 1: Write a failing index-coverage test**
+
+```rust
+#[tokio::test]
+async fn cooldown_until_column_and_index_exist() {
+    let pool = crate::store::open_sqlite_pool(":memory:").await.unwrap();
+    let columns: Vec<String> = sqlx::query_scalar(
+        "SELECT name FROM pragma_table_info('jobs') WHERE name = 'cooldown_until'",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(columns, vec!["cooldown_until".to_string()]);
+
+    let indexes: Vec<String> = sqlx::query_scalar(
+        "SELECT name FROM sqlite_master WHERE type='index' AND sql LIKE '%cooldown_until%'",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert!(
+        !indexes.is_empty(),
+        "expected an index covering cooldown_until, found none"
+    );
+}
+```
+
+Adjust the table name from `jobs` to whatever Task 1 Step 1 confirmed is real.
+
+- [ ] **Step 2: Run test and confirm failure**
+
+Run: `cargo test -p axon-jobs cooldown_until_column_and_index_exist --no-fail-fast`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Write the migration**
+
+Add the column and extend (or add a companion to) the existing claim index so the new predicate stays index-covered — do not add the column without also covering it, per the Global Constraints.
+
+- [ ] **Step 4: Run test**
+
+Run: `cargo test -p axon-jobs cooldown_until_column_and_index_exist --no-fail-fast`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/axon-jobs/src/migrations
+git commit -m "feat(jobs): add cooldown_until column with covering index"
+```
+
+## Task 3: Bound Cooling Windows And Wire Claim-Eligibility
+
+**Files:**
+- Modify: `crates/axon-jobs/src/unified/control.rs` (or the real status-update module found in Task 1)
+- Modify: `crates/axon-jobs/src/workers/unified.rs`
+- Test: `crates/axon-jobs/src/provider_cooling_tests.rs`
+
+**Interfaces:**
+- Consumes: Task 2's column/index.
+- Produces: a `Waiting` transition carrying `ProviderCooling` writes a clamped `cooldown_until`; the claim query excludes rows whose `cooldown_until` is in the future; any subsequent non-`Waiting` status write clears it.
+
+- [ ] **Step 1: Write a failing bounded-cooldown test**
+
+```rust
+#[tokio::test]
+async fn cooldown_until_is_clamped_to_a_maximum_window() {
+    let store = unified_store_fixture().await;
+    let job = store.create(job_request_fixture("embed")).await.unwrap();
+    let far_future = chrono::Utc::now() + chrono::Duration::days(365);
+    let cooling = axon_error::cooling::ProviderCooling::new(far_future).with_provider("tei");
+
+    transition_to_waiting_with_cooling(&store, job.job_id, cooling).await.unwrap();
+
+    let stored = store.get(job.job_id).await.unwrap().unwrap();
+    let cooldown_until = stored_cooldown_until(&store, job.job_id).await;
+    assert!(
+        cooldown_until <= chrono::Utc::now() + chrono::Duration::hours(1) + chrono::Duration::minutes(1),
+        "cooldown_until must be clamped to the configured maximum window, got {cooldown_until:?}"
+    );
+}
+```
+
+Adjust `transition_to_waiting_with_cooling`/`stored_cooldown_until` to whatever the real status-update API from Task 1 turns out to be.
+
+- [ ] **Step 2: Write a failing claim-eligibility test**
+
+```rust
+#[tokio::test]
+async fn cooling_job_is_not_claimable_before_cooldown_expires() {
+    let store = unified_store_fixture().await;
+    let job = store.create(job_request_fixture("embed")).await.unwrap();
+    let cooldown_until = chrono::Utc::now() + chrono::Duration::seconds(30);
+    let cooling = axon_error::cooling::ProviderCooling::new(cooldown_until).with_provider("tei");
+    transition_to_waiting_with_cooling(&store, job.job_id, cooling).await.unwrap();
+
+    let claimed = claim_next_unified_job_unchecked(&store.pool()).await.unwrap();
+    assert!(
+        claimed.is_none(),
+        "a job in its cooling window must not be claimable"
+    );
+}
+```
+
+- [ ] **Step 3: Write a failing clear-on-terminal test**
+
+```rust
+#[tokio::test]
+async fn cooldown_until_is_cleared_on_completion() {
+    let store = unified_store_fixture().await;
+    let job = store.create(job_request_fixture("embed")).await.unwrap();
+    let cooling = axon_error::cooling::ProviderCooling::new(chrono::Utc::now() + chrono::Duration::minutes(1))
+        .with_provider("tei");
+    transition_to_waiting_with_cooling(&store, job.job_id, cooling).await.unwrap();
+    mark_terminal_completed(&store, job.job_id).await.unwrap();
+
+    let cooldown_until = stored_cooldown_until(&store, job.job_id).await;
+    assert!(cooldown_until.is_none(), "cooldown_until must be cleared once the job leaves Waiting");
+}
+```
+
+- [ ] **Step 4: Run tests and confirm failure**
+
+Run: `cargo test -p axon-jobs cooldown_until_is_clamped cooling_job_is_not_claimable cooldown_until_is_cleared --no-fail-fast`
+
+Expected: all FAIL.
+
+- [ ] **Step 5: Implement clamping on write**
+
+In the status-update function that handles a `Waiting` transition with a `ProviderCooling`-bearing error, clamp `cooling.cooldown_until` to `min(cooling.cooldown_until, now + MAX_COOLDOWN_WINDOW)` before persisting, where `MAX_COOLDOWN_WINDOW` is a `const Duration` (start at 1 hour; do not make this configurable in this task — a fixed conservative bound is the point).
+
+- [ ] **Step 6: Implement claim-query exclusion**
+
+Add the `AND (cooldown_until IS NULL OR cooldown_until <= ?now)` predicate to the claim query, using the index added in Task 2.
+
+- [ ] **Step 7: Implement clear-on-non-waiting**
+
+In the terminal/generic status-write function, explicitly set `cooldown_until = NULL` whenever the new status is anything other than `Waiting`.
+
+- [ ] **Step 8: Wire the real provider-saturation call site**
+
+At the call site found in Task 1 Step 2, attach `ProviderCooling::new(cooldown_until).with_provider(provider_id)` to the `ApiError` before it propagates to the job runner's `Result<(), ApiError>`.
+
+- [ ] **Step 9: Run tests**
+
+```bash
+cargo test -p axon-jobs provider_cooling --no-fail-fast
+cargo test -p axon-jobs unified --no-fail-fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/axon-jobs/src crates/axon-services/src
+git commit -m "feat(jobs): bound and wire provider cooling into job claim eligibility"
+```
+
+## Task 4: Verification
+
+- [ ] **Step 1: Full crate gate**
+
+```bash
+cargo test -p axon-jobs --no-fail-fast
+cargo test -p axon-error --no-fail-fast
+cargo clippy -p axon-jobs -p axon-error --all-targets
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Update the source plan doc**
+
+Mark Phase 3B Task 3 done in `2026-07-04-phase-3b-security-error-memory-completion.md` with an evidence note pointing at this plan's commits.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/pipeline-unification/plans
+git commit -m "docs(pipeline): close out phase 3b task 3 provider cooling"
+```
+
+## Self-Review
+
+- Spec coverage: Phase 3B Task 3 → Tasks 1-3 here.
+- Engineering review findings applied: bounded cooldown window (DoS fix), covering index added in the same migration as the column (performance fix), explicit clear-on-terminal (correctness fix for the stale-clobber risk architecture review flagged).
+- Placeholder scan: Task 1 is an explicit read-first step precisely because the plan that spawned this one was caught inventing unverified API names — every downstream task depends on Task 1's findings rather than guessing.

--- a/docs/pipeline-unification/plans/2026-07-08-redaction-boundary-extension.md
+++ b/docs/pipeline-unification/plans/2026-07-08-redaction-boundary-extension.md
@@ -1,0 +1,222 @@
+# Redaction Boundary Extension Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close Phase 3B Task 4's remaining gap — extend the existing redaction boundary (already gating vector payloads, job events, graph evidence, memory rows, and MCP/REST error responses) to CLI JSON output, artifact metadata writes, and trace/log fields crossing public visibility.
+
+**Architecture:** Three independent gate-insertion points, each following the identical shape: find the write/render call site, prove a secret-bearing fixture is caught before it, wire the existing shared redaction function in. Split into three separate committed steps (not bundled into one task) per engineering review, since each is independently sized and none depends on the others — this also means an incomplete implementer can land 1-of-3 rather than being blocked on all three landing atomically.
+
+**Tech Stack:** Rust 2024, `axon-core`, `axon-cli`.
+
+## Global Constraints
+
+- Split out of `2026-07-08-finish-job-cutover-and-security-completion.md` per engineering review: independent of the job cutover.
+- Redaction failure fails closed: never call the downstream writer/render function after a redaction failure.
+- This plan's per-surface manual grep is explicitly a best-effort pass, not an exhaustive guarantee — Task 4 below files a tracked follow-up for CI/lint enforcement rather than claiming completeness the grep can't back.
+- Do not edit `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`.
+- Commit after each task's verification passes.
+
+---
+
+## Source-Of-Truth Contracts
+
+- `docs/pipeline-unification/plans/2026-07-04-phase-3b-security-error-memory-completion.md` (Task 4)
+- `docs/pipeline-unification/runtime/security-contract.md`
+
+## Current-State Anchors
+
+- Existing shared gate (already covers vector/job-event/graph/memory/MCP/REST-error paths): `crates/axon-core/src/redact.rs` + `crates/axon-core/src/redact/boundary.rs`. Read this file first for the real function name — it does not match the illustrative names (`redact_public_write`) used in the originating plan; confirm the real name before writing any task against it.
+- CLI JSON output: the shared `--json` render path referenced in this repo's root `CLAUDE.md` ("`--json` flag enables machine-readable output on all commands"). Find it under `crates/axon-cli/src/` — likely `json.rs` or similar, per `axon-cli`'s module map, but confirm by reading, don't assume the filename.
+- Artifact metadata writes: `ArtifactStore` public metadata write path, per `docs/pipeline-unification/runtime/storage-contract.md`'s `ArtifactStore Ownership` table (visibility/content_hash/relative_path/etc.).
+- Trace/log fields: `axon_core::logging`/`tracing::*!` call sites.
+
+## File Structure
+
+- Modify: `crates/axon-core/src/redact/boundary.rs`
+- Modify: CLI JSON render helper (path confirmed in Task 1)
+- Modify: artifact metadata write path
+- Modify: identified trace/log call sites crossing public visibility
+- Test: `crates/axon-core/src/redact/boundary_tests.rs`
+
+---
+
+## Task 1: Read The Real Gate Function And Locate The Three Chokepoints
+
+**Files:**
+- Read only: `crates/axon-core/src/redact/boundary.rs`, `crates/axon-cli/src/**`, artifact-write module, logging module
+
+**Interfaces:**
+- Consumes: nothing — research step.
+- Produces: confirmed real gate function name/signature and confirmed real file:line for each of the three chokepoints.
+
+- [ ] **Step 1: Read the existing gate**
+
+Read `crates/axon-core/src/redact/boundary.rs` in full. Record the real function name (not `redact_public_write`), its parameter shape (surface enum, value, context), and its return type (does it return `Result<RedactedValue, ApiError>` or something else — confirm exactly).
+
+- [ ] **Step 2: Find the CLI JSON chokepoint**
+
+Read `crates/axon-cli`'s module map (its `CLAUDE.md`) and locate the single shared function every `--json`-flagged command routes through before writing to stdout. Confirm it's genuinely shared (one function) and not duplicated per-command — if it's duplicated, note that as a larger finding requiring its own remediation before this task's fix can be applied in one place.
+
+- [ ] **Step 3: Find the artifact metadata chokepoint**
+
+Locate where `ArtifactStore` writes its public metadata row/fields (visibility, content_hash, relative_path, etc.).
+
+- [ ] **Step 4: Find candidate trace/log call sites**
+
+Grep for `tracing::info!`/`tracing::warn!`/`log_info`/`log_warn` call sites that log a value later exposed at `Visibility::Public` (e.g. a raw URL, a memory body snippet, a user-supplied query string). List every candidate found — this list becomes Task 4's scope.
+
+## Task 2: Gate CLI JSON Output
+
+**Files:**
+- Modify: the CLI JSON render helper found in Task 1 Step 2
+- Test: `crates/axon-core/src/redact/boundary_tests.rs`, `crates/axon-cli/src/json_tests.rs` (or wherever CLI JSON tests already live)
+
+**Interfaces:**
+- Consumes: Task 1's confirmed real gate function.
+- Produces: untrusted-mode `--json` renders pass through the gate before writing to stdout.
+
+- [ ] **Step 1: Write a failing fail-closed test**
+
+Using the existing vector-payload fail-closed test in `boundary_tests.rs` as the template for fixture shape and assertion style (do not invent a new fixture format), add a CLI-JSON-surface variant:
+
+```rust
+#[test]
+fn cli_json_output_secret_fixture_fails_before_render() {
+    let payload = secret_payload_fixture();
+    let err = /* real gate function name from Task 1 */(RedactionSurface::CliJson, payload).unwrap_err();
+    assert_eq!(err.code.to_string(), "redaction.failed");
+}
+```
+
+- [ ] **Step 2: Run test and confirm failure**
+
+Run: `cargo test -p axon-core cli_json_output_secret_fixture_fails_before_render --no-fail-fast`
+
+Expected: FAIL — `RedactionSurface::CliJson` likely doesn't exist yet as a variant, or the CLI render path doesn't call the gate.
+
+- [ ] **Step 3: Add the surface variant and wire the gate**
+
+Add `RedactionSurface::CliJson` if missing, and call the gate function from the CLI JSON render helper before writing to stdout, for untrusted-mode renders (check whether this repo distinguishes trusted-local vs untrusted CLI invocation contexts — if it doesn't, gate all `--json` output unconditionally, since a wrong-but-safe default is preferable to a right-but-unenforced one).
+
+- [ ] **Step 4: Run test**
+
+Run: `cargo test -p axon-core cli_json_output_secret_fixture_fails_before_render --no-fail-fast`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/axon-core/src crates/axon-cli/src
+git commit -m "feat(security): gate CLI JSON output through the redaction boundary"
+```
+
+## Task 3: Gate Artifact Metadata Writes
+
+**Files:**
+- Modify: the artifact-write module found in Task 1 Step 3
+- Test: `crates/axon-core/src/redact/boundary_tests.rs`
+
+**Interfaces:**
+- Consumes: Task 1's confirmed real gate function and artifact-write chokepoint.
+- Produces: `ArtifactStore` public metadata writes pass through the gate before the row is written.
+
+- [ ] **Step 1: Write a failing fail-closed test**
+
+```rust
+#[test]
+fn artifact_metadata_secret_fixture_fails_before_write() {
+    let metadata = secret_artifact_metadata_fixture();
+    let err = /* real gate function */(RedactionSurface::Artifact, metadata).unwrap_err();
+    assert_eq!(err.code.to_string(), "redaction.failed");
+}
+```
+
+- [ ] **Step 2: Run test and confirm failure**
+
+Run: `cargo test -p axon-core artifact_metadata_secret_fixture_fails_before_write --no-fail-fast`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add the surface variant and wire the gate**
+
+Add `RedactionSurface::Artifact` if missing, call the gate in the artifact-write chokepoint before the metadata row is persisted.
+
+- [ ] **Step 4: Run test**
+
+Run: `cargo test -p axon-core artifact_metadata_secret_fixture_fails_before_write --no-fail-fast`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/axon-core/src
+git commit -m "feat(security): gate artifact metadata writes through the redaction boundary"
+```
+
+## Task 4: Best-Effort Gate Trace/Log Call Sites, File A Follow-Up For Exhaustive Coverage
+
+**Files:**
+- Modify: the call sites identified in Task 1 Step 4
+- Test: `crates/axon-core/src/redact/boundary_tests.rs`
+
+**Interfaces:**
+- Consumes: Task 1's candidate list.
+- Produces: every candidate call site from Task 1 Step 4 gated; an explicit tracked follow-up (bd issue or a note in the source-of-truth plan doc) for a lint/CI mechanism, since this task's manual grep is not a completeness guarantee.
+
+- [ ] **Step 1: Write one fail-closed test per identified call site**
+
+For each call site found in Task 1 Step 4, add a targeted test proving a secret-bearing input to that specific function no longer reaches the log sink unredacted (use a test log subscriber/capture, matching whatever pattern this repo's existing logging tests already use).
+
+- [ ] **Step 2: Run tests and confirm failure**
+
+Run the new tests; expect FAIL for each call site not yet gated.
+
+- [ ] **Step 3: Wire each call site through the gate**
+
+For each, route the logged value through the gate function before the `tracing::*!`/`log_*` call, or redact inline if the gate function's surface shape doesn't fit a bare string (in which case, use whatever lower-level redaction primitive the gate function itself is built on — read `boundary.rs`'s implementation to find it rather than reimplementing detection logic).
+
+- [ ] **Step 4: Run tests**
+
+Expected: PASS for every call site gated in Step 3.
+
+- [ ] **Step 5: File the exhaustiveness follow-up**
+
+This repo uses `bd` for issue tracking (see root `CLAUDE.md`). Run `bd create --title="Add CI-enforced redaction call-site lint" --description="Task 4 of docs/pipeline-unification/plans/2026-07-08-redaction-boundary-extension.md gated trace/log call sites found by a manual grep, which is not exhaustive. Add a lint (clippy custom lint, or a grep-based xtask check) that fails CI when a new tracing::*!/log_* call site logs a value tagged as potentially-secret without routing through the redaction gate." --type=task --priority=2`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/axon-core/src crates/axon-services/src
+git commit -m "feat(security): gate identified trace/log call sites through the redaction boundary"
+```
+
+## Task 5: Verification
+
+- [ ] **Step 1: Full crate gate**
+
+```bash
+cargo test -p axon-core redact --no-fail-fast
+cargo test -p axon-cli --no-fail-fast
+cargo clippy -p axon-core -p axon-cli --all-targets
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Update the source plan doc**
+
+Mark Phase 3B Task 4 done (with the exhaustiveness caveat noted) in `2026-07-04-phase-3b-security-error-memory-completion.md`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/pipeline-unification/plans
+git commit -m "docs(pipeline): close out phase 3b task 4 redaction boundary extension"
+```
+
+## Self-Review
+
+- Spec coverage: Phase 3B Task 4 → Tasks 1-4 here.
+- Engineering review findings applied: task split into 3 independently-committable steps instead of one bundled task (matches this repo's own "commit after each task's verification passes" constraint, which the original bundled version violated in practice); exhaustiveness explicitly not claimed — a tracked follow-up replaces a false completeness signal.
+- Placeholder scan: Task 1 is an explicit read-first step for the same reason as the provider-cooling plan's Task 1 — a prior draft guessed at function/file names that turned out wrong.

--- a/docs/pipeline-unification/plans/2026-07-08-rest-memory-surface.md
+++ b/docs/pipeline-unification/plans/2026-07-08-rest-memory-surface.md
@@ -1,0 +1,249 @@
+# REST Memory Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close Phase 3B Task 9's remaining gap — split the single opaque `POST /v1/memory` passthrough into per-verb `/v1/memories` REST routes matching the contract, and add `import`/`export` to CLI, MCP, and REST (currently missing from all three transports).
+
+**Architecture:** `MemoryService` already implements the full lifecycle (remember/search/context/show/link/supersede/reinforce/contradict/pin/archive/forget/review/compact/import/export) per Phase 3B Tasks 5-7 — this is purely a transport-surface change, no new service logic.
+
+**Tech Stack:** Rust 2024, Axum, `axon-web`, `axon-cli`, `axon-mcp`.
+
+## Global Constraints
+
+- Split out of `2026-07-08-finish-job-cutover-and-security-completion.md` per engineering review: independent of the job cutover.
+- Import/export routes must have explicit size limits, and must go through the same auth-scope check every other `/v1/*` route uses — a security review found the current single passthrough handler shows no auth extraction, unlike `crates/axon-web/src/server/handlers/sources.rs`'s `AuthContext`-gated pattern, and the new import/export routes must not repeat that gap.
+- Do not delete the old `POST /v1/memory` passthrough route in the same change that adds the new per-verb routes without an explicit deprecation window — an external client (e.g. the desktop palette app) may already depend on the old shape. Mark it deprecated (still functional, logs a deprecation warning) for at least one release before removal, and file a follow-up for the actual removal.
+- Do not edit `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`.
+- Commit after each task's verification passes.
+
+---
+
+## Source-Of-Truth Contracts
+
+- `docs/pipeline-unification/plans/2026-07-04-phase-3b-security-error-memory-completion.md` (Task 9)
+- `docs/pipeline-unification/surfaces/rest-contract.md`
+
+## Current-State Anchors
+
+- Existing single passthrough route: `crates/axon-web/src/server/routing.rs` (confirmed at the `POST /v1/memory` registration), handler in `crates/axon-web/src/**/memory*.rs` — read the handler in full first to see its current request-shape handling and confirm it genuinely lacks auth extraction (a prior review pass flagged this; verify before assuming).
+- Auth-gated pattern to copy: `crates/axon-web/src/server/handlers/sources.rs::caller_context_from_auth(&AuthContext) -> CallerContext`.
+- `MemoryService`'s complete lifecycle methods (already implemented, Phase 3B Tasks 5-7): read `crates/axon-services/src/memory.rs` for the real method signatures for `remember`/`search`/`context`/`show`/`link`/`supersede`/`reinforce`/`contradict`/`pin`/`archive`/`forget`/`review`/`compact`/`import`/`export`.
+- CLI memory commands: `crates/axon-cli/src/commands/memory.rs` (13 of ~15 subactions already wired per prior audit — missing `import`/`export`).
+- MCP memory action: `crates/axon-mcp/src/server/handlers_memory.rs` (same gap).
+
+## File Structure
+
+- Modify: `crates/axon-web/src/server/routing.rs`
+- Modify/split: `crates/axon-web/src/**/memory*.rs` into per-verb handlers
+- Modify: `crates/axon-cli/src/commands/memory.rs`
+- Modify: `crates/axon-mcp/src/server/handlers_memory.rs`
+- Test: `crates/axon-web/src/memory_tests.rs`, `crates/axon-cli/src/commands/memory_tests.rs`, `crates/axon-mcp/src/memory_tests.rs`
+
+---
+
+## Task 1: Read The Current Handler And Confirm The Auth Gap
+
+**Files:**
+- Read only: `crates/axon-web/src/**/memory*.rs`, `crates/axon-web/src/server/handlers/sources.rs`, `crates/axon-services/src/memory.rs`
+
+**Interfaces:**
+- Consumes: nothing — research step.
+- Produces: confirmed real request/response shape of the current passthrough handler, confirmed presence/absence of auth extraction, confirmed real `MemoryService` method signatures.
+
+- [ ] **Step 1: Read the current handler in full**
+
+Read the existing `POST /v1/memory` handler completely. Note exactly what request shape it accepts today and how it dispatches to `MemoryService`. Confirm whether it extracts `AuthContext`/builds a `CallerContext` at all — if it already does, the "add auth gating" step below becomes "verify parity" instead of "add from scratch."
+
+- [ ] **Step 2: Read `MemoryService`'s real method signatures**
+
+Read `crates/axon-services/src/memory.rs` in full for the exact signatures of every lifecycle method, especially `import`/`export` (their request/response DTOs — `MemoryImportRequest`/`MemoryImportResult`/`MemoryExportRequest`/`MemoryExportResult` per Phase 3B Task 7).
+
+## Task 2: Add Per-Verb REST Routes With Auth Gating
+
+**Files:**
+- Modify: `crates/axon-web/src/server/routing.rs`
+- Modify/split: `crates/axon-web/src/**/memory*.rs`
+- Test: `crates/axon-web/src/memory_tests.rs`
+
+**Interfaces:**
+- Consumes: Task 1's confirmed shapes.
+- Produces: `POST /v1/memories`, `GET /v1/memories/search`, `GET /v1/memories/{memory_id}`, `POST /v1/memories/{memory_id}/link`, `POST /v1/memories/{memory_id}/supersede`, `POST /v1/memories/{memory_id}/reinforce`, `POST /v1/memories/{memory_id}/contradict`, `POST /v1/memories/{memory_id}/pin`, `POST /v1/memories/{memory_id}/archive`, `DELETE /v1/memories/{memory_id}` (forget), `POST /v1/memories/review`, `POST /v1/memories/{memory_id}/compact`, plus the old `POST /v1/memory` kept functional but marked deprecated.
+
+- [ ] **Step 1: Write failing route-existence test**
+
+```rust
+#[tokio::test]
+async fn rest_exposes_per_verb_memory_routes() {
+    let app = test_app().await;
+    for (method, path) in [
+        ("POST", "/v1/memories"),
+        ("GET", "/v1/memories/search"),
+        ("GET", "/v1/memories/{memory_id}"),
+        ("POST", "/v1/memories/{memory_id}/link"),
+        ("POST", "/v1/memories/{memory_id}/supersede"),
+        ("POST", "/v1/memories/{memory_id}/reinforce"),
+        ("POST", "/v1/memories/{memory_id}/contradict"),
+        ("POST", "/v1/memories/{memory_id}/pin"),
+        ("POST", "/v1/memories/{memory_id}/archive"),
+        ("DELETE", "/v1/memories/{memory_id}"),
+        ("POST", "/v1/memories/review"),
+        ("POST", "/v1/memories/{memory_id}/compact"),
+    ] {
+        assert!(route_exists(&app, method, path), "missing route {method} {path}");
+    }
+}
+
+#[tokio::test]
+async fn old_passthrough_route_still_works_but_logs_deprecation() {
+    let app = test_app().await;
+    assert!(route_exists(&app, "POST", "/v1/memory"));
+    // assert deprecation warning is logged/header set — match whatever
+    // deprecation-signaling pattern this repo already uses elsewhere, if any;
+    // otherwise add a `Deprecation` response header per RFC 8594.
+}
+```
+
+Reuse whatever `test_app()`/`route_exists()` helpers `crates/axon-web/src/jobs_tests.rs` (from the Task 3A durable-job-cutover work) already established — do not invent a second pattern.
+
+- [ ] **Step 2: Run test and confirm failure**
+
+Run: `cargo test -p axon-web rest_exposes_per_verb_memory_routes old_passthrough_route_still_works_but_logs_deprecation --no-fail-fast`
+
+Expected: both FAIL.
+
+- [ ] **Step 3: Implement per-verb handlers with auth gating**
+
+Split the single passthrough into per-verb Axum handlers, each: (1) extracts `AuthContext` and builds a `CallerContext`/`AuthSnapshot` via `caller_context_from_auth` exactly like `sources.rs` does, (2) parses its specific request DTO, (3) calls the matching `MemoryService` method — no duplicated lifecycle logic in the handler. Keep the old `POST /v1/memory` route registered, routing to the same underlying logic as the new `POST /v1/memories`, with a `Deprecation` response header (or this repo's existing deprecation-signaling convention if one exists — check first).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p axon-web memory --no-fail-fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/axon-web/src
+git commit -m "feat(web): split memory REST surface into per-verb routes, deprecate passthrough"
+```
+
+## Task 3: Add Import/Export To CLI, MCP, And REST
+
+**Files:**
+- Modify: `crates/axon-cli/src/commands/memory.rs`
+- Modify: `crates/axon-mcp/src/server/handlers_memory.rs`
+- Modify: `crates/axon-web/src/**/memory*.rs`
+- Test: `crates/axon-cli/src/commands/memory_tests.rs`, `crates/axon-mcp/src/memory_tests.rs`, `crates/axon-web/src/memory_tests.rs`
+
+**Interfaces:**
+- Consumes: `MemoryService::import`/`export` (Task 1's confirmed signatures).
+- Produces: `axon memory import <path>` / `axon memory export [--output <path>]` CLI subcommands; `import`/`export` MCP subactions; `POST /v1/memories/import`, `POST /v1/memories/export` REST routes — all with explicit size limits.
+
+- [ ] **Step 1: Write failing tests for all three transports**
+
+```rust
+// crates/axon-cli/src/commands/memory_tests.rs
+#[test]
+fn cli_memory_has_import_and_export_subcommands() {
+    let subcommands = memory_subcommand_names();
+    assert!(subcommands.contains(&"import"));
+    assert!(subcommands.contains(&"export"));
+}
+
+// crates/axon-mcp/src/memory_tests.rs
+#[test]
+fn mcp_memory_registry_contains_import_and_export() {
+    let actions = memory_subactions();
+    assert!(actions.contains(&"import"));
+    assert!(actions.contains(&"export"));
+}
+
+// crates/axon-web/src/memory_tests.rs
+#[tokio::test]
+async fn rest_exposes_import_and_export_routes_with_size_limit() {
+    let app = test_app().await;
+    assert!(route_exists(&app, "POST", "/v1/memories/import"));
+    assert!(route_exists(&app, "POST", "/v1/memories/export"));
+    let oversized_body = vec![0u8; MAX_MEMORY_IMPORT_BYTES + 1];
+    let response = post_memory_import(&app, oversized_body).await;
+    assert_eq!(response.status(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+}
+```
+
+- [ ] **Step 2: Run tests and confirm failure**
+
+```bash
+cargo test -p axon-cli cli_memory_has_import_and_export_subcommands --no-fail-fast
+cargo test -p axon-mcp mcp_memory_registry_contains_import_and_export --no-fail-fast
+cargo test -p axon-web rest_exposes_import_and_export_routes_with_size_limit --no-fail-fast
+```
+
+Expected: all FAIL.
+
+- [ ] **Step 3: Implement CLI import/export**
+
+Add `axon memory import <path>` reading a local file and calling `MemoryService::import`, and `axon memory export [--output <path>]` calling `MemoryService::export` and writing to the given path or stdout.
+
+- [ ] **Step 4: Implement MCP import/export**
+
+Add `import`/`export` to the MCP `memory` action's subaction list, following the existing subaction dispatch pattern in `handlers_memory.rs`.
+
+- [ ] **Step 5: Implement REST import/export with a size limit**
+
+Add `POST /v1/memories/import` and `POST /v1/memories/export`, with a `MAX_MEMORY_IMPORT_BYTES`/`MAX_MEMORY_EXPORT_BYTES` constant (pick a conservative default, e.g. 10 MiB, matching whatever size-limit convention other large-body routes in this codebase already use — check `crates/axon-web/src/server` for an existing body-size-limit pattern before inventing a new one) enforced via Axum's body-size-limit extractor or middleware, returning `413 Payload Too Large` on violation. Gate both routes with the same `AuthContext` extraction as Task 2's other new routes.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cargo test -p axon-cli memory --no-fail-fast
+cargo test -p axon-mcp memory --no-fail-fast
+cargo test -p axon-web memory --no-fail-fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/axon-cli/src crates/axon-mcp/src crates/axon-web/src
+git commit -m "feat: add memory import/export to CLI, MCP, and REST with size limits"
+```
+
+## Task 4: File The Old-Route Removal Follow-Up And Verify
+
+- [ ] **Step 1: File the deprecation-removal follow-up**
+
+```bash
+bd create --title="Remove deprecated POST /v1/memory passthrough route" --description="Task 2 of docs/pipeline-unification/plans/2026-07-08-rest-memory-surface.md kept the old single-route memory passthrough functional (marked deprecated) alongside the new per-verb /v1/memories routes, to avoid breaking existing external clients (e.g. desktop palette) without a migration window. Remove the old route once all known clients have migrated to the per-verb routes — check the palette app and any other REST memory consumers first." --type=task --priority=3
+```
+
+- [ ] **Step 2: Full crate gate**
+
+```bash
+cargo test -p axon-web memory --no-fail-fast
+cargo test -p axon-cli memory --no-fail-fast
+cargo test -p axon-mcp memory --no-fail-fast
+cargo clippy -p axon-web -p axon-cli -p axon-mcp --all-targets
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Update the source plan doc**
+
+Mark Phase 3B Task 9 done in `2026-07-04-phase-3b-security-error-memory-completion.md`, noting the old-route deprecation-not-removal decision and the filed follow-up.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/pipeline-unification/plans
+git commit -m "docs(pipeline): close out phase 3b task 9 REST memory surface"
+```
+
+## Self-Review
+
+- Spec coverage: Phase 3B Task 9 → Tasks 1-3 here.
+- Engineering review findings applied: auth gating required on every new route (matching `sources.rs`'s established pattern, not the current handler's apparent gap); explicit size limits on import/export (missing entirely from the originating plan); old route deprecated with a migration window instead of deleted outright in the same change (avoiding an undocumented breaking change to existing external clients).
+- Placeholder scan: Task 1 is an explicit read-first step to confirm the auth-gap claim before building around it, and to pin the real `MemoryService` signatures before writing handler code against them.


### PR DESCRIPTION
## Summary
- Adds 4 plan docs closing out the two open items in `2026-07-04-full-durable-job-cutover.md` (Tasks 6/8: cut crawl/embed/ingest over to the unified job store) and the remaining phase 3b security/error/memory gaps (reset legacy-store confirmation, provider cooling, redaction boundary extension, REST memory surface).
- Docs-only change — no code touched.

## Test plan
- [x] Docs-only per repo's Verification Scope Guard — no build/test required

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four implementation plan docs to finish the unified job cutover and wrap up remaining Phase 3B security/error/memory work. Docs-only; no code changes.

- **Plans**
  - Finish job cutover: move `Crawl`/`Embed`/`Ingest` to the unified `JobStore`, add concurrent unified worker and enqueue wakeups, fix unconditional `trusted_system` auth, retire legacy workers; add a CLI-flag-only reset confirmation for legacy-store wipes.
  - Provider cooling: add `cooldown_until` with a capped window and index; exclude cooling jobs from claims; clear on non-`Waiting` transitions.
  - Redaction boundary: gate CLI `--json`, artifact metadata, and selected logs/traces; fail closed; track a follow-up lint for exhaustiveness.
  - REST memory surface: split `POST /v1/memory` into per-verb `/v1/memories` routes with auth and size limits; add import/export across CLI, MCP, and REST; keep the old route functional but deprecated.

<sup>Written for commit 400d62920e268902bcc6671a88823324c735f855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

