### PR TITLE
Fix auto-tag handling for already-tagged components

### DIFF
--- a/xtask/src/checks/release_versions.rs
+++ b/xtask/src/checks/release_versions.rs
@@ -405,7 +405,7 @@ fn build_plan(
         .iter()
         .map(|component| {
             let version = read_version(root, &component.version_source)?;
-            Version::parse(&version).with_release_context(|| {
+            let candidate_version = Version::parse(&version).with_release_context(|| {
                 format!("{} version is not valid semver: {version}", component.id)
             })?;
             let candidate_tag = format!("{}{}", component.tag_prefix, version);
@@ -417,7 +417,22 @@ fn build_plan(
                     component_changed_since_ref(root, component, &compare_ref, head)?
                 }
                 GateMode::Main => match last_tag.as_deref() {
-                    Some(tag) => component_changed_since_ref(root, component, tag, head)?,
+                    Some(tag) => {
+                        let component_changed =
+                            component_changed_since_ref(root, component, tag, head)?;
+                        if !component_changed {
+                            false
+                        } else {
+                            let latest_version = version_from_tag(component, tag)
+                                .with_release_context(|| {
+                                    format!(
+                                        "{} latest tag has invalid version: {tag}",
+                                        component.id
+                                    )
+                                })?;
+                            candidate_version > latest_version && !tag_exists(root, &candidate_tag)?
+                        }
+                    }
                     None => true,
                 },
             };
@@ -490,20 +505,20 @@ fn latest_version_from_plan(
 ) -> ReleaseResult<Option<Version>> {
     plan.last_tag
         .as_deref()
-        .map(|tag| {
-            let version = tag
-                .strip_prefix(&component.tag_prefix)
-                .with_release_context(|| {
-                    format!("{} latest tag has wrong prefix: {tag}", component.id)
-                })?;
-            Version::parse(version).with_release_context(|| {
-                format!(
-                    "{} latest tag has invalid semver suffix: {tag}",
-                    component.id
-                )
-            })
-        })
+        .map(|tag| version_from_tag(component, tag))
         .transpose()
+}
+
+fn version_from_tag(component: &Component, tag: &str) -> ReleaseResult<Version> {
+    let version = tag
+        .strip_prefix(&component.tag_prefix)
+        .with_release_context(|| format!("{} latest tag has wrong prefix: {tag}", component.id))?;
+    Version::parse(version).with_release_context(|| {
+        format!(
+            "{} latest tag has invalid semver suffix: {tag}",
+            component.id
+        )
+    })
 }
 
 fn bump_hint(component: &Component) -> String {

--- a/xtask/src/checks/release_versions_tests.rs
+++ b/xtask/src/checks/release_versions_tests.rs
@@ -775,6 +775,24 @@ fn main_mode_marks_changed_since_latest_tag() {
 }
 
 #[test]
+fn main_mode_skips_changed_component_when_candidate_tag_already_exists() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "v1.0.0"]);
+    fs::write(fixture.path("src/lib.rs"), "pub fn post_release_fix() {}\n").unwrap();
+    fixture.git(&["add", "src/lib.rs"]);
+    fixture.git(&["commit", "-m", "post release fix"]);
+
+    check(fixture.root(), None, "HEAD", GateMode::Main, false)
+        .expect("post-release same-version changes do not make auto-tag fail");
+    let plans = plan(fixture.root(), None, "HEAD", GateMode::Main).unwrap();
+    let cli = plans.iter().find(|plan| plan.id == "cli").unwrap();
+    assert!(!cli.changed);
+    assert_eq!(cli.candidate_tag, "v1.0.0");
+    assert_eq!(cli.last_tag.as_deref(), Some("v1.0.0"));
+}
+
+#[test]
 fn main_mode_marks_unchanged_when_latest_tag_points_at_head() {
     let fixture = Fixture::new();
     fixture.init_repo();


### PR DESCRIPTION
## Summary
- make main auto-tag planning skip components whose candidate version/tag is already released
- keep PR-mode release bump enforcement intact
- add regression coverage for post-release corrective commits

## Verification
- cargo fmt --check
- cargo test --manifest-path xtask/Cargo.toml release_versions -- --nocapture
- cargo xtask check-release-versions --head HEAD --mode main --json
- cargo xtask check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix auto-tag to skip components whose candidate version/tag is already released in main mode. This prevents forced bumps after post-release fixes; PR-mode rules are unchanged.

- **Bug Fixes**
  - In main mode, mark a component unchanged if its candidate tag already exists or the candidate version isn’t greater than the latest tag.
  - Extracted `version_from_tag` and reused it for consistent tag parsing and errors.
  - Added a regression test for post-release corrective commits.

<sup>Written for commit f1839cf787e1320e04b762fe20b8b4151adfb3e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

