### PR TITLE
fix(release): derive fixups from release PR diff

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,17 +73,25 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           base_ref="$(git rev-parse --abbrev-ref HEAD)"
           jq -c '.[]' <<<"$PRS" | while read -r pr; do
-            branch="$(jq -r '.headBranchName' <<<"$pr")"
-            files="$(jq -r '.files[]?' <<<"$pr")"
-            git fetch origin "$branch"
+            branch="$(jq -er '.headBranchName | select(length > 0)' <<<"$pr")"
+            base_branch="$(jq -er '.baseBranchName | select(length > 0)' <<<"$pr")"
+            git fetch origin \
+              "+refs/heads/$base_branch:refs/remotes/origin/$base_branch" \
+              "+refs/heads/$branch:refs/remotes/origin/$branch"
             git checkout "$branch"
-            cargo xtask release-please-fixup-plan --files "$files" --json > fixup-plan.json
+            cargo xtask release-please-fixup-plan \
+              --base "origin/$base_branch" \
+              --head HEAD \
+              --json > fixup-plan.json
             while read -r fixup; do
               component="$(jq -r '.id' <<<"$fixup")"
               version="$(jq -r '.version' <<<"$fixup")"
               cargo xtask release-please-fixups --component "$component" --version "$version"
             done < <(jq -c '.[]' fixup-plan.json)
-            cargo xtask check-release-versions --base origin/main --head HEAD --mode pr
+            cargo xtask check-release-versions \
+              --base "origin/$base_branch" \
+              --head HEAD \
+              --mode pr
             if ! git diff --quiet; then
               git add --update
               git commit -m "chore: apply release-please fixups"

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -400,10 +400,18 @@ fn release_please_fixups_validate_and_forward_pr_branch_refs() {
     }
 
     assert!(
-        fixups.contains("git checkout \"$branch\"")
-            && fixups.contains("--base \"origin/$base_branch\"")
-            && fixups.contains("--head HEAD"),
-        "fixup planning must compare the checked-out release branch with its reported base branch"
+        fixups.contains("git checkout \"$branch\""),
+        "fixup planning must run from the reported release PR branch"
+    );
+    let (_, after_plan_start) = fixups
+        .split_once("cargo xtask release-please-fixup-plan")
+        .expect("release PR fixup planner invocation exists");
+    let (plan_args, _) = after_plan_start
+        .split_once("cargo xtask check-release-versions")
+        .expect("release version check follows fixup planning");
+    assert!(
+        plan_args.contains("--base \"origin/$base_branch\"") && plan_args.contains("--head HEAD"),
+        "the fixup planner itself must compare the release branch with its reported base branch"
     );
 }
 

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -383,6 +383,31 @@ fn auto_tag_uses_validated_xtask_release_plan() {
 }
 
 #[test]
+fn release_please_fixups_validate_and_forward_pr_branch_refs() {
+    let workflow = include_str!("../.github/workflows/release-please.yml");
+    let fixups = workflow_job_block(workflow, "release-pr-fixups");
+
+    for (variable, field) in [
+        ("branch", "headBranchName"),
+        ("base_branch", "baseBranchName"),
+    ] {
+        let extraction =
+            format!(r#"{variable}="$(jq -er '.{field} | select(length > 0)' <<<"$pr")""#);
+        assert!(
+            fixups.contains(&extraction),
+            "release PR fixups must fail closed when {field} is missing or empty"
+        );
+    }
+
+    assert!(
+        fixups.contains("git checkout \"$branch\"")
+            && fixups.contains("--base \"origin/$base_branch\"")
+            && fixups.contains("--head HEAD"),
+        "fixup planning must compare the checked-out release branch with its reported base branch"
+    );
+}
+
+#[test]
 fn ci_keeps_expensive_artifacts_off_ordinary_pull_requests() {
     let workflow = include_str!("../.github/workflows/ci.yml");
     let smoke = workflow_job_block(workflow, "smoke-binary");

--- a/xtask/src/checks/release_versions.rs
+++ b/xtask/src/checks/release_versions.rs
@@ -212,10 +212,12 @@ pub fn release_please_fixups(root: &Path, component_id: &str, version: &str) -> 
 
 pub fn release_please_fixup_plan(
     root: &Path,
-    files: &str,
+    base: &str,
+    head: &str,
 ) -> ReleaseResult<Vec<ReleasePleaseFixupItem>> {
     let manifest = load_manifest(root)?;
-    release_please::fixup_items(root, &manifest.components, files)
+    let changed_files = changed_paths_since_ref(root, base, head, &[".".to_owned()])?;
+    release_please::fixup_items(root, &manifest.components, &changed_files)
 }
 
 pub fn print_release_please_fixup_plan(

--- a/xtask/src/checks/release_versions.rs
+++ b/xtask/src/checks/release_versions.rs
@@ -216,7 +216,8 @@ pub fn release_please_fixup_plan(
     head: &str,
 ) -> ReleaseResult<Vec<ReleasePleaseFixupItem>> {
     let manifest = load_manifest(root)?;
-    let changed_files = changed_paths_since_ref(root, base, head, &[".".to_owned()])?;
+    let compare_ref = merge_base(root, base, head)?;
+    let changed_files = changed_paths_since_ref(root, &compare_ref, head, &[".".to_owned()])?;
     release_please::fixup_items(root, &manifest.components, &changed_files)
 }
 

--- a/xtask/src/checks/release_versions/release_please.rs
+++ b/xtask/src/checks/release_versions/release_please.rs
@@ -140,9 +140,9 @@ fn write_release_version_files(
 pub(super) fn fixup_items(
     root: &Path,
     components: &[Component],
-    files: &str,
+    files: &[String],
 ) -> ReleaseResult<Vec<ReleasePleaseFixupItem>> {
-    let changed_files = files.lines().collect::<BTreeSet<_>>();
+    let changed_files = files.iter().map(String::as_str).collect::<BTreeSet<_>>();
     let versions = read_release_please_manifest(root)?;
     let mut items = Vec::new();
 

--- a/xtask/src/checks/release_versions_tests.rs
+++ b/xtask/src/checks/release_versions_tests.rs
@@ -1080,6 +1080,54 @@ fn release_please_fixup_plan_derives_changed_files_from_git_refs() {
 }
 
 #[test]
+fn release_please_fixup_plan_ignores_changes_added_only_to_an_advanced_base() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["checkout", "-b", "release-palette"]);
+    fs::write(
+        fixture.path(".release-please-manifest.json"),
+        r#"{
+  "apps/palette-tauri": "6.0.0",
+  "apps/android": "1.3.2",
+  "apps/chrome-extension": "0.2.0"
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/palette-tauri/CHANGELOG.md"),
+        "# Changelog\n\n## [6.0.0]\n",
+    )
+    .unwrap();
+    fixture.git(&[
+        "add",
+        ".release-please-manifest.json",
+        "apps/palette-tauri/CHANGELOG.md",
+    ]);
+    fixture.git(&["commit", "-m", "chore(main): release palette 6.0.0"]);
+
+    fixture.git(&["checkout", "main"]);
+    fs::write(
+        fixture.path("apps/android/CHANGELOG.md"),
+        "# Changelog\n\n## [1.3.3]\n",
+    )
+    .unwrap();
+    fixture.git(&["add", "apps/android/CHANGELOG.md"]);
+    fixture.git(&["commit", "-m", "chore: advance main with android release"]);
+    fixture.git(&["checkout", "release-palette"]);
+
+    let items = release_please_fixup_plan(fixture.root(), "main", "HEAD").unwrap();
+
+    assert_eq!(
+        items,
+        vec![ReleasePleaseFixupItem {
+            id: "palette".to_owned(),
+            version: "6.0.0".to_owned(),
+        }],
+        "fixup planning must use the release branch diff from the merge base, not base-only changes"
+    );
+}
+
+#[test]
 fn release_please_fixup_plan_rejects_an_invalid_base_ref() {
     let fixture = Fixture::new();
     fixture.init_repo();
@@ -1087,8 +1135,8 @@ fn release_please_fixup_plan_rejects_an_invalid_base_ref() {
     let error = release_please_fixup_plan(fixture.root(), "missing-base", "HEAD")
         .expect_err("an invalid base ref must not produce an empty fixup plan");
 
-    assert!(error.to_string().contains("git diff failed"));
-    assert!(error.to_string().contains("missing-base..HEAD"));
+    assert!(error.to_string().contains("merge-base"));
+    assert!(error.to_string().contains("missing-base"));
 }
 
 #[test]

--- a/xtask/src/checks/release_versions_tests.rs
+++ b/xtask/src/checks/release_versions_tests.rs
@@ -1019,11 +1019,13 @@ fn release_please_dispatch_plan_rejects_object_paths() {
 #[test]
 fn release_please_fixup_plan_uses_component_manifest() {
     let fixture = Fixture::new();
-    let items = release_please_fixup_plan(
-        fixture.root(),
-        "apps/palette-tauri/CHANGELOG.md\napps/android/app/build.gradle.kts\napps/chrome-extension/CHANGELOG.md\n",
-    )
-    .unwrap();
+    let manifest = load_manifest(fixture.root()).unwrap();
+    let files = [
+        "apps/palette-tauri/CHANGELOG.md".to_owned(),
+        "apps/android/app/build.gradle.kts".to_owned(),
+        "apps/chrome-extension/CHANGELOG.md".to_owned(),
+    ];
+    let items = release_please::fixup_items(fixture.root(), &manifest.components, &files).unwrap();
     assert_eq!(
         items,
         vec![
@@ -1041,6 +1043,52 @@ fn release_please_fixup_plan_uses_component_manifest() {
             },
         ]
     );
+}
+
+#[test]
+fn release_please_fixup_plan_derives_changed_files_from_git_refs() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["checkout", "-b", "release-palette"]);
+    fs::write(
+        fixture.path(".release-please-manifest.json"),
+        r#"{
+  "apps/palette-tauri": "6.0.0",
+  "apps/android": "1.3.2",
+  "apps/chrome-extension": "0.2.0"
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/palette-tauri/CHANGELOG.md"),
+        "# Changelog\n\n## [6.0.0]\n",
+    )
+    .unwrap();
+    fixture.git(&["add", ".release-please-manifest.json"]);
+    fixture.git(&["add", "apps/palette-tauri/CHANGELOG.md"]);
+    fixture.git(&["commit", "-m", "chore(main): release palette 6.0.0"]);
+
+    let items = release_please_fixup_plan(fixture.root(), "main", "HEAD").unwrap();
+
+    assert_eq!(
+        items,
+        vec![ReleasePleaseFixupItem {
+            id: "palette".to_owned(),
+            version: "6.0.0".to_owned(),
+        }]
+    );
+}
+
+#[test]
+fn release_please_fixup_plan_rejects_an_invalid_base_ref() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+
+    let error = release_please_fixup_plan(fixture.root(), "missing-base", "HEAD")
+        .expect_err("an invalid base ref must not produce an empty fixup plan");
+
+    assert!(error.to_string().contains("git diff failed"));
+    assert!(error.to_string().contains("missing-base..HEAD"));
 }
 
 #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -128,10 +128,12 @@ enum Command {
         #[arg(long)]
         version: String,
     },
-    /// Print release-please postprocessing needed for a release PR file list.
+    /// Print release-please postprocessing needed for a release PR branch diff.
     ReleasePleaseFixupPlan {
         #[arg(long)]
-        files: String,
+        base: String,
+        #[arg(long, default_value = "HEAD")]
+        head: String,
         #[arg(long)]
         json: bool,
     },
@@ -231,8 +233,8 @@ fn main() -> Result<()> {
         Command::ReleasePleaseFixups { component, version } => Ok(
             checks::release_versions::release_please_fixups(&root, &component, &version)?,
         ),
-        Command::ReleasePleaseFixupPlan { files, json } => {
-            let items = checks::release_versions::release_please_fixup_plan(&root, &files)?;
+        Command::ReleasePleaseFixupPlan { base, head, json } => {
+            let items = checks::release_versions::release_please_fixup_plan(&root, &base, &head)?;
             checks::release_versions::print_release_please_fixup_plan(&items, json)?;
             Ok(())
         }


### PR DESCRIPTION
## Summary

- derive release-please fixup components from the checked-out release PR branch diff instead of the potentially empty action files payload
- validate and fetch the reported base and head branch names before planning fixups
- fail closed when the base ref is invalid, with regression coverage shaped like Palette release PR #489

## Root cause

The pinned release-please action returned a PR object whose files array was empty even though the release branch changed the manifest and Palette changelog. The workflow trusted that array, produced an empty fixup plan, and then failed version validation because derived Palette version files still held 5.14.5 while the manifest held 6.0.0.

## Verification

- cargo test -q -p xtask --locked: 423 passed
- cargo fmt --all -- --check
- actionlint .github/workflows/release-please.yml
- git diff --check
- pre-push path-aware and structural checks passed
- exact PR #489 replay planned Palette 6.0.0, applied all four derived version files, and passed check-release-versions

Bead: axon_rust-3h94c