### PR TITLE
fix(ci): prevent Android packaging heap exhaustion

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "apps/palette-tauri": "5.14.5",
-  "apps/android": "1.6.3",
+  "apps/android": "1.6.4",
   "apps/chrome-extension": "0.3.2"
 }

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] - 2026-08-03
+
+### Changed
+
+- Raise the Gradle heap ceiling for reliable debug APK packaging while retaining bounded worker concurrency.
+
 ## [1.6.3] - 2026-08-01
 
 ### Changed

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -19,9 +19,9 @@ android {
         applicationId = "com.axon.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 19 // x-release-please-version-code 1.6.3
+        versionCode = 20 // x-release-please-version-code 1.6.4
         // x-release-please-start-version
-        versionName = "1.6.3"
+        versionName = "1.6.4"
         // x-release-please-end
         manifestPlaceholders["appAuthRedirectScheme"] = "com.axon.app"
     }

--- a/apps/android/gradle.properties
+++ b/apps/android/gradle.properties
@@ -1,7 +1,7 @@
 # Keep CI and local composite builds within the memory envelope of the
-# repo-scoped system runners. Android/Kotlin compilation otherwise risks the
-# single-use Gradle daemon being OOM-killed under concurrent CI load.
-org.gradle.jvmargs=-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+# repo-scoped system runners. APK packaging needs a 2 GiB heap, while the
+# worker and metaspace caps bound total Gradle memory under concurrent CI load.
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.workers.max=2
 android.useAndroidX=true
 android.enableJetifier=false

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -272,6 +272,26 @@ fn android_ci_setup_does_not_install_unused_emulator_packages() {
 }
 
 #[test]
+fn android_ci_gradle_memory_covers_apk_packaging() {
+    let properties = include_str!("../apps/android/gradle.properties");
+
+    assert!(
+        properties.lines().any(|line| {
+            line.starts_with("org.gradle.jvmargs=")
+                && line.contains("-Xmx2048m")
+                && line.contains("-XX:MaxMetaspaceSize=512m")
+        }),
+        "Android CI needs a 2 GiB Gradle heap for debug APK packaging while retaining the metaspace cap"
+    );
+    assert!(
+        properties
+            .lines()
+            .any(|line| line.trim() == "org.gradle.workers.max=2"),
+        "Android CI must keep Gradle worker concurrency bounded on shared runners"
+    );
+}
+
+#[test]
 fn lefthook_pre_push_uses_path_aware_router() {
     let lefthook = include_str!("../lefthook.yml");
     let pre_push = lefthook


### PR DESCRIPTION
## Summary

- restore the Android Gradle heap from 1536 MiB to 2048 MiB after debug APK packaging exhausted the smaller heap
- retain the 512 MiB metaspace cap and two-worker concurrency limit on the 10 GiB system runner
- add a workflow contract that guards the memory envelope
- bump Android release metadata to 1.6.4 / build 20 as required by the shipping-path gate

## Root cause

The failed Android job reached `:app:packageDebug` and threw `java.lang.OutOfMemoryError: Java heap space` inside Zipflinger packaging. The system runner itself has a 10 GiB memory limit, so the Gradle heap was the binding limit.

## Verification

- full CI-equivalent Android command: 105 tasks, `BUILD SUCCESSFUL`, including unit tests, OpenAPI client verification, lint, `packageDebug`, and APK copy
- `cargo test --locked --test workflow_shapes`: 26 passed
- `cargo test --locked --test ci_changed_paths`: 18 passed
- `cargo fmt --all --check`
- `actionlint` on all path-selected workflows
- `target/debug/xtask check-release-versions --base origin/main --head HEAD --mode pr`
- `target/debug/xtask pre-push`

Closes axon_rust-puo4m.