### PR TITLE
Fix release upload repository resolution

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -219,6 +219,7 @@ jobs:
           inputs.publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           APK_PATH: ${{ steps.package.outputs.apk }}
         run: |
           set -euo pipefail

--- a/.github/workflows/chrome-extension-release.yml
+++ b/.github/workflows/chrome-extension-release.yml
@@ -83,6 +83,7 @@ jobs:
           inputs.publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           ZIP_PATH: ${{ steps.build.outputs.zip }}
         run: |
           set -euo pipefail

--- a/.github/workflows/palette-release.yml
+++ b/.github/workflows/palette-release.yml
@@ -197,6 +197,7 @@ jobs:
       - name: Attach artifacts to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,7 @@ jobs:
         if: ${{ hashFiles('dist/axon-linux-x86_64.tar.gz.minisig') != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
@@ -182,6 +183,7 @@ jobs:
       - name: Attach artifacts to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Summary
- set GH_REPO for all gh release upload/view workflow steps
- remove the hidden dependency on a checkout being present in release publish jobs

## Validation
- actionlint .github/workflows/palette-release.yml .github/workflows/chrome-extension-release.yml .github/workflows/android-release.yml .github/workflows/release.yml
- cargo test --locked --test ci_changed_paths
- cargo test --locked --test workflow_shapes
- lefthook structural checks via pre-push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release uploads by explicitly setting `GH_REPO` in all release workflows so `gh` targets the correct repository without requiring a checkout. Prevents misrouted or failing `gh release upload/view` steps in reusable jobs.

- **Bug Fixes**
  - Set `GH_REPO: ${{ github.repository }}` in `.github/workflows/release.yml`, `android-release.yml`, `chrome-extension-release.yml`, and `palette-release.yml`.
  - Removes the implicit dependency on a checkout for `gh release upload/view`.

<sup>Written for commit 66914035a4abac35ac7f54f5a70bc5474e7fa9c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated release publishing for Android, Chrome extension, palette, and application artifacts.
  * Ensured release uploads consistently target the correct repository, including signatures and checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->