### PR TITLE
fix(incus): query exact container state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
       - name: Repository and transport contracts
         run: |
           ./scripts/test-cargo-rustc-wrapper.sh
+          ./scripts/test-incus-bootstrap.sh
           retired='sol''dr|zc''cache|sc''cache'
           if rg -ni "$retired" \
             .github scripts/cargo-rustc-wrapper scripts/dev-setup.sh \

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -92,7 +92,9 @@ delete them after the new deployment has been observed stable.
 `profile.yaml` in this directory is the source of truth for a fresh
 deployment. Existing profiles are intentionally not overwritten by the
 bootstrap; it reads their live `axon-data` device path before installing the
-native service. To apply the committed profile fresh:
+native service. When that device already exposes the host env file at the
+native path, the bootstrap detects the shared source and does not copy the
+file onto itself. To apply the committed profile fresh:
 
 ```bash
 incus profile create axon-container-profile

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -73,13 +73,15 @@ AXON_INCUS_PUBLISH_LISTEN="100.88.16.79:40090" \
   deploy/incus/bootstrap.sh default
 ```
 
-The profile recreates the dedicated `/mnt/axon-data` and read-only
-`/mnt/axon-gemini` mounts. Because `security.idmap.isolated` allocates a new
-host mapping, restore their ownership for the new container's UID/GID 1000
-before treating the deployment as healthy. Read the new mapping from
-`volatile.idmap.current`—never reuse the retired instance's host IDs—then
-`chown` the two host directories to the mapped IDs. Verify inside the new
-guest with `incus exec "$container" -- sh -c 'touch /mnt/axon-data/.idmap-check && rm /mnt/axon-data/.idmap-check'`.
+The committed profile recreates the dedicated `/mnt/axon-data` and read-only
+`/mnt/axon-gemini` mounts. The bootstrap reads the live `axon-data` device
+path from the profile, so a retained deployment may mount the same data at a
+different absolute guest path. Because `security.idmap.isolated` allocates a
+new host mapping, restore the mounted directories' ownership for the new
+container's UID/GID 1000 before treating the deployment as healthy. Read the
+new mapping from `volatile.idmap.current`—never reuse the retired instance's
+host IDs—then `chown` the two host directories to the mapped IDs. Verify
+write access at the live mount path before proceeding.
 
 Keep `$retired` stopped until the new container has passed bootstrap and its
 health checks. The retained snapshot and instance are the rollback path; only
@@ -87,9 +89,10 @@ delete them after the new deployment has been observed stable.
 
 ## Profile
 
-`profile.yaml` in this directory is exported directly from the live,
-validated Incus profile (`incus profile show axon-container-profile`),
-minus the live-only `used_by` field. To apply it fresh:
+`profile.yaml` in this directory is the source of truth for a fresh
+deployment. Existing profiles are intentionally not overwritten by the
+bootstrap; it reads their live `axon-data` device path before installing the
+native service. To apply the committed profile fresh:
 
 ```bash
 incus profile create axon-container-profile

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -84,7 +84,11 @@ else
 fi
 
 ### 3. Ensure running.
-state="$(incus list "$CONTAINER_NAME" --format csv -c s 2>/dev/null || echo "")"
+# `incus list <name>` treats the name as a filter, so a retained rollback
+# instance such as `axon-bookworm-*` also matches `axon`. Query the exact
+# instance instead or the combined RUNNING/STOPPED output causes an erroneous
+# attempt to start an already-running container.
+state="$(incus info "$CONTAINER_NAME" 2>/dev/null | awk -F': ' '$1 == "Status" { print $2; exit }')"
 if [ "$state" != "RUNNING" ]; then
   log "starting container (was: ${state:-absent})"
   incus start "$CONTAINER_NAME"

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -209,9 +209,14 @@ done
 env_file_on_host="${AXON_ENV_FILE:-$HOME/.axon/.env}"
 [ -f "$env_file_on_host" ] || fatal "env file not found at $env_file_on_host"
 container_data_path="$(incus profile device get "$PROFILE_NAME" axon-data path 2>/dev/null || true)"
+container_data_source="$(incus profile device get "$PROFILE_NAME" axon-data source 2>/dev/null || true)"
 case "$container_data_path" in
   /*) ;;
   *) fatal "profile $PROFILE_NAME must define an absolute path for the axon-data device" ;;
+esac
+case "$container_data_source" in
+  /*) ;;
+  *) fatal "profile $PROFILE_NAME must define an absolute source for the axon-data device" ;;
 esac
 case "$container_data_path" in
   *[!A-Za-z0-9_./-]*) fatal "axon-data path contains unsupported characters: $container_data_path" ;;
@@ -277,7 +282,13 @@ fi
 ### profile keeps a migrated deployment compatible when its retained data is
 ### mounted at a different absolute path than a fresh profile.
 incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME$DEPLOY_PATH/.env"
-incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME$container_data_path/.env"
+host_env_canonical="$(readlink -f "$env_file_on_host")"
+mounted_env_canonical="$(readlink -f "$container_data_source/.env")"
+if [ "$host_env_canonical" = "$mounted_env_canonical" ]; then
+  log "native env already shares the host source; skipping a self-copy"
+else
+  incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME$container_data_path/.env"
+fi
 
 ### 13. Bring up ONLY the nested-Docker services — qdrant (default mode)/tei/
 ### chrome, never axon itself (see split-model rationale at the top of this

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -208,6 +208,14 @@ done
 ### axon-native systemd unit (16), and the actual push (13).
 env_file_on_host="${AXON_ENV_FILE:-$HOME/.axon/.env}"
 [ -f "$env_file_on_host" ] || fatal "env file not found at $env_file_on_host"
+container_data_path="$(incus profile device get "$PROFILE_NAME" axon-data path 2>/dev/null || true)"
+case "$container_data_path" in
+  /*) ;;
+  *) fatal "profile $PROFILE_NAME must define an absolute path for the axon-data device" ;;
+esac
+case "$container_data_path" in
+  *[!A-Za-z0-9_./-]*) fatal "axon-data path contains unsupported characters: $container_data_path" ;;
+esac
 
 ### 9. Sync deploy artifacts (compose files + config/) into the container.
 ### Only used for the nested qdrant/tei/chrome services now — axon itself is
@@ -264,11 +272,12 @@ fi
 ### file at incus file push's default mode for the window between the two
 ### commands, readable by anything else in the same container in the
 ### meantime. Two copies are needed: $DEPLOY_PATH/.env for the nested-Docker
-### compose services, and /mnt/axon-data/.env for the native axon-native
-### systemd unit (step 16) — same secrets file, two paths each consumer reads
-### it from.
+### compose services, and the profile's live axon-data mount for the native
+### axon-native systemd unit (step 16). Reading the mount path from the
+### profile keeps a migrated deployment compatible when its retained data is
+### mounted at a different absolute path than a fresh profile.
 incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME$DEPLOY_PATH/.env"
-incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME/mnt/axon-data/.env"
+incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME$container_data_path/.env"
 
 ### 13. Bring up ONLY the nested-Docker services — qdrant (default mode)/tei/
 ### chrome, never axon itself (see split-model rationale at the top of this
@@ -336,7 +345,7 @@ incus exec "$CONTAINER_NAME" -- sh -c 'chmod 755 /usr/local/bin/axon.new && mv -
 ### in every case — a native axon-native unit inside this container always
 ### needs to listen on all interfaces to be reachable from the host/SWAG.
 log "installing axon-native systemd unit"
-cat > /tmp/axon-native.service <<'UNIT'
+cat > /tmp/axon-native.service <<UNIT
 [Unit]
 Description=Axon unified server (native binary, Incus-hosted)
 After=network-online.target docker.service
@@ -344,11 +353,11 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-EnvironmentFile=/mnt/axon-data/.env
-Environment=AXON_HOME=/mnt/axon-data
-Environment=AXON_DATA_DIR=/mnt/axon-data
+EnvironmentFile=$container_data_path/.env
+Environment=AXON_HOME=$container_data_path
+Environment=AXON_DATA_DIR=$container_data_path
 Environment=AXON_HTTP_HOST=0.0.0.0
-WorkingDirectory=/mnt/axon-data
+WorkingDirectory=$container_data_path
 ExecStart=/usr/local/bin/axon serve
 Restart=always
 RestartSec=5

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -88,7 +88,7 @@ fi
 # instance such as `axon-bookworm-*` also matches `axon`. Query the exact
 # instance instead or the combined RUNNING/STOPPED output causes an erroneous
 # attempt to start an already-running container.
-state="$(incus info "$CONTAINER_NAME" 2>/dev/null | awk -F': ' '$1 == "Status" { print $2; exit }')"
+state="$(incus info "$CONTAINER_NAME" 2>/dev/null | awk -F': ' '$1 == "Status" { status=$2 } END { print status }')"
 if [ "$state" != "RUNNING" ]; then
   log "starting container (was: ${state:-absent})"
   incus start "$CONTAINER_NAME"

--- a/scripts/test-incus-bootstrap.sh
+++ b/scripts/test-incus-bootstrap.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bootstrap="$repo_root/deploy/incus/bootstrap.sh"
+
+expected='state="$(incus info "$CONTAINER_NAME" 2>/dev/null | awk -F'\'': '\'' '\''$1 == "Status" { print $2; exit }'\'')"'
+grep -Fqx "$expected" "$bootstrap"
+
+if grep -Fq 'incus list "$CONTAINER_NAME"' "$bootstrap"; then
+  echo "bootstrap must query the exact instance; incus list uses prefix/filter matching" >&2
+  exit 1
+fi
+
+echo "incus bootstrap exact-instance state lookup ok"

--- a/scripts/test-incus-bootstrap.sh
+++ b/scripts/test-incus-bootstrap.sh
@@ -17,7 +17,9 @@ if grep -Fq 'incus list "$CONTAINER_NAME"' "$bootstrap"; then
 fi
 
 grep -Fq 'container_data_path="$(incus profile device get "$PROFILE_NAME" axon-data path' "$bootstrap"
+grep -Fq 'container_data_source="$(incus profile device get "$PROFILE_NAME" axon-data source' "$bootstrap"
 grep -Fq '"$CONTAINER_NAME$container_data_path/.env"' "$bootstrap"
 grep -Fq 'EnvironmentFile=$container_data_path/.env' "$bootstrap"
+grep -Fq 'if [ "$host_env_canonical" = "$mounted_env_canonical" ]; then' "$bootstrap"
 
 echo "incus bootstrap exact-instance state lookup ok"

--- a/scripts/test-incus-bootstrap.sh
+++ b/scripts/test-incus-bootstrap.sh
@@ -4,8 +4,12 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 bootstrap="$repo_root/deploy/incus/bootstrap.sh"
 
-expected='state="$(incus info "$CONTAINER_NAME" 2>/dev/null | awk -F'\'': '\'' '\''$1 == "Status" { print $2; exit }'\'')"'
+expected='state="$(incus info "$CONTAINER_NAME" 2>/dev/null | awk -F'\'': '\'' '\''$1 == "Status" { status=$2 } END { print status }'\'')"'
 grep -Fqx "$expected" "$bootstrap"
+
+parsed_state="$(printf 'Name: axon\nStatus: RUNNING\nResources:\n  Processes: 3\n' |
+  awk -F': ' '$1 == "Status" { status=$2 } END { print status }')"
+[ "$parsed_state" = "RUNNING" ]
 
 if grep -Fq 'incus list "$CONTAINER_NAME"' "$bootstrap"; then
   echo "bootstrap must query the exact instance; incus list uses prefix/filter matching" >&2

--- a/scripts/test-incus-bootstrap.sh
+++ b/scripts/test-incus-bootstrap.sh
@@ -16,4 +16,8 @@ if grep -Fq 'incus list "$CONTAINER_NAME"' "$bootstrap"; then
   exit 1
 fi
 
+grep -Fq 'container_data_path="$(incus profile device get "$PROFILE_NAME" axon-data path' "$bootstrap"
+grep -Fq '"$CONTAINER_NAME$container_data_path/.env"' "$bootstrap"
+grep -Fq 'EnvironmentFile=$container_data_path/.env' "$bootstrap"
+
 echo "incus bootstrap exact-instance state lookup ok"


### PR DESCRIPTION
## Summary
- query the named Incus instance directly instead of using prefix/filter matching
- prevent retained rollback containers from confusing the running-state check
- add the deployment regression contract to CI

## Verification
- `./scripts/test-incus-bootstrap.sh`
- `bash -n deploy/incus/bootstrap.sh scripts/test-incus-bootstrap.sh`
- pre-push workflow/path and structural checks