### PR TITLE
fix: respect dynamic cargo job allocation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -69,7 +69,7 @@ machete:
     @if command -v cargo-machete >/dev/null 2>&1; then cargo machete; else echo "skip: cargo-machete not installed (cargo install cargo-machete)"; fi
 
 build:
-    {{rust_dev_env}}; CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --profile {{local_release_profile}} --locked
+    {{rust_dev_env}}; cargo build --profile {{local_release_profile}} --locked
     just link-bin {{local_release_profile}}
 
 release-build:
@@ -112,7 +112,7 @@ link-bin profile=local_release_profile:
     echo "artifact → bin/axon-$variant"
 
 install:
-    {{rust_dev_env}}; CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --profile {{local_release_profile}} --locked
+    {{rust_dev_env}}; cargo build --profile {{local_release_profile}} --locked
     just link-bin {{local_release_profile}}
 
 install-release:
@@ -182,7 +182,7 @@ sync-container:
       done < <(git ls-files -z -- Cargo.toml Cargo.lock rust-toolchain.toml .cargo build.rs src crates config.example.toml config migrations apps/web/out assets)
     fi
     if [ "$release_stale" -eq 1 ]; then
-      CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --profile "$profile" --locked --bin axon
+      cargo build --profile "$profile" --locked --bin axon
     else
       echo "release binary is current: $AXON_BIN"
     fi


### PR DESCRIPTION
## Summary
- remove Justfile overrides that forced CARGO_BUILD_JOBS=16
- let the managed cargo wrapper allocate jobs dynamically across concurrent Rust builds

## Verification
- just --summary
- git diff --check -- Justfile
- git push pre-push hook: cargo xtask pre-push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hard-coded `CARGO_BUILD_JOBS=16` in the `Justfile` so Cargo can choose jobs dynamically. This avoids oversubscription and better matches local/CI CPU limits.

- **Bug Fixes**
  - Removed `CARGO_BUILD_JOBS` overrides in `build`, `install`, and `sync-container` recipes.
  - Build profiles and `--locked` behavior are unchanged; only job allocation is now dynamic.

<sup>Written for commit 0404e04fc2d243705f9af8e0f38a248d9abd7088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

