### PR TITLE
build: repoint lab-auth git dep to dinglebear-ai/labby

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ license = "MIT"
 # build graph. sqlx-sqlite 0.8 pins libsqlite3-sys = "0.30.1", so using
 # rusqlite 0.32 here resolves to the same libsqlite3-sys version and eliminates
 # the conflict.
-[patch."https://github.com/jmagar/lab.git"]
+[patch."https://github.com/dinglebear-ai/labby.git"]
 lab-auth = { path = "vendor/lab-auth" }
 
 [package]

--- a/crates/axon-authz/Cargo.toml
+++ b/crates/axon-authz/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1"
 axon-api = { path = "../axon-api" }
 axon-error = { path = "../axon-error" }
 axum = { version = "0.8", features = ["ws"] }
-lab-auth = { git = "https://github.com/jmagar/lab.git", rev = "87cec3241f9baef22335de9cc8629ebbcd8ba047", package = "lab-auth" }
+lab-auth = { git = "https://github.com/dinglebear-ai/labby.git", rev = "87cec3241f9baef22335de9cc8629ebbcd8ba047", package = "lab-auth" }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/axon-mcp/Cargo.toml
+++ b/crates/axon-mcp/Cargo.toml
@@ -43,7 +43,7 @@ rmcp = { version = "1.7.0", features = [
   "schemars",
   "elicitation",
 ] }
-lab-auth = { git = "https://github.com/jmagar/lab.git", rev = "87cec3241f9baef22335de9cc8629ebbcd8ba047", package = "lab-auth" }
+lab-auth = { git = "https://github.com/dinglebear-ai/labby.git", rev = "87cec3241f9baef22335de9cc8629ebbcd8ba047", package = "lab-auth" }
 url = "2"
 
 [lints.rust]

--- a/crates/axon-web/Cargo.toml
+++ b/crates/axon-web/Cargo.toml
@@ -44,7 +44,7 @@ utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-axum = "0.2"
 utoipa-swagger-ui = { version = "9", features = ["axum", "debug-embed"] }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
-lab-auth = { git = "https://github.com/jmagar/lab.git", rev = "87cec3241f9baef22335de9cc8629ebbcd8ba047", package = "lab-auth" }
+lab-auth = { git = "https://github.com/dinglebear-ai/labby.git", rev = "87cec3241f9baef22335de9cc8629ebbcd8ba047", package = "lab-auth" }
 url = "2"
 libc = "0.2"
 mime_guess = "2"


### PR DESCRIPTION
The `lab-auth` dependency and its `[patch]` override both pointed at
`https://github.com/jmagar/lab.git` — a repo name that no longer exists and
resolved only via GitHub's transfer redirect. Relying on that redirect is fragile:
it can be broken by the original owner recreating the name, and it fails outright
in environments that do not follow redirects. This repoints both to the canonical
`https://github.com/dinglebear-ai/labby.git` at the **same pinned rev**
(`87cec3241f9baef22335de9cc8629ebbcd8ba047`).

### Why all four files move together

The `[patch."<url>"]` key in the root `Cargo.toml` must match the URL used in the
member-crate dependency declarations **exactly** — cargo matches the patch to the
source by URL string. If they disagree, the patch silently stops applying and
cargo resolves `lab-auth` from git instead of the vendored copy at
`vendor/lab-auth`. No error, just a different dependency. So the change is
atomic across:

- `Cargo.toml` — the `[patch."..."]` section key
- `crates/axon-authz/Cargo.toml`
- `crates/axon-mcp/Cargo.toml`
- `crates/axon-web/Cargo.toml`

Verified post-edit that the patch key and all three declarations resolve to the
single identical URL.

### Scope

Pure one-line URL swap in four files — 4 insertions, 4 deletions, no other
changes. **`Cargo.lock` is unchanged**, because the patch resolves `lab-auth` to
a path dependency on the vendored copy; the git URL never reaches the lockfile.
No version, rev, or feature changes.