### PR TITLE
fix(release): create releases and harden SQLite writes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -153,7 +153,25 @@ jobs:
           git push origin "${{ matrix.candidate_tag }}"
           echo "Pushed tag ${{ matrix.candidate_tag }}"
 
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ matrix.candidate_tag }}"
+          repo="${{ github.repository }}"
+          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+            echo "GitHub Release $tag already exists."
+          else
+            gh release create "$tag" \
+              --repo "$repo" \
+              --verify-tag \
+              --generate-notes \
+              --title "$tag"
+            echo "Created GitHub Release $tag."
+          fi
+
       - name: Dispatch release workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run "${{ matrix.release_workflow }}" --ref "${{ matrix.candidate_tag }}" -f publish=true
+        run: gh workflow run "${{ matrix.release_workflow }}" --repo "${{ github.repository }}" --ref "${{ matrix.candidate_tag }}" -f publish=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.9] - 2026-08-03
+
 ## [7.2.8] - 2026-08-02
 
 ## [7.2.7] - 2026-07-31

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "axon"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "axon-adapters"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "axon-api"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "axon-error",
  "chrono",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "axon-authz"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "axon-cli"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "anyhow",
  "axon-api",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "axon-core"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "axon-document"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "axon-embedding"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "axon-error"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "chrono",
  "schemars",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "axon-extract"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "axon-core",
  "axon-graph",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "axon-graph"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "axon-jobs"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "axon-ledger"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "axon-llm"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "axon-mcp"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "axon-api",
  "axon-authz",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "axon-memory"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-adapters",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "axon-observe"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "axon-parse"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "axon-api",
  "axon-graph",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "axon-prune"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "axon-retrieval"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "axon-route"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "axon-services"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "axon-vectors"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "axon-web"
-version = "7.2.8"
+version = "7.2.9"
 dependencies = [
  "async-trait",
  "axon-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 # `axon` package keeps an explicit `version` too (the release checker reads it as
 # a string); `cargo xtask bump-version patch --component cli` moves both in lockstep.
 [workspace.package]
-version = "7.2.8"
+version = "7.2.9"
 edition = "2024"
 rust-version = "1.97.1"
 keywords = ["rag", "mcp", "qdrant", "embeddings", "crawler"]
@@ -84,7 +84,7 @@ lab-auth = { path = "vendor/lab-auth" }
 
 [package]
 name = "axon"
-version = "7.2.8"
+version = "7.2.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted RAG engine in Rust: crawl, scrape, ingest, embed, and query any source, with hybrid retrieval and cited LLM synthesis over MCP, CLI, and REST.
 
-Version: 7.2.8
+Version: 7.2.9
 
 Every source — a web page, a site, a local checkout, a Git repo, a package, a
 Reddit subreddit, a YouTube transcript, or an AI session export — enters

--- a/apps/web/openapi/axon.json
+++ b/apps/web/openapi/axon.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "7.2.8"
+    "version": "7.2.9"
   },
   "paths": {
     "/healthz": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axon/admin-panel",
-  "version": "7.2.8",
+  "version": "7.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axon/admin-panel",
-      "version": "7.2.8",
+      "version": "7.2.9",
       "dependencies": {
         "lucide-react": "^1.16.0",
         "next": "^16.2.12",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,5 +37,5 @@
     "openapi:types": "node scripts/generate-openapi-types.mjs openapi/axon.json src/api/generated/axon-api.ts",
     "test": "vitest run"
   },
-  "version": "7.2.8"
+  "version": "7.2.9"
 }

--- a/crates/axon-memory/src/sqlite.rs
+++ b/crates/axon-memory/src/sqlite.rs
@@ -17,6 +17,7 @@ pub mod recall;
 pub mod rows;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use axon_api::source::*;
@@ -51,7 +52,7 @@ impl SqliteMemoryStore {
     /// Open a store whose schema is owned by the composed runtime migration.
     pub fn open_migrated(path: &str, clock: Arc<dyn Clock>) -> Result<Self> {
         let conn = Connection::open(path).map_err(|e| store_error(format!("open: {e}")))?;
-        Ok(Self::from_migrated_connection(conn, clock))
+        Self::from_migrated_connection(conn, clock)
     }
 
     /// Create an in-memory store (for tests).
@@ -61,11 +62,17 @@ impl SqliteMemoryStore {
     }
 
     fn from_connection(conn: Connection, clock: Arc<dyn Clock>) -> Result<Self> {
+        configure_connection(&conn)?;
         ensure_schema(&conn).map_err(|e| store_error(format!("migrate: {e}")))?;
-        Ok(Self::from_migrated_connection(conn, clock))
+        Ok(Self::from_configured_connection(conn, clock))
     }
 
-    fn from_migrated_connection(conn: Connection, clock: Arc<dyn Clock>) -> Self {
+    fn from_migrated_connection(conn: Connection, clock: Arc<dyn Clock>) -> Result<Self> {
+        configure_connection(&conn)?;
+        Ok(Self::from_configured_connection(conn, clock))
+    }
+
+    fn from_configured_connection(conn: Connection, clock: Arc<dyn Clock>) -> Self {
         Self {
             conn: Arc::new(Mutex::new(conn)),
             clock,
@@ -135,6 +142,17 @@ impl SqliteMemoryStore {
             None => Ok(None),
         }
     }
+}
+
+/// Apply the same transient-writer policy as the shared sqlx job pool.
+///
+/// The memory store uses a dedicated rusqlite connection against the unified
+/// database. Without a busy handler, a worker heartbeat or job-status update
+/// can win SQLite's single-writer race and make an otherwise valid memory
+/// mutation fail immediately with `database is locked`.
+fn configure_connection(conn: &Connection) -> Result<()> {
+    conn.busy_timeout(Duration::from_secs(30))
+        .map_err(|error| store_error(format!("configure busy timeout: {error}")))
 }
 
 #[async_trait]

--- a/crates/axon-memory/src/sqlite_tests.rs
+++ b/crates/axon-memory/src/sqlite_tests.rs
@@ -13,6 +13,40 @@ fn store() -> (SqliteMemoryStore, Arc<FixedClock>) {
     (store, clock)
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_store_waits_for_a_transient_external_writer() {
+    let path = std::env::temp_dir().join(format!(
+        "axon-memory-busy-timeout-{}.db",
+        uuid::Uuid::new_v4()
+    ));
+    let clock = Arc::new(FixedClock::at_2026());
+    let store = SqliteMemoryStore::open(&path.to_string_lossy(), clock)
+        .expect("open file-backed memory store");
+
+    let locker = rusqlite::Connection::open(&path).expect("open competing connection");
+    locker
+        .execute_batch("BEGIN IMMEDIATE")
+        .expect("hold SQLite writer lock");
+    let release = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        locker.execute_batch("COMMIT").expect("release writer lock");
+    });
+
+    let remembered = store
+        .remember(request(MemoryType::Fact, "waited for writer", "axon"))
+        .await;
+    release.join().expect("writer release thread");
+    assert!(
+        remembered.is_ok(),
+        "memory writes must wait for transient SQLite writers: {remembered:?}"
+    );
+
+    drop(store);
+    for suffix in ["", "-shm", "-wal"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
+    }
+}
+
 fn request(memory_type: MemoryType, body: &str, scope_value: &str) -> MemoryRequest {
     MemoryRequest {
         memory_type,

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -379,6 +379,29 @@ fn auto_tag_uses_validated_xtask_release_plan() {
             && !release.contains("Wait for CI to pass on this commit"),
         "one shared CI gate must run before the release matrix creates tags"
     );
+    let tag_step = release.find("Create and push tag").expect("tag step");
+    let github_release_step = release
+        .find("Create GitHub release")
+        .expect("GitHub Release step");
+    let dispatch_step = release
+        .find("Dispatch release workflow")
+        .expect("release dispatch step");
+    assert!(
+        tag_step < github_release_step && github_release_step < dispatch_step,
+        "auto-tag must create the tag, then the GitHub Release, then dispatch the artifact workflow"
+    );
+    for required in [
+        "gh release view \"$tag\" --repo \"$repo\"",
+        "gh release create \"$tag\"",
+        "--verify-tag",
+        "--generate-notes",
+        "--repo \"${{ github.repository }}\" --ref",
+    ] {
+        assert!(
+            release.contains(required),
+            "auto-tag release creation must include {required}"
+        );
+    }
     for required in [
         "if ! runs_json=$(gh run list",
         "--repo \"${{ github.repository }}\"",

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -396,7 +396,7 @@ fn auto_tag_uses_validated_xtask_release_plan() {
     );
     let tag_step = release.find("Create and push tag").expect("tag step");
     let github_release_step = release
-        .find("Create GitHub release")
+        .find("Ensure GitHub Release exists")
         .expect("GitHub Release step");
     let dispatch_step = release
         .find("Dispatch release workflow")
@@ -410,11 +410,12 @@ fn auto_tag_uses_validated_xtask_release_plan() {
         "gh release create \"$tag\"",
         "--verify-tag",
         "--generate-notes",
-        "--repo \"${{ github.repository }}\" --ref",
+        "--repo \"${{ github.repository }}\"",
+        "--ref \"${{ matrix.candidate_tag }}\"",
     ] {
         assert!(
             release.contains(required),
-            "auto-tag release creation must include {required}"
+            "auto-tag release flow must include {required}"
         );
     }
     for required in [


### PR DESCRIPTION
## Root causes

1. Auto-tag pushed component tags and dispatched artifact workflows before a GitHub Release existed. The artifact workflows then failed while attaching otherwise valid assets.
2. The dedicated rusqlite memory connection had no busy timeout, so unified-worker heartbeats could win SQLite's single-writer race and make detached memory compaction fail with `insert: database is locked`.
3. The CLI shipping surface changed after `v7.2.8`, so the release contract requires the next version to be greater than the existing tag.

## Fixes

- Create or reuse the GitHub Release after pushing each component tag and before dispatching its artifact workflow.
- Keep release creation idempotent, generate release notes, verify the tag, and pass explicit repository context.
- Configure every `SqliteMemoryStore` connection with the same 30-second transient-writer wait policy as the shared sqlx pool.
- Add a real external-writer regression proving a memory write waits for and survives a competing SQLite writer.
- Bump the CLI component and all generated/version-bearing surfaces from 7.2.8 to 7.2.9.
- Lock auto-tag ordering and required commands with workflow-shape regression coverage.

## Validation

- `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr`
- `actionlint .github/workflows/auto-tag.yml`
- 27 workflow-shape tests
- environment-boundary contract
- external SQLite writer-lock regression
- detached memory compaction regression, repeated successfully
- full pre-push path-aware, generated-contract, repository-structure, layering, and structural checks