### PR TITLE
fix(route,parse): stop fabricating unregistered parser hints; fall back on stale document hints

### DIFF
--- a/crates/axon-adapters/src/adapter_tests.rs
+++ b/crates/axon-adapters/src/adapter_tests.rs
@@ -425,7 +425,7 @@ fn route_plan(adapter_name: &str, source_kind: SourceKind, scope: SourceScope) -
             options: MetadataMap::new(),
         }],
         parser_hints: vec![ParserHint {
-            parser_id: "markdown".to_string(),
+            parser_id: "markdown_headings".to_string(),
             reason: "test parser hint".to_string(),
             options: MetadataMap::new(),
         }],

--- a/crates/axon-cli/src/commands/source.rs
+++ b/crates/axon-cli/src/commands/source.rs
@@ -10,7 +10,7 @@
 
 use axon_api::source::{
     ArtifactKind, ArtifactMode, ContentRef, LifecycleStatus, ResponseMode, SourceIntent,
-    SourceLimits, SourceRequest, SourceResult, SourceScope,
+    SourceLimits, SourceRequest, SourceResult, SourceScope, SourceWarning,
 };
 use axon_core::config::{CommandKind, Config};
 use axon_core::ui::{accent, muted, primary};
@@ -163,9 +163,32 @@ pub(crate) fn render_source_result(cfg: &Config, result: &SourceResult) {
             result.graph.nodes_upserted, result.graph.edges_upserted, result.graph.evidence_records,
         ))
     );
-    for warning in &result.warnings {
-        println!("  {}", muted(&format!("Warning: {}", warning.message)));
+    for (message, count) in grouped_warning_messages(&result.warnings) {
+        let line = if count > 1 {
+            format!("Warning: {message} (x{count})")
+        } else {
+            format!("Warning: {message}")
+        };
+        println!("  {}", muted(&line));
     }
+}
+
+/// Collapse identical warning messages into `(message, count)` pairs,
+/// preserving first-seen order. Per-document warnings repeat once per
+/// document, so a site-scope run can otherwise print hundreds of identical
+/// lines; JSON output keeps the full per-item list.
+fn grouped_warning_messages(warnings: &[SourceWarning]) -> Vec<(&str, usize)> {
+    let mut grouped: Vec<(&str, usize)> = Vec::new();
+    for warning in warnings {
+        match grouped
+            .iter_mut()
+            .find(|(message, _)| *message == warning.message)
+        {
+            Some((_, count)) => *count += 1,
+            None => grouped.push((warning.message.as_str(), 1)),
+        }
+    }
+    grouped
 }
 
 fn render_inline_source_content(result: &SourceResult) -> bool {
@@ -237,3 +260,7 @@ async fn write_scrape_output_if_requested(
         .map_err(|err| -> Box<dyn Error> { err.to_string().into() })?;
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "source_tests.rs"]
+mod tests;

--- a/crates/axon-cli/src/commands/source.rs
+++ b/crates/axon-cli/src/commands/source.rs
@@ -9,13 +9,15 @@
 //! MCP, and REST share one entrypoint.
 
 use axon_api::source::{
-    ArtifactKind, ArtifactMode, ContentRef, LifecycleStatus, ResponseMode, SourceIntent,
+    ArtifactKind, ArtifactMode, ContentRef, LifecycleStatus, ResponseMode, Severity, SourceIntent,
     SourceLimits, SourceRequest, SourceResult, SourceScope, SourceWarning,
 };
 use axon_core::config::{CommandKind, Config};
 use axon_core::ui::{accent, muted, primary};
 use axon_services::context::ServiceContext;
 use axon_services::index_source;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::error::Error;
 
 pub async fn run_source(
@@ -163,32 +165,52 @@ pub(crate) fn render_source_result(cfg: &Config, result: &SourceResult) {
             result.graph.nodes_upserted, result.graph.edges_upserted, result.graph.evidence_records,
         ))
     );
-    for (message, count) in grouped_warning_messages(&result.warnings) {
+    for (label, message, count) in grouped_warnings(&result.warnings) {
         let line = if count > 1 {
-            format!("Warning: {message} (x{count})")
+            format!("{label} {message} (x{count})")
         } else {
-            format!("Warning: {message}")
+            format!("{label} {message}")
         };
-        println!("  {}", muted(&line));
+        println!("  {}", muted(&sanitize_terminal_text(&line)));
     }
 }
 
-/// Collapse identical warning messages into `(message, count)` pairs,
-/// preserving first-seen order. Per-document warnings repeat once per
+/// Collapse identical `(severity label, message)` pairs into one entry with a
+/// count, preserving first-seen order. Per-document warnings repeat once per
 /// document, so a site-scope run can otherwise print hundreds of identical
-/// lines; JSON output keeps the full per-item list.
-fn grouped_warning_messages(warnings: &[SourceWarning]) -> Vec<(&str, usize)> {
-    let mut grouped: Vec<(&str, usize)> = Vec::new();
+/// lines; JSON output keeps the full per-item list. The `HashMap` index keeps
+/// grouping linear even when a large crawl emits mostly-unique messages.
+fn grouped_warnings(warnings: &[SourceWarning]) -> Vec<(&'static str, &str, usize)> {
+    let mut grouped: Vec<(&'static str, &str, usize)> = Vec::new();
+    let mut index: HashMap<(&'static str, &str), usize> = HashMap::new();
     for warning in warnings {
-        match grouped
-            .iter_mut()
-            .find(|(message, _)| *message == warning.message)
-        {
-            Some((_, count)) => *count += 1,
-            None => grouped.push((warning.message.as_str(), 1)),
+        let label = severity_label(warning);
+        match index.entry((label, warning.message.as_str())) {
+            Entry::Occupied(slot) => grouped[*slot.get()].2 += 1,
+            Entry::Vacant(slot) => {
+                slot.insert(grouped.len());
+                grouped.push((label, warning.message.as_str(), 1));
+            }
         }
     }
     grouped
+}
+
+/// Informational diagnostics (e.g. `parse.parser_hint_unregistered`) must not
+/// masquerade as degradations in human output.
+fn severity_label(warning: &SourceWarning) -> &'static str {
+    if matches!(warning.severity, Severity::Debug | Severity::Info) {
+        "Note:"
+    } else {
+        "Warning:"
+    }
+}
+
+/// Warning text can embed upstream-derived strings; strip control characters
+/// (including ANSI escape introducers) before the text joins an ANSI-styled
+/// terminal line.
+fn sanitize_terminal_text(text: &str) -> String {
+    text.chars().filter(|c| !c.is_control()).collect()
 }
 
 fn render_inline_source_content(result: &SourceResult) -> bool {

--- a/crates/axon-cli/src/commands/source_tests.rs
+++ b/crates/axon-cli/src/commands/source_tests.rs
@@ -1,11 +1,11 @@
 use super::*;
 
-use axon_api::source::{Severity, SourceItemKey};
+use axon_api::source::SourceItemKey;
 
-fn warning(message: &str) -> SourceWarning {
+fn warning(message: &str, severity: Severity) -> SourceWarning {
     SourceWarning {
         code: "test.warning".to_string(),
-        severity: Severity::Warning,
+        severity,
         message: message.to_string(),
         source_item_key: Some(SourceItemKey::from("item")),
         retryable: false,
@@ -13,34 +13,56 @@ fn warning(message: &str) -> SourceWarning {
 }
 
 #[test]
-fn grouped_warning_messages_collapses_repeats_in_first_seen_order() {
+fn grouped_warnings_collapses_repeats_in_first_seen_order() {
     let warnings = vec![
-        warning("requested parser is not registered: web"),
-        warning("pre-chunk redaction pass scrubbed sensitive values before chunking"),
-        warning("requested parser is not registered: web"),
-        warning("requested parser is not registered: web"),
+        warning("requested parser is not registered: web", Severity::Warning),
+        warning(
+            "pre-chunk redaction pass scrubbed sensitive values before chunking",
+            Severity::Warning,
+        ),
+        warning("requested parser is not registered: web", Severity::Warning),
+        warning("one-off", Severity::Warning),
+        warning("requested parser is not registered: web", Severity::Warning),
     ];
 
-    let grouped = grouped_warning_messages(&warnings);
-
     assert_eq!(
-        grouped,
+        grouped_warnings(&warnings),
         vec![
-            ("requested parser is not registered: web", 3),
+            ("Warning:", "requested parser is not registered: web", 3),
             (
+                "Warning:",
                 "pre-chunk redaction pass scrubbed sensitive values before chunking",
                 1
             ),
+            ("Warning:", "one-off", 1),
         ]
     );
 }
 
 #[test]
-fn grouped_warning_messages_keeps_unique_messages_untouched() {
-    let warnings = vec![warning("one"), warning("two")];
+fn grouped_warnings_labels_informational_severities_as_notes() {
+    let warnings = vec![
+        warning("hint fell back", Severity::Info),
+        warning("degraded", Severity::Warning),
+        warning("hint fell back", Severity::Info),
+        warning("verbose detail", Severity::Debug),
+    ];
 
     assert_eq!(
-        grouped_warning_messages(&warnings),
-        vec![("one", 1), ("two", 1)]
+        grouped_warnings(&warnings),
+        vec![
+            ("Note:", "hint fell back", 2),
+            ("Warning:", "degraded", 1),
+            ("Note:", "verbose detail", 1),
+        ]
     );
+}
+
+#[test]
+fn sanitize_terminal_text_strips_control_characters() {
+    assert_eq!(
+        sanitize_terminal_text("clean \x1b[31mred\x1b[0m\r\nline\t!"),
+        "clean [31mred[0mline!"
+    );
+    assert_eq!(sanitize_terminal_text("untouched"), "untouched");
 }

--- a/crates/axon-cli/src/commands/source_tests.rs
+++ b/crates/axon-cli/src/commands/source_tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+use axon_api::source::{Severity, SourceItemKey};
+
+fn warning(message: &str) -> SourceWarning {
+    SourceWarning {
+        code: "test.warning".to_string(),
+        severity: Severity::Warning,
+        message: message.to_string(),
+        source_item_key: Some(SourceItemKey::from("item")),
+        retryable: false,
+    }
+}
+
+#[test]
+fn grouped_warning_messages_collapses_repeats_in_first_seen_order() {
+    let warnings = vec![
+        warning("requested parser is not registered: web"),
+        warning("pre-chunk redaction pass scrubbed sensitive values before chunking"),
+        warning("requested parser is not registered: web"),
+        warning("requested parser is not registered: web"),
+    ];
+
+    let grouped = grouped_warning_messages(&warnings);
+
+    assert_eq!(
+        grouped,
+        vec![
+            ("requested parser is not registered: web", 3),
+            (
+                "pre-chunk redaction pass scrubbed sensitive values before chunking",
+                1
+            ),
+        ]
+    );
+}
+
+#[test]
+fn grouped_warning_messages_keeps_unique_messages_untouched() {
+    let warnings = vec![warning("one"), warning("two")];
+
+    assert_eq!(
+        grouped_warning_messages(&warnings),
+        vec![("one", 1), ("two", 1)]
+    );
+}

--- a/crates/axon-document/src/parse_tests.rs
+++ b/crates/axon-document/src/parse_tests.rs
@@ -78,6 +78,44 @@ fn manifest_document_routes_to_code_manifest() {
 }
 
 #[test]
+fn web_document_with_stale_route_hint_still_parses_markdown() {
+    // Regression: the router used to stamp every web document with a
+    // fabricated `ParserHint { parser_id: "web" }`. No parser is registered
+    // under that id, so every page of a site crawl degraded with "requested
+    // parser is not registered: web" and produced zero parse facts. An
+    // unregistered advisory hint must fall back to content-based selection.
+    let mut doc = source_doc(
+        ContentKind::Markdown,
+        "index.md",
+        "# Claude Code\n\nDocs body\n",
+    );
+    doc.canonical_uri = "https://code.claude.com/".to_string();
+    doc.path = None;
+    doc.parser_hints = vec![ParserHint {
+        parser_id: "web".to_string(),
+        reason: "route default parser".to_string(),
+        options: MetadataMap::new(),
+    }];
+
+    let parse = parse_document(&doc);
+
+    assert_eq!(parse.parser_id, "markdown_headings");
+    assert_ne!(parse.parser_version, "unavailable");
+    assert!(
+        parse
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "parse.parser_hint_unregistered")
+    );
+    assert!(
+        parse
+            .warnings
+            .iter()
+            .all(|warning| warning.code != "parse.requested_parser_unavailable")
+    );
+}
+
+#[test]
 fn prose_document_has_no_routed_profile_override() {
     let doc = source_doc(
         ContentKind::Markdown,

--- a/crates/axon-parse/src/parser_tests.rs
+++ b/crates/axon-parse/src/parser_tests.rs
@@ -254,6 +254,34 @@ fn unregistered_document_hint_falls_back_to_content_selection() {
 }
 
 #[test]
+fn unregistered_document_hint_is_recorded_even_when_nothing_matches() {
+    let registry = ParserRegistry::new()
+        .with_parser(parser("markdown").with_content_kind(ContentKind::Markdown));
+    let mut doc = source_doc(ContentKind::PlainText, None, None, "plain body");
+    doc.parser_hints.push(ParserHint {
+        parser_id: "web".to_string(),
+        reason: "route default parser".to_string(),
+        options: MetadataMap::new(),
+    });
+
+    let result = registry.parse(&input(doc));
+
+    assert_eq!(result.header.status, LifecycleStatus::Skipped);
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "parse.unsupported")
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.code == "parse.parser_hint_unregistered")
+    );
+}
+
+#[test]
 fn registered_document_hint_runs_only_that_parser() {
     let registry = production_registry();
     let mut doc = source_doc(
@@ -595,7 +623,7 @@ fn multiple_parsers_run_when_they_specifically_match_same_document() {
 }
 
 #[test]
-fn explicit_hint_runs_only_the_requested_parser() {
+fn explicit_requested_parser_runs_alone_even_with_specific_matches() {
     let registry = production_registry();
     let mut request = input(source_doc(
         ContentKind::Yaml,

--- a/crates/axon-parse/src/parser_tests.rs
+++ b/crates/axon-parse/src/parser_tests.rs
@@ -226,6 +226,61 @@ fn requested_missing_parser_degrades_without_fallback() {
 }
 
 #[test]
+fn unregistered_document_hint_falls_back_to_content_selection() {
+    let registry = ParserRegistry::new()
+        .with_parser(parser("markdown").with_content_kind(ContentKind::Markdown));
+    let mut doc = source_doc(ContentKind::Markdown, Some("README.md"), None, "# Readme");
+    doc.parser_hints.push(ParserHint {
+        parser_id: "web".to_string(),
+        reason: "route default parser".to_string(),
+        options: MetadataMap::new(),
+    });
+
+    let selected = registry
+        .select(&input(doc.clone()))
+        .expect("unregistered hint falls back to content selection");
+    assert_eq!(selected.capability().parser_id, "markdown");
+
+    let result = registry.parse(&input(doc));
+
+    assert_eq!(result.parser_id, "markdown");
+    assert_eq!(result.header.status, LifecycleStatus::Completed);
+    let hint_warning = result
+        .warnings
+        .iter()
+        .find(|warning| warning.code == "parse.parser_hint_unregistered")
+        .expect("fallback records the unregistered hint");
+    assert_eq!(hint_warning.severity, Severity::Info);
+}
+
+#[test]
+fn registered_document_hint_runs_only_that_parser() {
+    let registry = production_registry();
+    let mut doc = source_doc(
+        ContentKind::Yaml,
+        Some("docker-compose.yaml"),
+        None,
+        "services:\n  api:\n    image: alpine:3\n",
+    );
+    doc.parser_hints.push(ParserHint {
+        parser_id: "manifest".to_string(),
+        reason: "caller supplied".to_string(),
+        options: MetadataMap::new(),
+    });
+
+    let result = registry.parse(&input(doc));
+
+    assert_eq!(result.parser_id, "manifest");
+    assert!(result.facts.iter().all(|fact| fact.parser_id == "manifest"));
+    assert!(
+        result
+            .warnings
+            .iter()
+            .all(|warning| warning.code != "parse.parser_hint_unregistered")
+    );
+}
+
+#[test]
 fn production_registry_runs_real_parser_families() {
     let registry = production_registry();
 

--- a/crates/axon-parse/src/registry.rs
+++ b/crates/axon-parse/src/registry.rs
@@ -22,15 +22,18 @@ impl ParserRegistry {
         self
     }
 
-    /// Select the single "primary" parser for `input` — the best-scored
-    /// specific match (MIME type, path/extension, or content sniffing), or,
-    /// failing that, the highest-priority content-kind-only match. Used for
-    /// routing decisions (e.g. `DocumentPreparer` chunk-profile selection)
-    /// that need exactly one parser identity, not the full fan-out `parse`
-    /// may run.
+    /// Select the single "primary" parser for `input` — the caller-requested
+    /// or hint-named parser when it resolves, else the best-scored specific
+    /// match (MIME type, path/extension, or content sniffing), or, failing
+    /// that, the highest-priority content-kind-only match. Used for routing
+    /// decisions (e.g. `DocumentPreparer` chunk-profile selection) that need
+    /// exactly one parser identity, not the full fan-out `parse` may run.
     pub fn select(&self, input: &ParseInput) -> Option<Arc<dyn SourceParser>> {
-        if requested_parser_id(input).is_some() {
-            return self.select_explicit(input);
+        if let Some(requested) = input.requested_parser.as_deref() {
+            return self.select_by(|parser| parser.capability().parser_id == requested);
+        }
+        if let Some(hinted) = self.hinted_parser(input) {
+            return Some(hinted);
         }
         self.ranked_matches(input)
             .into_iter()
@@ -40,27 +43,38 @@ impl ParserRegistry {
 
     /// Parse `input` per parsing-contract.md's selection order:
     ///
-    /// 1. an explicit `ParserHint`/`requested_parser` runs alone — exclusive.
-    /// 2. otherwise every parser that specifically identifies the document
+    /// 1. an explicit `requested_parser` runs alone — exclusive. A request for
+    ///    an unregistered parser degrades without fallback: the caller demanded
+    ///    one specific parser and nothing else may answer for it.
+    /// 2. a document `ParserHint` naming a registered parser also runs alone.
+    ///    Hints are advisory metadata stamped by upstream stages, so a hint
+    ///    naming an unregistered parser falls back to content-based selection
+    ///    below (recording an informational warning) instead of degrading
+    ///    every hinted document.
+    /// 3. otherwise every parser that specifically identifies the document
     ///    (MIME type, path/extension, or content sniffing) runs and their
     ///    facts/graph candidates/warnings/errors merge into one result, since
     ///    "Multiple parsers may run when they emit different fact families"
     ///    (e.g. `docker-compose.yaml` gets both generic manifest facts and
     ///    Docker-specific facts).
-    /// 3. when nothing matches specifically, fall back to a single
+    /// 4. when nothing matches specifically, fall back to a single
     ///    content-kind-only match (the weakest, last-resort signal).
-    /// 4. when nothing matches at all, the input is `Skipped`, not `Failed`
+    /// 5. when nothing matches at all, the input is `Skipped`, not `Failed`
     ///    or `CompletedDegraded` — an unsupported item must not fail the job.
     ///
     /// Every result is sanitized before it leaves the registry: facts and
     /// graph-candidate evidence with an impossible/unordered source range are
     /// dropped and the result is degraded (see `validate::sanitize_result`).
     pub fn parse(&self, input: &ParseInput) -> ParseResult {
-        if let Some(requested) = requested_parser_id(input) {
-            return match self.select_by(|parser| parser.capability().parser_id == *requested) {
+        if let Some(requested) = input.requested_parser.as_deref() {
+            return match self.select_by(|parser| parser.capability().parser_id == requested) {
                 Some(parser) => sanitize_result(parser.parse(input)),
                 None => requested_parser_unavailable(input, requested),
             };
+        }
+
+        if let Some(parser) = self.hinted_parser(input) {
+            return sanitize_result(parser.parse(input));
         }
 
         let matches = self.ranked_matches(input);
@@ -72,12 +86,21 @@ impl ParserRegistry {
         for (_, parser) in &matches[1..] {
             merge_result(&mut merged, parser.parse(input));
         }
+        if let Some(hint) = input.document.parser_hints.first() {
+            merged
+                .warnings
+                .push(unregistered_hint_warning(input, &hint.parser_id));
+        }
         sanitize_result(merged)
     }
 
-    fn select_explicit(&self, input: &ParseInput) -> Option<Arc<dyn SourceParser>> {
-        let requested = requested_parser_id(input)?;
-        self.select_by(|parser| parser.capability().parser_id == *requested)
+    /// The parser named by the document's first `ParserHint`, when that hint
+    /// resolves to a registered parser. `None` covers both "no hint" and
+    /// "hint names an unregistered parser"; callers that must distinguish the
+    /// two check `input.document.parser_hints` themselves.
+    fn hinted_parser(&self, input: &ParseInput) -> Option<Arc<dyn SourceParser>> {
+        let hinted = input.document.parser_hints.first()?;
+        self.select_by(|parser| parser.capability().parser_id == hinted.parser_id)
     }
 
     fn select_by(
@@ -126,16 +149,6 @@ impl ParserRegistry {
             .map(|parser| vec![(0u8, parser.clone())])
             .unwrap_or_default()
     }
-}
-
-fn requested_parser_id(input: &ParseInput) -> Option<&String> {
-    input.requested_parser.as_ref().or_else(|| {
-        input
-            .document
-            .parser_hints
-            .first()
-            .map(|hint| &hint.parser_id)
-    })
 }
 
 /// Score a parser's specific (non-content-kind) identification signals per
@@ -195,6 +208,22 @@ fn unsupported_result(input: &ParseInput) -> ParseResult {
         parser_version: "0".to_string(),
         warnings: vec![warning],
         errors: Vec::new(),
+    }
+}
+
+/// Warning attached when a document's advisory `ParserHint` named a parser
+/// this registry does not know. The parse itself succeeded via content-based
+/// selection, so this is informational — unlike an explicit `requested_parser`
+/// miss, which degrades the result (see `requested_parser_unavailable`).
+fn unregistered_hint_warning(input: &ParseInput, parser_id: &str) -> SourceWarning {
+    SourceWarning {
+        code: "parse.parser_hint_unregistered".to_string(),
+        severity: Severity::Info,
+        message: format!(
+            "parser hint does not name a registered parser (used content-based selection): {parser_id}"
+        ),
+        source_item_key: Some(input.document.source_item_key.clone()),
+        retryable: false,
     }
 }
 

--- a/crates/axon-parse/src/registry.rs
+++ b/crates/axon-parse/src/registry.rs
@@ -25,12 +25,13 @@ impl ParserRegistry {
     /// Select the single "primary" parser for `input` — the caller-requested
     /// or hint-named parser when it resolves, else the best-scored specific
     /// match (MIME type, path/extension, or content sniffing), or, failing
-    /// that, the highest-priority content-kind-only match. Used for routing
-    /// decisions (e.g. `DocumentPreparer` chunk-profile selection) that need
-    /// exactly one parser identity, not the full fan-out `parse` may run.
+    /// that, the highest-priority content-kind-only match. This is a
+    /// one-parser probe sharing `parse`'s channel order; production chunk
+    /// routing consumes the parser identity `parse` returns, so this exists
+    /// for tests and tooling that need a selection without running a parse.
     pub fn select(&self, input: &ParseInput) -> Option<Arc<dyn SourceParser>> {
         if let Some(requested) = input.requested_parser.as_deref() {
-            return self.select_by(|parser| parser.capability().parser_id == requested);
+            return self.select_by_id(requested);
         }
         if let Some(hinted) = self.hinted_parser(input) {
             return Some(hinted);
@@ -46,11 +47,13 @@ impl ParserRegistry {
     /// 1. an explicit `requested_parser` runs alone — exclusive. A request for
     ///    an unregistered parser degrades without fallback: the caller demanded
     ///    one specific parser and nothing else may answer for it.
-    /// 2. a document `ParserHint` naming a registered parser also runs alone.
+    /// 2. a document `ParserHint` naming a registered parser also runs alone —
+    ///    exclusive like a request, suppressing the fan-out below. Only the
+    ///    document's first hint is consulted; later entries are ignored.
     ///    Hints are advisory metadata stamped by upstream stages, so a hint
     ///    naming an unregistered parser falls back to content-based selection
-    ///    below (recording an informational warning) instead of degrading
-    ///    every hinted document.
+    ///    below (recording an informational warning, on the unsupported path
+    ///    too) instead of degrading every hinted document.
     /// 3. otherwise every parser that specifically identifies the document
     ///    (MIME type, path/extension, or content sniffing) runs and their
     ///    facts/graph candidates/warnings/errors merge into one result, since
@@ -67,7 +70,7 @@ impl ParserRegistry {
     /// dropped and the result is degraded (see `validate::sanitize_result`).
     pub fn parse(&self, input: &ParseInput) -> ParseResult {
         if let Some(requested) = input.requested_parser.as_deref() {
-            return match self.select_by(|parser| parser.capability().parser_id == requested) {
+            return match self.select_by_id(requested) {
                 Some(parser) => sanitize_result(parser.parse(input)),
                 None => requested_parser_unavailable(input, requested),
             };
@@ -77,30 +80,44 @@ impl ParserRegistry {
             return sanitize_result(parser.parse(input));
         }
 
+        // Reaching this point with a hint present means it named an
+        // unregistered parser (a registered hint returned above). Record that
+        // on every fallback outcome — including the unsupported path — so the
+        // ignored hint stays observable.
+        let stale_hint_warning = input
+            .document
+            .parser_hints
+            .first()
+            .map(|hint| unregistered_hint_warning(input, &hint.parser_id));
+
         let matches = self.ranked_matches(input);
         if matches.is_empty() {
-            return unsupported_result(input);
+            let mut unsupported = unsupported_result(input);
+            unsupported.warnings.extend(stale_hint_warning);
+            return unsupported;
         }
 
         let mut merged = matches[0].1.parse(input);
         for (_, parser) in &matches[1..] {
             merge_result(&mut merged, parser.parse(input));
         }
-        if let Some(hint) = input.document.parser_hints.first() {
-            merged
-                .warnings
-                .push(unregistered_hint_warning(input, &hint.parser_id));
-        }
+        merged.warnings.extend(stale_hint_warning);
         sanitize_result(merged)
     }
 
     /// The parser named by the document's first `ParserHint`, when that hint
-    /// resolves to a registered parser. `None` covers both "no hint" and
-    /// "hint names an unregistered parser"; callers that must distinguish the
-    /// two check `input.document.parser_hints` themselves.
+    /// resolves to a registered parser. Only the first hint is consulted —
+    /// later entries are ignored regardless of registration status. `None`
+    /// covers both "no hint" and "hint names an unregistered parser"; callers
+    /// that must distinguish the two check `input.document.parser_hints`
+    /// themselves.
     fn hinted_parser(&self, input: &ParseInput) -> Option<Arc<dyn SourceParser>> {
         let hinted = input.document.parser_hints.first()?;
-        self.select_by(|parser| parser.capability().parser_id == hinted.parser_id)
+        self.select_by_id(&hinted.parser_id)
+    }
+
+    fn select_by_id(&self, parser_id: &str) -> Option<Arc<dyn SourceParser>> {
+        self.select_by(|parser| parser.capability().parser_id == parser_id)
     }
 
     fn select_by(
@@ -212,9 +229,11 @@ fn unsupported_result(input: &ParseInput) -> ParseResult {
 }
 
 /// Warning attached when a document's advisory `ParserHint` named a parser
-/// this registry does not know. The parse itself succeeded via content-based
+/// this registry does not know. The parse itself proceeded via content-based
 /// selection, so this is informational — unlike an explicit `requested_parser`
-/// miss, which degrades the result (see `requested_parser_unavailable`).
+/// miss, which degrades the result (see `requested_parser_unavailable`). The
+/// code and wording deliberately differ from `parse.requested_parser_unavailable`
+/// so alerts keyed on the strict channel never match advisory-hint fallbacks.
 fn unregistered_hint_warning(input: &ParseInput, parser_id: &str) -> SourceWarning {
     SourceWarning {
         code: "parse.parser_hint_unregistered".to_string(),

--- a/crates/axon-route/src/route_validation_tests.rs
+++ b/crates/axon-route/src/route_validation_tests.rs
@@ -152,7 +152,7 @@ fn router_carries_tool_execution_options_with_trusted_policy() {
 }
 
 #[test]
-fn router_uses_api_style_parser_ids_for_mcp_tools() {
+fn router_emits_no_default_parser_hints_for_mcp_tools() {
     let resolver = resolver();
     let router = SourceRouter::new(AdapterRegistry::target_defaults());
     let request = SourceRequest::new("mcp:context7/resolve-library-id");

--- a/crates/axon-route/src/router.rs
+++ b/crates/axon-route/src/router.rs
@@ -78,6 +78,10 @@ impl SourceRouter {
                 values: request.options.values.clone(),
             },
             chunking_hints: chunking_hints(adapter.source_kind),
+            // Pass through adapter-declared parser hints (every adapter
+            // declares none today). The route fabricates no defaults: a hint
+            // is exclusive per parsing-contract.md, and a per-source-kind
+            // guess cannot make a per-document parser decision.
             parser_hints: adapter.parser_hints.clone(),
             graph_fact_kinds: graph_fact_kinds(adapter.source_kind),
             watch_supported: adapter.watch_supported,

--- a/docs/development/adding-parser.md
+++ b/docs/development/adding-parser.md
@@ -92,27 +92,32 @@ below.
    advisory upstream metadata, not a caller demand: selection falls through
    to auto-selection below and the result records an informational
    `parse.parser_hint_unregistered` warning.
-3. Otherwise, run `select_best_match`: score every registered parser against
-   the input using `match_score`, which checks (in priority order, taking
-   the **maximum** matching score):
+3. Otherwise, run `ranked_matches`: **every** parser that specifically
+   identifies the document runs together (multi-parser fan-out; their facts,
+   graph candidates, warnings, and errors merge into one result). Specific
+   identification is scored per parser via `specific_score`, taking the
+   **maximum** matching signal:
 
    | Match | Score |
    |---|---|
-   | Path extension/suffix (`matches_path`) | 50 |
    | MIME type (`matches_mime_type`) | 40 |
-   | Content sniffing — text prefix match (`matches_sniffing`) | 30 |
-   | Content kind (`matches_content_kind`) | 10 |
+   | Path extension/suffix (`matches_path`) | 30 |
+   | Content sniffing — text prefix match (`matches_sniffing`) | 20 |
 
-   Ties on score are broken by lower `priority` value winning. A parser with
-   no match on any axis is excluded entirely (`match_score` returns `None`).
-4. If nothing matches, return an `unsupported_result` — a
-   `CompletedDegraded` result with a `parse.unsupported` warning and empty
-   facts/candidates, not an error. **Unsupported content must degrade
-   cleanly and never block ingestion.**
+   The best-scored match is the primary parser (its identity and header
+   win); ties break toward the lower `priority` value. Content kind
+   (`matches_content_kind`) is not a scored signal: only when no parser
+   matches specifically does the single highest-priority content-kind match
+   run alone, as the last resort — it never fans out.
+4. If nothing matches at all, return an `unsupported_result` — a `Skipped`
+   result with a `parse.unsupported` warning and empty facts/candidates, not
+   an error. **Unsupported content must degrade cleanly and never block
+   ingestion.**
 
-Design your `ParserCapability` to be specific: prefer `file_extensions`/
-`path_suffixes` over a bare `content_kinds` match when you can, since path
-matches score highest and are the least ambiguous signal.
+Design your `ParserCapability` to be specific: prefer `mime_types`/
+`file_extensions`/`path_suffixes` over a bare `content_kinds` match when you
+can — MIME type scores highest, and content kind is only the last-resort
+fallback.
 
 ## Step 3: Emit evidence-backed facts and graph candidates
 

--- a/docs/development/adding-parser.md
+++ b/docs/development/adding-parser.md
@@ -83,12 +83,16 @@ below.
 
 `ParserRegistry::parse(input)`:
 
-1. If the input requests an explicit parser (`ParseInput.requested_parser`,
-   falling back to the document's first `parser_hints` entry), look it up by
-   `parser_id`. If found, use it. If requested but not found, return a
-   `parse.requested_parser_unavailable` degraded result — never silently fall
-   through to auto-selection.
-2. Otherwise, run `select_best_match`: score every registered parser against
+1. If the caller demands an explicit parser (`ParseInput.requested_parser`),
+   look it up by `parser_id`. If found, it runs alone. If demanded but not
+   found, return a `parse.requested_parser_unavailable` degraded result —
+   never silently fall through to auto-selection.
+2. Otherwise, if the document's first `parser_hints` entry names a registered
+   parser, that parser runs alone. A hint naming an unregistered parser is
+   advisory upstream metadata, not a caller demand: selection falls through
+   to auto-selection below and the result records an informational
+   `parse.parser_hint_unregistered` warning.
+3. Otherwise, run `select_best_match`: score every registered parser against
    the input using `match_score`, which checks (in priority order, taking
    the **maximum** matching score):
 
@@ -101,7 +105,7 @@ below.
 
    Ties on score are broken by lower `priority` value winning. A parser with
    no match on any axis is excluded entirely (`match_score` returns `None`).
-3. If nothing matches, return an `unsupported_result` — a
+4. If nothing matches, return an `unsupported_result` — a
    `CompletedDegraded` result with a `parse.unsupported` warning and empty
    facts/candidates, not an error. **Unsupported content must degrade
    cleanly and never block ingestion.**

--- a/docs/pipeline-unification/sources/adapter-scopes.md
+++ b/docs/pipeline-unification/sources/adapter-scopes.md
@@ -102,7 +102,7 @@ Scope capability:
 | `accepts_uploads` | yes | Prepared uploads accepted. |
 | `output_item_kind` | yes | file/page/repo_file/package/transcript/etc. |
 | `option_schema` | yes | JSON schema for scope-specific options. |
-| `chunking_hints` | yes | Default chunk profile/parser hints. |
+| `chunking_hints` | yes | Default chunk profile. Parser hints are never defaulted per source kind; an adapter-declared parser hint must name a registered parser id (see parsing-contract.md). |
 | `required_graph_fact_kinds` | yes | Graph facts this scope must emit when the source contains the corresponding structures. |
 | `optional_graph_fact_kinds` | yes | Opportunistic graph facts this scope may emit without failing when absent. |
 | `degraded_modes` | yes | Allowed degraded behavior. |

--- a/docs/pipeline-unification/sources/parsing-contract.md
+++ b/docs/pipeline-unification/sources/parsing-contract.md
@@ -119,16 +119,22 @@ Parser selection order:
 
 1. explicit `requested_parser` — a caller demand. An unregistered id degrades
    the parse; it never falls through to auto-selection.
-2. a document `ParserHint` naming a registered parser. Hints are advisory
-   metadata stamped by upstream stages: a hint naming an unregistered parser
-   falls through to the signals below (recording an informational warning)
-   instead of degrading the document. Routes must not fabricate hints — a
-   hint is only valid when it names a registered parser id.
-3. adapter-declared parser support
-4. content kind
-5. MIME type
-6. path/extension
-7. lightweight content sniffing
+2. a document `ParserHint` naming a registered parser — runs alone, exclusive
+   like a request, suppressing the multi-parser fan-out below. Only the
+   document's first hint is consulted; later entries are ignored. Hints are
+   advisory metadata stamped by upstream stages (adapter capability
+   declarations passed through the route, enrichment): a hint naming an
+   unregistered parser falls through to the signals below, recording an
+   informational `parse.parser_hint_unregistered` warning even when nothing
+   below matches, instead of degrading the document. Routes must not
+   fabricate hints — a hint is only valid when it names a registered parser
+   id.
+3. specific identification — MIME type, path/extension, and lightweight
+   content sniffing (ranked in that order for the primary identity). Every
+   parser that specifically identifies the document runs, and their outputs
+   merge.
+4. content kind — the last-resort fallback; the single highest-priority
+   content-kind match runs alone.
 
 Multiple parsers may run when they emit different fact families. Example:
 `docker-compose.yaml` can use both YAML structure parsing and Docker-specific

--- a/docs/pipeline-unification/sources/parsing-contract.md
+++ b/docs/pipeline-unification/sources/parsing-contract.md
@@ -117,12 +117,18 @@ pub struct ParserCapability {
 
 Parser selection order:
 
-1. explicit `ParserHint`
-2. adapter-declared parser support
-3. content kind
-4. MIME type
-5. path/extension
-6. lightweight content sniffing
+1. explicit `requested_parser` — a caller demand. An unregistered id degrades
+   the parse; it never falls through to auto-selection.
+2. a document `ParserHint` naming a registered parser. Hints are advisory
+   metadata stamped by upstream stages: a hint naming an unregistered parser
+   falls through to the signals below (recording an informational warning)
+   instead of degrading the document. Routes must not fabricate hints — a
+   hint is only valid when it names a registered parser id.
+3. adapter-declared parser support
+4. content kind
+5. MIME type
+6. path/extension
+7. lightweight content sniffing
 
 Multiple parsers may run when they emit different fact families. Example:
 `docker-compose.yaml` can use both YAML structure parsing and Docker-specific


### PR DESCRIPTION
## Summary

Running `axon code.claude.com` (bare unified source command, web adapter, ~332 documents) printed **"Warning: requested parser is not registered: web" once per document** — hundreds of identical lines — and every document's parse silently degraded to zero facts and zero graph candidates.

Root cause: two defects compounding across a crate boundary, and the blast radius is **every source family, not just web**.

1. **`axon-route` fabricated parser hints.** `SourceRouter::route_with_policy` stamped every `RoutePlan` with one `ParserHint` whose `parser_id` was just the source-kind key (`web`, `local`, `git`, `registry`, `feed`, `reddit`, `youtube`, `session`, `cli_tool`, `mcp_tool`, `memory`, `upload`). None of those are registered parser ids (registered: `code_symbols`, `manifest`, `markdown_headings`, `api_schema`, `docker_manifest`, `env_example`, `session_jsonl`, `tool_output_jsonl`, `tool_schema`). Every adapter copies route hints onto its `SourceDocument`s.
2. **`axon-parse` treated the advisory hint as a hard demand.** `ParserRegistry::parse` resolved `requested_parser` *or* the document's first hint through one path: unknown id → `parse.requested_parser_unavailable`, `CompletedDegraded`, empty facts, **no fallback**. Combined with (1), fact extraction (`SourceParseFacts`, `GraphCandidate`, parser-driven chunk routing) was dead on the entire acquisition path.

## Changes

- **`axon-route/router.rs`** — stop emitting fabricated per-source-kind parser hints; `RoutePlan.parser_hints` is now empty, with a comment explaining why a per-source route cannot make a per-document parser decision. Removed the now-unused `parser_hints()`/`source_kind_key()` helpers. (The generated `docs/reference/sources/adapter-scopes.json` already models `parser_hints: []` — no regeneration needed.)
- **`axon-parse/registry.rs`** — split the two hint channels:
  - explicit `ParseInput.requested_parser` (caller demand) keeps strict behavior: unknown id still returns the degraded `parse.requested_parser_unavailable` result, no fallback;
  - an advisory document `ParserHint` naming an unregistered parser now **falls back to content-based selection** (MIME/path/sniffing/content-kind) and records an Info-severity `parse.parser_hint_unregistered` warning instead of degrading the document. `select()` mirrors the same order so chunk-profile routing follows the parser that actually ran.
- **`axon-cli/commands/source.rs`** — `render_source_result` groups identical warning messages and prints `Warning: <message> (xN)` instead of N lines (per-document warnings like the pre-chunk redaction notice repeat once per document). `--json` output keeps the full per-item list.
- **Docs** — `docs/pipeline-unification/sources/parsing-contract.md` and `docs/development/adding-parser.md` updated to the two-channel selection order.

## Tests (all new/updated tests pass)

- `axon-route/route_validation_tests.rs` — web/cli/mcp route plans emit no fabricated parser hints (regression comment documents the old failure mode).
- `axon-parse/parser_tests.rs` — unregistered document hint falls back to content selection with the Info warning (both `parse` and `select`); a registered document hint still runs exclusively; existing explicit-`requested_parser` strict-degradation tests unchanged and green.
- `axon-document/parse_tests.rs` — end-to-end regression for the reported scenario: a web markdown document carrying the old `ParserHint { parser_id: "web" }` parses via `markdown_headings` with facts flowing, not `parser_version: "unavailable"`.
- `axon-cli/commands/source_tests.rs` (new sidecar) — warning grouping preserves first-seen order and counts.

## Verification

Full stepwise gate (`just verify` recipes, isolated `AXON_DATA_DIR`/`AXON_CONFIG_PATH`) on this branch: `legacy-runtime-check`, `blocking-async-check`, `primitive-inventory-check`, `validate-plugin`, `web-check`, `fmt-check`, `check` — **all green**.

Three steps fail, and **all failures are pre-existing on the base branch head (9c360f40d)**, verified by running the identical checks/tests on the pristine base in the same environment:

- `clippy`: one error in `crates/axon-retrieval/src/citation.rs` (too-many-arguments) — present on base; base CI clippy job is also red.
- `machete`: `axon-services` (indicatif, spider) and `axon-cli` (rmcp) — present on base.
- `test` (`cargo nextest --workspace --no-fail-fast`): 56 failures on this branch vs 55 on pristine base running the same failing-test set; the sets are **identical** except `preflight_warns_when_required_child_dirs_are_missing`, which passes repeatedly in isolation on this branch — an order-dependent flake via the shared data dir (same non-hermeticity family as `run_search_rejects_empty_tavily_key`, tracked in bead axon_rust-29tql). This branch adds **zero** new failures; all 6 new tests pass.

Beads: axon_rust-cd146 (this fix) · axon_rust-29tql (non-hermetic tests) · axon_rust-gwcvy (main's path-filtered CI let non-compiling root tests + clippy-red axon-core land on main — why this PR targets the closeout wave instead of main).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes degraded parsing by removing fake per-source parser hints and making the parser fall back when a document hint is unregistered. The CLI now groups duplicate warnings with counts, labels Info/Debug as notes, and sanitizes output.

- **Bug Fixes**
  - `axon-route`: stop fabricating per-source-kind `ParserHint`s; pass through adapter-declared hints only (none today).
  - `axon-parse`: keep strict behavior for explicit `requested_parser`; use the first document hint only — if registered, run it exclusively; if unregistered, fall back to content-based selection and emit Info `parse.parser_hint_unregistered`, including on unsupported inputs.
  - `axon-cli`: group identical warnings as "Warning:/Note: <message> (xN)" with O(n) grouping, print Info/Debug as "Note:", and strip control characters; `--json` remains unchanged.

<sup>Written for commit b5922f0eca2443bf8b34e6345c0a11e85cf6a0a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

