### PR TITLE
fix(ci): keep auto-tag waits off self-hosted runners

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -79,29 +79,24 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           cat release-plan.json
 
-  release:
+  # Wait for the commit's CI workflow without occupying scarce self-hosted
+  # runners. One hosted gate serves the entire release matrix.
+  ci-gate:
     needs: plan
     if: ${{ needs.plan.outputs.matrix != '{"include":[]}' }}
-    name: ${{ matrix.id }}
-    runs-on: [self-hosted, unraid]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 65
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-        with:
-          fetch-depth: 0
-
-      # CI gate: do not cut a public release until the required CI checks for
-      # this exact commit have succeeded. auto-tag and CI both fire on the same
-      # push, so CI may still be in progress when this runs — hence the poll.
       - name: Wait for CI to pass on this commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           sha="${{ github.sha }}"
-          deadline=$(( $(date +%s) + 1800 ))  # 30 minute cap
+          deadline=$(( $(date +%s) + 3600 ))
           echo "Waiting for CI to succeed for $sha ..."
           while :; do
             gh_stderr="$(mktemp)"
@@ -135,6 +130,19 @@ jobs:
             echo "CI status='${status:-unknown}' conclusion='${conclusion:-pending}'; sleeping 20s ..."
             sleep 20
           done
+
+  release:
+    needs: [plan, ci-gate]
+    if: ${{ needs.plan.outputs.matrix != '{"include":[]}' }}
+    name: ${{ matrix.id }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          fetch-depth: 0
 
       - name: Create and push tag
         run: |

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -300,6 +300,7 @@ fn lefthook_pre_push_uses_path_aware_router() {
 fn auto_tag_uses_validated_xtask_release_plan() {
     let workflow = include_str!("../.github/workflows/auto-tag.yml");
     let plan = workflow_job_block(workflow, "plan");
+    let ci_gate = workflow_job_block(workflow, "ci-gate");
     let release = workflow_job_block(workflow, "release");
     assert!(
         plan.contains("cargo xtask check-release-versions --head HEAD --mode main --json"),
@@ -316,8 +317,19 @@ fn auto_tag_uses_validated_xtask_release_plan() {
         "auto-tag matrix must include only changed components"
     );
     assert!(
-        release.contains(r#"needs.plan.outputs.matrix != '{"include":[]}'"#),
-        "auto-tag must skip release job for an empty matrix"
+        ci_gate.contains(r#"needs.plan.outputs.matrix != '{"include":[]}'"#)
+            && release.contains(r#"needs.plan.outputs.matrix != '{"include":[]}'"#),
+        "auto-tag must skip CI gating and releases for an empty matrix"
+    );
+    assert!(
+        ci_gate.contains("runs-on: ubuntu-24.04")
+            && ci_gate.contains("timeout-minutes: 65")
+            && release.contains("runs-on: ubuntu-24.04"),
+        "auto-tag polling and tagging must not consume self-hosted runners"
+    );
+    assert!(
+        release.contains("needs: [plan, ci-gate]"),
+        "the release matrix must wait for the shared CI gate"
     );
     assert!(
         release.contains("fromJson(needs.plan.outputs.matrix)"),
@@ -328,11 +340,10 @@ fn auto_tag_uses_validated_xtask_release_plan() {
         "auto-tag must consume tags and workflows from the xtask release plan"
     );
     assert!(
-        release
-            .find("Wait for CI to pass on this commit")
-            .expect("CI wait step")
-            < release.find("Create and push tag").expect("tag step"),
-        "auto-tag must wait for CI before creating release tags"
+        ci_gate.contains("Wait for CI to pass on this commit")
+            && release.contains("Create and push tag")
+            && !release.contains("Wait for CI to pass on this commit"),
+        "one shared CI gate must run before the release matrix creates tags"
     );
     for required in [
         "if ! runs_json=$(gh run list",
@@ -344,7 +355,7 @@ fn auto_tag_uses_validated_xtask_release_plan() {
         ".headBranch == \"main\"",
     ] {
         assert!(
-            release.contains(required),
+            ci_gate.contains(required),
             "auto-tag CI polling must constrain {required}"
         );
     }


### PR DESCRIPTION
## Root cause

The auto-tag release matrix started on self-hosted Unraid runners and then polled the CI workflow for up to 30 minutes. When CLI, Palette, and Android all needed release tags, those three sleeping jobs occupied most of the Rust pool while the CI jobs they were waiting for remained queued. All three tag jobs timed out even though the eventual main CI run passed.

## Fix

- Add one shared `ci-gate` job on `ubuntu-24.04`.
- Extend the bounded CI wait to 60 minutes with a 65-minute job timeout.
- Make the release matrix depend on the shared gate.
- Run the lightweight tag-and-dispatch matrix on `ubuntu-24.04`, preserving self-hosted capacity for actual builds.
- Add workflow-shape regression coverage for hosted gating, dependency ordering, and constrained CI-run selection.

## Validation

- `actionlint .github/workflows/auto-tag.yml`
- rustfmt check
- all 25 `workflow_shapes` tests passed
- pre-push path-aware and structural checks passed
