### PR TITLE
docs(openwiki): fix broken relative links in domain-concepts

### DIFF
--- a/openwiki/domain-concepts.md
+++ b/openwiki/domain-concepts.md
@@ -60,7 +60,7 @@ The action docs model moved to a unified `source` interpretation for removed sou
 
 ## Next-linking for related concepts
 
-- [src/main.rs](../architecture/overview.md#runtime-and-error-handling-concept)
-- [Workflow gates](../workflows.md)
-- [Action parity matrix](../../docs/reference/api-parity.md)
-- [Action index](../../docs/reference/actions/README.md)
+- [src/main.rs](architecture/overview.md#runtime-behavior-impact)
+- [Workflow gates](workflows.md)
+- [Action parity matrix](../docs/reference/api-parity.md)
+- [Action index](../docs/reference/actions/README.md)


### PR DESCRIPTION
Fixes the `schema-contract-sync` gate failure that has blocked **every** PR since #460 merged.

`xtask docs check` reported 4 broken links, all in `openwiki/domain-concepts.md` — the OpenWiki generator emitted paths one level too deep for a file at the `openwiki/` root, plus a non-existent anchor:

| before | after |
|---|---|
| `../architecture/overview.md#runtime-and-error-handling-concept` | `architecture/overview.md#runtime-behavior-impact` |
| `../workflows.md` | `workflows.md` |
| `../../docs/reference/api-parity.md` | `../docs/reference/api-parity.md` |
| `../../docs/reference/actions/README.md` | `../docs/reference/actions/README.md` |

The anchor was also wrong — `overview.md`'s real heading is `## Runtime behavior impact`.

Verified in a clean tree: `check-doc-links (repo-wide): 497 markdown file(s), no broken relative links`.

Note: this is generator output, so OpenWiki may reintroduce it on its next refresh — worth a follow-up on the generator's relative-path handling if it recurs.