### PR TITLE
fix(ci): give hosted auto-tag gate repo context

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -101,6 +101,7 @@ jobs:
           while :; do
             gh_stderr="$(mktemp)"
             if ! runs_json=$(gh run list \
+              --repo "${{ github.repository }}" \
               --workflow=ci.yml \
               --commit "$sha" \
               --branch main \

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -347,6 +347,7 @@ fn auto_tag_uses_validated_xtask_release_plan() {
     );
     for required in [
         "if ! runs_json=$(gh run list",
+        "--repo \"${{ github.repository }}\"",
         "gh run list failed while polling ci.yml",
         "--branch main",
         "--event push",


### PR DESCRIPTION
## Root cause

The new hosted `ci-gate` correctly moved CI polling off self-hosted runners, but it does not check out the repository. `gh run list` therefore tried to infer the base repository from `.git` and failed immediately with `fatal: not a git repository`.

## Fix

- Pass `--repo "$GITHUB_REPOSITORY"` to `gh run list`.
- Add a workflow-shape regression requiring explicit repository context.

## Validation

- `actionlint .github/workflows/auto-tag.yml`
- rustfmt and diff checks
- all 25 workflow-shape tests
- pre-commit and pre-push path-aware/structural checks