### PR TITLE
fix(ci): make post-merge smoke and Rust tests portable

### DIFF
--- a/.github/actions/setup-rust-kache/action.yml
+++ b/.github/actions/setup-rust-kache/action.yml
@@ -38,6 +38,7 @@ runs:
         command -v cc >/dev/null 2>&1 || need_install=true
         command -v pkg-config >/dev/null 2>&1 || need_install=true
         command -v rg >/dev/null 2>&1 || need_install=true
+        command -v sqlite3 >/dev/null 2>&1 || need_install=true
         pkg-config --exists openssl 2>/dev/null || need_install=true
         pkg-config --exists dbus-1 2>/dev/null || need_install=true
         if [ "${{ inputs.install-tauri-deps }}" = "true" ]; then
@@ -54,7 +55,7 @@ runs:
         if [ "$need_install" = false ]; then
           exit 0
         fi
-        packages="build-essential pkg-config ripgrep libssl-dev libdbus-1-dev"
+        packages="build-essential pkg-config ripgrep sqlite3 libssl-dev libdbus-1-dev"
         if [ "${{ inputs.install-tauri-deps }}" = "true" ]; then
           packages="$packages curl file libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libxdo-dev patchelf wget"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,9 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true' || needs.changes.outputs.release == 'true' }}
     steps:
       - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: 1.97.1
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d
         with:
           install_args: cargo:taplo-cli
@@ -800,7 +803,7 @@ jobs:
 
   mcp-smoke:
     name: mcp-smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changes, binary-smoke-build]
     if: ${{ needs.binary-smoke-build.result == 'success' && (needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rust == 'true') && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
     timeout-minutes: 35
@@ -985,7 +988,7 @@ jobs:
 
   binary-smoke-build:
     name: binary-smoke-build
-    runs-on: ci-pool-rust
+    runs-on: ubuntu-24.04
     needs: [changes, rust-contracts, web-panel]
     if: ${{ always() && needs.rust-contracts.result == 'success' && needs.web-panel.result == 'success' && ((github.event_name != 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.release == 'true')) || (github.event_name == 'pull_request' && (needs.changes.outputs.release == 'true' || contains(github.event.pull_request.labels.*.name, 'ci:full')))) }}
     steps:

--- a/scripts/lib/live-cli-reporting.sh
+++ b/scripts/lib/live-cli-reporting.sh
@@ -29,14 +29,25 @@ trap cleanup_live_fixtures EXIT
 worktree_content_fingerprint() {
   (
     cd "$ROOT_DIR" || exit 1
+
+    # Keep symlink targets distinct from regular-file content. NUL delimiters
+    # preserve unusual but valid path and target bytes without ambiguity.
+    printf 'links\0'
     while IFS= read -r -d '' path; do
-      if [ -L "$path" ]; then
-        printf 'link\t%s\t%s\n' "$path" "$(readlink -- "$path")"
-      elif [ -f "$path" ]; then
-        printf 'file\t%s\t' "$path"
-        sha256sum -- "$path" | awk '{print $1}'
+      [ -L "$path" ] || continue
+      printf '%s\0%s\0' "$path" "$(readlink -- "$path")"
+    done < <(git ls-files -co --exclude-standard -z | LC_ALL=C sort -z)
+
+    # Hash regular files in batches. The previous implementation launched one
+    # sha256sum process per path, which made the 4,000+ file worktree
+    # fingerprint exceed nextest's 120-second timeout under load.
+    printf 'files\0'
+    while IFS= read -r -d '' path; do
+      if [ -f "$path" ] && [ ! -L "$path" ]; then
+        printf '%s\0' "$path"
       fi
-    done < <(git ls-files -co --exclude-standard -z | sort -z)
+    done < <(git ls-files -co --exclude-standard -z | LC_ALL=C sort -z) \
+      | xargs -0 -r sha256sum -z --
   ) | sha256sum | awk '{print $1}'
 }
 

--- a/tests/live_command_harness.rs
+++ b/tests/live_command_harness.rs
@@ -95,6 +95,80 @@ fn registry_mode_exercises_every_advertised_command_and_option() {
 }
 
 #[test]
+fn worktree_fingerprint_batches_hashing_and_detects_mutations() {
+    let helper_path =
+        fs::canonicalize("scripts/lib/live-cli-reporting.sh").expect("canonical reporting helper");
+    let helper = fs::read_to_string(&helper_path).expect("read reporting helper");
+    assert!(
+        helper.contains("xargs -0 -r sha256sum -z --"),
+        "regular files must be hashed in batches"
+    );
+    assert!(
+        !helper.contains("sha256sum -- \"$path\""),
+        "the fingerprint must not spawn one sha256sum process per file"
+    );
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let git_status = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(temp.path())
+        .status()
+        .expect("initialize temporary repository");
+    assert!(git_status.success());
+    fs::write(temp.path().join("alpha.txt"), "alpha\n").unwrap();
+    fs::write(temp.path().join("beta.txt"), "beta\n").unwrap();
+    std::os::unix::fs::symlink("alpha.txt", temp.path().join("current")).unwrap();
+
+    let shell = r#"
+set -euo pipefail
+ROOT_DIR="$FINGERPRINT_ROOT"
+OUTDIR="$ROOT_DIR/out"
+SETUP_HOME="$ROOT_DIR/setup-home"
+isolated_compose_project=""
+isolated_compose_network=""
+isolated_collections=()
+QDRANT_URL=""
+source "$FINGERPRINT_HELPER"
+before="$(worktree_content_fingerprint)"
+same="$(worktree_content_fingerprint)"
+printf 'changed\n' > "$ROOT_DIR/alpha.txt"
+after_file="$(worktree_content_fingerprint)"
+rm -- "$ROOT_DIR/current"
+ln -s beta.txt "$ROOT_DIR/current"
+after_link="$(worktree_content_fingerprint)"
+printf '%s\n%s\n%s\n%s\n' "$before" "$same" "$after_file" "$after_link"
+"#;
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(shell)
+        .env("FINGERPRINT_ROOT", temp.path())
+        .env("FINGERPRINT_HELPER", helper_path)
+        .output()
+        .expect("run worktree fingerprint probe");
+    assert!(
+        output.status.success(),
+        "fingerprint probe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let hashes = String::from_utf8(output.stdout)
+        .expect("fingerprint output")
+        .lines()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    assert_eq!(hashes.len(), 4, "expected four fingerprint samples");
+    assert!(hashes.iter().all(|hash| hash.len() == 64));
+    assert_eq!(hashes[0], hashes[1], "unchanged content must be stable");
+    assert_ne!(
+        hashes[1], hashes[2],
+        "file content changes must be detected"
+    );
+    assert_ne!(
+        hashes[2], hashes[3],
+        "symlink target changes must be detected"
+    );
+}
+
+#[test]
 fn scenario_mode_isolates_state_and_cleans_up_only_its_collection() {
     let temp = tempfile::tempdir().expect("tempdir");
     let registry = temp.path().join("commands.json");

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -397,6 +397,63 @@ fn ci_builds_web_assets_once_for_binary_artifact_jobs() {
 }
 
 #[test]
+fn rust_setup_installs_sqlite_for_cross_process_regressions() {
+    let setup = include_str!("../.github/actions/setup-rust-kache/action.yml");
+    assert!(
+        setup.contains("command -v sqlite3 >/dev/null 2>&1 || need_install=true"),
+        "the shared Rust setup must detect a missing sqlite3 CLI"
+    );
+    assert!(
+        setup.contains(
+            r#"packages="build-essential pkg-config ripgrep sqlite3 libssl-dev libdbus-1-dev""#
+        ),
+        "the shared Rust setup must install sqlite3 for cross-process WAL and stress tests"
+    );
+}
+
+#[test]
+fn linux_smoke_artifact_uses_a_pinned_compatible_runtime() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let binary_smoke_build = workflow_job_block(workflow, "binary-smoke-build");
+    let mcp_smoke = workflow_job_block(workflow, "mcp-smoke");
+
+    assert!(
+        binary_smoke_build.contains("runs-on: ubuntu-24.04"),
+        "the reusable Linux smoke binary must be built on the oldest supported smoke runtime"
+    );
+    assert!(
+        mcp_smoke.contains("runs-on: ubuntu-24.04"),
+        "the MCP consumer must run on the same pinned Ubuntu runtime as the binary producer"
+    );
+    assert!(
+        binary_smoke_build.contains("name: axon-linux-smoke")
+            && mcp_smoke.contains("name: axon-linux-smoke"),
+        "the producer and MCP consumer must share the same smoke artifact"
+    );
+}
+
+#[test]
+fn toml_fmt_installs_rust_before_mise_cargo_tools() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let toml_fmt = workflow_job_block(workflow, "toml-fmt");
+    let rust_setup = toml_fmt
+        .find("uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8")
+        .expect("toml-fmt Rust setup");
+    let mise_install = toml_fmt
+        .find("uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d")
+        .expect("toml-fmt mise install");
+
+    assert!(
+        toml_fmt.contains("toolchain: 1.97.1"),
+        "toml-fmt must use the repository-pinned Rust toolchain"
+    );
+    assert!(
+        rust_setup < mise_install,
+        "toml-fmt must install cargo before mise invokes the cargo taplo backend"
+    );
+}
+
+#[test]
 fn rust_ci_uses_the_repository_toolchain_pin() {
     let toolchain = include_str!("../rust-toolchain.toml");
     let channel = toolchain


### PR DESCRIPTION
## Summary

- install the sqlite3 CLI in the shared Rust setup action so cross-process WAL and stress-harness tests have their declared runtime dependency
- build the reusable Linux smoke binary on pinned Ubuntu 24.04
- run the MCP smoke consumer on the same pinned Ubuntu runtime, preventing OpenSSL ABI mismatches between TOOTIE-built artifacts and GitHub-hosted execution
- add workflow-shape regression tests for both portability contracts

## Root causes observed after PR #491 merged

- TOML formatting failed on a temporary DOOKIE runner whose mise subprocess inherited an unusable kache wrapper; that runner has been removed
- the full test job failed because the TOOTIE Rust runner lacked sqlite3; this caused both the WAL test and the stress harness to fail before the loopback-Qdrant assertion
- MCP smoke downloaded a TOOTIE-built binary requiring OpenSSL 3.2/3.3 and executed it on Ubuntu 24.04, which provides an older OpenSSL ABI

## Verification

- targeted workflow contracts: 24 passed
- loopback-Qdrant stress regression: passed
- cross-process SQLite WAL regression: passed
- full `just precommit`: 4,899/4,899 tests passed, 6 skipped
- Clippy, cargo check, rustfmt, repository policies, and actionlint passed
