### PR TITLE
docs: save pipeline Task 2A session log

### DIFF
--- a/docs/sessions/2026-07-26-pipeline-unification-task-2a.md
+++ b/docs/sessions/2026-07-26-pipeline-unification-task-2a.md
@@ -1,0 +1,258 @@
+---
+date: 2026-07-26 02:04:32 EDT
+repo: git@github.com:jmagar/axon.git
+branch: session-log/2026-07-26-pipeline-task2a
+head: 08346839d42aaad5f18f243235735fe84eb8724b
+plan: docs/superpowers/plans/2026-07-25-pipeline-unification-completion.md
+working directory: /home/jmagar/workspace/axon
+worktree: /home/jmagar/workspace/axon/.worktrees/codex-pipeline-wave-a-layering
+pr: 471, test(xtask): enforce live pipeline layering, https://github.com/dinglebear-ai/axon/pull/471
+beads: axon_rust-jc20j, axon_rust-jc20j.1 through axon_rust-jc20j.33
+---
+
+# Pipeline unification completion: Task 2A
+
+## User Request
+
+Recover the prior Axon pipeline-unification work, confirm the repository state,
+align the remaining plan with `docs/pipeline-unification/`, land all preserved
+work safely on `main`, and then use Work-it to execute the reviewed completion
+plan without disturbing the long-lived no-MCP marketplace branch.
+
+## Session Overview
+
+The session reconstructed the unfinished pipeline-unification program, reviewed
+and hardened its execution plan, normalized the repository to the protected
+`main` plus `marketplace-no-mcp` topology, and began implementation with Task
+2A. Draft PR #471 now replaces the stale layering checks with a fail-closed,
+Rust-aware gate over the live 23-crate workspace. Thirty-three review findings
+were tracked as child beads, fixed, verified, and closed. The parent bead remains
+open because Tasks 2B and 2C still remove exact temporary debt and require
+merged-main verification.
+
+## Sequence of Events
+
+1. Reconstructed the latest Axon work and durable pipeline-unification state,
+   including the 28 landed and 28 remaining findings.
+2. Audited the live checkout, remote state, worktrees, merged PRs, release tag,
+   and the intentionally retained `marketplace-no-mcp` branch.
+3. Reviewed the completion plan as an engineering artifact and updated it to
+   stay consistent with `docs/pipeline-unification/` contracts.
+4. Started Work-it Task 2A in
+   `.worktrees/codex-pipeline-wave-a-layering` from merged `origin/main`.
+5. Opened draft PR #471 and implemented the live layering and crate-inventory
+   gates with a recorded red baseline.
+6. Repeated independent Lavra architecture/simplicity reviews and the mandatory
+   seven PR-review passes in apply-fixes mode.
+7. Converted every actionable review finding into a child bead, fixed it,
+   reran focused and full verification, pushed evidence, and repeated until the
+   final bounded reviews returned PASS.
+8. Marked PR #471 ready after the final review disposition was published.
+
+## Key Findings
+
+- The old layering gate used deleted-crate prefixes and missed live transport,
+  provider, Cargo-alias, module-reachability, and dataflow violations.
+- A structural scan must fail closed on unreadable trees/files, malformed Rust
+  or TOML, missing crate roots, unresolved workspace dependencies, and stale or
+  drifting exception rows.
+- Provider receiver tracking required lexical alias resolution, exact provider
+  shapes, control-flow joins, loop stabilization, Rust 2024 let-chain scopes,
+  optional closure/async/short-circuit effects, and result-shape caching before
+  branch-local scopes close.
+- Temporary debt is now an exact ledger keyed by path, rule, owner bead,
+  occurrence count, and dependency table where applicable. The final live
+  baseline introduced no unowned or count-drifting exception.
+- `bindings.rs` exceeded the 500-line production limit during review and was
+  split into the modern sibling module
+  `syntax/bindings/expressions.rs`; no `mod.rs` was introduced.
+
+## Technical Decisions
+
+- Used `syn` traversal instead of text matching so comments and string literals
+  remain data while grouped, multiline, renamed, UFCS, macro-token, and scoped
+  Rust constructs are inspected structurally.
+- Kept straight-line assignment as strong replacement, but merged possible
+  states at real branches and used conservative monotone stabilization inside
+  loops.
+- Truncated findings from exploratory loop passes and retained one final
+  stabilized scan, preserving exact occurrence counts.
+- Scoped custom interprocedural helper-return inference and macro-specific
+  local grammars out of this lexical gate; Task 6 owns the sealed provider
+  facade that becomes the compile-time boundary.
+- Kept `axon_rust-jc20j` open until Tasks 2B and 2C land and the complete bead
+  is verified on merged `main`.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `Cargo.lock` | — | Record the direct xtask `proc-macro2` dependency | PR #471 |
+| modified | `docs/architecture/dependency-layering.md` | — | Document the live gate, exact debt ledger, and flow semantics | PR #471 |
+| modified | `xtask/Cargo.toml` | — | Enable `syn::visit` and direct token support | PR #471 |
+| modified | `xtask/src/checks/crate_contracts.rs` | — | Reconcile contracts, workspace membership, and disk inventory | PR #471 |
+| modified | `xtask/src/checks/crate_contracts_spec.rs` | — | Define the exact live crate contract set | PR #471 |
+| modified | `xtask/src/checks/crate_contracts_spec_cont.rs` | — | Continue the exact contract table below the monolith cap | PR #471 |
+| modified | `xtask/src/checks/crate_contracts_tests.rs` | — | Add inventory divergence and duplicate-row fixtures | 15/15 pass |
+| modified | `xtask/src/checks/layering.rs` | — | Replace the stale gate with fail-closed live traversal | PR #471 |
+| created | `xtask/src/checks/layering/exception_table.rs` | — | Store exact owned reach and manifest debt | Live gate pass |
+| created | `xtask/src/checks/layering/exceptions.rs` | — | Validate owners, tables, counts, duplicates, and stale debt | Live gate pass |
+| created | `xtask/src/checks/layering/syntax.rs` | — | Own the structural scanner and lexical traversal | 436 lines |
+| created | `xtask/src/checks/layering/syntax/aliases.rs` | — | Resolve scoped aliases to a fixed point | Focused fixtures |
+| created | `xtask/src/checks/layering/syntax/bindings.rs` | — | Track provider bindings and shapes | 364 lines |
+| created | `xtask/src/checks/layering/syntax/bindings/expressions.rs` | — | Classify provider expressions and receiver chains | 183 lines |
+| created | `xtask/src/checks/layering/syntax/cfg.rs` | — | Identify structurally test-only Rust items | Focused fixtures |
+| created | `xtask/src/checks/layering/syntax/flow.rs` | — | Model branch, loop, let-chain, and match state | 240 lines |
+| created | `xtask/src/checks/layering/syntax/modules.rs` | — | Traverse production/test module reachability from crate roots | Focused fixtures |
+| created | `xtask/src/checks/layering/syntax/providers.rs` | — | Define provider traits, handles, methods, and roots | Focused fixtures |
+| created | `xtask/src/checks/layering/syntax/tokens.rs` | — | Inspect macro token bodies without metadata false positives | Focused fixtures |
+| modified | `xtask/src/checks/layering_tests.rs` | — | Add 62 adversarial positive and negative fixtures | 62/62 pass |
+
+## Beads Activity
+
+- `axon_rust-jc20j` was claimed and remains `in_progress`; it owns Task 2A
+  through 2C closure and merged-main verification.
+- `axon_rust-jc20j.1` through `.33` were created for concrete review findings,
+  implemented, verified, commented, and closed.
+- The child set covered structural parsing, exact exceptions, live inventory,
+  provider methods/types/handles, macros, aliases, Cargo tables and inheritance,
+  test-module ancestry, control-flow/dataflow, result shapes, wrapper chains,
+  Rust 2024 let-chains, file-size cleanup, and final match-pattern caching.
+- `axon_rust-nl7au` remains the owner for Task 6 provider-facade debt.
+- `axon_rust-drahp` remains the owner for web-engine/pipeline collapse debt.
+- `bd dolt push` succeeded after every closure batch.
+
+## Repository Maintenance
+
+- Plans: the completion plan is active and was not moved to a completed folder.
+- Beads: every observed Task 2A review finding has a closed child bead; the
+  parent remains open for explicit remaining acceptance work.
+- Worktrees: protected `main`, `marketplace-no-mcp`, and the unrelated active
+  `feat/young-office-local-source-containment` worktree were preserved. The
+  Task 2A worktree remains active until PR #471 merges.
+- Branches: no active, dirty, unmerged, protected, or unclear branch was
+  deleted.
+- Stale docs: the dependency-layering architecture reference was updated in
+  PR #471. Broader pipeline contract and delivery-document reconciliation
+  remains scheduled in later plan tasks.
+- No destructive cleanup was performed.
+
+## Tools and Skills Used
+
+- Shell and Git: checkout/worktree inspection, diffs, commits, pushes, remote
+  ancestry, file-size checks, and safe branch/worktree management.
+- GitHub CLI: PR creation, metadata, comments, readiness, checks, branch
+  protection, and review evidence.
+- Beads CLI: claim, create, close, comment, inspect, and Dolt synchronization.
+- Cortex/session archaeology: recovered the preceding Axon work and remaining
+  review/deployment context.
+- `vibin:repo-status`, `vibin:work-it`, `vibin:worktree-setup`,
+  `vibin:review-pr`, `vibin:merge-status`, `vibin:quick-push`, and
+  `vibin:save-to-md`: repository orientation, isolated implementation,
+  mandatory review, closeout, and session documentation.
+- `lavra:lavra-eng-review`, `lavra:lavra-review`, and
+  `superpowers:writing-plans`/`executing-plans`: plan hardening, independent
+  architecture/simplicity review, and execution sequencing.
+- Dedicated implementation and independent review agents: implementation
+  ownership plus repeated architecture and simplicity checks.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `git status --short --branch` / `git worktree list --porcelain` | Protected and task worktrees identified; unrelated state preserved |
+| `cargo test -p xtask layering --no-fail-fast` | 62/62 passed |
+| focused crate-contract test filter | 15/15 passed |
+| `cargo clippy -p xtask --all-targets --locked -- -D warnings` | Passed |
+| `cargo xtask check-layering` | Passed with exact debt counts and zero drift |
+| `cargo xtask check-crate-contracts` | Passed for the exact 23 live crates |
+| `just precommit` | 4,711/4,711 passed; 6 skipped |
+| `bd dolt push` | Passed after review closure batches |
+| `gh pr ready 471` | PR marked ready after review completion |
+
+## Errors Encountered
+
+- The soldr/zccache-backed Cargo path repeatedly waited on a shared build lock.
+  Owned blocked commands were terminated and rerun with `SOLDR_BYPASS=1`,
+  `CARGO_TIMINGS=0`, and isolated `CARGO_TARGET_DIR` paths.
+- An early broad receiver-classification prototype created ten live false
+  positives around ordinary `Result`/`Option` chains. The implementation was
+  narrowed to recognized provider constructors, wrappers, dereferences, and
+  indexed provider-bearing values.
+- Two attempts to publish the seven-pass PR comment passed an empty shell
+  variable to `gh`; exporting the scoped variable before the command resolved
+  the issue. No repository state was changed by the failed attempts.
+- Review waves intentionally failed until concrete control-flow and lexical
+  bypasses were fixed; each was tracked and rerun rather than waived.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Layering scan | Text-oriented stale deleted-crate checks | Fail-closed `syn` traversal over live transport/service code |
+| Exceptions | Broad or stale allowance behavior | Exact path/rule/owner/count/table debt ledger |
+| Workspace contracts | Incomplete static inventory | Exact 23-crate disk/workspace/contract reconciliation |
+| Provider calls | Alias, wrapper, macro, and dataflow bypasses | Structural provider path, receiver, handle, UFCS, and macro enforcement |
+| Module scope | Filename heuristics and incomplete test ancestry | Root-driven transitive production/test reachability |
+| Cargo dependencies | Missed renamed, target, and inherited aliases | Canonical package resolution across all dependency-table shapes |
+| Failure behavior | Some scan/parse failures skipped | Relevant I/O, parse, root, ownership, and drift failures reject the gate |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| focused layering suite | All adversarial fixtures pass | 62/62 passed | pass |
+| focused crate-contract suite | Inventory fixtures pass | 15/15 passed | pass |
+| xtask clippy | No warnings | Clean with `-D warnings` | pass |
+| live layering gate | Exact owned debt only | Passed; zero count/ledger drift | pass |
+| live crate-contract gate | Exactly 23 live crates | Passed | pass |
+| `just precommit` | Structural, fmt, clippy, check, tests green | 4,711 passed; 6 skipped | pass |
+| pre-commit and pre-push hooks | Structural policies green | Passed | pass |
+| final Lavra architecture review | No bounded actionable regression | PASS on `4a028e0d4` | pass |
+| final Lavra simplicity review | Finite, balanced, non-duplicating flow model | PASS | pass |
+
+## Risks and Rollback
+
+- The analyzer is intentionally conservative around optional execution and
+  loops; false positives must be resolved through better structural modeling,
+  not wider exceptions.
+- Custom helper-return inference is outside Task 2A. The permanent reduction in
+  risk comes from Task 6 removing raw provider access behind a sealed facade.
+- Rollback is the PR merge revert. No database, runtime configuration, release
+  version, deployment, or live service was changed by Task 2A.
+
+## Decisions Not Taken
+
+- Did not merge or delete `marketplace-no-mcp`; it is an intentional long-lived
+  variant.
+- Did not close `axon_rust-jc20j` before Tasks 2B/2C and merged-main evidence.
+- Did not widen the exception table to silence new findings.
+- Did not attempt compiler-complete interprocedural analysis inside xtask.
+- Did not touch or merge the unrelated Young Office local-containment PR.
+
+## References
+
+- `docs/superpowers/plans/2026-07-25-pipeline-unification-completion.md`
+- `docs/pipeline-unification/`
+- `docs/architecture/dependency-layering.md`
+- https://github.com/dinglebear-ai/axon/pull/471
+- https://github.com/dinglebear-ai/axon/pull/471#issuecomment-5082295181
+
+## Open Questions
+
+- PR #471 still requires final hosted CI and merge-status approval.
+- Task 2B must move the pure screenshot filename helper into `axon-core`.
+- Task 2C must move chat provider construction behind the typed service facade
+  and preserve disconnect cancellation.
+- The independent v7.2 deployment baseline remains a separate operational
+  workstream.
+
+## Next Steps
+
+1. Land this session log independently on `main`.
+2. Rebase PR #471 onto the resulting `origin/main`, rerun required checks, and
+   execute the merge-status final gate.
+3. Merge #471, verify the targeted gates on merged `main`, and remove its
+   worktree/branch only after ancestry and cleanliness are proven.
+4. Start Task 2B from the newly merged `origin/main` in a fresh worktree and
+   draft PR, preserving the same review and verification protocol.


### PR DESCRIPTION
## Summary

- preserve the complete Task 2A implementation and review handoff
- record verification evidence, bead disposition, and remaining Task 2B/2C work

## Verification

- docs-only change under `docs/sessions/**`
- verified commit contains exactly one session-log file
- broad Rust hooks intentionally skipped per the repository Verification Scope Guard