### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-07-17-source-detach-default-and-memory-publication.md
+++ b/docs/sessions/2026-07-17-source-detach-default-and-memory-publication.md
@@ -1,0 +1,142 @@
+---
+date: 2026-07-17 21:30:36 EST
+repo: git@github.com:jmagar/axon.git
+branch: merge447
+head: a650d8ade
+session id: d9fba12b-3a60-4cd6-b3ab-0d03fc030fd2
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-axon/d9fba12b-3a60-4cd6-b3ab-0d03fc030fd2.jsonl
+working directory: /home/jmagar/workspace/axon
+pr: "#444 detached-by-default source command with automatic worker pickup (https://github.com/jmagar/axon/pull/444); #445 10 post-cutover live-smoke bugs (https://github.com/jmagar/axon/pull/445)"
+beads: axon_rust-x4gxr (created+closed), axon_rust-mijoc (closed), axon_rust-uvfcv (created), axon_rust-412ho (referenced)
+---
+
+# Source detached-by-default + memory publication root fix
+
+## User Request
+
+Started as a question — "when you `axon code.claude.com` isn't it async by default?" — after a live run of `axon code.claude.com` blocked in the foreground and indexed 332 documents inline. This surfaced a contract drift; the user then directed: make it "work how the docs say," with workers picking up detached jobs automatically ("the user should NOT have to manually start axon serve or use --wait"). Later: run a lavra multi-agent review of the resulting PR and address findings; then merge #444 and #445 on passing CI.
+
+## Session Overview
+
+- Confirmed `axon <source>` had drifted to inline/foreground execution, violating `docs/pipeline-unification/surfaces/command-contract.md` (which specifies detached-by-default, `--wait` opt-in).
+- Implemented detached-by-default source enqueue plus automatic worker pickup (PR #444, cli 7.1.0, merged as squash `79be18304`).
+- Ran a 6-agent lavra review of #444 (performance, architecture, simplicity, patterns, security, goal-verification); findings were addressed and merged with the PR.
+- While driving #445's CI green, diagnosed and fixed a real (not flaky) bug: memory records were durable in SQLite but never published to Qdrant because the fail-closed payload allowlist omitted 5 memory-family fields. Merged #445 (`dd25df251`).
+- Closed bead `axon_rust-mijoc` (the "no worker loop consumer" audit item that #444 resolves).
+
+## Sequence of Events
+
+1. Traced the CLI source path (`commands/source.rs` → `axon_services::index_source`) and confirmed it hard-wired `SourceExecutionContext::inline`, never consulting `cfg.wait` — foreground-always.
+2. Verified against pipeline-unification contracts that detached-by-default with a job descriptor was the specified behavior; the runtime job-contract snapshot already acknowledged the drift.
+3. Built the feature in a worktree from `origin/main`: detached enqueue, a cross-process SQLite drain lock, a standalone `axon jobs worker` drainer, and CLI auto-spawn of a worker when none holds the lock. Opened PR #444; CI went green; cli bumped to a new version.
+4. Spawned a separate task for the unrelated "requested parser is not registered: web" warning spam observed in the original run.
+5. Ran the lavra review; six reviewers returned findings (2 P1s + several P2/P3s), the most important being a cross-process drain-lock correctness bug (WAL vs rollback journal) and an auth-scope bypass. These were addressed before #444 merged.
+6. Turned to #445 (parallel work: 10 post-cutover live-smoke bugs). Its `mcp-smoke url_memory_remember` check failed; first assumed a flake, then proved it deterministic and root-caused it to the payload allowlist.
+7. Fixed the allowlist, regenerated schema/docs artifacts, verified memory now publishes, integrated with the parallel session's complementary tolerance fix, and merged #445.
+8. Verified both PRs on main; closed the resolved bead; cleaned up temporary worktrees.
+
+## Key Findings
+
+- **Contract drift:** `crates/axon-cli/src/commands/source.rs` ran `index_source` inline for `Source`; `command-contract.md` specifies `"wait": false` default and "Without `--wait`, async work returns immediately with a job descriptor." `--wait` was effectively a no-op on the bare source command.
+- **Drain-lock WAL hazard (load-bearing, from review):** the lock DB must use rollback journal (`journal_mode=DELETE`). Under sqlx's default WAL, a read-only `BEGIN EXCLUSIVE` does not take a cross-process lock, so multiple workers all "acquire" it and spawn-dedup silently breaks. In-process two-connection tests pass under WAL and hide this — proven only by a real subprocess test (`tests/worker_drain_lock_cross_process.rs`).
+- **Memory never published to Qdrant:** `crates/axon-vectors/src/payload_families.rs` (fail-closed `VECTOR_SOURCE_FAMILY_FIELDS`) omitted `memory_acquire`, `memory_decay_profile`, `memory_embedding_ref_count`, `memory_link_count`, `memory_normalize` — fields the memory adapter emits. One unknown key rejects the whole point, so memory was durable in SQLite but absent from the vector store. Masked for a long time by an earlier FK-ordering failure that aborted before payload validation; #445's non-web FK fix newly exposed it.
+- **Auth scope (from review):** `AuthSnapshot::trusted_cli` set `AuthMode::TrustedLocal`, which `snapshot_allows_scope` treated as authorized for every scope — its exclusion of `Execute`/`Admin` was decorative. Addressed by having `snapshot_allows_scope` withhold Execute/Admin from TrustedLocal unless explicitly granted.
+
+## Technical Decisions
+
+- **Cross-process coordination via a dedicated SQLite lock**, not a pidfile/TTL lease: `BEGIN EXCLUSIVE` on a rollback-journal DB is kernel-released on any exit (including SIGKILL), crash-safe, and cross-platform with no new dependency. It is advisory (spawn-dedup only) — job-claim correctness stays on the unified store's transactional claim, so racing drainers merely split the queue.
+- **Lock before context:** `axon jobs worker` takes the drain lock before building the worker-bearing `ServiceContext`, so a losing invocation exits in milliseconds having claimed nothing (avoids duplicate-spawn storms and claimed-then-orphaned jobs on large DBs).
+- **Root fix over symptom tolerance:** kept the payload-allowlist fix (memory actually publishes) alongside the parallel session's tolerance fix (memory action survives an inline failure). They touch different files and are complementary.
+
+## Files Changed
+
+Authored across two merged PRs (worktrees since removed). Representative, not exhaustive.
+
+| status | path | purpose |
+|---|---|---|
+| created | `crates/axon-cli/src/commands/source/detach.rs` | detached enqueue + auto-spawn worker (#444) |
+| created | `crates/axon-cli/src/commands/jobs/worker.rs` | standalone `axon jobs worker` drainer (#444) |
+| created | `crates/axon-services/src/jobs/worker_loop.rs` | idle-exiting worker loop + recover sweep (#444) |
+| created | `crates/axon-services/src/runtime/drain_lock.rs` | cross-process SQLite drain lock (#444) |
+| created | `tests/worker_drain_lock_cross_process.rs` | subprocess exclusion regression test (#444, review) |
+| modified | `crates/axon-cli/src/commands/source.rs` | `should_detach`, queued-descriptor render (#444) |
+| modified | `crates/axon-api/src/source/auth.rs` | `AuthSnapshot::trusted_cli` (#444) |
+| modified | `crates/axon-services/src/source/authorize.rs` | withhold Execute/Admin from TrustedLocal (#444, review) |
+| modified | `crates/axon-core/src/config/**` | `jobs.auto-worker`, `jobs.worker-idle-exit-secs` plumbing (#444) |
+| modified | `crates/axon-vectors/src/payload_families.rs` | allowlist 5 memory-family payload fields (#445) |
+| modified | `docs/reference/sources/vector-payload.{md,schema.json}` | regenerated payload schema (#445) |
+| modified | `docs/pipeline-unification/{surfaces/command-contract.md,runtime/job-contract.md}` | document detached default + `jobs worker` (#444) |
+| created | `docs/sessions/2026-07-17-source-detach-default-and-memory-publication.md` | this session log |
+
+## Beads Activity
+
+| id | title | action | status | why |
+|---|---|---|---|---|
+| axon_rust-x4gxr | CLI source command must detach by default per command contract | created, claimed, closed | CLOSED | The #444 tracking bead; closed on merge. |
+| axon_rust-mijoc | P10 new jobs table has no worker loop consumer; fire-and-forget pends forever | closed | CLOSED | #444 delivered the exact worker-loop consumer + drainer + auto-spawn it describes. |
+| axon_rust-uvfcv | Fix red help-coverage test on main (scrape missing from COMMAND_SECTIONS) | created | OPEN | Pre-existing red test discovered while baselining; also flagged as a task chip. |
+| axon_rust-412ho | Flaky: unified_worker_claims_and_runs_multiple_jobs_concurrently | referenced | OPEN | Pre-existing flaky test (`retries=0`) that repeatedly blocked merges; cleared on rerun. |
+
+## Repository Maintenance
+
+- **Plans:** No plan files were created or completed this session; none moved to `docs/plans/complete/`. The injected active plan (`android-phase2-stubbed-modes.md`) is unrelated.
+- **Beads:** Closed `axon_rust-x4gxr` and `axon_rust-mijoc` (both resolved by #444); created `axon_rust-uvfcv`; pushed via `bd dolt push`.
+- **Worktrees/branches:** Removed the temporary `.worktrees/pr445` worktree and `pr445-check` branch after #445 merged (evidence: merge `dd25df251`). Left `.worktrees/source-detach-default` in place — its HEAD `7f44a7827` is NOT an ancestor of `origin/main` (`git merge-base --is-ancestor` → false; #444 landed as a squash), and it holds the review-fix follow-up, so safe cleanup is not proven. Other `.worktrees/frfr-*` and `release-v7` worktrees are unrelated and untouched.
+- **Stale docs:** Updated `command-contract.md` and `job-contract.md` within #444 to match the new detached behavior; regenerated the vector-payload schema docs within #445. No further stale docs identified.
+- **Transparency:** All maintenance actions above are evidence-backed; the one deliberate no-op (leaving the source-detach-default worktree) is documented with the ancestry check.
+
+## Tools and Skills Used
+
+- **Shell/git/gh:** branch/worktree management, commits, pushes, PR merges, CI inspection (`gh run view --log`, `gh pr checks`). Notable friction: `gh run rerun --failed` refused while the workflow was still in progress; had to wait for completion.
+- **Build/test:** `cargo check/test/clippy`, `cargo run -p xtask` for schema/docs regeneration and version bump; monolith + lefthook pre-push gates.
+- **Skills:** `vibin:gh-fix-ci` (invoked for #445 CI), `vibin:save-to-md` (this log).
+- **Subagents:** six lavra review agents (performance, architecture, simplicity, patterns, security, goal-verification) run as background tasks.
+- **Monitors/background tasks:** Bash `run_in_background` for pushes/builds; Monitor for CI gate resolution. Two initial judgment calls were wrong and later corrected with evidence (see Errors).
+- **Memory:** wrote/updated notes for the detach behavior, the fail-closed payload allowlist, and main's latent red tests.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `axon <local> --skip-embed` (detached smoke) | `Source Queued <job>` + auto-spawned worker; job reached `completed` with no `axon serve` |
+| `axon memory://<id> --wait true` (post-fix) | `Source Indexed ... Vector points: 1` — memory now publishes |
+| `cargo run -p xtask -- schemas generate --check` / `docs generate --check` | clean after regeneration |
+| `gh pr merge 444 --squash` / `gh pr merge 445 --squash` | both MERGED (`79be18304`, `dd25df251`) |
+| `git merge-base --is-ancestor 7f44a7827 origin/main` | false (worktree left in place) |
+
+## Errors Encountered
+
+- **Misjudged the memory failure as a flake:** initially re-ran `mcp-smoke` assuming `url_memory_remember` was flaky like 444's failures. It was deterministic; corrected by reproducing it and root-causing the payload allowlist gap.
+- **Misjudged 445 as "actively developed" (racing me):** paused on stale in-progress CI data and asked the user. The user pushed back; evidence proved the branch had gone quiet ~50 min earlier and the parallel session had already fixed the clippy/docs issues, leaving it green and `CLEAN`. Merged it.
+- **Push rejected (non-fast-forward):** the parallel session advanced the 445 branch mid-work; re-fetched and integrated their commits (my root fix was preserved as an ancestor).
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| `axon <source>` (no `--wait`) | blocks foreground until fully indexed | enqueues a durable job, prints a descriptor, returns; a worker is auto-started if none is running |
+| worker availability | detached jobs pend forever without a manual `axon serve` | CLI auto-spawns `axon jobs worker`; `axon jobs worker` also usable standalone |
+| memory indexing | records durable in SQLite but never published to Qdrant | records published to Qdrant (searchable) |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| detached local source smoke | queued + auto-worker completes it | `completed`, no manual serve | pass |
+| `axon memory://<id> --wait true` | memory publishes | `Vector points: 1` | pass |
+| `gh pr checks 445` (final) | required gates green | ci-gate/codeql/compose/mcp-smoke pass | pass |
+| both merges on main | 444 + 445 present | drain_lock.rs + payload fix on main | pass |
+
+## Risks and Rollback
+
+- The drain lock is advisory; job correctness never depends on it, so a lock misbehavior degrades to redundant workers, not lost/duplicated jobs. Rollback path for either PR is a standard revert of the squash commit (`79be18304` / `dd25df251`).
+
+## Open Questions
+
+- `.worktrees/source-detach-default` retains post-merge review-fix commits not in main's ancestry (squash). Confirm whether any of that work is unlanded before removing the worktree.
+
+## Next Steps
+
+- **Not started (your call):** `axon_rust-uvfcv` — add `scrape` to `COMMAND_SECTIONS` in `crates/axon-core/src/config/help.rs` and assess the batch-flaky config parse tests; `axon_rust-412ho` — give the flaky concurrency test a retry budget; the architecture-review follow-up on non-`source_request` `request_json` provenance (`axon_rust-n72pa`).
+- **Running elsewhere:** the parser-warning-spam fix task.
+- **Untouched by design:** release-please PRs (#438/#439/#440) and the 298-closeout branch (#447).


### PR DESCRIPTION
Session log for the source detached-by-default (#444) + memory-publication root fix (#445) work. Docs only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a session log documenting the “source detached-by-default” change and the memory publication allowlist root fix, including context, decisions, and verification. Improves traceability and keeps docs aligned with the command contract and vector payload schema.

<sup>Written for commit 311eb1d87166467ab3339a46e95051cb57a4108d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/axon/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

