### PR TITLE
ci: align Axon workflows with fleet policy

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,10 +1,10 @@
 # Custom runner labels for this repo's self-hosted runners.
 #
 # actionlint validates `runs-on:` against its built-in label list and fails on
-# anything it does not recognise. The self-hosted runners introduced in #456
-# use a `unraid` label (see .github/workflows/compose-smoke.yml and
-# docker-image.yml), which is not a GitHub-hosted label, so it must be declared
-# here or `cargo xtask workflow-lint` fails for every workflow-touching change.
+# anything it does not recognise. Fleet pool labels are scheduling routes and
+# must be declared here so workflow-lint understands the repository contract.
 self-hosted-runner:
   labels:
-    - unraid
+    - ci-pool-ops
+    - ci-pool-rust
+    - ci-pool-typescript

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -7,10 +7,8 @@ name: android-release
 # Builds the release APK, signs it (zipalign + apksigner), checksums it, and
 # publishes a GitHub Release with the APK + SHA256 attached.
 #
-# Manual workflow_dispatch builds + signs the APK and uploads it to the run as
-# an artifact for inspection, but does NOT create a Release unless explicitly
-# called with publish=true on an android-v* tag. release-please.yml dispatches
-# this workflow after release-please creates the GitHub Release.
+# The heavy build starts only from a published android-v* GitHub Release and
+# checks out that immutable tag on a hosted x86_64 runner.
 #
 # ---------------------------------------------------------------------------
 # Required configuration (Settings → Secrets and variables → Actions)
@@ -31,12 +29,8 @@ name: android-release
 # (`owner/name`); the workflow checks it out and points the build at it via
 # AXON_AURORA_ANDROID_PATH. Optionally set AURORA_REF for a pinned branch/tag.
 on:
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: "Attach artifacts to an existing release-please android-v* release"
-        type: boolean
-        default: false
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -48,20 +42,23 @@ env:
 jobs:
   build:
     name: build android apk
-    runs-on: [self-hosted, unraid]
+    if: ${{ startsWith(github.event.release.tag_name, 'android-v') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     # Only this job publishes release artifacts; scope contents: write here rather than
     # granting it workflow-wide to every step (build/sign included).
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
+          ref: ${{ github.event.release.tag_name }}
           persist-credentials: false
 
       # Aurora composite checkout (see header). Lands a sibling checkout
       # alongside the repo and exports its android/ path for Gradle.
       - name: Checkout Aurora design system
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           persist-credentials: false
           repository: ${{ env.AURORA_REPO }}
@@ -75,12 +72,12 @@ jobs:
         run: echo "AXON_AURORA_ANDROID_PATH=$GITHUB_WORKSPACE/.aurora-design-system/android" >> "$GITHUB_ENV"
 
       - name: Set up pnpm for Aurora token generation
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10.33.2
 
       - name: Set up Node for Aurora token generation
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: "lts/*"
           cache: pnpm
@@ -91,16 +88,16 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 
       - name: Resolve and validate version
         id: version
@@ -116,8 +113,9 @@ jobs:
 
           # On release-please dispatch, the tag version must match versionName
           # so a release can never ship an APK the tag disagrees with.
-          if [[ "${GITHUB_REF}" == refs/tags/android-v* ]]; then
-            tag_version="${GITHUB_REF#refs/tags/android-v}"
+          tag="${{ github.event.release.tag_name }}"
+          if [[ "$tag" == android-v* ]]; then
+            tag_version="${tag#android-v}"
             if [[ "$tag_version" != "$version" ]]; then
               echo "::error::tag android-v$tag_version does not match versionName $version — bump $gradle before tagging" >&2
               exit 1
@@ -136,11 +134,7 @@ jobs:
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           PUBLISH_REQUESTED: >-
-            ${{
-              startsWith(github.ref, 'refs/tags/android-v') &&
-              github.event_name == 'workflow_dispatch' &&
-              inputs.publish
-            }}
+            ${{ startsWith(github.event.release.tag_name, 'android-v') }}
         run: |
           set -euo pipefail
           version="${{ steps.version.outputs.version }}"
@@ -202,7 +196,7 @@ jobs:
           echo "apk=$out" >> "$GITHUB_OUTPUT"
           echo "signed=$signed" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-android
           path: |
@@ -211,19 +205,15 @@ jobs:
           if-no-files-found: error
 
       - name: Attach artifacts to release
-        # Attach artifacts only when release-please dispatches this workflow on
-        # an existing android-v* release tag.
-        if: >-
-          startsWith(github.ref, 'refs/tags/android-v') &&
-          github.event_name == 'workflow_dispatch' &&
-          inputs.publish
+        # Attach artifacts only to the published release that triggered this
+        # run.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           APK_PATH: ${{ steps.package.outputs.apk }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${{ github.event.release.tag_name }}"
           gh release view "$tag" >/dev/null
           gh release upload "$tag" \
             "$APK_PATH" \

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -2,30 +2,32 @@ name: auto-tag
 
 # Selective, per-component auto-release detector.
 #
-# On every push to main this asks `cargo xtask check-release-versions` for the
-# shared release plan. Component metadata lives in `release/components.toml`.
+# After the `CI` workflow succeeds on main this asks
+# `cargo xtask check-release-versions` for the shared release plan. Component
+# metadata lives in `release/components.toml`.
 #
 # For each component, it diffs the component's shipping paths against that
 # component's most recent tag. If the code changed AND the version was bumped
-# (the computed tag does not exist), it waits for CI to pass on this commit,
-# creates the tag, and dispatches the component's release workflow. A component
+# (the computed tag does not exist), it creates the tag and publishes the
+# component GitHub Release. The resulting release.published event is the sole
+# trigger for heavy artifact workflows. A component
 # whose code did NOT change since its last tag is skipped — so a CLI-only change
 # never rebuilds android, and an android-only change never cuts a CLI release.
 #
 # RELEASE GATES (OPS-M1): before a tag is created we (1) verify the new version
 # is a strictly-monotonic bump over that component's highest existing tag, and
-# (2) wait for the entire `CI` workflow to succeed for
-# this exact commit. This prevents an accidental version edit or a red CI from
-# auto-publishing a broken public release.
+# (2) run only after the entire `CI` workflow succeeded for this exact commit.
+# This prevents an accidental version edit or a red CI from auto-publishing a
+# broken public release without occupying a runner while CI is still pending.
 #
 # BUMP ENFORCEMENT: if a component's code changed but its version was NOT bumped
 # (the computed tag already exists), the component's job FAILS with a message
 # naming the component — nothing ships silently. `fail-fast: false` keeps the
 # other components releasing independently; the red job flags the missing bump.
 #
-# NOTE: tags pushed via GITHUB_TOKEN do NOT trigger other workflows (GitHub
-# security model). We therefore dispatch each release workflow explicitly via
-# the API after creating its tag — no PAT required.
+# NOTE: GitHub suppresses workflow events created by GITHUB_TOKEN. The release
+# is therefore published with RELEASE_PLEASE_TOKEN so release.published reaches
+# the heavy artifact workflows.
 #
 # Version bumping rules (from CLAUDE.md): bump ONLY the component you changed.
 #   feat!: / BREAKING CHANGE → major (X+1.0.0)
@@ -33,19 +35,20 @@ name: auto-tag
 #   everything else           → patch (X.Y.Z+1)
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
 
 permissions:
   contents: write   # required to create and push component release tags
-  actions: write   # required to dispatch the release workflows
 
 # Serialize runs for the same ref so two rapid merges to main cannot race on
 # creating/pushing the same component tag (which would fail one run's `git
 # push`). cancel-in-progress: false lets an in-flight release finish tagging
 # rather than being cancelled by the next push.
 concurrency:
-  group: auto-tag-${{ github.ref }}
+  group: auto-tag-main
   cancel-in-progress: false
 
 env:
@@ -55,14 +58,17 @@ env:
 
 jobs:
   plan:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 20
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-rust-kache
@@ -83,58 +89,16 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.matrix != '{"include":[]}' }}
     name: ${{ matrix.id }}
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
-
-      # CI gate: do not cut a public release until the required CI checks for
-      # this exact commit have succeeded. auto-tag and CI both fire on the same
-      # push, so CI may still be in progress when this runs — hence the poll.
-      - name: Wait for CI to pass on this commit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          sha="${{ github.sha }}"
-          deadline=$(( $(date +%s) + 1800 ))  # 30 minute cap
-          echo "Waiting for CI to succeed for $sha ..."
-          while :; do
-            gh_stderr="$(mktemp)"
-            if ! runs_json=$(gh run list \
-              --workflow=ci.yml \
-              --commit "$sha" \
-              --branch main \
-              --event push \
-              --json databaseId,status,conclusion,headSha,event,headBranch 2>"$gh_stderr"); then
-              echo "::error::gh run list failed while polling ci.yml for $sha" >&2
-              cat "$gh_stderr" >&2
-              exit 1
-            fi
-            run_json=$(jq -c --arg sha "$sha" \
-              '[.[] | select(.headSha == $sha and .event == "push" and .headBranch == "main")][0] // null' \
-              <<<"${runs_json:-[]}")
-            conclusion=$(jq -r '.conclusion // ""' <<<"${run_json:-null}")
-            status=$(jq -r '.status // ""' <<<"${run_json:-null}")
-            if [ "$conclusion" = "success" ]; then
-              echo "CI succeeded for $sha — proceeding to tag."
-              break
-            fi
-            if [ "$conclusion" = "failure" ] || [ "$conclusion" = "cancelled" ] || [ "$conclusion" = "timed_out" ]; then
-              echo "::error::CI concluded '$conclusion' for $sha — refusing to cut a release." >&2
-              exit 1
-            fi
-            if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::timed out waiting for CI to finish for $sha." >&2
-              exit 1
-            fi
-            echo "CI status='${status:-unknown}' conclusion='${conclusion:-pending}'; sleeping 20s ..."
-            sleep 20
-          done
 
       - name: Create and push tag
         run: |
@@ -144,7 +108,15 @@ jobs:
           git push origin "${{ matrix.candidate_tag }}"
           echo "Pushed tag ${{ matrix.candidate_tag }}"
 
-      - name: Dispatch release workflow
+      # Publishing the GitHub Release is the only heavy-work trigger. The
+      # component workflow selects its tag from release.published.
+      - name: Publish component release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run "${{ matrix.release_workflow }}" --ref "${{ matrix.candidate_tag }}" -f publish=true
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          gh release create "${{ matrix.candidate_tag }}" \
+            --verify-tag \
+            --generate-notes \
+            --title "${{ matrix.candidate_tag }}"

--- a/.github/workflows/chrome-extension-release.yml
+++ b/.github/workflows/chrome-extension-release.yml
@@ -7,17 +7,11 @@ name: chrome-extension-release
 # Builds the distributable zip (real files, no symlinks), checksums it, and
 # publishes a GitHub Release with the zip + SHA256 attached.
 #
-# Manual workflow_dispatch builds the zip and uploads it to the run as an
-# artifact for inspection, but does NOT create a Release unless explicitly
-# called with publish=true on a chrome-ext-v* tag. release-please.yml dispatches
-# this workflow after release-please creates the GitHub Release.
+# Packaging starts only from a published chrome-ext-v* GitHub Release and
+# checks out that immutable tag on a hosted x86_64 runner.
 on:
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: "Attach artifacts to an existing release-please chrome-ext-v* release"
-        type: boolean
-        default: false
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -25,11 +19,16 @@ permissions:
 jobs:
   build:
     name: package chrome extension
-    runs-on: [self-hosted, unraid]
+    if: ${{ startsWith(github.event.release.tag_name, 'chrome-ext-v') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: write  # required to upload release artifacts
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
 
       - name: Build extension zip
         id: build
@@ -45,8 +44,9 @@ jobs:
 
           # On release-please dispatch, the tag version must match the manifest
           # version so a release can never ship a zip the tag disagrees with.
-          if [[ "${GITHUB_REF}" == refs/tags/chrome-ext-v* ]]; then
-            tag_version="${GITHUB_REF#refs/tags/chrome-ext-v}"
+          tag="${{ github.event.release.tag_name }}"
+          if [[ "$tag" == chrome-ext-v* ]]; then
+            tag_version="${tag#chrome-ext-v}"
             if [[ "$tag_version" != "$version" ]]; then
               echo "::error::tag chrome-ext-v$tag_version does not match manifest version $version — bump $manifest before tagging" >&2
               exit 1
@@ -62,7 +62,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "zip=$dist/$name" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon
           path: |
@@ -71,19 +71,15 @@ jobs:
           if-no-files-found: error
 
       - name: Attach artifacts to release
-        # Attach artifacts only when release-please dispatches this workflow on
-        # an existing chrome-ext-v* release tag.
-        if: >-
-          startsWith(github.ref, 'refs/tags/chrome-ext-v') &&
-          github.event_name == 'workflow_dispatch' &&
-          inputs.publish
+        # Attach artifacts only to the published release that triggered this
+        # run.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           ZIP_PATH: ${{ steps.build.outputs.zip }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${{ github.event.release.tag_name }}"
           gh release view "$tag" >/dev/null
           gh release upload "$tag" \
             "$ZIP_PATH" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,16 +47,16 @@ env:
 jobs:
   fleet-policy:
     name: Fleet workflow policy
-    uses: dinglebear-ai/workflows/.github/workflows/fleet-policy.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-policy.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       release-file-regex: '(^|/)(release|android-release|chrome-extension-release|palette-release|docker-image)\.ya?ml$'
 
   fleet-contract:
     name: Fleet repository contract
-    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       profile: rust
-      implementation-ref: 542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+      implementation-ref: 66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
 
   changes:
     name: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,7 +533,7 @@ jobs:
     runs-on: [self-hosted, ci-pool-rust]
     timeout-minutes: 30
     needs: [changes, rust-contracts]
-    if: ${{ github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true') }}
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true' }}
     env:
       TEI_URL: http://127.0.0.1:52000
       QDRANT_URL: http://127.0.0.1:53333
@@ -832,8 +832,8 @@ jobs:
   mcp-smoke:
     name: mcp-smoke
     runs-on: [self-hosted, ci-pool-rust]
-    needs: [changes, release]
-    if: ${{ needs.release.result == 'success' && (needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rust == 'true') && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
+    needs: [changes, smoke-binary]
+    if: ${{ needs.smoke-binary.result == 'success' && (needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rust == 'true') && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
@@ -899,10 +899,10 @@ jobs:
           echo "AXON_ALLOW_FALLBACK_WEB_ASSETS=1" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
-          name: axon-release-linux-smoke
-          path: target/release
-      - name: Prepare release binary
-        run: chmod +x ./target/release/axon
+          name: axon-debug-linux-smoke
+          path: target/debug
+      - name: Prepare debug binary
+        run: chmod +x ./target/debug/axon
 
       - name: Write CI mcporter config
         run: |
@@ -981,7 +981,7 @@ jobs:
           AXON_LOG_DIR: .cache/axon-ci/logs
           AXON_SQLITE_PATH: .cache/axon-ci/jobs.db
         run: |
-          ./target/release/axon mcp --transport http &
+          ./target/debug/axon mcp --transport http &
           echo $! > /tmp/axon-mcp.pid
           for _ in {1..30}; do
             if nc -z 127.0.0.1 8001 2>/dev/null; then
@@ -1014,44 +1014,6 @@ jobs:
           docker rm -f axon-tei || true
           docker compose --env-file "$HOME/.axon/.env" -f docker-compose.prod.yaml down || true
 
-  release:
-    name: release
-    runs-on: [self-hosted, ci-pool-rust]
-    timeout-minutes: 60
-    needs: [changes, rust-contracts, web-panel]
-    if: ${{ always() && needs.rust-contracts.result == 'success' && needs.web-panel.result == 'success' && ((github.event_name != 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.release == 'true')) || (github.event_name == 'pull_request' && (needs.changes.outputs.release == 'true' || contains(github.event.pull_request.labels.*.name, 'ci:full')))) }}
-    steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
-      - uses: ./.github/actions/setup-rust-kache
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
-        with:
-          name: axon-web-assets
-          path: apps/web/out
-      - name: cargo build release axon
-        run: cargo build --release --locked --bin axon
-      - name: Upload release smoke binary
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: axon-release-linux-smoke
-          path: target/release/axon
-          if-no-files-found: error
-
-  release-smoke:
-    name: release-smoke
-    runs-on: [self-hosted, ci-pool-rust]
-    timeout-minutes: 10
-    needs: [changes, release]
-    if: ${{ needs.release.result == 'success' }}
-    steps:
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
-        with:
-          name: axon-release-linux-smoke
-          path: target/release
-      - name: smoke test release binary help output
-        run: |
-          chmod +x ./target/release/axon
-          ./target/release/axon --help
-
   ci-gate:
     name: ci-gate
     runs-on: [self-hosted, ci-pool-ops]
@@ -1078,8 +1040,6 @@ jobs:
       - mcp-smoke
       - rag-changes
       - live-rag-pr
-      - release
-      - release-smoke
     steps:
       - name: verify required jobs passed or were intentionally skipped
         run: |
@@ -1120,8 +1080,6 @@ jobs:
           require_success_or_intentional_skip clippy "${{ needs.clippy.result }}" "${{ needs.changes.outputs.rust }}"
           require_success_or_intentional_skip test "${{ needs.test.result }}" "${{ needs.changes.outputs.rust }}"
           require_success_or_intentional_skip security "${{ needs.security.result }}" "${{ needs.changes.outputs.security }}"
-          require_success_or_intentional_skip mcp-smoke "${{ needs.mcp-smoke.result }}" "${{ needs.release.result == 'success' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true') && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) }}"
+          require_success_or_intentional_skip mcp-smoke "${{ needs.mcp-smoke.result }}" "${{ needs.smoke-binary.result == 'success' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true') && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) }}"
           require_success_or_intentional_skip rag-changes "${{ needs.rag-changes.result }}" "${{ github.event_name == 'pull_request' }}"
           require_success_or_intentional_skip live-rag-pr "${{ needs.live-rag-pr.result }}" "${{ github.event_name == 'pull_request' && needs.rag-changes.outputs.rag == 'true' }}"
-          require_success_or_intentional_skip release "${{ needs.release.result }}" "${{ (github.event_name != 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.release == 'true')) || (github.event_name == 'pull_request' && (needs.changes.outputs.release == 'true' || contains(github.event.pull_request.labels.*.name, 'ci:full'))) }}"
-          require_success_or_intentional_skip release-smoke "${{ needs.release-smoke.result }}" "${{ needs.release.result == 'success' }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,23 @@ env:
   AURORA_REF: ${{ vars.AURORA_REF || '8748eb6434b3bbe4c75f25bfff71950b7efc051b' }}
 
 jobs:
+  fleet-policy:
+    name: Fleet workflow policy
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-policy.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    with:
+      release-file-regex: '(^|/)(release|android-release|chrome-extension-release|palette-release|docker-image)\.ya?ml$'
+
+  fleet-contract:
+    name: Fleet repository contract
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    with:
+      profile: rust
+      implementation-ref: 542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+
   changes:
     name: changes
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     outputs:
       all: ${{ steps.classify.outputs.all }}
       docs: ${{ steps.classify.outputs.docs }}
@@ -65,7 +79,7 @@ jobs:
       version_files: ${{ steps.classify.outputs.version_files }}
       openapi: ${{ steps.classify.outputs.openapi }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
       - name: Prepare trusted changed path classifier
@@ -111,22 +125,23 @@ jobs:
   # and transport contracts before starting the expensive clippy/test fanout.
   rust-contracts:
     name: rust-contracts
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 40
     needs: [changes]
     if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.openapi == 'true' || needs.changes.outputs.workflow == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.version_files == 'true' || needs.changes.outputs.release == 'true' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-rust-kache
         with:
           components: rustfmt
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 11.3.0
       - name: create web assets placeholder
@@ -224,26 +239,28 @@ jobs:
 
   aurora-primitive-inventory:
     name: aurora-primitive-inventory
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     needs: [changes]
     if: ${{ needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.docs == 'true' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Check Aurora primitive inventory guard
         run: python3 scripts/check_aurora_primitive_inventory.py
 
   android:
     name: android
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-typescript]
+    timeout-minutes: 45
     needs: [changes]
     if: ${{ needs.changes.outputs.android == 'true' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           persist-credentials: false
 
       - name: Checkout Aurora design system
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           persist-credentials: false
           repository: ${{ env.AURORA_REPO }}
@@ -255,12 +272,12 @@ jobs:
         run: echo "AXON_AURORA_ANDROID_PATH=$GITHUB_WORKSPACE/.aurora-design-system/android" >> "$GITHUB_ENV"
 
       - name: Set up pnpm for Aurora token generation
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10.33.2
 
       - name: Set up Node for Aurora token generation
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: "lts/*"
           cache: pnpm
@@ -271,16 +288,16 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
         with:
           # The Gradle build uses the hosted runner SDK; installing the legacy
           # `tools` package pulls the emulator and has failed on corrupt
@@ -311,7 +328,7 @@ jobs:
         run: test -s bin/axon-android-release.apk
 
       - name: Upload Android APK artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-android-apks
           path: |
@@ -321,11 +338,12 @@ jobs:
 
   toml-fmt:
     name: toml-fmt
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     needs: [changes]
     if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true' || needs.changes.outputs.release == 'true' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d
         with:
           install_args: cargo:taplo-cli
@@ -343,25 +361,27 @@ jobs:
 
   lefthook-pre-commit-speed:
     name: lefthook pre-commit speed guard
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     needs: [changes]
     if: ${{ needs.changes.outputs.workflow == 'true' || needs.changes.outputs.rust == 'true' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: enforce pre-commit stays fast
         run: python3 scripts/check_lefthook_pre_commit_speed.py
 
   palette-tauri:
     name: palette-tauri
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 45
     needs: [changes]
     if: ${{ needs.changes.outputs.palette == 'true' }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 11.3.0
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
           cache: pnpm
@@ -430,11 +450,11 @@ jobs:
     needs: [changes, rust-contracts]
     if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true' }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.97.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           shared-key: xtask-windows
       - name: create web assets placeholder
@@ -472,7 +492,8 @@ jobs:
     # Kept on ubuntu-latest: on the self-hosted unraid runner rustc failed to
     # execute (os error 2) with missing target .d files — a runner env/workspace
     # issue. This cross-compile is proven on ubuntu-latest, so pin it here.
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 60
     needs: [changes, rust-contracts, web-panel]
     if: ${{ always() && needs.rust-contracts.result == 'success' && needs.web-panel.result == 'success' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true') && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
     env:
@@ -480,8 +501,8 @@ jobs:
       CXX_x86_64_pc_windows_gnu: x86_64-w64-mingw32-g++
       AR_x86_64_pc_windows_gnu: x86_64-w64-mingw32-ar
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           # Match rust-toolchain.toml so the Windows target is installed on
           # the same toolchain cargo uses under the repo override.
@@ -491,17 +512,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends mingw-w64
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           shared-key: axon-windows-gnu
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: axon-web-assets
           path: apps/web/out
       - name: cargo build --release -p axon (windows-gnu cross)
         run: cargo build --release --locked -p axon --target x86_64-pc-windows-gnu
       - name: Upload axon.exe artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-windows-x86_64
           path: target/x86_64-pc-windows-gnu/release/axon.exe
@@ -509,14 +530,15 @@ jobs:
 
   smoke-binary:
     name: smoke-binary
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 30
     needs: [changes, rust-contracts]
     if: ${{ github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true') }}
     env:
       TEI_URL: http://127.0.0.1:52000
       QDRANT_URL: http://127.0.0.1:53333
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - uses: ./.github/actions/setup-rust-kache
       - name: create web assets placeholder
         run: |
@@ -531,7 +553,7 @@ jobs:
       - name: Smoke test MCP OAuth protection
         run: ./scripts/test-mcp-oauth-protection.sh
       - name: Upload debug smoke binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-debug-linux-smoke
           path: target/debug/axon
@@ -539,12 +561,13 @@ jobs:
 
   web-panel:
     name: web-panel
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-typescript]
+    timeout-minutes: 20
     needs: [changes]
     if: ${{ needs.changes.outputs.web == 'true' || needs.changes.outputs.release == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.rust == 'true') || contains(github.event.pull_request.labels.*.name, 'ci:full') }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 22
           cache: npm
@@ -558,7 +581,7 @@ jobs:
       - name: Build web panel assets once
         run: npm --prefix apps/web run build
       - name: Upload web panel assets
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-web-assets
           path: apps/web/out
@@ -566,12 +589,13 @@ jobs:
 
   chrome-extension:
     name: chrome-extension
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-typescript]
+    timeout-minutes: 15
     needs: [changes]
     if: ${{ needs.changes.outputs.chrome == 'true' }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 22
       - name: Test Chrome extension
@@ -581,11 +605,12 @@ jobs:
   # The fast contract job must pass before either expensive Rust lane starts.
   clippy:
     name: clippy
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 45
     needs: [changes, rust-contracts]
     if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - uses: ./.github/actions/setup-rust-kache
         with:
           components: clippy
@@ -598,7 +623,8 @@ jobs:
 
   test:
     name: test
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 60
     needs: [changes, rust-contracts]
     if: ${{ needs.changes.outputs.rust == 'true' }}
     env:
@@ -608,9 +634,9 @@ jobs:
       RUST_MIN_STACK: "8388608"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - uses: ./.github/actions/setup-rust-kache
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf
         with:
           tool: cargo-nextest@0.9.140
       - name: create web assets placeholder
@@ -632,7 +658,8 @@ jobs:
   live-qdrant:
     name: live-qdrant
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_live_qdrant_tests) }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 45
     services:
       qdrant:
         image: qdrant/qdrant:v1.13.1
@@ -641,11 +668,11 @@ jobs:
     env:
       AXON_TEST_QDRANT_URL: http://127.0.0.1:6333
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.97.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: live Qdrant vector tests
         run: cargo test --locked --features live-qdrant qdrant -- --ignored
 
@@ -655,12 +682,13 @@ jobs:
   # `rag` boolean output consumed by `live-rag-pr`.
   rag-changes:
     name: rag-changes
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     if: ${{ github.event_name == 'pull_request' }}
     outputs:
       rag: ${{ steps.filter.outputs.rag }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
       - name: Detect RAG-path changes
@@ -693,7 +721,7 @@ jobs:
   # retrieval/RRF/rerank regression could merge and auto-release unverified.
   live-rag-pr:
     name: live-rag-pr
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-rust]
     needs: [rag-changes]
     if: ${{ github.event_name == 'pull_request' && needs.rag-changes.outputs.rag == 'true' }}
     timeout-minutes: 30
@@ -708,16 +736,16 @@ jobs:
       AXON_TEST_QDRANT_URL: http://127.0.0.1:6333
       AXON_TEST_TEI_URL: http://127.0.0.1:52000
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.97.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           shared-key: live-rag-pr
 
       - name: Restore Hugging Face model cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: .cache/huggingface
           key: hf-tei-${{ runner.os }}-BAAI-bge-small-en-v1.5-v1
@@ -777,14 +805,15 @@ jobs:
 
   security:
     name: security
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 30
     needs: [changes, rust-contracts]
     if: ${{ needs.changes.outputs.security == 'true' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - uses: ./.github/actions/setup-rust-kache
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf
         with:
           tool: cargo-audit@0.22.1,cargo-deny@0.19.0
 
@@ -802,12 +831,12 @@ jobs:
 
   mcp-smoke:
     name: mcp-smoke
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-rust]
     needs: [changes, release]
     if: ${{ needs.release.result == 'success' && (needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rust == 'true') && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Fetch MCP doc fixture for smoke test
         run: mkdir -p docs && git show HEAD:docs/reference/mcp/overview.md > docs/reference/mcp/overview.md
 
@@ -837,14 +866,14 @@ jobs:
           mcporter --version
 
       - name: Restore Hugging Face model cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: .cache/huggingface
           key: hf-tei-${{ runner.os }}-BAAI-bge-small-en-v1.5-v1
 
       - name: Cache Docker images (TEI + Qdrant)
         id: docker-cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: /tmp/docker-images
           key: docker-${{ runner.os }}-tei-cpu-v1-qdrant-1.13.1
@@ -868,7 +897,7 @@ jobs:
         run: |
           mkdir -p apps/web/out
           echo "AXON_ALLOW_FALLBACK_WEB_ASSETS=1" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: axon-release-linux-smoke
           path: target/release
@@ -973,7 +1002,7 @@ jobs:
 
       - name: Upload mcporter logs
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: mcp-smoke-logs
           path: .cache/mcporter-test/
@@ -987,20 +1016,21 @@ jobs:
 
   release:
     name: release
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 60
     needs: [changes, rust-contracts, web-panel]
     if: ${{ always() && needs.rust-contracts.result == 'success' && needs.web-panel.result == 'success' && ((github.event_name != 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.release == 'true')) || (github.event_name == 'pull_request' && (needs.changes.outputs.release == 'true' || contains(github.event.pull_request.labels.*.name, 'ci:full')))) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - uses: ./.github/actions/setup-rust-kache
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: axon-web-assets
           path: apps/web/out
       - name: cargo build release axon
         run: cargo build --release --locked --bin axon
       - name: Upload release smoke binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-release-linux-smoke
           path: target/release/axon
@@ -1008,11 +1038,12 @@ jobs:
 
   release-smoke:
     name: release-smoke
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 10
     needs: [changes, release]
     if: ${{ needs.release.result == 'success' }}
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: axon-release-linux-smoke
           path: target/release
@@ -1023,9 +1054,12 @@ jobs:
 
   ci-gate:
     name: ci-gate
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     if: always()
     needs:
+      - fleet-policy
+      - fleet-contract
       - changes
       - rust-contracts
       - aurora-primitive-inventory
@@ -1070,6 +1104,8 @@ jobs:
             esac
           }
           require_success changes "${{ needs.changes.result }}"
+          require_success fleet-policy "${{ needs.fleet-policy.result }}"
+          require_success fleet-contract "${{ needs.fleet-contract.result }}"
           require_success_or_intentional_skip rust-contracts "${{ needs.rust-contracts.result }}" "${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.openapi == 'true' || needs.changes.outputs.workflow == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.version_files == 'true' || needs.changes.outputs.release == 'true' }}"
           require_success_or_intentional_skip aurora-primitive-inventory "${{ needs.aurora-primitive-inventory.result }}" "${{ needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.docs == 'true' }}"
           require_success_or_intentional_skip android "${{ needs.android.result }}" "${{ needs.changes.outputs.android }}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,8 @@
 name: Claude Code
 
+permissions:
+  contents: read
+
 on:
   issue_comment:
     types: [created]
@@ -17,7 +20,8 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: read
@@ -26,13 +30,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c96dd0a84e0232ab86947fca5fe34f1caae8792f
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -47,4 +51,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,12 @@ env:
 jobs:
   changes:
     name: changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -103,7 +104,8 @@ jobs:
 
   analyze:
     name: analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 60
     needs: [changes]
     permissions:
       security-events: write
@@ -113,13 +115,13 @@ jobs:
       matrix: ${{ fromJson(needs.changes.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           persist-credentials: false
 
       - name: Checkout Aurora design system
         if: matrix.language == 'java-kotlin'
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           persist-credentials: false
           repository: ${{ env.AURORA_REPO }}
@@ -133,13 +135,13 @@ jobs:
 
       - name: Set up pnpm for Aurora token generation
         if: matrix.language == 'java-kotlin'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10.33.2
 
       - name: Set up Node for Aurora token generation
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: "lts/*"
           cache: pnpm
@@ -152,21 +154,21 @@ jobs:
 
       - name: Set up JDK 17
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Gradle
         if: matrix.language == 'java-kotlin'
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a
 
       - name: Set up Android SDK
         if: matrix.language == 'java-kotlin'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@bce182f857edf1feab116e9795a3393d21977282
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build_mode }}
@@ -177,13 +179,14 @@ jobs:
         run: apps/android/gradlew -p apps/android :app:compileDebugKotlin --no-daemon --stacktrace
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@bce182f857edf1feab116e9795a3393d21977282
         with:
           category: "/language:${{ matrix.language }}"
 
   codeql-gate:
     name: codeql-gate
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     if: always()
     needs:
       - changes

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -15,12 +15,13 @@ concurrency:
 jobs:
   changes:
     name: changes
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     outputs:
       compose: ${{ steps.classify.outputs.compose }}
       docker: ${{ steps.classify.outputs.docker }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
       - name: Prepare trusted changed path classifier
@@ -63,11 +64,12 @@ jobs:
 
   compose-config:
     name: compose-config
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 15
     needs: [changes]
     if: ${{ needs.changes.outputs.compose == 'true' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
       # Docker Compose v5 validates external networks exist even during config --quiet.
       # Create the network so both prod and dev compose files pass static validation.
@@ -99,13 +101,14 @@ jobs:
 
   image-build-smoke:
     name: image-build-smoke
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 60
     needs: [changes]
     if: ${{ needs.changes.outputs.docker == 'true' }}
     steps:
       # Full checkout: Dockerfile runs cargo build inside the container,
       # so the entire source tree must be in the Docker build context.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Build Axon image
@@ -120,7 +123,8 @@ jobs:
 
   compose-smoke-gate:
     name: compose-smoke-gate
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     if: always()
     needs:
       - changes

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   publish:
     if: ${{ startsWith(github.event.release.tag_name, 'v') }}
-    uses: dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       checkout-ref: ${{ github.event.release.tag_name }}
       image: ghcr.io/${{ github.repository_owner }}/axon

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,72 +1,27 @@
 name: Docker image
 
 on:
-  push:
-    branches: [main]
-    tags: ["v*"]
-  workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read
   packages: write
+  attestations: write
+  id-token: write
 
 jobs:
-  changes:
-    name: changes
-    runs-on: [self-hosted, unraid]
-    outputs:
-      docker: ${{ steps.classify.outputs.docker }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Prepare trusted changed path classifier
-        run: |
-          set -euo pipefail
-          classifier="scripts/ci/changed_paths.py"
-          trusted="/tmp/axon-changed-paths.py"
-          cp "$classifier" "$trusted"
-          chmod +x "$trusted"
-          echo "AXON_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
-      - name: Classify changed paths
-        id: classify
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
-          HEAD_SHA: ${{ github.sha }}
-        run: python3 "$AXON_CHANGED_PATHS" --event "$EVENT_NAME" --output "$GITHUB_OUTPUT" --write-changed-files changed-files.txt
-
-  build:
-    name: build-and-push
-    runs-on: [self-hosted, unraid]
-    needs: [changes]
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || needs.changes.outputs.docker == 'true' }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/axon
-          tags: |
-            type=sha
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: config/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  publish:
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
+    uses: dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    with:
+      checkout-ref: ${{ github.event.release.tag_name }}
+      image: ghcr.io/${{ github.repository_owner }}/axon
+      release-tag: ${{ github.event.release.tag_name }}
+      dockerfile: config/Dockerfile
+      smoke-command: docker run --rm "$IMAGE_REF" --help
+      cache-scope: axon-container-release
+      timeout-minutes: 90
+    secrets:
+      REGISTRY_USERNAME: ${{ github.actor }}
+      REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/palette-release.yml
+++ b/.github/workflows/palette-release.yml
@@ -7,17 +7,11 @@ name: palette-release
 # Builds the portable palette binary for Linux + Windows, packages each with a
 # SHA256 checksum, and publishes a GitHub Release with both artifacts attached.
 #
-# Manual workflow_dispatch builds + packages the binaries and uploads them to
-# the run as artifacts for inspection, but does NOT create a Release unless
-# explicitly called with publish=true on a palette-v* tag. release-please.yml
-# dispatches this workflow after release-please creates the GitHub Release.
+# The heavy build starts only from a published palette-v* GitHub Release and
+# checks out that immutable tag on hosted x86_64 runners.
 on:
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: "Attach artifacts to an existing release-please palette-v* release"
-        type: boolean
-        default: false
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -35,11 +29,16 @@ env:
 jobs:
   version:
     name: resolve and validate version
-    runs-on: [self-hosted, unraid]
+    if: ${{ startsWith(github.event.release.tag_name, 'palette-v') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
       - name: Resolve and validate version
         id: version
         run: |
@@ -66,8 +65,9 @@ jobs:
           # On release-please dispatch, the tag version must match
           # tauri.conf.json so a release can never ship a binary the tag
           # disagrees with.
-          if [[ "${GITHUB_REF}" == refs/tags/palette-v* ]]; then
-            tag_version="${GITHUB_REF#refs/tags/palette-v}"
+          tag="${{ github.event.release.tag_name }}"
+          if [[ "$tag" == palette-v* ]]; then
+            tag_version="${tag#palette-v}"
             if [[ "$tag_version" != "$version" ]]; then
               echo "::error::tag palette-v$tag_version does not match version $version — bump $conf before tagging" >&2
               exit 1
@@ -78,23 +78,47 @@ jobs:
   palette-linux:
     name: build axon-palette (linux)
     needs: version
-    runs-on: [self-hosted, unraid]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
     steps:
       # Full checkout: LFS blobs come down as pointers (lfs: false default) and
       # are not needed to build.
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 11.3.0
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: apps/palette-tauri/pnpm-lock.yaml
-      - uses: ./.github/actions/setup-rust-kache
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.97.1
-          install-tauri-deps: "true"
+      - uses: kunobi-ninja/kache-action@a257c055543c2840700a9bbca8f9c3094a421b1b
+        with:
+          version: "0.12.0"
+          s3-bucket: kache
+          s3-region: us-east-1
+          s3-prefix: rust
+          s3-endpoint: https://s3.tootie.tv
+          s3-access-key-id: ${{ secrets.KACHE_S3_ACCESS_KEY }}
+          s3-secret-access-key: ${{ secrets.KACHE_S3_SECRET_KEY }}
+          manifest-key: release-palette-${{ runner.os }}-x64
+          namespace: release-palette-${{ runner.os }}-x64
+          cache-executables: "true"
+          warm: "true"
+          sync: "false"
+          pr-comment: "false"
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+            librsvg2-dev libxdo-dev patchelf
       - name: Install palette dependencies
         run: pnpm --dir apps/palette-tauri install --frozen-lockfile
       # `tauri build --no-bundle` runs the frontend `beforeBuildCommand`
@@ -109,7 +133,7 @@ jobs:
           cd apps/palette-tauri/src-tauri/target/release
           tar -czf axon-palette-linux-x86_64.tar.gz axon-palette-tauri
           sha256sum axon-palette-linux-x86_64.tar.gz > axon-palette-linux-x86_64.tar.gz.sha256
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-palette-linux-x86_64
           path: |
@@ -121,22 +145,26 @@ jobs:
     name: build axon-palette (windows)
     needs: version
     runs-on: windows-latest
+    timeout-minutes: 90
     steps:
       # Full checkout: LFS blobs come down as pointers (lfs: false default) and
       # are not needed to build.
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 11.3.0
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: apps/palette-tauri/pnpm-lock.yaml
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.97.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: apps/palette-tauri/src-tauri
           shared-key: release-palette-windows
@@ -161,7 +189,7 @@ jobs:
           $hash = (Get-FileHash axon-palette-windows-x86_64.zip -Algorithm SHA256).Hash.ToLower()
           "$hash  axon-palette-windows-x86_64.zip" | Out-File -Encoding ascii axon-palette-windows-x86_64.zip.sha256
           Pop-Location
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-palette-windows-x86_64
           path: |
@@ -172,17 +200,15 @@ jobs:
   publish:
     name: publish github release
     needs: [version, palette-linux, palette-windows]
-    runs-on: [self-hosted, unraid]
-    # Attach artifacts only when release-please dispatches this workflow on an
-    # existing palette-v* release tag.
-    if: >-
-      startsWith(github.ref, 'refs/tags/palette-v') &&
-      github.event_name == 'workflow_dispatch' &&
-      inputs.publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    # Attach artifacts only to the published palette-v* release that triggered
+    # this run.
+    if: ${{ startsWith(github.event.release.tag_name, 'palette-v') }}
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           path: dist
           merge-multiple: true
@@ -194,7 +220,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${{ github.event.release.tag_name }}"
           gh release view "$tag" >/dev/null
           gh release upload "$tag" \
             dist/axon-palette-linux-x86_64.tar.gz \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,8 @@ env:
 jobs:
   release-please:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 20
     permissions:
       contents: write       # required to create release commits and tags
       issues: write         # required for release-please labels
@@ -53,11 +54,12 @@ jobs:
     # prs_created=true. Run fixups for any PR payload it returns so component
     # source version files cannot drift behind the manifest/changelog bump.
     if: ${{ needs.release-please.outputs.prs != '' && needs.release-please.outputs.prs != '[]' && needs.release-please.outputs.prs != 'null' }}
-    runs-on: [self-hosted, unraid]
+    runs-on: [self-hosted, ci-pool-rust]
+    timeout-minutes: 30
     permissions:
       contents: write  # required to push generated fixup commits to release PR branches
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -88,36 +90,4 @@ jobs:
               git push origin HEAD:"$branch"
             fi
             git checkout "$base_ref"
-          done
-
-  dispatch-artifacts:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: [self-hosted, unraid]
-    permissions:
-      contents: read
-      actions: write  # required to dispatch artifact workflows
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-rust-kache
-      - name: Build dispatch plan
-        env:
-          RELEASE_OUTPUTS: ${{ toJson(needs.release-please.outputs) }}
-        run: |
-          cargo xtask release-please-dispatch-plan \
-            --release-outputs "$RELEASE_OUTPUTS" \
-            --json > dispatch-plan.json
-          jq . dispatch-plan.json
-      - name: Dispatch artifact workflows
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          jq -c '.[]' dispatch-plan.json | while read -r item; do
-            workflow="$(jq -r '.workflow' <<<"$item")"
-            tag="$(jq -r '.tag' <<<"$item")"
-            git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null
-            gh workflow run "$workflow" --ref "$tag" -f publish=true
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,11 @@ name: release
 # release so that a palette-only change does not require a CLI version bump and
 # vice-versa.
 #
-# Manual workflow_dispatch builds everything but skips attaching artifacts by
-# default. release-please.yml dispatches this workflow with publish=true on the
-# newly created v* tag after release-please creates the GitHub Release.
+# The heavy build starts only when GitHub reports the component release as
+# published. That event supplies the immutable tag checked out by every job.
 on:
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: "Attach artifacts to an existing release-please v* release"
-        type: boolean
-        default: false
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -33,7 +28,9 @@ env:
 jobs:
   axon-linux:
     name: build axon (linux)
-    runs-on: [self-hosted, unraid]
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
     # The `secrets` context is NOT allowed in step-level `if:` conditionals, so
     # the optional signing secret is promoted to job-level env here (where
     # referencing `secrets` IS allowed) and the signing steps gate on
@@ -45,10 +42,28 @@ jobs:
       # Full checkout: the non-cone sparse list previously omitted root
       # Cargo.toml/Cargo.lock, which broke every build. LFS blobs come down as
       # pointers (lfs: false default) and are not needed to build.
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/setup-rust-kache
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.97.1
+      - uses: kunobi-ninja/kache-action@a257c055543c2840700a9bbca8f9c3094a421b1b
+        with:
+          version: "0.12.0"
+          s3-bucket: kache
+          s3-region: us-east-1
+          s3-prefix: rust
+          s3-endpoint: https://s3.tootie.tv
+          s3-access-key-id: ${{ secrets.KACHE_S3_ACCESS_KEY }}
+          s3-secret-access-key: ${{ secrets.KACHE_S3_SECRET_KEY }}
+          manifest-key: release-${{ runner.os }}-x64
+          namespace: release-${{ runner.os }}-x64
+          cache-executables: "true"
+          warm: "true"
+          sync: "false"
+          pr-comment: "false"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: lts/*
@@ -85,7 +100,7 @@ jobs:
             -m axon-linux-x86_64.tar.gz -x axon-linux-x86_64.tar.gz.minisig
           shred -u /tmp/axon-minisign.key
           echo "Signed axon-linux-x86_64.tar.gz -> .minisig"
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-linux-x86_64
           path: |
@@ -94,7 +109,7 @@ jobs:
           if-no-files-found: error
       # Separate upload so the optional signature does not weaken the
       # required-file guarantee above. Only present when signing ran.
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         if: ${{ env.SIGNING_KEY != '' }}
         with:
           name: axon-linux-x86_64-signature
@@ -103,16 +118,21 @@ jobs:
 
   axon-windows:
     name: build axon (windows)
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
     runs-on: windows-latest
+    timeout-minutes: 90
     steps:
       # Full checkout: the non-cone sparse list previously omitted root
       # Cargo.toml/Cargo.lock, which broke every build. LFS blobs come down as
       # pointers (lfs: false default) and are not needed to build.
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.97.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           shared-key: release-axon-windows
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
@@ -140,7 +160,7 @@ jobs:
           $hash = (Get-FileHash axon-windows-x86_64.zip -Algorithm SHA256).Hash.ToLower()
           "$hash  axon-windows-x86_64.zip" | Out-File -Encoding ascii axon-windows-x86_64.zip.sha256
           Pop-Location
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: axon-windows-x86_64
           path: |
@@ -151,17 +171,14 @@ jobs:
   publish:
     name: publish github release
     needs: [axon-linux, axon-windows]
-    runs-on: [self-hosted, unraid]
-    # Attach artifacts only when release-please dispatches this workflow on an
-    # existing v* release tag.
-    if: >-
-      startsWith(github.ref, 'refs/tags/v') &&
-      github.event_name == 'workflow_dispatch' &&
-      inputs.publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    # Attach artifacts only to the published v* release that triggered the run.
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           path: dist
           merge-multiple: true
@@ -178,7 +195,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${{ github.event.release.tag_name }}"
           gh release view "$tag" >/dev/null
           gh release upload "$tag" dist/axon-linux-x86_64.tar.gz.minisig --clobber
       - name: Attach artifacts to release
@@ -187,7 +204,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${{ github.event.release.tag_name }}"
           gh release view "$tag" >/dev/null
           gh release upload "$tag" \
             dist/axon-linux-x86_64.tar.gz \

--- a/.github/workflows/session-log-automerge.yml
+++ b/.github/workflows/session-log-automerge.yml
@@ -29,7 +29,8 @@ concurrency:
 jobs:
   automerge:
     name: auto-merge session logs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -256,7 +256,7 @@ fn android_ci_setup_does_not_install_unused_emulator_packages() {
         .expect("android SDK setup block exists");
 
     assert!(
-        setup.contains("uses: android-actions/setup-android@v3"),
+        setup.contains("uses: android-actions/setup-android@"),
         "android job must set up SDK licenses/tooling before Gradle runs"
     );
     assert!(
@@ -323,31 +323,18 @@ fn auto_tag_uses_validated_xtask_release_plan() {
         release.contains("fromJson(needs.plan.outputs.matrix)"),
         "auto-tag must expand the xtask plan as a matrix"
     );
+    assert!(release.contains("matrix.candidate_tag"));
+    assert!(workflow.contains("workflow_run:"));
+    assert!(workflow.contains("github.event.workflow_run.conclusion == 'success'"));
+    assert!(workflow.contains("ref: ${{ github.event.workflow_run.head_sha }}"));
     assert!(
-        release.contains("matrix.candidate_tag") && release.contains("matrix.release_workflow"),
-        "auto-tag must consume tags and workflows from the xtask release plan"
+        !workflow.contains("gh run list") && !workflow.contains("sleep 20"),
+        "auto-tag must not occupy a farm runner while polling CI"
     );
     assert!(
-        release
-            .find("Wait for CI to pass on this commit")
-            .expect("CI wait step")
-            < release.find("Create and push tag").expect("tag step"),
-        "auto-tag must wait for CI before creating release tags"
+        release.contains("gh release create") && release.contains("--verify-tag"),
+        "auto-tag must publish a release so heavy workflows start from release.published"
     );
-    for required in [
-        "if ! runs_json=$(gh run list",
-        "gh run list failed while polling ci.yml",
-        "--branch main",
-        "--event push",
-        ".headSha == $sha",
-        ".event == \"push\"",
-        ".headBranch == \"main\"",
-    ] {
-        assert!(
-            release.contains(required),
-            "auto-tag CI polling must constrain {required}"
-        );
-    }
 }
 
 #[test]
@@ -381,7 +368,7 @@ fn ci_builds_web_assets_once_for_binary_artifact_jobs() {
     assert!(web.contains("name: axon-web-assets"));
     for (name, job) in [("release", release), ("windows-build", windows)] {
         assert!(
-            job.contains("uses: actions/download-artifact@v5")
+            job.contains("uses: actions/download-artifact@")
                 && job.contains("name: axon-web-assets"),
             "{name} must reuse the web-panel artifact"
         );
@@ -550,11 +537,57 @@ fn compose_and_docker_workflows_use_changed_path_classifier() {
     assert!(compose.contains("compose-smoke-gate:"));
     assert!(compose.contains("require_success_or_intentional_skip compose-config"));
     assert!(compose.contains("require_success_or_intentional_skip image-build-smoke"));
-    assert!(docker.contains("scripts/ci/changed_paths.py"));
-    assert!(docker.contains("AXON_CHANGED_PATHS"));
-    assert!(docker.contains("python3 \"$AXON_CHANGED_PATHS\""));
-    assert!(docker.contains("needs.changes.outputs.docker == 'true'"));
-    assert!(docker.contains("startsWith(github.ref, 'refs/tags/v')"));
+    assert!(docker.contains("release:"));
+    assert!(docker.contains("types: [published]"));
+    assert!(docker.contains(
+        "dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec"
+    ));
+    assert!(docker.contains("startsWith(github.event.release.tag_name, 'v')"));
+    assert!(docker.contains("checkout-ref: ${{ github.event.release.tag_name }}"));
+}
+
+#[test]
+fn fleet_workflows_enforce_pool_and_release_boundaries() {
+    let fast = [
+        include_str!("../.github/workflows/ci.yml"),
+        include_str!("../.github/workflows/codeql.yml"),
+        include_str!("../.github/workflows/compose-smoke.yml"),
+        include_str!("../.github/workflows/auto-tag.yml"),
+        include_str!("../.github/workflows/release-please.yml"),
+        include_str!("../.github/workflows/session-log-automerge.yml"),
+        include_str!("../.github/workflows/claude.yml"),
+    ];
+    for workflow in fast {
+        assert!(!workflow.contains("runs-on: ubuntu-"));
+        assert!(!workflow.contains("runs-on: [self-hosted, unraid]"));
+        for line in workflow
+            .lines()
+            .filter(|line| line.trim_start().starts_with("runs-on: [self-hosted"))
+        {
+            assert!(line.contains("ci-pool-"), "missing pool route: {line}");
+        }
+    }
+
+    let releases = [
+        include_str!("../.github/workflows/release.yml"),
+        include_str!("../.github/workflows/palette-release.yml"),
+        include_str!("../.github/workflows/android-release.yml"),
+        include_str!("../.github/workflows/chrome-extension-release.yml"),
+        include_str!("../.github/workflows/docker-image.yml"),
+    ];
+    for workflow in releases {
+        assert!(workflow.contains("release:"));
+        assert!(workflow.contains("types: [published]"));
+        assert!(!workflow.contains("workflow_dispatch:"));
+        assert!(!workflow.contains("runs-on: [self-hosted"));
+    }
+
+    for workflow in fast.into_iter().chain(releases) {
+        let lower = workflow.to_ascii_lowercase();
+        assert!(!lower.contains("arm64"));
+        assert!(!lower.contains("aarch64"));
+        assert!(!lower.contains("setup-qemu"));
+    }
 }
 
 #[test]

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -537,7 +537,7 @@ fn compose_and_docker_workflows_use_changed_path_classifier() {
     assert!(docker.contains("release:"));
     assert!(docker.contains("types: [published]"));
     assert!(docker.contains(
-        "dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec"
+        "dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d"
     ));
     assert!(docker.contains("startsWith(github.event.release.tag_name, 'v')"));
     assert!(docker.contains("checkout-ref: ${{ github.event.release.tag_name }}"));

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -341,42 +341,41 @@ fn auto_tag_uses_validated_xtask_release_plan() {
 fn ci_keeps_expensive_artifacts_off_ordinary_pull_requests() {
     let workflow = include_str!("../.github/workflows/ci.yml");
     let smoke = workflow_job_block(workflow, "smoke-binary");
-    assert!(smoke.contains("github.event_name == 'pull_request'"));
+    assert!(smoke.contains("needs.changes.outputs.rust == 'true'"));
     assert!(smoke.contains("cargo build --locked --bin axon"));
     assert!(!smoke.contains("cargo build --release"));
 
-    let release = workflow_job_block(workflow, "release");
     let mcp_smoke = workflow_job_block(workflow, "mcp-smoke");
     let windows_check = workflow_job_block(workflow, "windows-check");
     let windows_build = workflow_job_block(workflow, "windows-build");
-    assert!(release.contains("github.event_name != 'pull_request'"));
-    assert!(release.contains("needs.changes.outputs.release == 'true'"));
-    assert!(release.contains("'ci:full'"));
+    assert!(
+        !workflow.contains("\n  release:\n") && !workflow.contains("\n  release-smoke:\n"),
+        "CI must not duplicate release-mode artifact builds on the self-hosted farm"
+    );
+    assert!(mcp_smoke.contains("needs: [changes, smoke-binary]"));
+    assert!(mcp_smoke.contains("axon-debug-linux-smoke"));
     assert!(mcp_smoke.contains("'ci:full'"));
     assert!(windows_check.contains("github.event_name == 'pull_request'"));
     assert!(windows_build.contains("'ci:full'"));
 }
 
 #[test]
-fn ci_builds_web_assets_once_for_binary_artifact_jobs() {
+fn ci_builds_web_assets_once_for_ci_binary_jobs() {
     let workflow = include_str!("../.github/workflows/ci.yml");
     let web = workflow_job_block(workflow, "web-panel");
-    let release = workflow_job_block(workflow, "release");
     let windows = workflow_job_block(workflow, "windows-build");
 
     assert!(web.contains("npm --prefix apps/web run build"));
     assert!(web.contains("name: axon-web-assets"));
-    for (name, job) in [("release", release), ("windows-build", windows)] {
-        assert!(
-            job.contains("uses: actions/download-artifact@")
-                && job.contains("name: axon-web-assets"),
-            "{name} must reuse the web-panel artifact"
-        );
-        assert!(
-            !job.contains("npm ci --prefix apps/web"),
-            "{name} must not reinstall web dependencies"
-        );
-    }
+    assert!(
+        windows.contains("uses: actions/download-artifact@")
+            && windows.contains("name: axon-web-assets"),
+        "windows-build must reuse the web-panel artifact"
+    );
+    assert!(
+        !windows.contains("npm ci --prefix apps/web"),
+        "windows-build must not reinstall web dependencies"
+    );
 }
 
 #[test]
@@ -462,8 +461,6 @@ fn ci_gate_covers_expensive_and_contract_jobs() {
         "mcp-smoke",
         "rag-changes",
         "live-rag-pr",
-        "release",
-        "release-smoke",
     ] {
         assert!(
             gate.contains(&format!("- {job}")),


### PR DESCRIPTION
## Summary
- route fast Linux CI through typed runner-farm pools
- make heavy Android, Palette, Chrome, container, and release artifacts release.published-only on GitHub-hosted x86_64
- remove the duplicate self-hosted release-mode CI build while preserving debug/MCP smoke coverage
- use immutable central workflow and Kache action pins with MinIO cache support
- replace auto-tag CI polling with a successful workflow_run trigger
- preserve Axon-specific RAG, MCP, security, CodeQL, Android, Tauri, Windows, and compose contracts
- enforce zero ARM/emulation workflow paths

## Validation
- actionlint
- workflow_shapes: 23/23
- ci_changed_paths: 18/18
- fleet contract and policy
- cargo fmt
- immutable action scan
- zero ARM/aarch64/QEMU/multiplatform scan
- pre-push structural and path-aware checks