### PR TITLE
ci: authenticate OpenWiki Tailscale with OAuth

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Connect Tailscale
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTH_KEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: 100.120.242.29
 
       - name: Install OpenWiki
         run: npm install --global openwiki


### PR DESCRIPTION
Switches the OpenWiki workflow from the stale auth key to Tailscale OAuth credentials with tag:ci and pings tootie before preflight.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the OpenWiki update workflow to Tailscale OAuth using `tailscale/github-action@v4` for more secure and stable CI auth.
Adds `tag:ci` and a preflight `ping` to 100.120.242.29 to verify connectivity before running.

<sup>Written for commit 49a575cc86751ed63f8b6709f267b86d130580b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

