### PR TITLE
Repair release-please source fixups

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,10 @@ jobs:
 
   release-pr-fixups:
     needs: release-please
-    if: ${{ needs.release-please.outputs.prs_created == 'true' }}
+    # release-please may update already-open release PRs without setting
+    # prs_created=true. Run fixups for any PR payload it returns so component
+    # source version files cannot drift behind the manifest/changelog bump.
+    if: ${{ needs.release-please.outputs.prs != '' && needs.release-please.outputs.prs != '[]' && needs.release-please.outputs.prs != 'null' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write  # required to push generated fixup commits to release PR branches

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -19,9 +19,9 @@ android {
         applicationId = "com.axon.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 16 // x-release-please-version-code 1.6.0
+        versionCode = 17 // x-release-please-version-code 1.6.1
         // x-release-please-start-version
-        versionName = "1.6.0"
+        versionName = "1.6.1"
         // x-release-please-end
         manifestPlaceholders["appAuthRedirectScheme"] = "com.axon.app"
     }

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Axon",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scrape, crawl, extract, search and ask Axon over the page you're on.",
   "options_page": "src/options/options.html",
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axon-chrome-extension",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Axon Chrome extension — MV3 side panel, popup command console, and context-menu capture.",
   "scripts": {
     "test": "node --test"

--- a/apps/palette-tauri/package.json
+++ b/apps/palette-tauri/package.json
@@ -54,5 +54,5 @@
     "vite:dev": "vite --host 127.0.0.1"
   },
   "type": "module",
-  "version": "5.14.0"
+  "version": "5.14.1"
 }

--- a/apps/palette-tauri/src-tauri/Cargo.lock
+++ b/apps/palette-tauri/src-tauri/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "axon-palette-tauri"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/apps/palette-tauri/src-tauri/Cargo.toml
+++ b/apps/palette-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axon-palette-tauri"
-version = "5.14.0"
+version = "5.14.1"
 description = "Tauri command palette for the Axon REST API"
 edition = "2024"
 rust-version = "1.94.0"

--- a/apps/palette-tauri/src-tauri/tauri.conf.json
+++ b/apps/palette-tauri/src-tauri/tauri.conf.json
@@ -59,5 +59,5 @@
   },
   "identifier": "tv.tootie.axon.palette",
   "productName": "Axon Palette",
-  "version": "5.14.0"
+  "version": "5.14.1"
 }

--- a/xtask/src/checks/release_versions.rs
+++ b/xtask/src/checks/release_versions.rs
@@ -1,5 +1,6 @@
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::path::Path;
 
 type ReleaseResult<T> = std::result::Result<T, ReleaseVersionError>;
@@ -30,8 +31,8 @@ use files::{
     check_component_parity, read_version, read_workspace_package_version, write_version_file,
 };
 use git::{
-    check_gradle_version_code_increased, compare_ref_for_component, component_changed_since_ref,
-    latest_tag, merge_base, tag_exists,
+    changed_paths_since_ref, check_gradle_version_code_increased, compare_ref_for_component,
+    component_changed_since_ref, latest_tag, merge_base, tag_exists,
 };
 
 #[cfg(test)]
@@ -467,26 +468,38 @@ fn collect_changed_component_errors(
     })?;
 
     let latest = latest_version_from_plan(component, plan)?;
-    if let Some(latest) = latest
-        && candidate <= latest
-    {
-        errors.push(format!(
-            "{} code changed but version {} is not greater than latest {} tag version {}. Let release-please bump {} before merging.",
-            component.id,
-            plan.version,
-            component.tag_prefix,
-            latest,
-            bump_hint(component)
-        ));
-    }
+    let existing_candidate_tag = tag_exists(root, &plan.candidate_tag)?;
+    let release_fixup_only = release_fixup_only_pr_change(
+        root,
+        component,
+        &candidate,
+        latest.as_ref(),
+        base,
+        head,
+        mode,
+    )?;
+    if !release_fixup_only {
+        if let Some(latest) = latest
+            && candidate <= latest
+        {
+            errors.push(format!(
+                "{} code changed but version {} is not greater than latest {} tag version {}. Let release-please bump {} before merging.",
+                component.id,
+                plan.version,
+                component.tag_prefix,
+                latest,
+                bump_hint(component)
+            ));
+        }
 
-    if tag_exists(root, &plan.candidate_tag)? {
-        errors.push(format!(
-            "{} code changed but tag {} already exists. Let release-please bump {} before merging.",
-            component.id,
-            plan.candidate_tag,
-            bump_hint(component)
-        ));
+        if existing_candidate_tag {
+            errors.push(format!(
+                "{} code changed but tag {} already exists. Let release-please bump {} before merging.",
+                component.id,
+                plan.candidate_tag,
+                bump_hint(component)
+            ));
+        }
     }
 
     if component_has_kind(component, VersionKind::GradleVersionCode)
@@ -497,6 +510,36 @@ fn collect_changed_component_errors(
     }
 
     Ok(())
+}
+
+fn release_fixup_only_pr_change(
+    root: &Path,
+    component: &Component,
+    candidate: &Version,
+    latest: Option<&Version>,
+    base: Option<&str>,
+    head: &str,
+    mode: GateMode,
+) -> ReleaseResult<bool> {
+    if mode != GateMode::Pr || !component.release_please_managed {
+        return Ok(false);
+    }
+    if latest != Some(candidate) {
+        return Ok(false);
+    }
+    let Some(compare_ref) = compare_ref_for_component(root, component, base, head, mode)? else {
+        return Ok(false);
+    };
+    let changed = changed_paths_since_ref(root, &compare_ref, head, &component.shipping_paths)?;
+    if changed.is_empty() {
+        return Ok(false);
+    }
+    let allowed = component
+        .version_files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect::<BTreeSet<_>>();
+    Ok(changed.iter().all(|path| allowed.contains(path.as_str())))
 }
 
 fn latest_version_from_plan(

--- a/xtask/src/checks/release_versions/git.rs
+++ b/xtask/src/checks/release_versions/git.rs
@@ -187,7 +187,7 @@ fn is_non_shipping_documentation_path(path: &str) -> bool {
         || path.starts_with("docs/")
 }
 
-fn changed_paths_since_ref(
+pub(super) fn changed_paths_since_ref(
     root: &Path,
     base: &str,
     head: &str,

--- a/xtask/src/checks/release_versions_tests.rs
+++ b/xtask/src/checks/release_versions_tests.rs
@@ -793,6 +793,46 @@ fn main_mode_skips_changed_component_when_candidate_tag_already_exists() {
 }
 
 #[test]
+fn pr_mode_allows_release_please_source_fixup_after_tag_exists() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fs::write(
+        fixture.path(".release-please-manifest.json"),
+        r#"{
+  ".": "1.0.0",
+  "apps/palette-tauri": "5.10.2",
+  "apps/android": "1.3.2",
+  "apps/chrome-extension": "0.2.1"
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/chrome-extension/CHANGELOG.md"),
+        "# Changelog\n\n## [0.2.1]\n",
+    )
+    .unwrap();
+    fixture.git(&[
+        "add",
+        ".release-please-manifest.json",
+        "apps/chrome-extension/CHANGELOG.md",
+    ]);
+    fixture.git(&["commit", "-m", "chore(main): release chrome-ext 0.2.1"]);
+    fixture.git(&["tag", "chrome-ext-v0.2.1"]);
+
+    release_please_fixups(fixture.root(), "chrome", "0.2.1").unwrap();
+    fixture.git(&[
+        "add",
+        "apps/chrome-extension/manifest.json",
+        "apps/chrome-extension/package.json",
+    ]);
+    fixture.git(&["commit", "-m", "chore: apply release-please fixups"]);
+
+    check(fixture.root(), Some("HEAD~1"), "HEAD", GateMode::Pr, false)
+        .expect("source-only release fixups are allowed after release-please tags");
+}
+
+#[test]
 fn main_mode_marks_unchanged_when_latest_tag_points_at_head() {
     let fixture = Fixture::new();
     fixture.init_repo();


### PR DESCRIPTION
## Summary
- apply release-please source version fixups for palette 5.14.1, chrome-ext 0.3.1, and android 1.6.1
- run release-pr-fixups for updated existing release PRs, not only newly-created PRs
- allow narrow PR-mode release gate recovery when a release-please source-fixup commit only touches configured version files for an already-created tag

## Validation
- cargo fmt --check
- cargo test --manifest-path xtask/Cargo.toml release_versions -- --nocapture
- cargo xtask check-release-versions --base origin/main --head HEAD --mode pr
- cargo xtask check-release-versions --head HEAD --mode main --json
- cargo xtask check-version-sync
- actionlint .github/workflows/release-please.yml
- pre-push path-aware checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the release-please flow to keep version files in sync and let PRs with version-only fixups pass the gate after a tag exists. Applies source fixups for `palette-tauri` 5.14.1, `chrome-extension` 0.3.1, and Android 1.6.1.

- **Bug Fixes**
  - Run `release-pr-fixups` when `release-please` updates an existing PR (checks `outputs.prs` instead of `prs_created`).
  - PR gate allows version-only changes when the latest tag already exists by checking changed paths against configured version files (tests added).

- **Dependencies**
  - `apps/palette-tauri` → 5.14.1 (package.json, Cargo.toml/lock, tauri.conf.json).
  - `apps/chrome-extension` → 0.3.1 (manifest.json, package.json).
  - `apps/android` → 1.6.1 (versionName, versionCode).

<sup>Written for commit 0d523b9a45f35648f4c34286b0030ac526556e73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

