### PR TITLE
ci: use tootie Tailscale OpenWiki endpoint

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           OPENWIKI_PROVIDER: openai-compatible
           OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
-          OPENAI_COMPATIBLE_BASE_URL: https://cli-api.tootie.tv/v1
+          OPENAI_COMPATIBLE_BASE_URL: http://100.120.242.29:8317/v1
           OPENWIKI_MODEL_ID: gpt-5.3-codex-spark
 
       - name: Create OpenWiki update pull request


### PR DESCRIPTION
Updates the OpenWiki workflow to call the OpenAI-compatible proxy over Tailscale at http://100.120.242.29:8317/v1 instead of the public cli-api hostname.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the OpenWiki workflow to the Tailscale OpenAI-compatible proxy by updating `OPENAI_COMPATIBLE_BASE_URL` to `http://100.120.242.29:8317/v1`, replacing `https://cli-api.tootie.tv/v1`. This routes requests over Tailscale for private and more reliable access.

<sup>Written for commit eac202a4e94b7f81677fcda64da822c5790d4a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

