### PR TITLE
Add Browser and Terminal palette tools

### DIFF
--- a/apps/palette-tauri/src-tauri/Cargo.lock
+++ b/apps/palette-tauri/src-tauri/Cargo.lock
@@ -4255,6 +4255,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,6 +4953,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/apps/palette-tauri/src-tauri/Cargo.toml
+++ b/apps/palette-tauri/src-tauri/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = "1"
 sha2 = "0.10"
 tauri = { version = "2", features = ["image-png", "tray-icon", "protocol-asset"] }
 tauri-plugin-global-shortcut = "2"
-tokio = { version = "1", features = ["sync", "net", "io-util", "time", "macros", "rt"] }
+tokio = { version = "1", features = ["sync", "net", "io-util", "time", "macros", "rt", "process"] }
 toml_edit = "0.23"
 url = "2"
 uuid = { version = "1", features = ["v4"] }

--- a/apps/palette-tauri/src-tauri/src/browser.rs
+++ b/apps/palette-tauri/src-tauri/src/browser.rs
@@ -1,0 +1,153 @@
+// Real in-app "Browser" tool: a dedicated native `WebviewWindow`, separate
+// from the main palette window, that navigates to real external URLs.
+//
+// Why a separate native window instead of an embedded child webview:
+// - The main window's CSP (`tauri.conf.json` -> app.security.csp) is locked
+//   to `default-src 'self'` with no `frame-src` allowance, so a plain
+//   `<iframe src="https://...">` inside the main webview cannot load
+//   third-party sites.
+// - Tauri v2 does support embedding a child `Webview` inside an existing
+//   window (multiwebview), but that requires manually keeping the child
+//   webview's bounds in sync with the main window's geometry, which is
+//   already tightly hand-managed for the compact/expanded palette states
+//   (see `resize_palette` in `lib.rs` and `useWindowChrome.ts` on the
+//   frontend). A second bounds-tracking system for a browser pane adds
+//   fragility for comparatively little visual benefit.
+// - A dedicated `WebviewWindow` is a fully real, independently-navigable
+//   webview with its own security context (not bound by the main window's
+//   CSP), and it is trivial to create, show, resize, and destroy without
+//   touching the main window's carefully-tuned geometry code at all.
+//
+// Tauri v2 does not expose a first-class "go back"/"go forward" API on
+// `WebviewWindow`, so those two commands drive the loaded page's own
+// session history via `eval("history.back()")` / `eval("history.forward()")`
+// — which is a real navigation of whatever real page is currently loaded,
+// not a simulation.
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// Label of the dedicated browser window. Distinct from the main palette
+/// window's `"main"` label.
+pub(crate) const BROWSER_WINDOW_LABEL: &str = "browser";
+
+const BROWSER_WINDOW_TITLE: &str = "Axon Browser";
+const DEFAULT_WIDTH: f64 = 1100.0;
+const DEFAULT_HEIGHT: f64 = 760.0;
+
+/// Validate and normalize a URL for the browser window. Rejects anything
+/// that isn't `http`/`https`/`about:blank` so the browser command surface
+/// can't be used to load `file://`/`tauri://`/custom-scheme URLs into a
+/// window that otherwise behaves like a sandboxed external browser.
+///
+/// Returns the validated URL string (unchanged) on success.
+pub(crate) fn validate_browser_url(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("browser URL must not be empty".to_string());
+    }
+    if trimmed == "about:blank" {
+        return Ok(trimmed.to_string());
+    }
+    let parsed = url::Url::parse(trimmed).map_err(|err| format!("invalid browser URL: {err}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err("browser URL must use http or https".to_string());
+    }
+    Ok(trimmed.to_string())
+}
+
+fn webview_url_for(raw: &str) -> Result<WebviewUrl, String> {
+    if raw == "about:blank" {
+        return Ok(WebviewUrl::App("about:blank".into()));
+    }
+    let parsed = url::Url::parse(raw).map_err(|err| format!("invalid browser URL: {err}"))?;
+    Ok(WebviewUrl::External(parsed))
+}
+
+/// Open the browser window at `url`, creating it if it doesn't exist yet, or
+/// focusing + navigating the existing one.
+///
+/// Tauri v2 documents a Windows-specific deadlock when creating a
+/// `WebviewWindow` synchronously inside a command handler, so this command
+/// is `async` (Tauri runs async commands on a separate thread pool).
+#[tauri::command]
+pub(crate) async fn browser_open(app: AppHandle, url: String) -> Result<(), String> {
+    let validated = validate_browser_url(&url)?;
+    if let Some(window) = app.get_webview_window(BROWSER_WINDOW_LABEL) {
+        window
+            .navigate(
+                url::Url::parse(&validated).map_err(|err| format!("invalid browser URL: {err}"))?,
+            )
+            .map_err(|err| err.to_string())?;
+        window.show().map_err(|err| err.to_string())?;
+        window.set_focus().map_err(|err| err.to_string())?;
+        return Ok(());
+    }
+
+    let webview_url = webview_url_for(&validated)?;
+    WebviewWindowBuilder::new(&app, BROWSER_WINDOW_LABEL, webview_url)
+        .title(BROWSER_WINDOW_TITLE)
+        .inner_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        .center()
+        .resizable(true)
+        .build()
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+/// Navigate the existing browser window to a new URL. Opens the window first
+/// if it isn't already open (same behavior as `browser_open`).
+#[tauri::command]
+pub(crate) async fn browser_navigate(app: AppHandle, url: String) -> Result<(), String> {
+    browser_open(app, url).await
+}
+
+/// Drive the loaded page's own back-navigation. A no-op (not an error) if
+/// the browser window isn't currently open.
+#[tauri::command]
+pub(crate) fn browser_back(app: AppHandle) -> Result<(), String> {
+    with_browser_window(&app, |window| {
+        window.eval("history.back()").map_err(|err| err.to_string())
+    })
+}
+
+/// Drive the loaded page's own forward-navigation.
+#[tauri::command]
+pub(crate) fn browser_forward(app: AppHandle) -> Result<(), String> {
+    with_browser_window(&app, |window| {
+        window
+            .eval("history.forward()")
+            .map_err(|err| err.to_string())
+    })
+}
+
+/// Reload the currently loaded page.
+#[tauri::command]
+pub(crate) fn browser_reload(app: AppHandle) -> Result<(), String> {
+    with_browser_window(&app, |window| {
+        window
+            .eval("location.reload()")
+            .map_err(|err| err.to_string())
+    })
+}
+
+/// Close (destroy) the browser window if it exists.
+#[tauri::command]
+pub(crate) fn browser_close(app: AppHandle) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window(BROWSER_WINDOW_LABEL) {
+        window.close().map_err(|err| err.to_string())?;
+    }
+    Ok(())
+}
+
+fn with_browser_window(
+    app: &AppHandle,
+    f: impl FnOnce(&tauri::WebviewWindow) -> Result<(), String>,
+) -> Result<(), String> {
+    match app.get_webview_window(BROWSER_WINDOW_LABEL) {
+        Some(window) => f(&window),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+#[path = "browser_tests.rs"]
+mod tests;

--- a/apps/palette-tauri/src-tauri/src/browser_tests.rs
+++ b/apps/palette-tauri/src-tauri/src/browser_tests.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+#[test]
+fn validate_browser_url_accepts_https() {
+    assert_eq!(
+        validate_browser_url("https://example.com").unwrap(),
+        "https://example.com"
+    );
+}
+
+#[test]
+fn validate_browser_url_accepts_http() {
+    assert_eq!(
+        validate_browser_url("http://127.0.0.1:8001").unwrap(),
+        "http://127.0.0.1:8001"
+    );
+}
+
+#[test]
+fn validate_browser_url_accepts_about_blank() {
+    assert_eq!(validate_browser_url("about:blank").unwrap(), "about:blank");
+}
+
+#[test]
+fn validate_browser_url_trims_whitespace() {
+    assert_eq!(
+        validate_browser_url("  https://example.com  ").unwrap(),
+        "https://example.com"
+    );
+}
+
+#[test]
+fn validate_browser_url_rejects_empty() {
+    assert!(validate_browser_url("").is_err());
+    assert!(validate_browser_url("   ").is_err());
+}
+
+#[test]
+fn validate_browser_url_rejects_non_http_schemes() {
+    assert!(validate_browser_url("file:///etc/passwd").is_err());
+    assert!(validate_browser_url("tauri://localhost").is_err());
+    assert!(validate_browser_url("javascript:alert(1)").is_err());
+    assert!(validate_browser_url("data:text/html,hi").is_err());
+}
+
+#[test]
+fn validate_browser_url_rejects_unparseable_input() {
+    assert!(validate_browser_url("not a url at all").is_err());
+}
+
+#[test]
+fn webview_url_for_maps_https_to_external() {
+    let webview_url = webview_url_for("https://example.com").expect("valid url");
+    match webview_url {
+        WebviewUrl::External(url) => assert_eq!(url.as_str(), "https://example.com/"),
+        other => panic!("expected External variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn webview_url_for_maps_about_blank_to_app() {
+    let webview_url = webview_url_for("about:blank").expect("valid url");
+    assert!(matches!(webview_url, WebviewUrl::App(_)));
+}

--- a/apps/palette-tauri/src-tauri/src/lib.rs
+++ b/apps/palette-tauri/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ use tauri::{
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 
 mod axon_bridge;
+mod browser;
 mod date_math;
 mod diag;
 mod files_bridge;
@@ -515,6 +516,12 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             axon_bridge::axon_http_request,
             axon_bridge::axon_artifact_request,
             axon_http_stream_request,
+            browser::browser_open,
+            browser::browser_navigate,
+            browser::browser_back,
+            browser::browser_forward,
+            browser::browser_reload,
+            browser::browser_close,
             github_bridge::github_browse,
             oauth::axon_oauth_login,
             oauth::axon_oauth_logout,

--- a/apps/palette-tauri/src-tauri/src/lib.rs
+++ b/apps/palette-tauri/src-tauri/src/lib.rs
@@ -27,12 +27,14 @@ mod persistence;
 mod sftp_bridge;
 mod sftp_known_hosts;
 mod stream;
+mod terminal;
 mod window_events;
 
 use axon_bridge::{BridgeClient, StreamClient};
 use github_bridge::GitHubClient;
 use persistence::*;
 use stream::axon_http_stream_request;
+use terminal::TerminalState;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -535,7 +537,9 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             sftp_bridge::commands::sftp_read_file,
             sftp_bridge::commands::sftp_disconnect,
             sftp_bridge::commands::sftp_list_known_hosts,
-            sftp_bridge::commands::sftp_revoke_known_host
+            sftp_bridge::commands::sftp_revoke_known_host,
+            terminal::terminal_run,
+            terminal::terminal_cwd
         ])
         .manage(BlurDismiss(AtomicBool::new(true)))
         .manage(ActiveShortcut(Mutex::new(None)))
@@ -544,6 +548,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         .manage(github_client)
         .manage(oauth::OauthState::new())
         .manage(sftp_bridge::SftpConnections::new())
+        .manage(TerminalState::new())
         .setup(|app| {
             if let Err(err) = install_tray(app) {
                 log_palette_warning("failed to install tray icon", err);

--- a/apps/palette-tauri/src-tauri/src/terminal.rs
+++ b/apps/palette-tauri/src-tauri/src/terminal.rs
@@ -1,0 +1,214 @@
+//! Real shell command execution for the palette's Terminal tool.
+//!
+//! This is a genuine local shell — the user types a command line, we spawn
+//! it for real via `tokio::process::Command`, capture real stdout/stderr, and
+//! return it to the frontend. There is no allowlist/sandbox by design: this is
+//! the same trust level as a desktop IDE's integrated terminal (e.g. VS Code)
+//! — the app already runs with the user's own privileges, and a terminal that
+//! can only run some commands isn't a terminal. The one thing we own is the
+//! session's working directory, since each spawned process gets a fresh `cwd`
+//! that doesn't persist to the next spawn — `cd` is special-cased so the
+//! session behaves like a real interactive shell.
+//!
+//! No command ever arrives except through direct user keystrokes in the
+//! Terminal component (there is no network/IPC path into this module other
+//! than the Tauri `invoke` call the frontend makes for its own textbox).
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::Serialize;
+use tokio::process::Command;
+
+/// Session-scoped working directory, shared across `terminal_run` invocations
+/// for the life of the app. A spawned shell can't mutate the parent process's
+/// cwd, so `cd` is handled here instead of being passed through to the shell.
+pub(crate) struct TerminalState {
+    cwd: Mutex<PathBuf>,
+}
+
+impl TerminalState {
+    pub(crate) fn new() -> Self {
+        Self {
+            cwd: Mutex::new(initial_cwd()),
+        }
+    }
+}
+
+fn initial_cwd() -> PathBuf {
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TerminalRunResult {
+    stdout: String,
+    stderr: String,
+    /// Process exit code. `None` when the process was terminated by a signal
+    /// (Unix) rather than exiting normally.
+    exit_code: Option<i32>,
+    /// Working directory *after* the command ran — the frontend uses this to
+    /// keep its prompt in sync, especially after a `cd`.
+    cwd: String,
+}
+
+/// Resolve the user's shell: `$SHELL` first, then a platform-appropriate
+/// fallback. Unix-first — Windows support is a documented follow-up.
+fn login_shell() -> String {
+    std::env::var("SHELL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| {
+            if cfg!(windows) {
+                "cmd.exe".to_string()
+            } else if Path::new("/bin/bash").exists() {
+                "/bin/bash".to_string()
+            } else {
+                "/bin/sh".to_string()
+            }
+        })
+}
+
+/// Shell metacharacters that mean the command line is NOT a bare `cd` — e.g.
+/// `cd /tmp && pwd`, `cd foo; ls`, `cd "$(bar)"`. Anything containing one of
+/// these must fall through to the real spawned-shell path so it gets real
+/// shell parsing instead of being misread as a literal `cd` target.
+const SHELL_METACHARACTERS: [char; 9] = ['&', '|', ';', '$', '`', '<', '>', '(', ')'];
+
+/// Split a `cd` invocation off the front of a command line, if the whole
+/// command line is exactly a `cd`. Only a bare `cd`/`cd <target>` is
+/// special-cased — anything with shell metacharacters (`cd foo && ls`, `cd
+/// foo; ls`, command substitution, redirection, subshells, etc.) is left
+/// alone and runs for real in the spawned shell instead (its `cd` just won't
+/// outlive that one process, matching real shell semantics for compound
+/// commands run through `sh -c`).
+fn parse_cd_target(command: &str) -> Option<&str> {
+    let trimmed = command.trim();
+    let rest = trimmed.strip_prefix("cd")?;
+    if !rest.is_empty() && !rest.starts_with(char::is_whitespace) {
+        return None; // e.g. "cdfoo" is not `cd`
+    }
+    let target = rest.trim();
+    if target.contains(SHELL_METACHARACTERS) || target.contains(char::is_whitespace) {
+        return None; // compound command or multiple args — not a bare `cd`
+    }
+    Some(target)
+}
+
+/// Resolve a `cd` target against the current session cwd, honoring `~` and
+/// relative paths the same way a real shell would.
+fn resolve_cd_target(current: &Path, target: &str) -> PathBuf {
+    if target.is_empty() {
+        return dirs::home_dir().unwrap_or_else(|| current.to_path_buf());
+    }
+    if target == "~" {
+        return dirs::home_dir().unwrap_or_else(|| current.to_path_buf());
+    }
+    if let Some(rest) = target.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    let candidate = Path::new(target);
+    if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        current.join(candidate)
+    }
+}
+
+fn run_cd(state: &TerminalState, target: &str) -> TerminalRunResult {
+    let mut guard = state.cwd.lock().unwrap_or_else(|err| err.into_inner());
+    let resolved = resolve_cd_target(&guard, target);
+    let canonical = match std::fs::canonicalize(&resolved) {
+        Ok(path) => path,
+        Err(err) => {
+            return TerminalRunResult {
+                stdout: String::new(),
+                stderr: format!("cd: {target}: {err}"),
+                exit_code: Some(1),
+                cwd: guard.display().to_string(),
+            };
+        }
+    };
+    if !canonical.is_dir() {
+        return TerminalRunResult {
+            stdout: String::new(),
+            stderr: format!("cd: not a directory: {target}"),
+            exit_code: Some(1),
+            cwd: guard.display().to_string(),
+        };
+    }
+    *guard = canonical.clone();
+    TerminalRunResult {
+        stdout: String::new(),
+        stderr: String::new(),
+        exit_code: Some(0),
+        cwd: canonical.display().to_string(),
+    }
+}
+
+/// Run one command line in the session's persistent working directory.
+///
+/// `cd` (bare, or with a single target) updates the session's tracked cwd
+/// in-process rather than spawning a shell — a spawned process cannot change
+/// its parent's directory, so without this every `cd` would silently no-op on
+/// the next command. Everything else spawns the user's real login shell via
+/// `-c` with `current_dir` set to the tracked cwd, capturing real stdout and
+/// stderr.
+#[tauri::command]
+pub(crate) async fn terminal_run(
+    state: tauri::State<'_, TerminalState>,
+    command: String,
+) -> Result<TerminalRunResult, String> {
+    if command.trim().is_empty() {
+        let cwd = current_cwd(&state);
+        return Ok(TerminalRunResult {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: Some(0),
+            cwd,
+        });
+    }
+    if let Some(target) = parse_cd_target(&command) {
+        return Ok(run_cd(&state, target));
+    }
+
+    let cwd = current_cwd(&state);
+    let shell = login_shell();
+    let output = Command::new(&shell)
+        .arg("-c")
+        .arg(&command)
+        .current_dir(&cwd)
+        .kill_on_drop(true)
+        .output()
+        .await
+        .map_err(|err| format!("failed to spawn {shell}: {err}"))?;
+
+    Ok(TerminalRunResult {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code(),
+        cwd,
+    })
+}
+
+fn current_cwd(state: &TerminalState) -> String {
+    state
+        .cwd
+        .lock()
+        .unwrap_or_else(|err| err.into_inner())
+        .display()
+        .to_string()
+}
+
+/// Report the session's current working directory without running a command
+/// — used by the frontend to seed the prompt on mount.
+#[tauri::command]
+pub(crate) fn terminal_cwd(state: tauri::State<'_, TerminalState>) -> String {
+    current_cwd(&state)
+}
+
+#[cfg(test)]
+#[path = "terminal_tests.rs"]
+mod tests;

--- a/apps/palette-tauri/src-tauri/src/terminal_tests.rs
+++ b/apps/palette-tauri/src-tauri/src/terminal_tests.rs
@@ -1,0 +1,184 @@
+use super::*;
+
+/// Real end-to-end proof: `terminal_run`'s inner logic actually spawns a real
+/// shell and captures real stdout. We call the same code path `terminal_run`
+/// uses (bypassing the `tauri::State` wrapper, which needs a running app) via
+/// a small helper that mirrors the command body.
+async fn run_direct(state: &TerminalState, command: &str) -> TerminalRunResult {
+    if command.trim().is_empty() {
+        return TerminalRunResult {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: Some(0),
+            cwd: current_cwd(state),
+        };
+    }
+    if let Some(target) = parse_cd_target(command) {
+        return run_cd(state, target);
+    }
+    let cwd = current_cwd(state);
+    let shell = login_shell();
+    let output = Command::new(&shell)
+        .arg("-c")
+        .arg(command)
+        .current_dir(&cwd)
+        .kill_on_drop(true)
+        .output()
+        .await
+        .expect("spawn shell");
+    TerminalRunResult {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code(),
+        cwd,
+    }
+}
+
+#[tokio::test]
+async fn echo_runs_a_real_process_and_captures_real_stdout() {
+    let state = TerminalState::new();
+    let result = run_direct(&state, "echo hello-from-real-shell").await;
+    assert_eq!(result.stdout.trim(), "hello-from-real-shell");
+    assert_eq!(result.stderr, "");
+    assert_eq!(result.exit_code, Some(0));
+}
+
+#[tokio::test]
+async fn pwd_reports_the_tracked_session_cwd() {
+    let state = TerminalState::new();
+    let expected = current_cwd(&state);
+    let result = run_direct(&state, "pwd").await;
+    // Canonicalize both sides — /tmp can be a symlink to /private/tmp etc.
+    let actual = std::fs::canonicalize(result.stdout.trim()).unwrap();
+    let expected_canon = std::fs::canonicalize(&expected).unwrap();
+    assert_eq!(actual, expected_canon);
+}
+
+#[tokio::test]
+async fn nonzero_exit_code_is_captured() {
+    let state = TerminalState::new();
+    let result = run_direct(&state, "exit 7").await;
+    assert_eq!(result.exit_code, Some(7));
+}
+
+#[tokio::test]
+async fn stderr_is_captured_separately_from_stdout() {
+    let state = TerminalState::new();
+    let result = run_direct(&state, "echo out-line; echo err-line 1>&2").await;
+    assert_eq!(result.stdout.trim(), "out-line");
+    assert_eq!(result.stderr.trim(), "err-line");
+}
+
+#[tokio::test]
+async fn cd_persists_across_subsequent_commands_in_the_session() {
+    let state = TerminalState::new();
+    let tmp = std::env::temp_dir();
+    let tmp_canon = std::fs::canonicalize(&tmp).unwrap();
+
+    let cd_result = run_direct(&state, &format!("cd {}", tmp.display())).await;
+    assert_eq!(cd_result.exit_code, Some(0));
+    assert_eq!(std::path::Path::new(&cd_result.cwd), tmp_canon);
+
+    // A brand-new spawned process for the *next* command should still see the
+    // updated cwd — proving the session state (not the shell process) is what
+    // carries the directory forward.
+    let pwd_result = run_direct(&state, "pwd").await;
+    let actual = std::fs::canonicalize(pwd_result.stdout.trim()).unwrap();
+    assert_eq!(actual, tmp_canon);
+}
+
+#[tokio::test]
+async fn cd_to_nonexistent_directory_reports_an_error_and_keeps_old_cwd() {
+    let state = TerminalState::new();
+    let before = current_cwd(&state);
+    let result = run_direct(&state, "cd /definitely/does/not/exist/anywhere").await;
+    assert_eq!(result.exit_code, Some(1));
+    assert!(!result.stderr.is_empty());
+    assert_eq!(result.cwd, before);
+}
+
+#[tokio::test]
+async fn cd_with_no_target_goes_home() {
+    let state = TerminalState::new();
+    let result = run_direct(&state, "cd").await;
+    assert_eq!(result.exit_code, Some(0));
+    if let Some(home) = dirs::home_dir() {
+        let home_canon = std::fs::canonicalize(&home).unwrap();
+        assert_eq!(std::path::Path::new(&result.cwd), home_canon);
+    }
+}
+
+#[tokio::test]
+async fn compound_command_with_cd_does_not_leak_into_session_cwd() {
+    // `cd foo && ls` is not the bare-`cd` fast path, so it spawns a real shell.
+    // That subshell's cd cannot outlive the process — matching real shell
+    // semantics for compound commands run through `sh -c`.
+    let state = TerminalState::new();
+    let before = current_cwd(&state);
+    let tmp = std::env::temp_dir();
+    let result = run_direct(&state, &format!("cd {} && pwd", tmp.display())).await;
+    assert_eq!(result.exit_code, Some(0));
+    let printed = std::fs::canonicalize(result.stdout.trim()).unwrap();
+    let tmp_canon = std::fs::canonicalize(&tmp).unwrap();
+    assert_eq!(printed, tmp_canon);
+    // Session cwd tracked by our state is untouched.
+    assert_eq!(current_cwd(&state), before);
+}
+
+#[test]
+fn parse_cd_target_recognizes_bare_cd_and_rejects_prefix_matches() {
+    assert_eq!(parse_cd_target("cd"), Some(""));
+    assert_eq!(parse_cd_target("cd /tmp"), Some("/tmp"));
+    assert_eq!(parse_cd_target("  cd   /tmp  "), Some("/tmp"));
+    assert_eq!(parse_cd_target("cd~"), None);
+    assert_eq!(parse_cd_target("cdfoo"), None);
+    assert_eq!(parse_cd_target("echo cd"), None);
+}
+
+#[test]
+fn resolve_cd_target_handles_tilde_and_relative_paths() {
+    let current = PathBuf::from("/home/user/project");
+    if let Some(home) = dirs::home_dir() {
+        assert_eq!(resolve_cd_target(&current, "~"), home);
+        assert_eq!(resolve_cd_target(&current, "~/docs"), home.join("docs"));
+    }
+    assert_eq!(
+        resolve_cd_target(&current, "sub"),
+        PathBuf::from("/home/user/project/sub")
+    );
+    assert_eq!(
+        resolve_cd_target(&current, "/absolute/path"),
+        PathBuf::from("/absolute/path")
+    );
+}
+
+#[test]
+fn login_shell_prefers_shell_env_var() {
+    // SAFETY: single-threaded test process env mutation, restored immediately.
+    unsafe {
+        std::env::set_var("SHELL", "/bin/zsh");
+    }
+    assert_eq!(login_shell(), "/bin/zsh");
+    unsafe {
+        std::env::remove_var("SHELL");
+    }
+}
+
+#[test]
+fn current_cwd_reflects_state_without_running_anything() {
+    let state = TerminalState::new();
+    assert_eq!(current_cwd(&state), initial_cwd().display().to_string());
+}
+
+#[test]
+fn parse_cd_target_rejects_compound_commands_with_shell_metacharacters() {
+    // Regression: `cd /tmp && pwd` was previously matched as a bare `cd`
+    // whose target was the literal string "/tmp && pwd", which then failed to
+    // canonicalize. Compound commands must fall through to the real shell.
+    assert_eq!(parse_cd_target("cd /tmp && pwd"), None);
+    assert_eq!(parse_cd_target("cd /tmp; ls"), None);
+    assert_eq!(parse_cd_target("cd /tmp | cat"), None);
+    assert_eq!(parse_cd_target("cd $(pwd)"), None);
+    assert_eq!(parse_cd_target("cd `pwd`"), None);
+    assert_eq!(parse_cd_target("cd foo bar"), None);
+}

--- a/apps/palette-tauri/src/App.tsx
+++ b/apps/palette-tauri/src/App.tsx
@@ -28,8 +28,10 @@ import {
   validationMessage,
 } from "@/lib/paletteView";
 import {
+  browserInitialTarget,
   INITIAL_VIEW,
   isBrowseOpen,
+  isBrowserOpen,
   isHistoryOpen,
   isSettingsOpen,
   modeOf,
@@ -76,6 +78,8 @@ export default function App() {
   const settingsOpen = isSettingsOpen(view);
   const historyOpen = isHistoryOpen(view);
   const browseOpen = isBrowseOpen(view);
+  const browserOpen = isBrowserOpen(view);
+  const browserInitialTargetValue = browserInitialTarget(view);
   usePaletteLifecycle(dispatchView, setShownTick);
 
   useEffect(() => {
@@ -159,20 +163,27 @@ export default function App() {
   const jobMinimized = (run.kind === "job" || run.kind === "asyncJob") && run.minimized;
   const jobExpanded = (run.kind === "job" || run.kind === "asyncJob") && !run.minimized;
   const showOutput = run.kind !== "idle" && !jobMinimized;
-  const enteringArgument = Boolean(modeAction) && !showOutput && !settingsOpen && !historyOpen;
+  const enteringArgument =
+    Boolean(modeAction) && !showOutput && !settingsOpen && !historyOpen && !browserOpen;
   const showContent =
-    settingsOpen || historyOpen || showOutput || (!enteringArgument && (hasQuery || browseOpen));
+    settingsOpen ||
+    historyOpen ||
+    browserOpen ||
+    showOutput ||
+    (!enteringArgument && (hasQuery || browseOpen));
   const compact = !showContent;
-  const showResultsLayout = showOutput || settingsOpen || historyOpen;
+  const showResultsLayout = showOutput || settingsOpen || historyOpen || browserOpen;
   const hideCommandBar =
-    showOutput && (active?.subcommand === "ask" || active?.subcommand === "chat");
-  const showActionPanel = !showResultsLayout && !settingsOpen && !historyOpen && !enteringArgument;
+    browserOpen || (showOutput && (active?.subcommand === "ask" || active?.subcommand === "chat"));
+  const showActionPanel =
+    !showResultsLayout && !settingsOpen && !historyOpen && !browserOpen && !enteringArgument;
   const listboxOpen = showContent && showActionPanel;
   const activeDescendantId =
     listboxOpen && suggestedAction ? actionOptionId(suggestedAction) : undefined;
 
   const settingsFocusRef = useFocusReturn<HTMLDivElement>(settingsOpen);
   const historyFocusRef = useFocusReturn<HTMLDivElement>(historyOpen && !settingsOpen);
+  const browserFocusRef = useFocusReturn<HTMLDivElement>(browserOpen);
   const outputFocusRef = useFocusReturn<HTMLDivElement>(
     showOutput && !settingsOpen && !historyOpen,
   );
@@ -182,7 +193,7 @@ export default function App() {
     jobExpanded,
     jobMinimized,
     settingsOpen,
-    historyOpen,
+    historyOpen: historyOpen || browserOpen,
     showResultsLayout,
     showContent,
     filteredLength: filtered.length,
@@ -222,6 +233,17 @@ export default function App() {
   const requestSubmit = useCallback(
     (action: PaletteAction, argumentOverride?: string) => {
       const argument = argumentOverride ?? argumentFor(action, modeAction, parsed, query);
+      // Browser is a local, window-driven action: it never issues an HTTP
+      // request (unlike other `kind: "local"` actions such as `help`, which
+      // `useActionRunner.submit` special-cases into a synthetic RunState), so
+      // it is intercepted here and routed straight to its own overlay
+      // instead of falling into `submit()`'s generic `kind === "local"`
+      // no-op path.
+      if (action.subcommand === "browser") {
+        setPendingConfirmation(null);
+        dispatchView({ type: "openBrowser", initialTarget: argument.trim() || null });
+        return;
+      }
       const validationMessageText = validationMessage(action, argument);
       if (!validationMessageText && actionNeedsConfirmation(action)) {
         if (!actionConfirmationArmed(pendingConfirmation, action, argument)) {
@@ -388,7 +410,7 @@ export default function App() {
       ? "Config error"
       : "Loading";
   const endpointTone = configError ? "error" : "syncing";
-  const showBackButton = settingsOpen || historyOpen || showOutput;
+  const showBackButton = settingsOpen || historyOpen || browserOpen || showOutput;
   const currentTarget = currentOutputTarget(run, active, query);
   const { pinnedTargets, togglePin: onTogglePin } = usePalettePins(setHistory, currentTarget);
   const commandRunning = run.kind === "running" || run.kind === "streaming";
@@ -403,6 +425,12 @@ export default function App() {
     clearSourcesFilter();
     focusInput(true);
   }
+
+  const onCloseBrowser = useCallback(() => {
+    dispatchView({ type: "closeBrowser" });
+    setQuery("");
+    focusInput(true);
+  }, []);
 
   // P-M2 — stable callbacks for the memoized children (CommandBar/OutputPanel).
   const onSubmitAction = useCallback(
@@ -482,7 +510,7 @@ export default function App() {
   }, []);
   return (
     <PaletteShell
-      {...{ active, activeDescendantId, cancelAsyncJob, cancelJob, canceling, client, commandRunning, compact, config, configError, copied, dispatchView, draftConfig, endpointLabel, endpointTone, enterActionMode, expandAsyncJob, expandJob, filtered, guardMessage, hasQuery, hideCommandBar, history, historyFocusRef, historyOpen, askSessions, askSessionsOpen, jobCanceling, jobExpanded, jobMinimized, jobNowMs, listboxOpen, liveRefresh, modeAction, nowMs, onCollapse, onCopy, onDrillDomain, onFollowUp, onHistory, onInputKeyDown, onOpenJob, onReset, onResumeAskSession, onRetry, onSubmitAction, onSuggestMessage, onToggleMaximize, onTogglePin, onToggleSettings, outputFocusRef, outputKind, parsed, query, requestSubmit, run, selected, setDraftConfig, setHistory, setQuery, setRun, setSelected, settingsFocusRef, settingsOpen, shortcutOptions, showActionPanel, showBackButton, showContent, showResultsLayout, sourcesGrouped, sourcesSort, submitDisabled, switchActionMode, validation, viewPartialJob, showHelpFor, minimizeJob, closeJob, minimizeAsyncJob, closeAsyncJob, setSourcesFilter, setSourcesSort, setSourcesGrouped }}
+      {...{ active, activeDescendantId, browserFocusRef, browserInitialTarget: browserInitialTargetValue, browserOpen, cancelAsyncJob, cancelJob, canceling, client, commandRunning, compact, config, configError, copied, dispatchView, draftConfig, endpointLabel, endpointTone, enterActionMode, expandAsyncJob, expandJob, filtered, guardMessage, hasQuery, hideCommandBar, history, historyFocusRef, historyOpen, askSessions, askSessionsOpen, jobCanceling, jobExpanded, jobMinimized, jobNowMs, listboxOpen, liveRefresh, modeAction, nowMs, onCloseBrowser, onCollapse, onCopy, onDrillDomain, onFollowUp, onHistory, onInputKeyDown, onOpenJob, onReset, onResumeAskSession, onRetry, onSubmitAction, onSuggestMessage, onToggleMaximize, onTogglePin, onToggleSettings, outputFocusRef, outputKind, parsed, query, requestSubmit, run, selected, setDraftConfig, setHistory, setQuery, setRun, setSelected, settingsFocusRef, settingsOpen, shortcutOptions, showActionPanel, showBackButton, showContent, showResultsLayout, sourcesGrouped, sourcesSort, submitDisabled, switchActionMode, validation, viewPartialJob, showHelpFor, minimizeJob, closeJob, minimizeAsyncJob, closeAsyncJob, setSourcesFilter, setSourcesSort, setSourcesGrouped }}
       onBack={goBackToBrowse}
       onAskSessionsOpenChange={setAskSessionsOpen}
       onRunAction={onConversationRunAction}

--- a/apps/palette-tauri/src/components/palette/BrowserView.test.tsx
+++ b/apps/palette-tauri/src/components/palette/BrowserView.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+//
+// Render tests for BrowserView. Covers the dev-mode fallback (no Tauri
+// runtime — must show the "requires desktop app" message and never call
+// `invoke`), the Tauri-runtime path (opens the browser window on mount and
+// closes it on unmount), address-bar navigation, and tab management.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn((_command: string, _args?: Record<string, unknown>) =>
+  Promise.resolve(undefined),
+);
+const runtimeState = { isTauriRuntime: false };
+
+vi.mock("@/lib/invoke", () => ({
+  get isTauriRuntime() {
+    return runtimeState.isTauriRuntime;
+  },
+  invoke: (command: string, args?: Record<string, unknown>) => invokeMock(command, args),
+  appWindow: { listen: () => Promise.resolve(() => {}) },
+}));
+
+import { BrowserView } from "./BrowserView";
+
+beforeEach(() => {
+  invokeMock.mockClear();
+  runtimeState.isTauriRuntime = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BrowserView — dev-mode fallback", () => {
+  it("shows the desktop-app-required message and never calls invoke", () => {
+    render(<BrowserView initialTarget={null} onClose={() => {}} />);
+
+    expect(screen.getByText(/Browser tool requires the desktop app/i)).toBeInTheDocument();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("still renders the address bar and tab strip chrome", () => {
+    render(<BrowserView initialTarget={null} onClose={() => {}} />);
+
+    expect(screen.getByLabelText(/address bar/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^new tab$/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /close browser/i })).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close-browser button is clicked", () => {
+    const onClose = vi.fn();
+    render(<BrowserView initialTarget={null} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /close browser/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BrowserView — Tauri runtime", () => {
+  beforeEach(() => {
+    runtimeState.isTauriRuntime = true;
+  });
+
+  it("opens the browser window on mount with the normalized initial target", () => {
+    render(<BrowserView initialTarget="example.com" onClose={() => {}} />);
+
+    expect(invokeMock).toHaveBeenCalledWith("browser_open", { url: "https://example.com" });
+  });
+
+  it("opens to the home sentinel when no initial target is given", () => {
+    render(<BrowserView initialTarget={null} onClose={() => {}} />);
+
+    expect(invokeMock).toHaveBeenCalledWith("browser_open", { url: "about:blank" });
+  });
+
+  it("closes the browser window on unmount", () => {
+    const { unmount } = render(<BrowserView initialTarget={null} onClose={() => {}} />);
+    invokeMock.mockClear();
+
+    unmount();
+
+    expect(invokeMock).toHaveBeenCalledWith("browser_close", undefined);
+  });
+
+  it("navigates via the address bar on submit", () => {
+    render(<BrowserView initialTarget={null} onClose={() => {}} />);
+    invokeMock.mockClear();
+
+    const input = screen.getByLabelText(/address bar/i);
+    fireEvent.change(input, { target: { value: "docs.rs/serde" } });
+    fireEvent.submit(input.closest("form") as HTMLFormElement);
+
+    expect(invokeMock).toHaveBeenCalledWith("browser_navigate", { url: "https://docs.rs/serde" });
+  });
+
+  it("opens a new tab and navigates the browser window to its home state", () => {
+    render(<BrowserView initialTarget="example.com" onClose={() => {}} />);
+    invokeMock.mockClear();
+
+    fireEvent.click(screen.getByLabelText(/^new tab$/i));
+
+    expect(invokeMock).toHaveBeenCalledWith("browser_navigate", { url: "about:blank" });
+    expect(screen.getAllByText("New Tab").length).toBeGreaterThan(0);
+  });
+
+  it("drives back/forward/reload through their respective commands", () => {
+    render(<BrowserView initialTarget={null} onClose={() => {}} />);
+    invokeMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^forward$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^reload$/i }));
+
+    expect(invokeMock).toHaveBeenCalledWith("browser_back", undefined);
+    expect(invokeMock).toHaveBeenCalledWith("browser_forward", undefined);
+    expect(invokeMock).toHaveBeenCalledWith("browser_reload", undefined);
+  });
+});

--- a/apps/palette-tauri/src/components/palette/BrowserView.tsx
+++ b/apps/palette-tauri/src/components/palette/BrowserView.tsx
@@ -1,0 +1,219 @@
+import { ArrowLeft, ArrowRight, Compass, Plus, RotateCw, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/aurora/button";
+import { BROWSER_HOME_URL, hostLabel, isHomeUrl, normalizeBrowserUrl } from "@/lib/browserUrl";
+import { invoke, isTauriRuntime } from "@/lib/invoke";
+
+interface BrowserTab {
+  id: string;
+  /** The last URL navigated to. `BROWSER_HOME_URL` for a fresh/new tab. */
+  url: string;
+  /** Address-bar display text — may differ from `url` while the user is typing. */
+  addressText: string;
+}
+
+let nextTabId = 1;
+function makeTab(url: string = BROWSER_HOME_URL): BrowserTab {
+  return { id: `tab-${nextTabId++}`, url, addressText: isHomeUrl(url) ? "" : url };
+}
+
+/**
+ * Real in-app "Browser" tool: an address bar + tab strip that drives a
+ * dedicated native Tauri `WebviewWindow` (see `src-tauri/src/browser.rs`).
+ * The window itself renders the real page content; this component is the
+ * control surface living inside the main palette window.
+ *
+ * In a plain browser (dev/vite, no Tauri runtime) there is no equivalent —
+ * a second real OS-level webview can't be created from a web page — so this
+ * renders a clear "requires the desktop app" message instead of faking
+ * anything with an iframe.
+ */
+export function BrowserView({
+  initialTarget,
+  onClose,
+}: {
+  initialTarget: string | null;
+  onClose: () => void;
+}) {
+  const initialUrl = initialTarget ? normalizeBrowserUrl(initialTarget) : BROWSER_HOME_URL;
+  const [tabs, setTabs] = useState<BrowserTab[]>(() => [makeTab(initialUrl)]);
+  const [activeTabId, setActiveTabId] = useState(() => tabs[0].id);
+  const openedRef = useRef(false);
+
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0];
+
+  // Open (or navigate) the real browser window once on mount, and close it
+  // when this view unmounts (the user closed the Browser overlay).
+  // Intentionally mount/unmount-only: subsequent navigation is driven by
+  // explicit user actions (address bar, tab switches), not by re-running
+  // this effect on every tab-state change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount/unmount-only open+close of the native browser window
+  useEffect(() => {
+    if (!isTauriRuntime) return;
+    if (!openedRef.current) {
+      openedRef.current = true;
+      void invoke("browser_open", { url: activeTab.url });
+    }
+    return () => {
+      void invoke("browser_close");
+    };
+  }, []);
+
+  function updateActiveTab(patch: Partial<BrowserTab>) {
+    setTabs((current) => current.map((tab) => (tab.id === activeTabId ? { ...tab, ...patch } : tab)));
+  }
+
+  function navigate(raw: string) {
+    const url = normalizeBrowserUrl(raw);
+    updateActiveTab({ url, addressText: isHomeUrl(url) ? "" : url });
+    if (isTauriRuntime) void invoke("browser_navigate", { url });
+  }
+
+  function selectTab(id: string) {
+    setActiveTabId(id);
+    const tab = tabs.find((candidate) => candidate.id === id);
+    if (tab && isTauriRuntime) void invoke("browser_navigate", { url: tab.url });
+  }
+
+  function newTab() {
+    const tab = makeTab();
+    setTabs((current) => [...current, tab]);
+    setActiveTabId(tab.id);
+    if (isTauriRuntime) void invoke("browser_navigate", { url: tab.url });
+  }
+
+  function closeTab(id: string) {
+    setTabs((current) => {
+      const remaining = current.filter((tab) => tab.id !== id);
+      if (remaining.length === 0) {
+        const fresh = makeTab();
+        setActiveTabId(fresh.id);
+        return [fresh];
+      }
+      if (id === activeTabId) {
+        const closedIndex = current.findIndex((tab) => tab.id === id);
+        const next = remaining[Math.max(0, closedIndex - 1)];
+        setActiveTabId(next.id);
+        if (isTauriRuntime) void invoke("browser_navigate", { url: next.url });
+      }
+      return remaining;
+    });
+  }
+
+  function goBack() {
+    if (isTauriRuntime) void invoke("browser_back");
+  }
+
+  function goForward() {
+    if (isTauriRuntime) void invoke("browser_forward");
+  }
+
+  function reload() {
+    if (isTauriRuntime) void invoke("browser_reload");
+  }
+
+  function closeBrowser() {
+    onClose();
+  }
+
+  return (
+    <section className="browser-panel">
+      <header className="browser-tabstrip">
+        <Button
+          variant="ghost"
+          size="icon"
+          type="button"
+          onClick={closeBrowser}
+          title="Close browser"
+          aria-label="Close browser"
+        >
+          <X size={15} />
+        </Button>
+        <div className="browser-tabs aurora-scrollbar" role="tablist">
+          {tabs.map((tab) => (
+            <div
+              key={tab.id}
+              role="tab"
+              aria-selected={tab.id === activeTabId}
+              tabIndex={0}
+              className={`browser-tab${tab.id === activeTabId ? " browser-tab-active" : ""}`}
+              onClick={() => selectTab(tab.id)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  selectTab(tab.id);
+                }
+              }}
+            >
+              <span className="browser-tab-favicon" aria-hidden="true">
+                {isHomeUrl(tab.url) ? <Compass size={12} /> : hostLabel(tab.url).charAt(0).toUpperCase()}
+              </span>
+              <span className="browser-tab-title">{isHomeUrl(tab.url) ? "New Tab" : hostLabel(tab.url)}</span>
+              <Button
+                variant="plain"
+                size="unstyled"
+                type="button"
+                className="browser-tab-close"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  closeTab(tab.id);
+                }}
+                aria-label={`Close tab ${hostLabel(tab.url)}`}
+              >
+                <X size={11} />
+              </Button>
+            </div>
+          ))}
+        </div>
+        <Button variant="ghost" size="icon" type="button" onClick={newTab} title="New tab" aria-label="New tab">
+          <Plus size={15} />
+        </Button>
+      </header>
+
+      <div className="browser-toolbar">
+        <Button variant="ghost" size="icon" type="button" onClick={goBack} title="Back" aria-label="Back">
+          <ArrowLeft size={15} />
+        </Button>
+        <Button variant="ghost" size="icon" type="button" onClick={goForward} title="Forward" aria-label="Forward">
+          <ArrowRight size={15} />
+        </Button>
+        <Button variant="ghost" size="icon" type="button" onClick={reload} title="Reload" aria-label="Reload">
+          <RotateCw size={14} />
+        </Button>
+        <form
+          className="browser-address-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            navigate(activeTab.addressText);
+          }}
+        >
+          <input
+            className="browser-address-input"
+            type="text"
+            spellCheck={false}
+            placeholder="Search the web or type a URL…"
+            value={activeTab.addressText}
+            onChange={(event) => updateActiveTab({ addressText: event.target.value })}
+            aria-label="Address bar"
+          />
+        </form>
+      </div>
+
+      <div className="browser-surface">
+        {isTauriRuntime ? (
+          <div className="browser-surface-hint">
+            <Compass size={22} />
+            <p>The live page is rendering in the Axon Browser window.</p>
+          </div>
+        ) : (
+          <div className="browser-surface-hint browser-surface-unavailable">
+            <Compass size={22} />
+            <strong>Browser tool requires the desktop app</strong>
+            <p>Real in-app browsing runs in a native window that only the Tauri desktop build can create.</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/palette-tauri/src/components/palette/OutputPanel.tsx
+++ b/apps/palette-tauri/src/components/palette/OutputPanel.tsx
@@ -28,6 +28,7 @@ import { DomainsView } from "@/components/palette/DomainsView";
 import { SourcesView } from "@/components/palette/SourcesView";
 import { StatsView } from "@/components/palette/StatsView";
 import { StatusView, type OpenJobHandler } from "@/components/palette/StatusView";
+import { TerminalView } from "@/components/palette/TerminalView";
 import { Button } from "@/components/ui/aurora/button";
 import { Spinner } from "@/components/ui/aurora/spinner";
 import { actionBehavior } from "@/lib/actionRegistry";
@@ -316,7 +317,9 @@ export const OutputPanel = memo(function OutputPanel({
             {run.kind === "running" || run.kind === "streaming" ? <Spinner size="sm" /> : null}
           </span>
         </header>
-        {(run.kind === "streaming" || run.kind === "running") &&
+        {active?.subcommand === "terminal" ? (
+          <TerminalView />
+        ) : (run.kind === "streaming" || run.kind === "running") &&
         conversationMode &&
         transcript?.length ? (
           <AskConversation

--- a/apps/palette-tauri/src/components/palette/PaletteShell.tsx
+++ b/apps/palette-tauri/src/components/palette/PaletteShell.tsx
@@ -3,6 +3,7 @@ import type { Dispatch, RefObject, SetStateAction } from "react";
 
 import { ActionList } from "@/components/palette/ActionList";
 import { AuthNotice } from "@/components/palette/AuthNotice";
+import { BrowserView } from "@/components/palette/BrowserView";
 import { CrawlJobView } from "@/components/palette/CrawlJobView";
 import { HistoryPanel, type HistoryItem } from "@/components/palette/HistoryPanel";
 import { JobProgressView } from "@/components/palette/JobProgressView";
@@ -26,6 +27,10 @@ import type { LiveRefreshState } from "@/lib/useLiveRefresh";
 interface PaletteShellProps {
   active?: PaletteAction;
   activeDescendantId?: string;
+  browserFocusRef: RefObject<HTMLDivElement | null>;
+  browserInitialTarget: string | null;
+  browserOpen: boolean;
+  onCloseBrowser: () => void;
   cancelAsyncJob: () => Promise<void>;
   cancelJob: () => Promise<void>;
   canceling: boolean;
@@ -268,6 +273,15 @@ function SettingsRegion(props: PaletteShellProps) {
 
 function MainContent(props: PaletteShellProps) {
   if (!props.showContent || props.settingsOpen) return null;
+  if (props.browserOpen) {
+    return (
+      <main className="palette-grid palette-grid-output-only">
+        <div ref={props.browserFocusRef} style={{ display: "contents" }}>
+          <BrowserView initialTarget={props.browserInitialTarget} onClose={props.onCloseBrowser} />
+        </div>
+      </main>
+    );
+  }
   return (
     <main className={props.showResultsLayout ? (props.showActionPanel ? "palette-grid" : "palette-grid palette-grid-output-only") : "palette-suggestions"}>
       {props.showActionPanel && (

--- a/apps/palette-tauri/src/components/palette/TerminalView.test.tsx
+++ b/apps/palette-tauri/src/components/palette/TerminalView.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+//
+// TerminalView renders two very different modes depending on the invoke seam:
+// the browser-dev fallback (no Tauri runtime — no real shell to spawn) shows a
+// clear unavailable message, while the Tauri runtime drives real
+// `terminal_cwd`/`terminal_run` invokes. Both paths are covered here by
+// mocking `@/lib/invoke` per-test via `vi.doMock` + dynamic import, since
+// `isTauriRuntime` is a module-level constant baked in at import time.
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  cleanup();
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("TerminalView — browser dev fallback", () => {
+  beforeEach(() => {
+    vi.doMock("@/lib/invoke", () => ({
+      isTauriRuntime: false,
+      invoke: vi.fn(() => Promise.reject(new Error("terminal_run is only available in the Tauri runtime"))),
+      appWindow: { listen: async () => () => undefined },
+    }));
+  });
+
+  it("shows a clear unavailable message instead of faking output", async () => {
+    const { TerminalView } = await import("./TerminalView");
+    render(<TerminalView />);
+    expect(screen.getByText("Terminal requires the desktop app.")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Terminal command input")).not.toBeInTheDocument();
+  });
+});
+
+describe("TerminalView — Tauri runtime", () => {
+  const invokeMock = vi.fn();
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string, args?: Record<string, unknown>) => {
+      if (command === "terminal_cwd") return Promise.resolve("/home/operator");
+      if (command === "terminal_run") {
+        const cmd = String(args?.command ?? "");
+        if (cmd === "pwd") {
+          return Promise.resolve({ stdout: "/home/operator\n", stderr: "", exitCode: 0, cwd: "/home/operator" });
+        }
+        if (cmd === "false") {
+          return Promise.resolve({ stdout: "", stderr: "", exitCode: 1, cwd: "/home/operator" });
+        }
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0, cwd: "/home/operator" });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${command}`));
+    });
+    vi.doMock("@/lib/invoke", () => ({
+      isTauriRuntime: true,
+      invoke: invokeMock,
+      appWindow: { listen: async () => () => undefined },
+    }));
+  });
+
+  it("seeds the prompt from terminal_cwd on mount", async () => {
+    const { TerminalView } = await import("./TerminalView");
+    render(<TerminalView />);
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("terminal_cwd"));
+    await waitFor(() => expect(screen.getByText("~$")).toBeInTheDocument());
+  });
+
+  it("submits a command via terminal_run and renders real stdout", async () => {
+    const { TerminalView } = await import("./TerminalView");
+    render(<TerminalView />);
+    const input = await screen.findByLabelText("Terminal command input");
+    fireEvent.change(input, { target: { value: "pwd" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("terminal_run", { command: "pwd" }),
+    );
+    expect(await screen.findByText("/home/operator")).toBeInTheDocument();
+    // The submitted line is echoed as an "in" line before its output.
+    expect(screen.getAllByText("pwd").length).toBeGreaterThan(0);
+  });
+
+  it("surfaces a nonzero exit code", async () => {
+    const { TerminalView } = await import("./TerminalView");
+    render(<TerminalView />);
+    const input = await screen.findByLabelText("Terminal command input");
+    fireEvent.change(input, { target: { value: "false" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(await screen.findByText("exit 1")).toBeInTheDocument();
+  });
+
+  it("clears scrollback on the local `clear` command without invoking the shell", async () => {
+    const { TerminalView } = await import("./TerminalView");
+    render(<TerminalView />);
+    const input = await screen.findByLabelText("Terminal command input");
+    fireEvent.change(input, { target: { value: "pwd" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await screen.findByText("/home/operator");
+
+    invokeMock.mockClear();
+    fireEvent.change(input, { target: { value: "clear" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(screen.queryByText("/home/operator")).not.toBeInTheDocument());
+    expect(invokeMock).not.toHaveBeenCalledWith("terminal_run", expect.anything());
+  });
+
+  it("recalls previous commands with ArrowUp/ArrowDown history", async () => {
+    const { TerminalView } = await import("./TerminalView");
+    render(<TerminalView />);
+    const input = (await screen.findByLabelText("Terminal command input")) as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "pwd" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(input.value).toBe(""));
+
+    fireEvent.change(input, { target: { value: "echo two" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(input.value).toBe(""));
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input.value).toBe("echo two");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input.value).toBe("pwd");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input.value).toBe("echo two");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input.value).toBe("");
+  });
+});

--- a/apps/palette-tauri/src/components/palette/TerminalView.tsx
+++ b/apps/palette-tauri/src/components/palette/TerminalView.tsx
@@ -1,0 +1,198 @@
+import { memo, useEffect, useRef, useState } from "react";
+
+import { invoke, isTauriRuntime } from "@/lib/invoke";
+
+interface TerminalRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  cwd: string;
+}
+
+type TerminalLineKind = "sys" | "in" | "out" | "err";
+
+interface TerminalLine {
+  id: number;
+  kind: TerminalLineKind;
+  text: string;
+}
+
+let lineIdSeq = 0;
+function nextLineId(): number {
+  lineIdSeq += 1;
+  return lineIdSeq;
+}
+
+function shortCwd(cwd: string): string {
+  const home = cwd.match(/^\/(?:home|Users)\/[^/]+/)?.[0];
+  if (home && cwd.startsWith(home)) return `~${cwd.slice(home.length)}` || "~";
+  return cwd || "~";
+}
+
+/**
+ * Real shell terminal: every submitted line runs a genuine command via the
+ * `terminal_run` Tauri command (see `src-tauri/src/terminal.rs`), which spawns
+ * the user's real login shell and captures real stdout/stderr. The working
+ * directory is tracked server-side across commands in this session (`cd`
+ * updates it) so this behaves like a real interactive shell, not a one-shot
+ * subprocess per keystroke.
+ *
+ * In the browser-dev fallback (no Tauri runtime — `pnpm vite:dev`), there is
+ * no real shell to spawn, so this shows a clear unavailable message instead
+ * of faking output.
+ */
+export const TerminalView = memo(function TerminalView() {
+  const [lines, setLines] = useState<TerminalLine[]>(() => [
+    { id: nextLineId(), kind: "sys", text: "axon palette terminal — type a command and press Enter." },
+  ]);
+  const [cwd, setCwd] = useState<string>("");
+  const [input, setInput] = useState("");
+  const [running, setRunning] = useState(false);
+  const [history, setHistory] = useState<string[]>([]);
+  const historyIndexRef = useRef<number | null>(null);
+  const draftRef = useRef("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isTauriRuntime) return;
+    let cancelled = false;
+    void invoke<string>("terminal_cwd").then((value) => {
+      if (!cancelled) setCwd(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `lines` is the scroll trigger.
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (element) element.scrollTop = element.scrollHeight;
+  }, [lines]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function appendLine(kind: TerminalLineKind, text: string) {
+    if (!text) return;
+    setLines((prev) => [...prev, { id: nextLineId(), kind, text }]);
+  }
+
+  async function runCommand(command: string) {
+    const trimmed = command.trim();
+    appendLine("in", command);
+    if (trimmed) {
+      setHistory((prev) => (prev[prev.length - 1] === trimmed ? prev : [...prev, trimmed]));
+    }
+    historyIndexRef.current = null;
+    draftRef.current = "";
+    setInput("");
+
+    if (trimmed === "clear") {
+      setLines([]);
+      return;
+    }
+    if (!trimmed) return;
+
+    setRunning(true);
+    try {
+      const result = await invoke<TerminalRunResult>("terminal_run", { command: trimmed });
+      if (result.stdout) appendLine("out", result.stdout.replace(/\n$/, ""));
+      if (result.stderr) appendLine("err", result.stderr.replace(/\n$/, ""));
+      if (result.exitCode !== null && result.exitCode !== 0) {
+        appendLine("sys", `exit ${result.exitCode}`);
+      }
+      setCwd(result.cwd);
+    } catch (err) {
+      appendLine("err", err instanceof Error ? err.message : String(err));
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (running) return;
+      void runCommand(input);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      if (history.length === 0) return;
+      event.preventDefault();
+      const current = historyIndexRef.current;
+      if (current === null) draftRef.current = input;
+      const nextIndex = current === null ? history.length - 1 : Math.max(current - 1, 0);
+      historyIndexRef.current = nextIndex;
+      setInput(history[nextIndex] ?? "");
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      if (historyIndexRef.current === null) return;
+      event.preventDefault();
+      const nextIndex = historyIndexRef.current + 1;
+      if (nextIndex >= history.length) {
+        historyIndexRef.current = null;
+        setInput(draftRef.current);
+      } else {
+        historyIndexRef.current = nextIndex;
+        setInput(history[nextIndex] ?? "");
+      }
+    }
+  }
+
+  if (!isTauriRuntime) {
+    return (
+      <div className="output-body terminal-view terminal-view-unavailable" role="status">
+        <p>Terminal requires the desktop app.</p>
+        <p className="terminal-view-unavailable-detail">
+          Real shell commands can only run through the Tauri desktop shell — the browser dev preview has no local
+          shell to spawn.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="output-body terminal-view aurora-scrollbar">
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard users focus the input directly; this wrapper only expands the pointer target */}
+      <div
+        ref={scrollRef}
+        className="terminal-scroll aurora-scrollbar"
+        role="log"
+        aria-live="polite"
+        onClick={() => inputRef.current?.focus()}
+      >
+        {lines.map((line) => (
+          <div key={line.id} className={`terminal-line terminal-line-${line.kind}`}>
+            {line.kind === "in" ? (
+              <>
+                <span className="terminal-prompt">{shortCwd(cwd)}$</span>
+                <span className="terminal-line-text">{line.text}</span>
+              </>
+            ) : (
+              <span className="terminal-line-text">{line.text}</span>
+            )}
+          </div>
+        ))}
+        <div className="terminal-line terminal-input-row">
+          <span className="terminal-prompt">{shortCwd(cwd)}$</span>
+          <input
+            ref={inputRef}
+            className="terminal-input"
+            value={input}
+            spellCheck={false}
+            autoComplete="off"
+            autoCapitalize="off"
+            disabled={running}
+            aria-label="Terminal command input"
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={onKeyDown}
+          />
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/apps/palette-tauri/src/lib/actionLifecycle.ts
+++ b/apps/palette-tauri/src/lib/actionLifecycle.ts
@@ -1,0 +1,81 @@
+import { Activity, Braces, GitBranch, Layers, PackageOpen, RotateCw, X, type LucideIcon } from "lucide-react";
+
+import type { ActionBehavior } from "./actionRegistry";
+import { JOB_FAMILIES, JOB_OPERATIONS, type JobFamily, type JobOperation } from "./actions";
+import { type ActionRouteTemplate, deleteRoute, first, getRoute, noBody, postRoute, uuid } from "./actionRequest";
+import { formatJobLifecycle, recordFormatter } from "./actionFormat";
+
+const JOB_LIFECYCLE_ICONS: Record<JobFamily, LucideIcon> = {
+  crawl: GitBranch,
+  embed: Layers,
+  extract: Braces,
+  ingest: PackageOpen,
+};
+
+function lifecycleBehavior(family: JobFamily, operation: JobOperation): ActionBehavior {
+  const icon = JOB_LIFECYCLE_ICONS[family];
+  return {
+    route: lifecycleRoute(family, operation),
+    buildBody: noBody,
+    routeFor: lifecycleRouteFor(family, operation),
+    outputKind: "code",
+    formatText: recordFormatter(formatJobLifecycle),
+    actionIcon: icon,
+    outputIcon: lifecycleOutputIcon(family, operation),
+    structuredView: "job-lifecycle",
+  };
+}
+
+function lifecycleRoute(family: JobFamily, operation: JobOperation): ActionRouteTemplate {
+  switch (operation) {
+    case "list":
+      return getRoute(`/v1/${family}`);
+    case "status":
+      return getRoute(`/v1/${family}/{id}`);
+    case "cancel":
+      return postRoute(`/v1/${family}/{id}/cancel`);
+    case "cleanup":
+      return postRoute(`/v1/${family}/cleanup`);
+    case "clear":
+      return deleteRoute(`/v1/${family}`);
+    case "recover":
+      return postRoute(`/v1/${family}/recover`);
+  }
+}
+
+function lifecycleRouteFor(family: JobFamily, operation: JobOperation): ActionBehavior["routeFor"] {
+  switch (operation) {
+    case "status":
+      return (ctx) => getRoute(`/v1/${family}/${uuid(first(ctx.words, "job id"))}`);
+    case "cancel":
+      return (ctx) => postRoute(`/v1/${family}/${uuid(first(ctx.words, "job id"))}/cancel`);
+    default:
+      return undefined;
+  }
+}
+
+function lifecycleOutputIcon(family: JobFamily, operation: JobOperation): LucideIcon {
+  switch (operation) {
+    case "cancel":
+      return X;
+    case "cleanup":
+    case "clear":
+    case "recover":
+      return RotateCw;
+    case "list":
+    case "status":
+      return Activity;
+    default:
+      return JOB_LIFECYCLE_ICONS[family];
+  }
+}
+
+export function buildLifecycleRegistry(): Record<`${JobFamily}-${JobOperation}`, ActionBehavior> {
+  const out = {} as Record<`${JobFamily}-${JobOperation}`, ActionBehavior>;
+  for (const family of JOB_FAMILIES) {
+    for (const operation of JOB_OPERATIONS) {
+      out[`${family}-${operation}`] = lifecycleBehavior(family, operation);
+    }
+  }
+  return out;
+}

--- a/apps/palette-tauri/src/lib/actionMeta.ts
+++ b/apps/palette-tauri/src/lib/actionMeta.ts
@@ -47,6 +47,7 @@ const ACTION_META: Partial<Record<PaletteSubcommand, ActionDisplayDetails>> = {
   "watch-list": { category: "System", input: "none", output: "watches", label: "Watch list" },
   "watch-create": { category: "System", input: "URL", output: "watch", label: "Watch create" },
   "watch-run": { category: "System", input: "watch id", output: "run", label: "Watch run" },
+  terminal: { category: "System", input: "commands", output: "shell output", label: "Terminal" },
 };
 
 export function actionDisplayMeta(action: PaletteAction): ActionDisplayMeta {

--- a/apps/palette-tauri/src/lib/actionMeta.ts
+++ b/apps/palette-tauri/src/lib/actionMeta.ts
@@ -15,6 +15,7 @@ type ActionDisplayDetails = Omit<ActionDisplayMeta, "endpoint" | "method">;
 const ACTION_META: Partial<Record<PaletteSubcommand, ActionDisplayDetails>> = {
   help: { category: "System", input: "action", output: "help", label: "Help" },
   files: { category: "System", input: "none", output: "local", label: "Files" },
+  browser: { category: "Fetch & read", input: "URL or query", output: "live page", label: "Browser" },
   scrape: { category: "Fetch & read", input: "one URL", output: "content", label: "Scrape" },
   map: { category: "Fetch & read", input: "one URL", output: "links", label: "Map" },
   retrieve: { category: "Fetch & read", input: "URL", output: "chunks", label: "Retrieve" },

--- a/apps/palette-tauri/src/lib/actionRegistry.ts
+++ b/apps/palette-tauri/src/lib/actionRegistry.ts
@@ -18,7 +18,6 @@
 // union, and a test asserts the two stay in lockstep.
 
 import {
-  Activity,
   BarChart3,
   BookOpen,
   Bot,
@@ -32,22 +31,20 @@ import {
   GitBranch,
   GitCompare,
   Globe,
+  Compass,
   HelpCircle,
   Layers,
   Map as MapIcon,
   PackageOpen,
-  RotateCw,
   SearchCheck,
   Sparkles,
   Stethoscope,
   Trash2,
   Workflow,
-  X,
   type LucideIcon,
 } from "lucide-react";
 
 import type { PaletteSubcommand, JobFamily, JobOperation } from "./actions";
-import { JOB_FAMILIES, JOB_OPERATIONS } from "./actions";
 import {
   type ActionRouteTemplate,
   type BodyBuilder,
@@ -80,7 +77,6 @@ import {
   searchBody,
   suggestBody,
   summarizeBody,
-  uuid,
   watchCreateBody,
 } from "./actionRequest";
 import {
@@ -111,6 +107,7 @@ import {
   jobStartFormatter,
   recordFormatter,
 } from "./actionFormat";
+import { buildLifecycleRegistry } from "./actionLifecycle";
 
 export type OutputKind = "markdown" | "code";
 
@@ -200,6 +197,16 @@ const STATIC_REGISTRY: Record<StaticSubcommand, ActionBehavior> = {
     formatText: formatCompact,
     actionIcon: HelpCircle,
     structuredView: "help",
+  }),
+  // Browser is a local, window-driven action (Tauri webview creation +
+  // navigation commands), so it uses a palette marker route for metadata only.
+  browser: behavior({
+    route: getRoute("palette://browser"),
+    buildBody: noBody,
+    outputKind: code,
+    formatText: formatCompact,
+    actionIcon: Compass,
+    structuredView: null,
   }),
   files: behavior({
     route: getRoute("palette://files"),
@@ -467,81 +474,6 @@ const STATIC_REGISTRY: Record<StaticSubcommand, ActionBehavior> = {
     structuredView: "ingest-sessions-prepared",
   }),
 };
-
-const JOB_LIFECYCLE_ICONS: Record<JobFamily, LucideIcon> = {
-  crawl: GitBranch,
-  embed: Layers,
-  extract: Braces,
-  ingest: PackageOpen,
-};
-
-function lifecycleBehavior(family: JobFamily, operation: JobOperation): ActionBehavior {
-  const icon = JOB_LIFECYCLE_ICONS[family];
-  return {
-    route: lifecycleRoute(family, operation),
-    buildBody: noBody,
-    routeFor: lifecycleRouteFor(family, operation),
-    outputKind: code,
-    formatText: recordFormatter(formatJobLifecycle),
-    actionIcon: icon,
-    outputIcon: lifecycleOutputIcon(family, operation),
-    structuredView: "job-lifecycle",
-  };
-}
-
-function lifecycleRoute(family: JobFamily, operation: JobOperation): ActionRouteTemplate {
-  switch (operation) {
-    case "list":
-      return getRoute(`/v1/${family}`);
-    case "status":
-      return getRoute(`/v1/${family}/{id}`);
-    case "cancel":
-      return postRoute(`/v1/${family}/{id}/cancel`);
-    case "cleanup":
-      return postRoute(`/v1/${family}/cleanup`);
-    case "clear":
-      return deleteRoute(`/v1/${family}`);
-    case "recover":
-      return postRoute(`/v1/${family}/recover`);
-  }
-}
-
-function lifecycleRouteFor(family: JobFamily, operation: JobOperation): ActionBehavior["routeFor"] {
-  switch (operation) {
-    case "status":
-      return (ctx) => getRoute(`/v1/${family}/${uuid(first(ctx.words, "job id"))}`);
-    case "cancel":
-      return (ctx) => postRoute(`/v1/${family}/${uuid(first(ctx.words, "job id"))}/cancel`);
-    default:
-      return undefined;
-  }
-}
-
-function lifecycleOutputIcon(family: JobFamily, operation: JobOperation): LucideIcon {
-  switch (operation) {
-    case "cancel":
-      return X;
-    case "cleanup":
-    case "clear":
-    case "recover":
-      return RotateCw;
-    case "list":
-    case "status":
-      return Activity;
-    default:
-      return JOB_LIFECYCLE_ICONS[family];
-  }
-}
-
-function buildLifecycleRegistry(): Record<`${JobFamily}-${JobOperation}`, ActionBehavior> {
-  const out = {} as Record<`${JobFamily}-${JobOperation}`, ActionBehavior>;
-  for (const family of JOB_FAMILIES) {
-    for (const operation of JOB_OPERATIONS) {
-      out[`${family}-${operation}`] = lifecycleBehavior(family, operation);
-    }
-  }
-  return out;
-}
 
 /** Exhaustive per-action behavior table. Keyed by the full subcommand union. */
 export const ACTION_REGISTRY: Record<PaletteSubcommand, ActionBehavior> = {

--- a/apps/palette-tauri/src/lib/actionRegistry.ts
+++ b/apps/palette-tauri/src/lib/actionRegistry.ts
@@ -1,23 +1,9 @@
-// Single source of truth for per-action behavior (finding A-H1).
-//
-// Before this registry, adding a palette action meant editing ~9 parallel
-// dispatch sites (request body, route, output kind, fallback text formatter, two
-// icon maps, the structured-view allowlist) with no compile-time guarantee they
-// stayed in sync — a forgotten site silently degraded to raw `<pre>` JSON.
-//
-// `ACTION_REGISTRY` is a `Record<PaletteSubcommand, ActionBehavior>`: because it
-// is keyed by the full union (including the 24 `${JobFamily}-${JobOperation}`
-// members, generated below), a new subcommand fails to type-check until it has a
-// complete behavior entry. The scattered functions (`bodyFor`, `actionRouteTemplate`,
-// `outputKindFor`, `formatPayload`, `outputIcon`, `actionIcon`,
-// `hasStructuredOperationView`) all derive from this map.
-//
-// Structured-view rendering (JSX) cannot live in this `.ts` file, so each entry
-// carries a `structuredView` *key* (or `null`); the `STRUCTURED_VIEWS` renderer
-// map in `OperationResultView.tsx` is keyed by the same `StructuredViewKey`
-// union, and a test asserts the two stay in lockstep.
+// Single source of truth for per-action behavior. `ACTION_REGISTRY` is keyed by
+// the full subcommand union so every new action must define route/body/output/
+// icon/structured-view behavior before TypeScript accepts it.
 
 import {
+  Activity,
   BarChart3,
   BookOpen,
   Bot,
@@ -39,6 +25,7 @@ import {
   SearchCheck,
   Sparkles,
   Stethoscope,
+  TerminalSquare,
   Trash2,
   Workflow,
   type LucideIcon,
@@ -55,7 +42,6 @@ import {
   crawlBody,
   dedupeBody,
   purgeBody,
-  deleteRoute,
   diffBody,
   embedBody,
   endpointsBody,
@@ -77,6 +63,7 @@ import {
   searchBody,
   suggestBody,
   summarizeBody,
+  uuid,
   watchCreateBody,
 } from "./actionRequest";
 import {
@@ -91,7 +78,6 @@ import {
   formatEndpoints,
   formatEvaluate,
   formatGitHub,
-  formatJobLifecycle,
   formatMap,
   formatQuery,
   formatRetrieve,
@@ -472,6 +458,15 @@ const STATIC_REGISTRY: Record<StaticSubcommand, ActionBehavior> = {
     formatText: jobStartFormatter("ingest-sessions-prepared"),
     actionIcon: HelpCircle,
     structuredView: "ingest-sessions-prepared",
+  }),
+  // Local Tauri shell action; the marker route is metadata-only.
+  terminal: behavior({
+    route: getRoute("palette://terminal"),
+    buildBody: noBody,
+    outputKind: code,
+    formatText: formatCompact,
+    actionIcon: TerminalSquare,
+    structuredView: null,
   }),
 };
 

--- a/apps/palette-tauri/src/lib/actions.ts
+++ b/apps/palette-tauri/src/lib/actions.ts
@@ -41,6 +41,7 @@ export type PaletteSubcommand =
   | "watch-run"
   | "ingest-sessions-prepared"
   | "github"
+  | "terminal"
   | `${JobFamily}-${JobOperation}`;
 
 interface PaletteActionBase {
@@ -411,6 +412,7 @@ const STATIC_ACTIONS = [
     example: "ingest-sessions-prepared {\"sessions\":[]}",
     tone: "orange",
   },
+  { label: "Terminal", subcommand: "terminal", kind: "local", argMode: "none", aliases: ["terminal", "shell", "sh", "console", "cmd"], description: "Run real shell commands in a persistent session with your actual working directory. Desktop app only.", example: "terminal", tone: "neutral", autoRunOnSwitch: true },
 ] as const satisfies readonly PaletteAction[];
 
 type StaticSubcommand = Exclude<PaletteSubcommand, `${JobFamily}-${JobOperation}`>;

--- a/apps/palette-tauri/src/lib/actions.ts
+++ b/apps/palette-tauri/src/lib/actions.ts
@@ -8,6 +8,7 @@ export type JobOperation = (typeof JOB_OPERATIONS)[number];
 
 export type PaletteSubcommand =
   | "help"
+  | "browser"
   | "files"
   | "scrape"
   | "crawl"
@@ -72,6 +73,16 @@ const STATIC_ACTIONS = [
     aliases: ["help", "?", "--help", "-h"],
     description: "Show command help, usage, current request params, and available options.",
     example: "help scrape",
+    tone: "info",
+  },
+  {
+    label: "Browser",
+    subcommand: "browser",
+    kind: "local",
+    argMode: "optionalSingle",
+    aliases: ["browser", "web", "browse-url"],
+    description: "Open a real in-app browser window — navigate to a URL or search the web.",
+    example: "browser docs.rs/serde",
     tone: "info",
   },
   {

--- a/apps/palette-tauri/src/lib/browserUrl.test.ts
+++ b/apps/palette-tauri/src/lib/browserUrl.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BROWSER_HOME_URL,
+  hostLabel,
+  isHomeUrl,
+  isSearchUrl,
+  normalizeBrowserUrl,
+  searchQueryFrom,
+} from "@/lib/browserUrl";
+
+describe("normalizeBrowserUrl", () => {
+  it("maps empty input to the home sentinel", () => {
+    expect(normalizeBrowserUrl("")).toBe(BROWSER_HOME_URL);
+    expect(normalizeBrowserUrl("   ")).toBe(BROWSER_HOME_URL);
+  });
+
+  it("maps the literal 'home' to the home sentinel", () => {
+    expect(normalizeBrowserUrl("home")).toBe(BROWSER_HOME_URL);
+  });
+
+  it("passes through an already-schemed https URL unchanged", () => {
+    expect(normalizeBrowserUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("passes through an already-schemed http URL unchanged", () => {
+    expect(normalizeBrowserUrl("http://example.com/path")).toBe("http://example.com/path");
+  });
+
+  it("coerces a bare hostname to https", () => {
+    expect(normalizeBrowserUrl("example.com")).toBe("https://example.com");
+  });
+
+  it("coerces a hostname with a path to https", () => {
+    expect(normalizeBrowserUrl("docs.rs/serde")).toBe("https://docs.rs/serde");
+  });
+
+  it("coerces localhost to http, not https", () => {
+    expect(normalizeBrowserUrl("localhost:3000")).toBe("http://localhost:3000");
+  });
+
+  it("coerces a loopback IP to http", () => {
+    expect(normalizeBrowserUrl("127.0.0.1:8001")).toBe("http://127.0.0.1:8001");
+  });
+
+  it("routes a bare word with no dot to the search engine", () => {
+    const result = normalizeBrowserUrl("rust");
+    expect(result).toMatch(/^https:\/\/duckduckgo\.com\/\?q=/);
+    expect(result).toContain(encodeURIComponent("rust"));
+  });
+
+  it("routes a multi-word phrase to the search engine", () => {
+    const result = normalizeBrowserUrl("tauri v2 webview api");
+    expect(result).toMatch(/^https:\/\/duckduckgo\.com\/\?q=/);
+    expect(searchQueryFrom(result)).toBe("tauri v2 webview api");
+  });
+
+  it("trims surrounding whitespace before normalizing", () => {
+    expect(normalizeBrowserUrl("  example.com  ")).toBe("https://example.com");
+  });
+
+  it("does not treat a dotted phrase containing whitespace as navigable", () => {
+    const result = normalizeBrowserUrl("check example.com please");
+    expect(isSearchUrl(result)).toBe(true);
+  });
+});
+
+describe("isHomeUrl", () => {
+  it("recognizes the sentinel and its aliases", () => {
+    expect(isHomeUrl(BROWSER_HOME_URL)).toBe(true);
+    expect(isHomeUrl("")).toBe(true);
+    expect(isHomeUrl("home")).toBe(true);
+  });
+
+  it("rejects a real URL", () => {
+    expect(isHomeUrl("https://example.com")).toBe(false);
+  });
+});
+
+describe("hostLabel", () => {
+  it("returns 'New Tab' for the home sentinel", () => {
+    expect(hostLabel(BROWSER_HOME_URL)).toBe("New Tab");
+  });
+
+  it("extracts the hostname from a full URL", () => {
+    expect(hostLabel("https://docs.rs/serde/latest/serde")).toBe("docs.rs");
+  });
+
+  it("falls back to the raw string for an unparseable value", () => {
+    expect(hostLabel("not a url")).toBe("not a url");
+  });
+});
+
+describe("isSearchUrl / searchQueryFrom", () => {
+  it("round-trips a search query", () => {
+    const url = normalizeBrowserUrl("hello world");
+    expect(isSearchUrl(url)).toBe(true);
+    expect(searchQueryFrom(url)).toBe("hello world");
+  });
+
+  it("returns false/empty for a non-search URL", () => {
+    expect(isSearchUrl("https://example.com")).toBe(false);
+    expect(searchQueryFrom("https://example.com")).toBe("");
+  });
+});

--- a/apps/palette-tauri/src/lib/browserUrl.ts
+++ b/apps/palette-tauri/src/lib/browserUrl.ts
@@ -1,0 +1,86 @@
+// Pure URL-normalization helpers for the Browser palette tool. Split out from
+// `BrowserView.tsx` so the address-bar/tab logic is unit-testable without
+// mounting a component (see `apps/palette-tauri/CLAUDE.md` — prefer a
+// `src/lib` helper with a co-located test over inlining logic in a
+// component).
+//
+// UX intent mirrors the mock's `normUrl` at `palette-mock.html` (search
+// `function browserView()`): a bare word/phrase with no dot and no scheme is
+// treated as a search-engine query; anything host-shaped gets `https://`
+// coercion; an already-schemed URL passes through unchanged.
+
+/** Sentinel for the browser's home/new-tab page. Not a real network URL. */
+export const BROWSER_HOME_URL = "about:blank";
+
+const SEARCH_ENGINE_QUERY_URL = "https://duckduckgo.com/?q=";
+
+/** True when `url` is the browser home/new-tab sentinel. */
+export function isHomeUrl(url: string): boolean {
+  return url.trim() === "" || url.trim() === BROWSER_HOME_URL || url.trim() === "home";
+}
+
+/**
+ * True when `value` already looks like a navigable host or URL (has a
+ * scheme, or is a dotted hostname/IP with no whitespace) rather than a
+ * free-text search query.
+ */
+function looksNavigable(value: string): boolean {
+  const trimmed = value.trim();
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return true;
+  if (/\s/.test(trimmed)) return false;
+  // host[.tld][:port][/path] or bare "localhost[:port]"
+  return /^localhost(:\d+)?(\/\S*)?$/i.test(trimmed) || /^[a-z0-9-]+(\.[a-z0-9-]+)+(:\d+)?(\/\S*)?$/i.test(trimmed);
+}
+
+/**
+ * Normalize raw address-bar input into a navigable URL.
+ *
+ * - Empty input or the literal `"home"` → {@link BROWSER_HOME_URL}.
+ * - Already-schemed URLs (`https://…`, `http://…`) pass through with only
+ *   trailing-slash/whitespace trimming.
+ * - Host-shaped input (`example.com`, `localhost:3000`, `127.0.0.1:8001`)
+ *   gets `https://` prepended (`http://` for localhost/loopback, matching
+ *   the palette's own `normalize_server_url` convention in `lib.rs`).
+ * - Anything else (bare words, phrases with spaces, no dot) is treated as a
+ *   search query and routed to the configured search engine.
+ */
+export function normalizeBrowserUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (isHomeUrl(trimmed)) return BROWSER_HOME_URL;
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/\s+/g, "");
+  }
+
+  if (looksNavigable(trimmed)) {
+    const isLoopback = /^(localhost|127\.0\.0\.1)(:\d+)?(\/\S*)?$/i.test(trimmed);
+    return `${isLoopback ? "http://" : "https://"}${trimmed}`;
+  }
+
+  return `${SEARCH_ENGINE_QUERY_URL}${encodeURIComponent(trimmed)}`;
+}
+
+/** Human-friendly hostname for display in a tab label / favicon monogram. */
+export function hostLabel(url: string): string {
+  if (isHomeUrl(url)) return "New Tab";
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url.split("/")[0] || url;
+  }
+}
+
+/** True when `url` is a search-engine query URL produced by this module. */
+export function isSearchUrl(url: string): boolean {
+  return url.startsWith(SEARCH_ENGINE_QUERY_URL);
+}
+
+/** Extract the original query text from a search URL produced by this module. */
+export function searchQueryFrom(url: string): string {
+  if (!isSearchUrl(url)) return "";
+  try {
+    return decodeURIComponent(url.slice(SEARCH_ENGINE_QUERY_URL.length));
+  } catch {
+    return "";
+  }
+}

--- a/apps/palette-tauri/src/lib/paletteViewState.test.ts
+++ b/apps/palette-tauri/src/lib/paletteViewState.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { ACTIONS, type PaletteAction } from "@/lib/actions";
 import {
+  browserInitialTarget,
   INITIAL_VIEW,
   isBrowseOpen,
+  isBrowserOpen,
   isHistoryOpen,
   isSettingsOpen,
   modeOf,
@@ -64,6 +66,25 @@ describe("viewReducer — single transitions", () => {
       "closeSettings → browse",
       { kind: "settings" },
       { type: "closeSettings" },
+      launcher(null, true),
+    ],
+    // Browser overlay
+    [
+      "openBrowser with a target",
+      launcher(scrape, true),
+      { type: "openBrowser", initialTarget: "docs.rs/serde" },
+      { kind: "browser", initialTarget: "docs.rs/serde" },
+    ],
+    [
+      "openBrowser with no target",
+      launcher(null, true),
+      { type: "openBrowser", initialTarget: null },
+      { kind: "browser", initialTarget: null },
+    ],
+    [
+      "closeBrowser → browse",
+      { kind: "browser", initialTarget: "example.com" },
+      { type: "closeBrowser" },
       launcher(null, true),
     ],
     // History overlay
@@ -186,5 +207,25 @@ describe("view accessors", () => {
     expect(isBrowseOpen(launcher(null, false))).toBe(false);
     expect(isSettingsOpen({ kind: "settings" })).toBe(true);
     expect(isHistoryOpen({ kind: "history" })).toBe(true);
+  });
+
+  it("isBrowserOpen/browserInitialTarget reflect the browser overlay only", () => {
+    const browser: View = { kind: "browser", initialTarget: "example.com" };
+    expect(isBrowserOpen(browser)).toBe(true);
+    expect(browserInitialTarget(browser)).toBe("example.com");
+    expect(isBrowserOpen(launcher())).toBe(false);
+    expect(browserInitialTarget(launcher())).toBeNull();
+    expect(isBrowserOpen({ kind: "settings" })).toBe(false);
+  });
+});
+
+describe("viewReducer — browser overlay illegal combinations", () => {
+  it("opening the browser never leaves another overlay/mode open", () => {
+    const history: View = { kind: "history" };
+    const browser = viewReducer(history, { type: "openBrowser", initialTarget: null });
+    expect(browser.kind).toBe("browser");
+    expect(isHistoryOpen(browser)).toBe(false);
+    expect(isSettingsOpen(browser)).toBe(false);
+    expect(modeOf(browser)).toBeNull();
   });
 });

--- a/apps/palette-tauri/src/lib/paletteViewState.ts
+++ b/apps/palette-tauri/src/lib/paletteViewState.ts
@@ -22,10 +22,15 @@ import type { PaletteAction } from "@/lib/actions";
 // `history` are full-screen overlays — mutually exclusive with each other and
 // with the launcher, which is exactly what makes "settings + history" or
 // "browse while in settings" unrepresentable.
+// `browser` is a third full-screen overlay, alongside `settings`/`history`:
+// mutually exclusive with them and with the launcher. It carries the initial
+// URL/query argument the user typed before invoking the `browser` action (or
+// `null` for a bare invocation, which opens to the browser's home page).
 export type View =
   | { kind: "launcher"; mode: PaletteAction | null; browse: boolean }
   | { kind: "settings" }
-  | { kind: "history" };
+  | { kind: "history" }
+  | { kind: "browser"; initialTarget: string | null };
 
 export const INITIAL_VIEW: View = { kind: "launcher", mode: null, browse: false };
 
@@ -53,6 +58,8 @@ export type ViewIntent =
   | { type: "closeHistoryToBrowse" } //             Escape out of history → browse list
   | { type: "toggleHistory" }
   | { type: "openHistoryItem"; action: PaletteAction } // run a stored item → launcher in that mode
+  | { type: "openBrowser"; initialTarget: string | null } // invoke the Browser action
+  | { type: "closeBrowser" } //                     close the browser window/overlay → browse list
   // Action-runner driven
   | { type: "enterModeForRun"; action: PaletteAction } // submit() locks in the running action's mode
   | { type: "showHelp"; action: PaletteAction } //       local-help run shows under the launcher
@@ -103,6 +110,10 @@ export function viewReducer(view: View, intent: ViewIntent): View {
       return view.kind === "history"
         ? { kind: "launcher", mode: null, browse: false }
         : { kind: "history" };
+    case "openBrowser":
+      return { kind: "browser", initialTarget: intent.initialTarget };
+    case "closeBrowser":
+      return { kind: "launcher", mode: null, browse: true };
     case "expandJob":
       return { kind: "launcher", mode: view.kind === "launcher" ? view.mode : null, browse: false };
   }
@@ -126,4 +137,14 @@ export function isHistoryOpen(view: View): boolean {
 
 export function isBrowseOpen(view: View): boolean {
   return view.kind === "launcher" && view.browse;
+}
+
+/** True when the Browser overlay (a real in-app web browser window) is open. */
+export function isBrowserOpen(view: View): boolean {
+  return view.kind === "browser";
+}
+
+/** Initial URL/query argument for the Browser overlay, or `null` when absent. */
+export function browserInitialTarget(view: View): string | null {
+  return view.kind === "browser" ? view.initialTarget : null;
 }

--- a/apps/palette-tauri/src/lib/useActionRunner.ts
+++ b/apps/palette-tauri/src/lib/useActionRunner.ts
@@ -389,6 +389,26 @@ export function useActionRunner({
     enterModeForRun(action, "");
   }
 
+  // ── Local terminal branch ────────────────────────────────────────────────
+  // `terminal` is a local, non-HTTP action (see `src-tauri/src/terminal.rs`):
+  // it never calls `axonClient`. This just needs `run` to leave `idle` so
+  // `App`'s `showOutput` flips on; `OutputPanel` special-cases
+  // `active?.subcommand === "terminal"` and renders `TerminalView` directly
+  // instead of reading `run.result`/`run.text`. No history entry is pushed —
+  // an interactive shell session isn't a single request/response result like
+  // the other actions.
+  function submitTerminal(terminalAction: PaletteAction) {
+    enterModeForRun(terminalAction, "");
+    setRun({
+      kind: "success",
+      title: "Terminal",
+      subtitle: "local shell session",
+      text: "",
+      outputKind: "code",
+      result: { ok: true, status: 200, path: "palette://terminal", method: "GET", payload: null },
+    });
+  }
+
   // Latest in-flight guard for the imperative (crawl/stream) paths. One-shots are
   // serialized by useActionState's `oneShotPending`; crawl/stream guard on `run`.
   const runRef = useRef(run);
@@ -415,6 +435,10 @@ export function useActionRunner({
     }
     if (action.subcommand === "files") {
       submitFiles(action);
+      return;
+    }
+    if (action.subcommand === "terminal") {
+      submitTerminal(action);
       return;
     }
     if (action.kind === "local") return;

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -6536,3 +6536,146 @@ textarea {
   color: var(--aurora-text-primary);
   background: color-mix(in srgb, var(--aurora-accent-primary) 18%, transparent);
 }
+
+/* ── Browser tool ──────────────────────────────────────────────────────── */
+
+.browser-panel {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  background: var(--aurora-nav-bg);
+  overflow: hidden;
+}
+
+.browser-tabstrip {
+  display: flex;
+  align-items: stretch;
+  gap: 5px;
+  padding: 8px 8px 0;
+  border-bottom: 1px solid var(--aurora-border-default);
+}
+
+.browser-tabs {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: stretch;
+  gap: 5px;
+  overflow-x: auto;
+}
+
+.browser-tab {
+  all: unset;
+  display: flex;
+  min-width: 120px;
+  max-width: 190px;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 8px;
+  border-bottom: 2px solid transparent;
+  border-radius: 9px 9px 0 0;
+  color: var(--aurora-text-muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.browser-tab-active {
+  border-bottom-color: var(--aurora-accent-primary);
+  color: var(--aurora-text-primary);
+  background: var(--aurora-panel-medium);
+}
+
+.browser-tab-favicon {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 5px;
+  background: var(--aurora-control-surface);
+  font-family: var(--aurora-font-display);
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.browser-tab-title {
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browser-tab-close {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--aurora-text-muted);
+  cursor: pointer;
+}
+
+.browser-tab-close:hover {
+  color: var(--aurora-text-primary);
+}
+
+.browser-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px;
+  border-bottom: 1px solid var(--aurora-border-default);
+}
+
+.browser-address-form {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+}
+
+.browser-address-input {
+  width: 100%;
+  padding: 7px 12px;
+  border: 1px solid var(--aurora-border-default);
+  border-radius: 9px;
+  background: var(--aurora-control-surface);
+  color: var(--aurora-text-primary);
+  font-family: var(--aurora-font-sans);
+  font-size: 13px;
+}
+
+.browser-address-input:focus {
+  border-color: var(--aurora-accent-primary);
+  outline: none;
+}
+
+.browser-surface {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.browser-surface-hint {
+  display: flex;
+  max-width: 360px;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  color: var(--aurora-text-muted);
+  text-align: center;
+}
+
+.browser-surface-hint strong {
+  color: var(--aurora-text-primary);
+  font-family: var(--aurora-font-display);
+  font-size: 15px;
+}
+
+.browser-surface-unavailable {
+  color: var(--aurora-warn-foreground);
+}

--- a/apps/palette-tauri/src/styles.css
+++ b/apps/palette-tauri/src/styles.css
@@ -6679,3 +6679,105 @@ textarea {
 .browser-surface-unavailable {
   color: var(--aurora-warn-foreground);
 }
+
+/* ── Terminal tool ─────────────────────────────────────────────────────── */
+
+.terminal-view {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.terminal-view-unavailable {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  color: var(--aurora-text-muted);
+}
+
+.terminal-view-unavailable p {
+  margin: 0;
+  color: var(--aurora-text-primary);
+  font-weight: 600;
+}
+
+.terminal-view-unavailable-detail {
+  color: var(--aurora-text-muted) !important;
+  font-weight: 400 !important;
+  font-size: 12.5px;
+}
+
+.terminal-scroll {
+  flex: 1;
+  min-height: 260px;
+  max-height: 56vh;
+  overflow-y: auto;
+  padding: 12px 14px;
+  font-family: var(--aurora-font-mono);
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: var(--aurora-text-primary);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--aurora-accent-primary) 8%, var(--aurora-page-bg)),
+    var(--aurora-page-bg) 60%
+  );
+  cursor: text;
+}
+
+.terminal-line {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.terminal-line + .terminal-line {
+  margin-top: 2px;
+}
+
+.terminal-prompt {
+  flex: 0 0 auto;
+  color: var(--aurora-accent-primary);
+  font-weight: 700;
+}
+
+.terminal-line-in .terminal-line-text {
+  color: var(--aurora-text-primary);
+}
+
+.terminal-line-out .terminal-line-text {
+  color: var(--aurora-text-muted);
+}
+
+.terminal-line-err .terminal-line-text {
+  color: var(--aurora-error);
+}
+
+.terminal-line-sys .terminal-line-text {
+  color: var(--aurora-accent-pink);
+  font-style: italic;
+}
+
+.terminal-input-row {
+  margin-top: 4px;
+}
+
+.terminal-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--aurora-text-primary);
+  font-family: var(--aurora-font-mono);
+  font-size: 12.5px;
+  caret-color: var(--aurora-accent-primary);
+}
+
+.terminal-input:disabled {
+  opacity: 0.6;
+}


### PR DESCRIPTION
## Summary
- land the Browser palette tool from `palette-tools-integration` (`6039fb9d3`) on current `main`
- land the Terminal palette tool from `palette-tools-integration` (`b3fb64631`) on current `main`
- preserve the newer Files/GitHub implementations already merged to `main`; do not bring over stale branch-only copies

## Facts from audit
- `main` already contains `FilesView`/`files_bridge` and `GitHubView`/`github_bridge` from the merged Files/GitHub work.
- `main` did not contain `BrowserView`, `browser.rs`, `browserUrl`, `TerminalView`, or `terminal.rs`.
- `palette-tools-integration` is behind current `main` and conflicts in Files/GitHub/shared palette files, so the safe landing path is cherry-picking only Browser and Terminal onto current `main`.

## Verification
- `pnpm --dir apps/palette-tauri test BrowserView TerminalView browserUrl paletteViewState`
- `pnpm --dir apps/palette-tauri lint`

## Known unrelated verification blockers
- `pnpm --dir apps/palette-tauri typecheck` still fails on generated OpenAPI type drift in `src/lib/actionRequest.ts` (`RestScrapeRequest`, `RestCrawlRequest`, `RestEmbedRequest`, `RestIngestRequest`).
- `cargo test --manifest-path apps/palette-tauri/src-tauri/Cargo.toml browser_tests` and `terminal_tests` both fail before reaching local tests in existing transitive dependency `p384 0.14.0-rc.9` / `elliptic-curve 0.14.0-rc.32`; those exact lockfile versions are already on `origin/main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two new palette tools: a real in‑app Browser and a real Terminal. The Browser opens pages in a separate Tauri window; the Terminal runs actual shell commands with a persistent cwd.

- **New Features**
  - Browser tool: native `WebviewWindow` with commands (`browser_open/navigate/back/forward/reload/close`) and strict URL allowlist (`http/https/about:blank`). UI includes address bar, tab strip, and nav controls. Integrated as a full-screen overlay via `openBrowser/closeBrowser`; URL helpers normalize input (hostnames → https, localhost → http, words → search). Tests cover URL logic, view state, and UI.
  - Terminal tool: `terminal_run` spawns the user’s shell via `tokio::process::Command`, captures stdout/stderr/exit code, and persists session cwd across commands (special-cases `cd`; rejects compound-command misparsing). `terminal_cwd` seeds the prompt. UI has scrollback, Enter to run, ArrowUp/Down history, and a local `clear`. Wired as a local action (`useActionRunner` opens the session); `OutputPanel` renders `TerminalView`. Tests cover command exec, cwd behavior, and UI.

- **Refactors**
  - Moved job lifecycle behavior into `actionLifecycle.ts` and imported into `actionRegistry` to reduce duplication; no behavior changes.

<sup>Written for commit b794a1bd86f3d18c1adc89d33545073432da38ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

