### PR TITLE
build: centralize cargo artifact wrapper

### DIFF
--- a/scripts/cargo-rustc-wrapper
+++ b/scripts/cargo-rustc-wrapper
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+export CARGO_BIN_ARTIFACT_REPO="$repo"
+export CARGO_BIN_ARTIFACT_LEGACY_PREFIX=AXON_RUSTC_WRAPPER
+export CARGO_BIN_ARTIFACT_BIN_DIR="${AXON_ARTIFACT_BIN_DIR:-$repo/bin}"
+export CARGO_BIN_ARTIFACT_ALLOWED_CRATES="axon,axon-palette-tauri,axon_palette_tauri"
+export CARGO_BIN_ARTIFACT_NAME_MAP="axon-palette-tauri=axon-palette,axon_palette_tauri=axon-palette"
+export CARGO_BIN_ARTIFACT_INSTALL_LATEST=0
+export CARGO_BIN_ARTIFACT_LOCAL_CRATE=axon
+export CARGO_BIN_ARTIFACT_LOCAL_BIN="${AXON_RUSTC_WRAPPER_LOCAL_BIN:-$HOME/.local/bin/axon}"
+
+helper="${CARGO_BIN_ARTIFACT_WRAPPER_HELPER:-}"
+if [ -z "$helper" ]; then
+  if command -v cargo-bin-artifact-wrapper >/dev/null 2>&1; then
+    helper="$(command -v cargo-bin-artifact-wrapper)"
+  elif [ -x /home/jmagar/.local/bin/cargo-bin-artifact-wrapper ]; then
+    helper=/home/jmagar/.local/bin/cargo-bin-artifact-wrapper
+  fi
+fi
+
+if [ -n "$helper" ]; then
+  exec "$helper" "$@"
+fi
+
 if [ "$#" -lt 1 ]; then
   echo "usage: cargo-rustc-wrapper <rustc> [rustc-args...]" >&2
   exit 2
@@ -9,134 +32,12 @@ fi
 rustc="$1"
 shift
 
-crate_name=""
-crate_type=""
-out=""
-out_dir=""
-extra_filename=""
-is_test=0
-args=("$@")
-
-i=0
-while [ "$i" -lt "${#args[@]}" ]; do
-  arg="${args[$i]}"
-  case "$arg" in
-    --crate-name)
-      i=$((i + 1))
-      crate_name="${args[$i]:-}"
-      ;;
-    --crate-name=*)
-      crate_name="${arg#--crate-name=}"
-      ;;
-    --crate-type)
-      i=$((i + 1))
-      crate_type="${args[$i]:-}"
-      ;;
-    --crate-type=*)
-      crate_type="${arg#--crate-type=}"
-      ;;
-    -o)
-      i=$((i + 1))
-      out="${args[$i]:-}"
-      ;;
-    --out-dir)
-      i=$((i + 1))
-      out_dir="${args[$i]:-}"
-      ;;
-    -C)
-      i=$((i + 1))
-      codegen_opt="${args[$i]:-}"
-      case "$codegen_opt" in
-        extra-filename=*) extra_filename="${codegen_opt#extra-filename=}" ;;
-      esac
-      ;;
-    -Cextra-filename=*)
-      extra_filename="${arg#-Cextra-filename=}"
-      ;;
-    --test)
-      is_test=1
-      ;;
-  esac
-  i=$((i + 1))
-done
-
 if [ -n "${AXON_RUSTC_WRAPPER_DELEGATE:-}" ]; then
-  delegate=("$AXON_RUSTC_WRAPPER_DELEGATE" "$rustc")
-elif [ "${AXON_RUSTC_WRAPPER_NO_SCCACHE:-0}" != "1" ] \
-  && command -v sccache-wrapper >/dev/null 2>&1 \
-  && sccache-wrapper "$rustc" -vV >/dev/null 2>&1; then
-  delegate=(sccache-wrapper "$rustc")
-elif [ "${AXON_RUSTC_WRAPPER_NO_SCCACHE:-0}" != "1" ] \
-  && command -v sccache >/dev/null 2>&1 \
-  && sccache --version >/dev/null 2>&1; then
-  delegate=(sccache "$rustc")
+  exec "$AXON_RUSTC_WRAPPER_DELEGATE" "$rustc" "$@"
+elif [ "${AXON_RUSTC_WRAPPER_NO_SCCACHE:-0}" != "1" ] && command -v sccache-wrapper >/dev/null 2>&1; then
+  exec sccache-wrapper "$rustc" "$@"
+elif [ "${AXON_RUSTC_WRAPPER_NO_SCCACHE:-0}" != "1" ] && command -v sccache >/dev/null 2>&1; then
+  exec sccache "$rustc" "$@"
 else
-  delegate=("$rustc")
+  exec "$rustc" "$@"
 fi
-
-"${delegate[@]}" "${args[@]}"
-
-if [ -z "$out" ] && [ -n "$out_dir" ] && [ -n "$extra_filename" ]; then
-  out="$out_dir/$crate_name$extra_filename"
-fi
-
-if [ "$crate_type" != "bin" ] || [ "$is_test" -eq 1 ] || [ -z "$out" ] || [ ! -x "$out" ]; then
-  exit 0
-fi
-
-case "$crate_name" in
-  axon|axon-palette-tauri|axon_palette_tauri) ;;
-  *) exit 0 ;;
-esac
-
-case "$out" in
-  target/*/deps/"$crate_name"*|*/target/*/deps/"$crate_name"*|target/*/*/deps/"$crate_name"*|*/target/*/*/deps/"$crate_name"*) ;;
-  *) exit 0 ;;
-esac
-
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-profile="unknown"
-target_triple=""
-after_target="${out##*target/}"
-IFS=/ read -r first second third _rest <<<"$after_target"
-if [ "$second" = "deps" ]; then
-  profile="$first"
-elif [ "$third" = "deps" ]; then
-  target_triple="$first"
-  profile="$second"
-fi
-
-case "$profile" in
-  release-fast) variant="fast-release" ;;
-  debug|release) variant="$profile" ;;
-  *) variant="$profile" ;;
-esac
-
-case "$crate_name" in
-  axon) artifact_base="axon" ;;
-  axon-palette-tauri|axon_palette_tauri) artifact_base="axon-palette" ;;
-esac
-
-ext=""
-case "$out" in
-  *.exe) ext=".exe" ;;
-esac
-
-if [ -n "$target_triple" ]; then
-  artifact_name="${artifact_base}-${target_triple}-${variant}${ext}"
-else
-  artifact_name="${artifact_base}-${variant}${ext}"
-fi
-
-bin_dir="${AXON_ARTIFACT_BIN_DIR:-$repo_root/bin}"
-mkdir -p "$bin_dir"
-install -m 755 "$out" "$bin_dir/$artifact_name"
-
-if [ "$crate_name" != "axon" ]; then
-  exit 0
-fi
-
-local_bin="${AXON_RUSTC_WRAPPER_LOCAL_BIN:-$HOME/.local/bin/axon}"
-
-mkdir -p "$(dirname "$local_bin")"
-install -m 755 "$out" "$local_bin"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralized Cargo artifact handling by delegating to `cargo-bin-artifact-wrapper`, removing custom parsing and install logic. This simplifies the `cargo-rustc` wrapper and standardizes binary outputs.

- **Refactors**
  - Delegates to `cargo-bin-artifact-wrapper` when available; falls back to `sccache-wrapper`, `sccache`, or `rustc`.
  - Exports `CARGO_BIN_ARTIFACT_*` env vars to configure repo path, bin dir, allowed crates (`axon`, `axon-palette-tauri`, `axon_palette_tauri`), and name mapping.
  - Removes ad-hoc `rustc` arg parsing and local install steps; the helper manages packaging and installation.

<sup>Written for commit 4af4778579d207ba5ffb7b38df138abde0ce498c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

