### PR TITLE
ci: enforce repository contract

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,3 +8,4 @@
 self-hosted-runner:
   labels:
     - unraid
+    - ci-pool-ops

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,5 +7,8 @@
 # here or `cargo xtask workflow-lint` fails for every workflow-touching change.
 self-hosted-runner:
   labels:
+    - ci-pool-rust
+    - ci-pool-typescript
+    - ci-pool-system
     - unraid
     - ci-pool-ops

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   changes:
     name: changes
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-ops
     outputs:
       all: ${{ steps.classify.outputs.all }}
       docs: ${{ steps.classify.outputs.docs }}
@@ -111,7 +111,7 @@ jobs:
   # and transport contracts before starting the expensive clippy/test fanout.
   rust-contracts:
     name: rust-contracts
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-rust
     needs: [changes]
     if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.openapi == 'true' || needs.changes.outputs.workflow == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.version_files == 'true' || needs.changes.outputs.release == 'true' }}
     steps:
@@ -224,7 +224,7 @@ jobs:
 
   aurora-primitive-inventory:
     name: aurora-primitive-inventory
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-ops
     needs: [changes]
     if: ${{ needs.changes.outputs.android == 'true' || needs.changes.outputs.palette == 'true' || needs.changes.outputs.docs == 'true' }}
     steps:
@@ -234,7 +234,7 @@ jobs:
 
   android:
     name: android
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-system
     needs: [changes]
     if: ${{ needs.changes.outputs.android == 'true' }}
     steps:
@@ -321,7 +321,7 @@ jobs:
 
   toml-fmt:
     name: toml-fmt
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-ops
     needs: [changes]
     if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true' || needs.changes.outputs.release == 'true' }}
     steps:
@@ -343,7 +343,7 @@ jobs:
 
   lefthook-pre-commit-speed:
     name: lefthook pre-commit speed guard
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-ops
     needs: [changes]
     if: ${{ needs.changes.outputs.workflow == 'true' || needs.changes.outputs.rust == 'true' }}
     steps:
@@ -353,7 +353,7 @@ jobs:
 
   palette-tauri:
     name: palette-tauri
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-rust
     needs: [changes]
     if: ${{ needs.changes.outputs.palette == 'true' }}
     steps:
@@ -509,7 +509,7 @@ jobs:
 
   smoke-binary:
     name: smoke-binary
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-rust
     needs: [changes, rust-contracts]
     if: ${{ github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.mcp == 'true') }}
     env:
@@ -539,7 +539,7 @@ jobs:
 
   web-panel:
     name: web-panel
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-typescript
     needs: [changes]
     if: ${{ needs.changes.outputs.web == 'true' || needs.changes.outputs.release == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.rust == 'true') || contains(github.event.pull_request.labels.*.name, 'ci:full') }}
     steps:
@@ -566,7 +566,7 @@ jobs:
 
   chrome-extension:
     name: chrome-extension
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-typescript
     needs: [changes]
     if: ${{ needs.changes.outputs.chrome == 'true' }}
     steps:
@@ -581,7 +581,7 @@ jobs:
   # The fast contract job must pass before either expensive Rust lane starts.
   clippy:
     name: clippy
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-rust
     needs: [changes, rust-contracts]
     if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
@@ -598,7 +598,7 @@ jobs:
 
   test:
     name: test
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-rust
     needs: [changes, rust-contracts]
     if: ${{ needs.changes.outputs.rust == 'true' }}
     env:
@@ -655,7 +655,7 @@ jobs:
   # `rag` boolean output consumed by `live-rag-pr`.
   rag-changes:
     name: rag-changes
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-ops
     if: ${{ github.event_name == 'pull_request' }}
     outputs:
       rag: ${{ steps.filter.outputs.rag }}
@@ -777,7 +777,7 @@ jobs:
 
   security:
     name: security
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-rust
     needs: [changes, rust-contracts]
     if: ${{ needs.changes.outputs.security == 'true' }}
     steps:
@@ -1023,7 +1023,7 @@ jobs:
 
   ci-gate:
     name: ci-gate
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-ops
     if: always()
     needs:
       - changes

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   changes:
     name: changes
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-ops
     outputs:
       compose: ${{ steps.classify.outputs.compose }}
       docker: ${{ steps.classify.outputs.docker }}
@@ -63,7 +63,7 @@ jobs:
 
   compose-config:
     name: compose-config
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-system
     needs: [changes]
     if: ${{ needs.changes.outputs.compose == 'true' }}
     steps:
@@ -99,7 +99,7 @@ jobs:
 
   image-build-smoke:
     name: image-build-smoke
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-system
     needs: [changes]
     if: ${{ needs.changes.outputs.docker == 'true' }}
     steps:
@@ -120,7 +120,7 @@ jobs:
 
   compose-smoke-gate:
     name: compose-smoke-gate
-    runs-on: [self-hosted, unraid]
+    runs-on: ci-pool-ops
     if: always()
     needs:
       - changes

--- a/.github/workflows/repository-contract.yml
+++ b/.github/workflows/repository-contract.yml
@@ -16,7 +16,7 @@ jobs:
   contract:
     permissions:
       contents: read
-    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@d1a41a7af9c41189e0f1062234364f5814bda99d
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@d1a41a7af9c41189e0f1062234364f5814bda99d # fleet-2026-07-31
     with:
       profile: rust
       implementation-ref: d1a41a7af9c41189e0f1062234364f5814bda99d

--- a/.github/workflows/repository-contract.yml
+++ b/.github/workflows/repository-contract.yml
@@ -1,0 +1,40 @@
+name: Repository contract
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: repository-contract-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+jobs:
+  contract:
+    permissions:
+      contents: read
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@d1a41a7af9c41189e0f1062234364f5814bda99d
+    with:
+      profile: rust
+      implementation-ref: d1a41a7af9c41189e0f1062234364f5814bda99d
+    secrets: inherit
+
+  repository-contract:
+    name: Repository Contract
+    if: always()
+    needs: [contract]
+    runs-on: ci-pool-ops
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Require repository contract
+        env:
+          RESULT: ${{ needs.contract.result }}
+        run: |
+          if [[ "$RESULT" != "success" ]]; then
+            echo "repository contract concluded $RESULT" >&2
+            exit 1
+          fi


### PR DESCRIPTION
Adds the immutable fleet repository contract at d1a41a7 behind a stable Repository Contract aggregate gate. Local verification: Actionlint, fleet contract, and git diff hygiene.