### PR TITLE
fix: route rust builds through sccache wrapper

### DIFF
--- a/scripts/cargo-rustc-wrapper
+++ b/scripts/cargo-rustc-wrapper
@@ -63,6 +63,10 @@ done
 if [ -n "${AXON_RUSTC_WRAPPER_DELEGATE:-}" ]; then
   delegate=("$AXON_RUSTC_WRAPPER_DELEGATE" "$rustc")
 elif [ "${AXON_RUSTC_WRAPPER_NO_SCCACHE:-0}" != "1" ] \
+  && command -v sccache-wrapper >/dev/null 2>&1 \
+  && sccache-wrapper "$rustc" -vV >/dev/null 2>&1; then
+  delegate=(sccache-wrapper "$rustc")
+elif [ "${AXON_RUSTC_WRAPPER_NO_SCCACHE:-0}" != "1" ] \
   && command -v sccache >/dev/null 2>&1 \
   && sccache --version >/dev/null 2>&1; then
   delegate=(sccache "$rustc")


### PR DESCRIPTION
Routes the repo-local Cargo artifact wrapper through the managed `sccache-wrapper` before falling back to raw `sccache`, matching the host-wide managed sccache socket/toolchain setup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Rust builds through the managed `sccache-wrapper` when available, falling back to `sccache` only if needed. This aligns the repo-local wrapper with the host-wide sccache socket and toolchain setup.

<sup>Written for commit d2544e83c8a1471946f1f0ec86369e9331ef62ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

