### PR TITLE
ci: include dependency bumps in release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,10 @@
       "section": "Fixed"
     },
     {
+      "type": "deps",
+      "section": "Dependencies"
+    },
+    {
       "type": "perf",
       "section": "Changed"
     },


### PR DESCRIPTION
Align release-please and Dependabot so dependency update commits use deps(...) and appear under a Dependencies changelog section. Also keeps release PRs refreshed with always-update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `deps` commit type mapping in `release-please` so dependency bumps show under a Dependencies section in release notes. Aligns with `Dependabot` PRs.

<sup>Written for commit 8f547a6b0338adc618f105151db8a58ed9f36755. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

