### PR TITLE
ci: run OpenWiki on Tailscale runner

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux-lab]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -33,14 +33,70 @@ jobs:
       - name: Install OpenWiki
         run: npm install --global openwiki
 
+      - name: Preflight OpenWiki API
+        env:
+          OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+          OPENAI_COMPATIBLE_BASE_URL: http://100.120.242.29:8317/v1
+        run: |
+          set -euo pipefail
+
+          for env_file in "$HOME/docs/.env" /home/jmagar/docs/.env; do
+            if [[ -f "$env_file" ]]; then
+              set -a
+              source "$env_file"
+              set +a
+              break
+            fi
+          done
+          export OPENAI_COMPATIBLE_BASE_URL="http://100.120.242.29:8317/v1"
+
+          if [[ -z "${OPENAI_COMPATIBLE_API_KEY:-}" ]]; then
+            echo "::error::OPENAI_COMPATIBLE_API_KEY is required for OpenWiki updates"
+            exit 1
+          fi
+
+          response="$(mktemp)"
+          status="$(
+            curl --silent --show-error --location \
+              --output "$response" \
+              --write-out "%{http_code}" \
+              --header "Authorization: Bearer ${OPENAI_COMPATIBLE_API_KEY}" \
+              "${OPENAI_COMPATIBLE_BASE_URL%/}/models" || true
+          )"
+          if [[ "$status" != "200" ]]; then
+            echo "::error::OpenWiki API preflight failed for ${OPENAI_COMPATIBLE_BASE_URL%/}/models with HTTP ${status}"
+            head -c 300 "$response"
+            echo
+            exit 1
+          fi
+
       - name: Run OpenWiki
-        run: openwiki --update --print
         env:
           OPENWIKI_PROVIDER: openai-compatible
           OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
           OPENAI_COMPATIBLE_BASE_URL: http://100.120.242.29:8317/v1
           OPENWIKI_MODEL_ID: gpt-5.3-codex-spark
+        run: |
+          set -euo pipefail
 
+          for env_file in "$HOME/docs/.env" /home/jmagar/docs/.env; do
+            if [[ -f "$env_file" ]]; then
+              set -a
+              source "$env_file"
+              set +a
+              break
+            fi
+          done
+          export OPENWIKI_PROVIDER="${OPENWIKI_PROVIDER:-openai-compatible}"
+          export OPENAI_COMPATIBLE_BASE_URL="http://100.120.242.29:8317/v1"
+          export OPENWIKI_MODEL_ID="${OPENWIKI_MODEL_ID:-gpt-5.3-codex-spark}"
+
+          if [[ -z "${OPENAI_COMPATIBLE_API_KEY:-}" ]]; then
+            echo "::error::OPENAI_COMPATIBLE_API_KEY is required for OpenWiki updates"
+            exit 1
+          fi
+
+          openwiki --update --print
       - name: Create OpenWiki update pull request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
Runs OpenWiki on the trusted self-hosted Linux runner, sources the local OpenWiki env when available, forces the Tailscale OpenAI-compatible endpoint, and adds an API preflight.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run OpenWiki updates on the trusted self-hosted `linux-lab` runner behind Tailscale, forcing the Tailscale OpenAI-compatible endpoint and adding a preflight check to fail fast if the API is unavailable. The workflow also sources a local `.env` when present for lab configuration.

- **New Features**
  - Switch to `[self-hosted, linux-lab]` runner for `openwiki` updates.
  - Add API preflight against `/models` using `OPENAI_COMPATIBLE_API_KEY`.
  - Source `$HOME/docs/.env` or `/home/jmagar/docs/.env`; enforce `OPENAI_COMPATIBLE_BASE_URL`, default `OPENWIKI_PROVIDER` and `OPENWIKI_MODEL_ID`.

<sup>Written for commit fca02072592e637b3c09cbf5d9c258cb7f549908. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenWiki update reliability by adding API availability checks before updates run.
  * Added clearer validation for required API configuration and safer handling of environment settings.
  * Updates now fail early when the configured API is unavailable or credentials are missing.

* **Chores**
  * OpenWiki updates now run on a dedicated Linux environment for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->