### PR TITLE
ci: connect OpenWiki workflow to Tailscale

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: [self-hosted, linux-lab]
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -29,6 +29,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+
+      - name: Connect Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          authkey: ${{ secrets.TS_AUTH_KEY }}
 
       - name: Install OpenWiki
         run: npm install --global openwiki


### PR DESCRIPTION
Uses the Tailscale GitHub Action on hosted runners while keeping the OpenWiki endpoint pinned to tootie via 100.120.242.29:8317.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the OpenWiki update workflow to GitHub-hosted `ubuntu-latest` and adds `tailscale/github-action@v4` to join the tailnet during runs. The OpenWiki endpoint stays pinned to 100.120.242.29:8317 (`tootie`) to ensure access over Tailscale.

<sup>Written for commit b96d727f9ef4eb1778d0c1844dd79ddb16347699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

