### PR TITLE
fix(release): enforce single component ownership

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -5,12 +5,13 @@ name: auto-tag
 # On every push to main this asks `cargo xtask check-release-versions` for the
 # shared release plan. Component metadata lives in `release/components.toml`.
 #
-# For each component, it diffs the component's shipping paths against that
-# component's most recent tag. If the code changed AND the version was bumped
-# (the computed tag does not exist), it waits for CI to pass on this commit,
-# creates the tag, and dispatches the component's release workflow. A component
-# whose code did NOT change since its last tag is skipped — so a CLI-only change
-# never rebuilds android, and an android-only change never cuts a CLI release.
+# For each release-please-unmanaged component, it diffs the component's shipping
+# paths against that component's most recent tag. If the code changed AND the
+# version was bumped (the computed tag does not exist), it waits for CI to pass
+# on this commit, creates the tag and GitHub Release, and dispatches the
+# component's artifact workflow. Release-please-managed components are excluded:
+# their release PR, tag, GitHub Release, and artifact dispatch remain owned by
+# release-please.yml.
 #
 # RELEASE GATES (OPS-M1): before a tag is created we (1) verify the new version
 # is a strictly-monotonic bump over that component's highest existing tag, and
@@ -18,10 +19,10 @@ name: auto-tag
 # this exact commit. This prevents an accidental version edit or a red CI from
 # auto-publishing a broken public release.
 #
-# BUMP ENFORCEMENT: if a component's code changed but its version was NOT bumped
-# (the computed tag already exists), the component's job FAILS with a message
-# naming the component — nothing ships silently. `fail-fast: false` keeps the
-# other components releasing independently; the red job flags the missing bump.
+# BUMP ENFORCEMENT: if an unmanaged component's code changed but its version was
+# NOT bumped (the computed tag already exists), the plan fails before a tag is
+# created. Managed components defer their version edits to release-please and
+# never enter this workflow's matrix.
 #
 # NOTE: tags pushed via GITHUB_TOKEN do NOT trigger other workflows (GitHub
 # security model). We therefore dispatch each release workflow explicitly via
@@ -75,7 +76,12 @@ jobs:
         run: |
           set -euo pipefail
           cargo xtask check-release-versions --head HEAD --mode main --json > release-plan.json
-          matrix=$(jq -c '{include: [.[] | select(.changed == true)]}' release-plan.json)
+          if ! jq -e 'type == "array" and all(.[]; (.release_please_managed | type) == "boolean")' release-plan.json >/dev/null; then
+            echo "::error::release plan must be an array whose items declare boolean release_please_managed ownership" >&2
+            cat release-plan.json >&2
+            exit 1
+          fi
+          matrix=$(jq -c '{include: [.[] | select(.changed == true and .release_please_managed == false)]}' release-plan.json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           cat release-plan.json
 
@@ -153,7 +159,25 @@ jobs:
           git push origin "${{ matrix.candidate_tag }}"
           echo "Pushed tag ${{ matrix.candidate_tag }}"
 
+      - name: Ensure GitHub Release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ matrix.candidate_tag }}"
+          repo="${{ github.repository }}"
+          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+            echo "GitHub Release $tag already exists."
+          else
+            gh release create "$tag" --verify-tag --generate-notes --repo "$repo"
+            echo "Created GitHub Release $tag."
+          fi
+
       - name: Dispatch release workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run "${{ matrix.release_workflow }}" --ref "${{ matrix.candidate_tag }}" -f publish=true
+        run: |
+          gh workflow run "${{ matrix.release_workflow }}" \
+            --repo "${{ github.repository }}" \
+            --ref "${{ matrix.candidate_tag }}" \
+            -f publish=true

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -150,14 +150,52 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Create and push tag
         run: |
+          set -euo pipefail
+          tag="${{ matrix.candidate_tag }}"
+          expected_sha="${{ github.sha }}"
+          head_sha="$(git rev-parse --verify "HEAD^{commit}")"
+          if [ "$head_sha" != "$expected_sha" ]; then
+            echo "::error::checked-out HEAD $head_sha does not match workflow commit $expected_sha" >&2
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "${{ matrix.candidate_tag }}"
-          git push origin "${{ matrix.candidate_tag }}"
-          echo "Pushed tag ${{ matrix.candidate_tag }}"
+
+          local_target=""
+          if git show-ref --verify --quiet "refs/tags/$tag"; then
+            local_target="$(git rev-parse --verify "$tag^{commit}")"
+            if [ "$local_target" != "$expected_sha" ]; then
+              echo "::error::local tag $tag resolves to $local_target, expected $expected_sha" >&2
+              exit 1
+            fi
+          fi
+
+          remote_refs="$(git ls-remote --tags origin "refs/tags/$tag" "refs/tags/$tag^{}")"
+          remote_target="$(awk '
+            $2 ~ /\^\{\}$/ { peeled = $1 }
+            $2 !~ /\^\{\}$/ { direct = $1 }
+            END { if (peeled != "") print peeled; else if (direct != "") print direct }
+          ' <<<"$remote_refs")"
+          if [ -n "$remote_target" ] && [ "$remote_target" != "$expected_sha" ]; then
+            echo "::error::remote tag $tag resolves to $remote_target, expected $expected_sha" >&2
+            exit 1
+          fi
+
+          if [ -n "$remote_target" ]; then
+            echo "Remote tag $tag already resolves to $expected_sha."
+          elif [ -n "$local_target" ]; then
+            git push origin "refs/tags/$tag"
+            echo "Pushed existing local tag $tag at $expected_sha."
+          else
+            git tag "$tag" "$expected_sha"
+            git push origin "refs/tags/$tag"
+            echo "Created and pushed tag $tag at $expected_sha."
+          fi
 
       - name: Ensure GitHub Release exists
         env:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -188,13 +188,25 @@ jobs:
 
           if [ -n "$remote_target" ]; then
             echo "Remote tag $tag already resolves to $expected_sha."
-          elif [ -n "$local_target" ]; then
-            git push origin "refs/tags/$tag"
-            echo "Pushed existing local tag $tag at $expected_sha."
           else
-            git tag "$tag" "$expected_sha"
-            git push origin "refs/tags/$tag"
-            echo "Created and pushed tag $tag at $expected_sha."
+            remote_main="$(git ls-remote --heads origin refs/heads/main | awk 'NR == 1 { print $1 }')"
+            if [ -z "$remote_main" ]; then
+              echo "::error::remote refs/heads/main is missing" >&2
+              exit 1
+            fi
+            if [ "$remote_main" != "$expected_sha" ]; then
+              echo "::error::remote main now resolves to $remote_main, not workflow commit $expected_sha" >&2
+              exit 1
+            fi
+
+            if [ -n "$local_target" ]; then
+              git push origin "refs/tags/$tag"
+              echo "Pushed existing local tag $tag at $expected_sha."
+            else
+              git tag "$tag" "$expected_sha"
+              git push origin "refs/tags/$tag"
+              echo "Created and pushed tag $tag at $expected_sha."
+            fi
           fi
 
       - name: Ensure GitHub Release exists

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -752,9 +752,10 @@ and all version-bearing files agree (plus, for release-please-managed
 components, that the release-please manifest agrees too). After
 release-please creates a release for `palette`/`android`/`chrome`,
 `.github/workflows/release-please.yml` dispatches that component's artifact
-workflow. `cli`'s `release.yml` still triggers the normal way, off its
-`vX.Y.Z` tag push — nothing about that trigger changed, only what puts the tag
-there (manual now, not a merged release-please PR).
+workflow. For the unmanaged `cli`, `.github/workflows/auto-tag.yml` selects
+only components whose `release_please_managed` plan field is `false`, waits for
+exact-main CI, creates the `vX.Y.Z` tag and GitHub Release, then dispatches
+`release.yml` to attach the artifacts.
 
 **Implications:**
 
@@ -766,22 +767,16 @@ there (manual now, not a merged release-please PR).
   **not** in any component's shipping paths, so a tooling/docs-only merge cuts
   no release and needs no version bump. `Cargo.toml`, `Cargo.lock`, and
   `rust-toolchain.toml` are CLI shipping paths and are not part of this carve-out.
-- If a component's code changed but its version was **not** bumped (the tag
-  already exists), `cargo xtask check-release-versions --base origin/main --head
-  HEAD --mode pr` fails before merge with a message naming the component —
-  this still applies to `cli`, it just means "someone forgot to run `cargo
-  xtask bump-version patch --component cli`" instead of "release-please hasn't opened its PR
-  yet".
-
-To cut a release manually (e.g. re-release or hotfix without a code change),
-push the component's tag directly:
-
-```bash
-git tag vX.Y.Z         && git push origin vX.Y.Z          # cli
-git tag palette-vX.Y.Z && git push origin palette-vX.Y.Z  # palette
-git tag android-vX.Y.Z && git push origin android-vX.Y.Z  # android
-git tag chrome-ext-vX.Y.Z && git push origin chrome-ext-vX.Y.Z  # chrome
-```
+- An ordinary `palette`/`android`/`chrome` feature PR changes shipping files
+  without touching version files. The PR gate validates current parity and
+  defers the bump to release-please. It rejects a feature PR that mixes those
+  shipping changes with manual version edits. The generated release PR is the
+  only normal place those managed version files move.
+- A `cli` shipping PR must include the manual `cargo xtask bump-version ...`
+  result. The PR gate rejects an unchanged or already-tagged CLI version.
+- Direct tags for release-please-managed components are break-glass incident
+  operations, not a normal release path. Do not use them to bypass the managed
+  release PR, tag, or GitHub Release owner.
 
 ### Version bumping rules
 
@@ -855,8 +850,10 @@ one beyond the heading).
 
 `xtask` is a validation, manual-bump, and release-please postprocessing
 helper: `check-release-versions` verifies component parity and changed
-shipping paths (skipping the release-please-manifest check for `cli`, since
-it has no manifest entry to check against), `bump-version` is the manual
+shipping paths, defers ordinary managed-app feature bumps to release-please,
+and rejects mixed manual version edits (while skipping the
+release-please-manifest check for `cli`, since it has no manifest entry to
+check against). `bump-version` is the manual
 writer for `cli`, `release-please-fixup-plan`/`release-please-fixups` handle
 derived files release-please cannot update directly for
 `palette`/`android`/`chrome`, and `release-please-dispatch-plan` translates
@@ -881,7 +878,7 @@ Short release checklist:
   1. Run `cargo xtask bump-version patch|minor|major --component cli` locally, picking the level yourself.
   2. Review the diff — every file listed above should move together, nothing else.
   3. Include the bump in your PR (or a dedicated bump PR) and run `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr`.
-  4. Merge; `.github/workflows/auto-tag.yml` — unaffected by any of this, since it's driven entirely by `release/components.toml`, not release-please's manifest — detects the bumped-but-untagged `cli` version, creates and pushes the `vX.Y.Z` tag once `CI` is green, and dispatches `release.yml` exactly as it always has.
+  4. Merge; `.github/workflows/auto-tag.yml` detects the bumped-but-untagged unmanaged `cli` version, waits for exact-main CI, creates the `vX.Y.Z` tag and GitHub Release, then dispatches `release.yml` to attach artifacts.
 
 The compatibility command `cargo xtask check-version-sync` still enforces
 **CLI** version parity across `Cargo.toml`, `README.md`, `CHANGELOG.md`,

--- a/README.md
+++ b/README.md
@@ -503,7 +503,9 @@ Required before a production release:
 Releases are per-component. Three of four (`palette`, `android`, `chrome`) are
 release-please-managed; `cli` is bumped manually with
 `cargo xtask bump-version patch|minor|major --component cli` (release-please can't handle
-`version.workspace = true`). The PR gate is:
+`version.workspace = true`). Ordinary managed-app PRs leave version files
+alone for release-please; auto-tag selects only the unmanaged CLI and creates
+its tag and GitHub Release before dispatching artifact builds. The PR gate is:
 
 ```bash
 cargo xtask check-release-versions --base origin/main --head HEAD --mode pr

--- a/docs/android-apk-release.md
+++ b/docs/android-apk-release.md
@@ -1,84 +1,75 @@
 ---
 title: "Android APK Release Workflow"
 created: 2026-06-09
-updated: 2026-07-30
+updated: 2026-08-03
 ---
 
 # Android APK Release Workflow
 
-Summary of the Android APK release workflow added in PR
-[#195](https://github.com/jmagar/axon/pull/195)
-(`feat: add Android APK release workflow`, branch
-`claude/apk-release-workflow-ibxnpz`).
+Android is a release-please-managed component. Release-please is the sole
+normal owner of its version edits, changelog, `android-v*` tag, and GitHub
+Release. Axon's Android workflow builds and attaches the APK; it does not
+create a competing release record.
 
-## What it is
+## Ownership and sequence
 
-`.github/workflows/android-release.yml` builds, signs, checksums, and publishes
-the Axon Android APK as a GitHub Release. It is modeled on the existing
-`chrome-extension-release` workflow so the Android app versions **independently**
-of the main axon `v*` releases.
+1. An ordinary Android feature/fix PR changes `apps/android` shipping files
+   but leaves `versionName`, `versionCode`, the Android changelog, and
+   `.release-please-manifest.json` alone.
+2. `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr`
+   validates current parity and defers the managed version bump.
+3. After green main CI, release-please opens or refreshes the Android release
+   PR. That PR owns the manifest, changelog, `versionName`, and `versionCode`.
+4. Merging the green release PR lets release-please create the `android-v*`
+   tag and GitHub Release.
+5. `.github/workflows/release-please.yml` dispatches
+   `.github/workflows/android-release.yml` at that exact tag with
+   `publish=true`; the workflow signs, checksums, and uploads the APK to the
+   existing Release.
 
-## How it works
+`.github/workflows/auto-tag.yml` must never select Android. Auto-tag is only
+for components with `release_please_managed = false` (currently the CLI).
+
+## Build behavior
 
 | Aspect | Behavior |
-|--------|----------|
-| **Trigger** | Push a tag `android-v<versionName>` (e.g. `android-v1.1`). |
-| **Version guard** | Validates the pushed tag matches `versionName` in `apps/android/app/build.gradle.kts` before building — a release can never ship an APK the tag disagrees with. |
-| **Build** | JDK 17 (temurin), Node/pnpm plus Aurora dependencies for token generation, Gradle + Android SDK, then `apps/android/gradlew -p apps/android :app:assembleRelease`. |
-| **Sign** | zipalign + `apksigner` using release-keystore secrets, then verifies. Falls back to a clearly named `*-unsigned.apk` when secrets are absent. |
-| **Publish** | Uploads APK + SHA256 as a run artifact and, on real tag pushes, creates a GitHub Release with `make_latest: false` (keeps the repo's latest-release badge tracking axon `v*` tags). |
-| **Dry-run** | `workflow_dispatch` runs the same build and uploads the artifact **without** creating a Release. |
+|---|---|
+| Version guard | An `android-v*` dispatch must match `versionName` in `apps/android/app/build.gradle.kts`. |
+| Build | Checks out Aurora, installs its token dependencies, configures JDK/Gradle/Android SDK, and assembles the release APK. |
+| Sign | Uses zipalign and apksigner when all four signing secrets exist. A publish request fails closed if they are missing. |
+| Publish | Uploads APK and SHA256 as a run artifact, then attaches both to the pre-existing release-please GitHub Release. |
+| Dry run | Manual `workflow_dispatch` with `publish=false` builds and uploads a run artifact without changing Releases. |
 
 ## Required configuration
 
-Set under **Settings → Secrets and variables → Actions**.
+Set these under repository Actions secrets and variables.
 
-### Signing secrets (all four → signed APK; otherwise unsigned)
+Signing secrets (all four are required to publish):
 
-- `ANDROID_KEYSTORE_BASE64` — `base64 -w0 release.jks`
+- `ANDROID_KEYSTORE_BASE64`
 - `ANDROID_KEYSTORE_PASSWORD`
 - `ANDROID_KEY_ALIAS`
 - `ANDROID_KEY_PASSWORD`
 
-### Aurora design system (optional)
+Aurora configuration:
 
-The app depends on `tv.tootie.aurora:aurora` via a local Gradle composite build
-(see `apps/android/settings.gradle.kts`), **not** from Maven. To build it in CI:
+- `AURORA_REPO` repository variable (defaults to the configured Aurora source)
+- optional `AURORA_REF`
+- optional `AURORA_TOKEN` for a private checkout
 
-- repository **variable** `AURORA_REPO` — the Aurora repo (`owner/name`); checked
-  out and wired via `AXON_AURORA_ANDROID_PATH`
-- optional variable `AURORA_REF` — pinned branch/tag
-- optional secret `AURORA_TOKEN` — for a private Aurora repo
+## Verification
 
-If `AURORA_REPO` is unset, the build proceeds and Aurora resolves from Maven
-(which only works if it is actually published there).
+Before merging an Android release PR:
 
-## Cutting a release
+```bash
+cargo xtask check-release-versions --base origin/main --head HEAD --mode pr
+```
 
-1. Merge PR #195.
-2. Add the signing secrets (and `AURORA_REPO` if Aurora is needed).
-3. **Run a `workflow_dispatch` dry-run first** — the Android app has never built
-   in CI, so this is the real smoke test for Aurora composite resolution and
-   Android SDK build-tools availability on `ubuntu-latest`.
-4. Bump `versionName` (and `versionCode`) in `apps/android/app/build.gradle.kts`.
-5. Tag and push:
+Then require green Android CI and confirm the generated release PR advances
+the manifest, changelog, `versionName`, and `versionCode` together. After the
+release PR merges, confirm the artifact workflow ran at the release-please tag
+and attached a signed APK plus checksum to the existing GitHub Release.
 
-   ```bash
-   git tag android-v<versionName>
-   git push origin android-v<versionName>
-   ```
-
-## Notes
-
-- Mirrors `chrome-extension-release.yml`: component-specific tag, version
-  validation, checksum, `make_latest: false`, curated release body.
-- The version bump that ships with the PR moves the repo to **5.6.0** across all
-  version-bearing files: `Cargo.toml`, `Cargo.lock`, `README.md`, `CHANGELOG.md`,
-  `plugins/axon/.claude-plugin/plugin.json`, `apps/web/package.json`,
-  `apps/web/package-lock.json`, and the generated `apps/web/openapi/axon.json`
-  (the last three are enforced by the `version_bearing_files_stay_in_sync` test
-  and the `rest-api-parity` OpenAPI check).
-- **Caveat:** the workflow YAML is validated and all PR CI checks are green, but
-  the Android build itself has never run in CI. The `workflow_dispatch` dry-run
-  is where Aurora resolution and build-tools availability get verified
-  end-to-end.
+Directly creating or pushing an Android tag is a break-glass incident action,
+not a normal hotfix shortcut. Never create a second Android version/tag/Release
+lane alongside release-please.

--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -1,7 +1,7 @@
 ---
 title: "Release Checklist — Axon"
 created: 2026-07-07
-updated: 2026-07-30
+updated: 2026-08-03
 ---
 
 # Release Checklist — Axon
@@ -12,17 +12,21 @@ model this checklist enforces; this file is the short operational checklist
 version of it.
 
 Releases are per-component (`cli`, `palette`, `android`, `chrome`) and
-selective — release-please owns release PRs, version bumps, changelogs, tags,
-and GitHub Release records after `CI` is green on `main`. `xtask` only
-validates and postprocesses; it does not cut releases itself.
+selective. Release-please owns release PRs, version bumps, changelogs, tags,
+and GitHub Releases for `palette`, `android`, and `chrome`. The CLI is the only
+unmanaged component: its version is bumped with `xtask`, then auto-tag creates
+its tag and GitHub Release after exact-main CI before dispatching artifacts.
 
 ## Before merging a change that ships in a release
 
-- [ ] Component version-bearing files are in sync for every component whose
-      shipping paths changed (see the table below).
+- [ ] CLI shipping changes include an `xtask bump-version` result and all CLI
+      version-bearing files are in sync.
+- [ ] Ordinary `palette`/`android`/`chrome` feature PRs do **not** edit version
+      files; release-please owns those edits in the generated release PR.
 - [ ] `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr`
-      passes — this is the PR gate and fails with the affected component name
-      if code changed but the version did not move.
+      passes. It requires a CLI bump, defers managed feature bumps, rejects
+      mixed managed shipping/version edits, and fully validates generated
+      release PR version parity.
 - [ ] Conventional commit prefixes are correct: `feat!`/`BREAKING CHANGE` →
       major, `feat` → minor, `fix` → patch. `perf`/`refactor` show in the
       Changed changelog section; `chore`/`ci`/`docs`/`test`/`build`/`style`
@@ -106,24 +110,29 @@ See [`contributing.md`](contributing.md#monolith-policy) for the full policy.
       appropriate
 - [ ] No `NEXT_PUBLIC_*` variables leak server-side secrets
 
-## Cutting the release
+## Cutting a managed release (`palette`, `android`, `chrome`)
 
-1. Let release-please open the release PR after green `CI` on `main`.
-2. Review that the release PR updates `.release-please-manifest.json`,
-   component versions, and changelogs correctly.
+1. Let release-please open or refresh the component release PR after green
+   `CI` on `main`.
+2. Review that the release PR updates `.release-please-manifest.json`, the
+   component version files, and its changelog together.
 3. Run `cargo xtask check-release-versions --base origin/main --head HEAD --mode pr`.
 4. Merge only after the release/version gate and CI are green.
-5. Confirm the per-component artifact workflow (`release.yml`,
-   `palette-release.yml`, `android-release.yml`,
-   `chrome-extension-release.yml`) ran and attached signed/checksummed
-   assets to the GitHub Release release-please created.
+5. Confirm release-please created the component tag and GitHub Release.
+6. Confirm `palette-release.yml`, `android-release.yml`, or
+   `chrome-extension-release.yml` attached the signed/checksummed artifacts to
+   that existing Release.
 
-To cut a release manually (hotfix/re-release without a code change), push the
-component's tag directly instead of waiting on release-please:
+## Cutting a CLI release
 
-```bash
-git tag vX.Y.Z             && git push origin vX.Y.Z              # cli
-git tag palette-vX.Y.Z     && git push origin palette-vX.Y.Z      # palette
-git tag android-vX.Y.Z     && git push origin android-vX.Y.Z      # android
-git tag chrome-ext-vX.Y.Z  && git push origin chrome-ext-vX.Y.Z   # chrome
-```
+1. Run `cargo xtask bump-version patch|minor|major --component cli` and review
+   every CLI version-bearing file.
+2. Include the bump with the shipping PR and run the PR release-version gate.
+3. Merge only after CI is green.
+4. Confirm auto-tag selected only the unmanaged CLI, waited for exact-main CI,
+   created the `vX.Y.Z` tag and GitHub Release, then dispatched `release.yml`.
+5. Confirm the Linux and Windows assets and checksums were attached.
+
+Direct tags for release-please-managed components are break-glass incident
+operations. Do not use them as a normal hotfix path or create a second owner
+for managed version files, tags, or GitHub Releases.

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -486,7 +486,8 @@ bash -euo pipefail -c "$AUTO_TAG_SCRIPT"
 test "$(git rev-parse {tag}^{{commit}})" = "$(git rev-parse HEAD)"
 "#
     );
-    let output = std::process::Command::new("bash")
+    let mut command = command_without_git_local_env("bash");
+    let output = command
         .args(["-euo", "pipefail", "-c", &harness])
         .env("AUTO_TAG_SCRIPT", script)
         .output()
@@ -495,6 +496,121 @@ test "$(git rev-parse {tag}^{{commit}})" = "$(git rev-parse HEAD)"
     assert!(
         output.status.success(),
         "a rerun after the tag was pushed must continue to GitHub Release creation and dispatch; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn auto_tag_partial_success_rerun_accepts_the_existing_tag_after_main_advances() {
+    let workflow = include_str!("../.github/workflows/auto-tag.yml");
+    let release = workflow_job_block(workflow, "release");
+    let script = workflow_step_script(
+        release,
+        "Create and push tag",
+        "Ensure GitHub Release exists",
+    );
+
+    let tag = "v99.99.97-recovery";
+    let script = script
+        .replace("${{ matrix.candidate_tag }}", tag)
+        .replace("${{ github.sha }}", "$(git rev-parse HEAD)");
+    let harness = format!(
+        r#"
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+git init --bare "$root/remote.git"
+git init "$root/checkout"
+cd "$root/checkout"
+git config user.name "Axon Test"
+git config user.email "axon-test@example.invalid"
+echo candidate > README.md
+git add README.md
+git commit -m "candidate"
+candidate_sha="$(git rev-parse HEAD)"
+git remote add origin "$root/remote.git"
+git push origin HEAD:main
+git tag {tag}
+git push origin {tag}
+echo advanced > README.md
+git add README.md
+git commit -m "advance main"
+git push origin HEAD:main
+git switch --detach "$candidate_sha"
+bash -euo pipefail -c "$AUTO_TAG_SCRIPT"
+test "$(git rev-parse {tag}^{{commit}})" = "$candidate_sha"
+test "$(git ls-remote --heads origin refs/heads/main | awk 'NR == 1 {{ print $1 }}')" != "$candidate_sha"
+"#
+    );
+    let mut command = command_without_git_local_env("bash");
+    let output = command
+        .args(["-euo", "pipefail", "-c", &harness])
+        .env("AUTO_TAG_SCRIPT", script)
+        .output()
+        .expect("run auto-tag recovery step after main advances");
+
+    assert!(
+        output.status.success(),
+        "a rerun must recover GitHub Release creation and dispatch after its tag was pushed, even when main advanced; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn auto_tag_rejects_a_superseded_main_commit_before_creating_a_tag() {
+    let workflow = include_str!("../.github/workflows/auto-tag.yml");
+    let release = workflow_job_block(workflow, "release");
+    let script = workflow_step_script(
+        release,
+        "Create and push tag",
+        "Ensure GitHub Release exists",
+    );
+
+    let tag = "v99.99.98-superseded";
+    let script = script
+        .replace("${{ matrix.candidate_tag }}", tag)
+        .replace("${{ github.sha }}", "$(git rev-parse HEAD)");
+    let harness = format!(
+        r#"
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+git init --bare "$root/remote.git"
+git init "$root/checkout"
+cd "$root/checkout"
+git config user.name "Axon Test"
+git config user.email "axon-test@example.invalid"
+echo candidate > README.md
+git add README.md
+git commit -m "candidate"
+candidate_sha="$(git rev-parse HEAD)"
+git remote add origin "$root/remote.git"
+git push origin HEAD:main
+echo advanced > README.md
+git add README.md
+git commit -m "advance main"
+git push origin HEAD:main
+git switch --detach "$candidate_sha"
+if bash -euo pipefail -c "$AUTO_TAG_SCRIPT"; then
+  echo "superseded workflow commit unexpectedly passed the tag guard" >&2
+  exit 1
+fi
+if git ls-remote --exit-code --tags origin "refs/tags/{tag}" >/dev/null 2>&1; then
+  echo "superseded workflow commit created remote tag {tag}" >&2
+  exit 1
+fi
+"#
+    );
+    let mut command = command_without_git_local_env("bash");
+    let output = command
+        .args(["-euo", "pipefail", "-c", &harness])
+        .env("AUTO_TAG_SCRIPT", script)
+        .output()
+        .expect("run auto-tag tag step against advanced remote main");
+
+    assert!(
+        output.status.success(),
+        "an obsolete main push run must fail closed before tag creation; stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -885,6 +1001,27 @@ fn workflow_step_script(job: &str, step_name: &str, next_step_name: &str) -> Str
         .map(|line| line.strip_prefix("          ").unwrap_or(line))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn command_without_git_local_env(program: &str) -> std::process::Command {
+    let local_env = std::process::Command::new("git")
+        .args(["rev-parse", "--local-env-vars"])
+        .output()
+        .expect("list repository-local Git environment variables");
+    assert!(
+        local_env.status.success(),
+        "git rev-parse --local-env-vars failed: {}",
+        String::from_utf8_lossy(&local_env.stderr)
+    );
+
+    let mut command = std::process::Command::new(program);
+    for variable in String::from_utf8_lossy(&local_env.stdout)
+        .lines()
+        .filter(|variable| !variable.is_empty())
+    {
+        command.env_remove(variable);
+    }
+    command
 }
 
 fn sparse_checkout_covers(block: &str, path: &str) -> bool {

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -346,9 +346,24 @@ fn auto_tag_uses_validated_xtask_release_plan() {
     );
     assert!(
         plan.contains(
-            "matrix=$(jq -c '{include: [.[] | select(.changed == true)]}' release-plan.json)"
+            "if ! jq -e 'type == \"array\" and all(.[]; (.release_please_managed | type) == \"boolean\")' release-plan.json"
+        ) && plan.contains("exit 1"),
+        "auto-tag must fail closed unless every release-plan item declares boolean release_please_managed ownership"
+    );
+    assert!(
+        plan.contains(
+            "matrix=$(jq -c '{include: [.[] | select(.changed == true and .release_please_managed == false)]}' release-plan.json)"
         ),
-        "auto-tag matrix must include only changed components"
+        "auto-tag matrix must include only changed components that release-please does not own"
+    );
+    assert_eq!(
+        plan.matches("matrix=$(jq -c").count(),
+        1,
+        "auto-tag must have exactly one matrix assignment so a broader selector cannot bypass ownership"
+    );
+    assert!(
+        !plan.contains("select(.changed == true)]"),
+        "the former changed-only selector would reintroduce release-please-owned components"
     );
     assert!(
         ci_gate.contains(r#"needs.plan.outputs.matrix != '{"include":[]}'"#)
@@ -394,6 +409,47 @@ fn auto_tag_uses_validated_xtask_release_plan() {
             "auto-tag CI polling must constrain {required}"
         );
     }
+}
+
+#[test]
+fn auto_tag_creates_github_release_before_explicit_artifact_dispatch() {
+    let workflow = include_str!("../.github/workflows/auto-tag.yml");
+    let release = workflow_job_block(workflow, "release");
+
+    let tag_step = release
+        .find("- name: Create and push tag")
+        .expect("auto-tag creates the component tag");
+    let github_release_step = release
+        .find("- name: Ensure GitHub Release exists")
+        .expect("auto-tag idempotently creates the GitHub Release");
+    let dispatch_step = release
+        .find("- name: Dispatch release workflow")
+        .expect("auto-tag dispatches the artifact workflow");
+    assert!(
+        tag_step < github_release_step && github_release_step < dispatch_step,
+        "auto-tag must push the tag, ensure its GitHub Release, then dispatch artifacts"
+    );
+
+    let github_release = &release[github_release_step..dispatch_step];
+    let view = github_release
+        .find("if gh release view \"$tag\" --repo \"$repo\"")
+        .expect("GitHub Release existence check uses the explicit repository");
+    let create = github_release
+        .find("gh release create \"$tag\" --verify-tag --generate-notes --repo \"$repo\"")
+        .expect("missing GitHub Release is created from the verified tag");
+    assert!(
+        view < create,
+        "GitHub Release creation must be guarded by the idempotent existence check"
+    );
+
+    let dispatch = &release[dispatch_step..];
+    assert!(
+        dispatch.contains("gh workflow run \"${{ matrix.release_workflow }}\"")
+            && dispatch.contains("--repo \"${{ github.repository }}\"")
+            && dispatch.contains("--ref \"${{ matrix.candidate_tag }}\"")
+            && dispatch.contains("-f publish=true"),
+        "artifact dispatch must name the workflow, repository, tag ref, and publish input explicitly"
+    );
 }
 
 #[test]

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -453,6 +453,54 @@ fn auto_tag_creates_github_release_before_explicit_artifact_dispatch() {
 }
 
 #[test]
+fn auto_tag_partial_success_rerun_accepts_the_existing_tag_at_the_same_commit() {
+    let workflow = include_str!("../.github/workflows/auto-tag.yml");
+    let release = workflow_job_block(workflow, "release");
+    let script = workflow_step_script(
+        release,
+        "Create and push tag",
+        "Ensure GitHub Release exists",
+    );
+
+    let tag = "v99.99.99-test";
+    let script = script
+        .replace("${{ matrix.candidate_tag }}", tag)
+        .replace("${{ github.sha }}", "$(git rev-parse HEAD)");
+    let harness = format!(
+        r#"
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+git init --bare "$root/remote.git"
+git init "$root/checkout"
+cd "$root/checkout"
+git config user.name "Axon Test"
+git config user.email "axon-test@example.invalid"
+echo retry-fixture > README.md
+git add README.md
+git commit -m "retry fixture"
+git remote add origin "$root/remote.git"
+git push origin HEAD:main
+git tag {tag}
+git push origin {tag}
+bash -euo pipefail -c "$AUTO_TAG_SCRIPT"
+test "$(git rev-parse {tag}^{{commit}})" = "$(git rev-parse HEAD)"
+"#
+    );
+    let output = std::process::Command::new("bash")
+        .args(["-euo", "pipefail", "-c", &harness])
+        .env("AUTO_TAG_SCRIPT", script)
+        .output()
+        .expect("run auto-tag tag step");
+
+    assert!(
+        output.status.success(),
+        "a rerun after the tag was pushed must continue to GitHub Release creation and dispatch; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn release_please_fixups_validate_and_forward_pr_branch_refs() {
     let workflow = include_str!("../.github/workflows/release-please.yml");
     let fixups = workflow_job_block(workflow, "release-pr-fixups");
@@ -816,6 +864,27 @@ fn workflow_job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {
         })
         .unwrap_or(rest.len());
     &rest[..end]
+}
+
+fn workflow_step_script(job: &str, step_name: &str, next_step_name: &str) -> String {
+    let step_marker = format!("      - name: {step_name}\n");
+    let next_marker = format!("      - name: {next_step_name}\n");
+    let step = job
+        .split_once(&step_marker)
+        .unwrap_or_else(|| panic!("missing workflow step {step_name}"))
+        .1
+        .split_once(&next_marker)
+        .unwrap_or_else(|| panic!("missing workflow step {next_step_name}"))
+        .0;
+    let script = step
+        .split_once("        run: |\n")
+        .unwrap_or_else(|| panic!("workflow step {step_name} has no shell script"))
+        .1;
+    script
+        .lines()
+        .map(|line| line.strip_prefix("          ").unwrap_or(line))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn sparse_checkout_covers(block: &str, path: &str) -> bool {

--- a/xtask/src/checks/release_versions.rs
+++ b/xtask/src/checks/release_versions.rs
@@ -150,10 +150,6 @@ pub fn check(
                 .map(|error| format!("{}: {error}", component.id)),
         );
 
-        if !plan.changed {
-            continue;
-        }
-
         collect_changed_component_errors(root, component, plan, base, head, mode, &mut errors)?;
     }
 
@@ -234,7 +230,7 @@ pub fn release_please_dispatch_plan(
     release_outputs: &str,
 ) -> ReleaseResult<Vec<ReleasePleaseDispatchItem>> {
     let manifest = load_manifest(root)?;
-    release_please_dispatch_items(&manifest.components, release_outputs)
+    release_please_dispatch_items(root, &manifest.components, release_outputs)
 }
 
 pub fn print_release_please_dispatch_plan(
@@ -350,6 +346,12 @@ pub fn bump_component_version(
         .iter()
         .find(|component| component.id == component_id)
         .with_release_context(|| format!("unknown release component {component_id}"))?;
+    if component.release_please_managed {
+        release_bail!(
+            "{} is release-please-managed and cannot be bumped manually",
+            component.id
+        );
+    }
 
     let current = read_version(root, &component.version_source)?;
     let current = Version::parse(&current).with_release_context(|| {

--- a/xtask/src/checks/release_versions.rs
+++ b/xtask/src/checks/release_versions.rs
@@ -1,6 +1,5 @@
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
 use std::path::Path;
 
 type ReleaseResult<T> = Result<T, ReleaseVersionError>;
@@ -13,6 +12,7 @@ macro_rules! release_bail {
 
 mod error;
 mod files;
+mod gate;
 mod git;
 mod manifest;
 mod release_please;
@@ -30,9 +30,9 @@ use manifest::same_version_file;
 use files::{
     check_component_parity, read_version, read_workspace_package_version, write_version_file,
 };
+use gate::{collect_changed_component_errors, version_from_tag};
 use git::{
-    changed_paths_since_ref, check_gradle_version_code_increased, compare_ref_for_component,
-    component_changed_since_ref, latest_tag, merge_base, tag_exists,
+    changed_paths_since_ref, component_changed_since_ref, latest_tag, merge_base, tag_exists,
 };
 
 #[cfg(test)]
@@ -67,6 +67,7 @@ pub struct ComponentPlan {
     pub last_tag: Option<String>,
     pub release_workflow: String,
     pub shipping_paths: Vec<String>,
+    pub release_please_managed: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -451,134 +452,10 @@ fn build_plan(
                 last_tag,
                 release_workflow: component.release_workflow.clone(),
                 shipping_paths: component.shipping_paths.clone(),
+                release_please_managed: component.release_please_managed,
             })
         })
         .collect()
-}
-
-fn collect_changed_component_errors(
-    root: &Path,
-    component: &Component,
-    plan: &ComponentPlan,
-    base: Option<&str>,
-    head: &str,
-    mode: GateMode,
-    errors: &mut Vec<String>,
-) -> ReleaseResult<()> {
-    let candidate = Version::parse(&plan.version).with_release_context(|| {
-        format!(
-            "{} version is not valid semver: {}",
-            component.id, plan.version
-        )
-    })?;
-
-    let latest = latest_version_from_plan(component, plan)?;
-    let existing_candidate_tag = tag_exists(root, &plan.candidate_tag)?;
-    let release_fixup_only = release_fixup_only_pr_change(
-        root,
-        component,
-        &candidate,
-        latest.as_ref(),
-        base,
-        head,
-        mode,
-    )?;
-    if !release_fixup_only {
-        if let Some(latest) = latest
-            && candidate <= latest
-        {
-            errors.push(format!(
-                "{} code changed but version {} is not greater than latest {} tag version {}. Let release-please bump {} before merging.",
-                component.id,
-                plan.version,
-                component.tag_prefix,
-                latest,
-                bump_hint(component)
-            ));
-        }
-
-        if existing_candidate_tag {
-            errors.push(format!(
-                "{} code changed but tag {} already exists. Let release-please bump {} before merging.",
-                component.id,
-                plan.candidate_tag,
-                bump_hint(component)
-            ));
-        }
-    }
-
-    if component_has_kind(component, VersionKind::GradleVersionCode)
-        && let Some(compare_ref) = compare_ref_for_component(root, component, base, head, mode)?
-        && let Err(error) = check_gradle_version_code_increased(root, component, &compare_ref)
-    {
-        errors.push(format!("{}: {error}", component.id));
-    }
-
-    Ok(())
-}
-
-fn release_fixup_only_pr_change(
-    root: &Path,
-    component: &Component,
-    candidate: &Version,
-    latest: Option<&Version>,
-    base: Option<&str>,
-    head: &str,
-    mode: GateMode,
-) -> ReleaseResult<bool> {
-    if mode != GateMode::Pr || !component.release_please_managed {
-        return Ok(false);
-    }
-    if latest != Some(candidate) {
-        return Ok(false);
-    }
-    let Some(compare_ref) = compare_ref_for_component(root, component, base, head, mode)? else {
-        return Ok(false);
-    };
-    let changed = changed_paths_since_ref(root, &compare_ref, head, &component.shipping_paths)?;
-    if changed.is_empty() {
-        return Ok(false);
-    }
-    let allowed = component
-        .version_files
-        .iter()
-        .map(|file| file.path.as_str())
-        .collect::<BTreeSet<_>>();
-    Ok(changed.iter().all(|path| allowed.contains(path.as_str())))
-}
-
-fn latest_version_from_plan(
-    component: &Component,
-    plan: &ComponentPlan,
-) -> ReleaseResult<Option<Version>> {
-    plan.last_tag
-        .as_deref()
-        .map(|tag| version_from_tag(component, tag))
-        .transpose()
-}
-
-fn version_from_tag(component: &Component, tag: &str) -> ReleaseResult<Version> {
-    let version = tag
-        .strip_prefix(&component.tag_prefix)
-        .with_release_context(|| format!("{} latest tag has wrong prefix: {tag}", component.id))?;
-    Version::parse(version).with_release_context(|| {
-        format!(
-            "{} latest tag has invalid semver suffix: {tag}",
-            component.id
-        )
-    })
-}
-
-fn bump_hint(component: &Component) -> String {
-    match component.id.as_str() {
-        "android" => "apps/android/app/build.gradle.kts versionName and versionCode".to_owned(),
-        "chrome" => "apps/chrome-extension/manifest.json".to_owned(),
-        _ => format!("the {} version files", component.id),
-    }
-}
-
-fn component_has_kind(component: &Component, kind: VersionKind) -> bool {
-    component.version_files.iter().any(|file| file.kind == kind)
 }
 
 #[cfg(test)]

--- a/xtask/src/checks/release_versions.rs
+++ b/xtask/src/checks/release_versions.rs
@@ -21,7 +21,7 @@ use error::{ReleaseContext, ReleaseVersionError};
 use manifest::validate_manifest;
 use release_please::{
     ReleasePleaseDispatchItem, ReleasePleaseFixupItem, release_please_dispatch_items,
-    run_cargo_update,
+    run_cargo_update, validate_release_please_ownership,
 };
 
 #[cfg(test)]
@@ -397,6 +397,7 @@ fn load_manifest(root: &Path) -> ReleaseResult<Manifest> {
         );
     }
     validate_manifest(root, &manifest)?;
+    validate_release_please_ownership(root, &manifest.components)?;
     Ok(manifest)
 }
 

--- a/xtask/src/checks/release_versions/gate.rs
+++ b/xtask/src/checks/release_versions/gate.rs
@@ -1,0 +1,177 @@
+use semver::Version;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use super::error::ReleaseContext;
+use super::git::{
+    changed_paths_since_ref, check_gradle_version_code_increased, compare_ref_for_component,
+    tag_exists,
+};
+use super::{Component, ComponentPlan, GateMode, ReleaseResult, VersionKind};
+
+pub(super) fn collect_changed_component_errors(
+    root: &Path,
+    component: &Component,
+    plan: &ComponentPlan,
+    base: Option<&str>,
+    head: &str,
+    mode: GateMode,
+    errors: &mut Vec<String>,
+) -> ReleaseResult<()> {
+    let candidate = Version::parse(&plan.version).with_release_context(|| {
+        format!(
+            "{} version is not valid semver: {}",
+            component.id, plan.version
+        )
+    })?;
+
+    if collect_managed_pr_ownership_errors(root, component, base, head, mode, errors)? {
+        return Ok(());
+    }
+
+    let latest = latest_version_from_plan(component, plan)?;
+    let existing_candidate_tag = tag_exists(root, &plan.candidate_tag)?;
+    let release_fixup_only = release_fixup_only_pr_change(
+        root,
+        component,
+        &candidate,
+        latest.as_ref(),
+        base,
+        head,
+        mode,
+    )?;
+    if !release_fixup_only {
+        if let Some(latest) = latest
+            && candidate <= latest
+        {
+            errors.push(format!(
+                "{} code changed but version {} is not greater than latest {} tag version {}. Let release-please bump {} before merging.",
+                component.id,
+                plan.version,
+                component.tag_prefix,
+                latest,
+                bump_hint(component)
+            ));
+        }
+
+        if existing_candidate_tag {
+            errors.push(format!(
+                "{} code changed but tag {} already exists. Let release-please bump {} before merging.",
+                component.id,
+                plan.candidate_tag,
+                bump_hint(component)
+            ));
+        }
+    }
+
+    if component_has_kind(component, VersionKind::GradleVersionCode)
+        && let Some(compare_ref) = compare_ref_for_component(root, component, base, head, mode)?
+        && let Err(error) = check_gradle_version_code_increased(root, component, &compare_ref)
+    {
+        errors.push(format!("{}: {error}", component.id));
+    }
+
+    Ok(())
+}
+
+fn collect_managed_pr_ownership_errors(
+    root: &Path,
+    component: &Component,
+    base: Option<&str>,
+    head: &str,
+    mode: GateMode,
+    errors: &mut Vec<String>,
+) -> ReleaseResult<bool> {
+    if mode != GateMode::Pr || !component.release_please_managed {
+        return Ok(false);
+    }
+    let compare_ref = compare_ref_for_component(root, component, base, head, mode)?
+        .release_context("PR release check is missing a comparison ref")?;
+    let changed = changed_paths_since_ref(root, &compare_ref, head, &component.shipping_paths)?;
+    let version_file_paths = component
+        .version_files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect::<BTreeSet<_>>();
+    let (changed_version_files, ordinary_shipping_changes): (Vec<_>, Vec<_>) = changed
+        .into_iter()
+        .partition(|path| version_file_paths.contains(path.as_str()));
+
+    if changed_version_files.is_empty() {
+        return Ok(true);
+    }
+    if !ordinary_shipping_changes.is_empty() {
+        errors.push(format!(
+            "{} PR mixes ordinary shipping changes with release-please-owned version files: ordinary [{}]; version files [{}]. Keep feature PRs version-free and let release-please create the version-only release PR.",
+            component.id,
+            ordinary_shipping_changes.join(", "),
+            changed_version_files.join(", ")
+        ));
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn release_fixup_only_pr_change(
+    root: &Path,
+    component: &Component,
+    candidate: &Version,
+    latest: Option<&Version>,
+    base: Option<&str>,
+    head: &str,
+    mode: GateMode,
+) -> ReleaseResult<bool> {
+    if mode != GateMode::Pr || !component.release_please_managed {
+        return Ok(false);
+    }
+    if latest != Some(candidate) {
+        return Ok(false);
+    }
+    let Some(compare_ref) = compare_ref_for_component(root, component, base, head, mode)? else {
+        return Ok(false);
+    };
+    let changed = changed_paths_since_ref(root, &compare_ref, head, &component.shipping_paths)?;
+    if changed.is_empty() {
+        return Ok(false);
+    }
+    let allowed = component
+        .version_files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect::<BTreeSet<_>>();
+    Ok(changed.iter().all(|path| allowed.contains(path.as_str())))
+}
+
+fn latest_version_from_plan(
+    component: &Component,
+    plan: &ComponentPlan,
+) -> ReleaseResult<Option<Version>> {
+    plan.last_tag
+        .as_deref()
+        .map(|tag| version_from_tag(component, tag))
+        .transpose()
+}
+
+pub(super) fn version_from_tag(component: &Component, tag: &str) -> ReleaseResult<Version> {
+    let version = tag
+        .strip_prefix(&component.tag_prefix)
+        .with_release_context(|| format!("{} latest tag has wrong prefix: {tag}", component.id))?;
+    Version::parse(version).with_release_context(|| {
+        format!(
+            "{} latest tag has invalid semver suffix: {tag}",
+            component.id
+        )
+    })
+}
+
+fn bump_hint(component: &Component) -> String {
+    match component.id.as_str() {
+        "android" => "apps/android/app/build.gradle.kts versionName and versionCode".to_owned(),
+        "chrome" => "apps/chrome-extension/manifest.json".to_owned(),
+        _ => format!("the {} version files", component.id),
+    }
+}
+
+fn component_has_kind(component: &Component, kind: VersionKind) -> bool {
+    component.version_files.iter().any(|file| file.kind == kind)
+}

--- a/xtask/src/checks/release_versions/gate.rs
+++ b/xtask/src/checks/release_versions/gate.rs
@@ -27,7 +27,12 @@ pub(super) fn collect_changed_component_errors(
         )
     })?;
 
-    if collect_managed_pr_ownership_errors(root, component, base, head, mode, errors)? {
+    if collect_managed_pr_ownership_errors(root, component, plan.changed, base, head, mode, errors)?
+    {
+        return Ok(());
+    }
+
+    if !plan.changed {
         return Ok(());
     }
 
@@ -79,6 +84,7 @@ pub(super) fn collect_changed_component_errors(
 fn collect_managed_pr_ownership_errors(
     root: &Path,
     component: &Component,
+    shipping_changed: bool,
     base: Option<&str>,
     head: &str,
     mode: GateMode,
@@ -100,6 +106,14 @@ fn collect_managed_pr_ownership_errors(
             "{} PR mixes ordinary shipping changes with release-please-owned version fields: ordinary [{}]; version fields [{}]. Keep feature PRs version-free and let release-please create the version-only release PR.",
             component.id,
             changes.ordinary.join(", "),
+            changes.version_fields.join(", ")
+        ));
+        return Ok(true);
+    }
+    if !shipping_changed {
+        errors.push(format!(
+            "{} PR changes release-please-owned version fields without a synchronized managed release version change: version fields [{}]. A generated release PR must update the component version source together with its changelog heading.",
+            component.id,
             changes.version_fields.join(", ")
         ));
         return Ok(true);

--- a/xtask/src/checks/release_versions/gate.rs
+++ b/xtask/src/checks/release_versions/gate.rs
@@ -9,6 +9,8 @@ use super::git::{
 };
 use super::{Component, ComponentPlan, GateMode, ReleaseResult, VersionKind};
 
+mod ownership;
+
 pub(super) fn collect_changed_component_errors(
     root: &Path,
     component: &Component,
@@ -88,24 +90,17 @@ fn collect_managed_pr_ownership_errors(
     let compare_ref = compare_ref_for_component(root, component, base, head, mode)?
         .release_context("PR release check is missing a comparison ref")?;
     let changed = changed_paths_since_ref(root, &compare_ref, head, &component.shipping_paths)?;
-    let version_file_paths = component
-        .version_files
-        .iter()
-        .map(|file| file.path.as_str())
-        .collect::<BTreeSet<_>>();
-    let (changed_version_files, ordinary_shipping_changes): (Vec<_>, Vec<_>) = changed
-        .into_iter()
-        .partition(|path| version_file_paths.contains(path.as_str()));
+    let changes = ownership::classify(root, component, &compare_ref, head, changed)?;
 
-    if changed_version_files.is_empty() {
+    if changes.version_fields.is_empty() {
         return Ok(true);
     }
-    if !ordinary_shipping_changes.is_empty() {
+    if !changes.ordinary.is_empty() {
         errors.push(format!(
-            "{} PR mixes ordinary shipping changes with release-please-owned version files: ordinary [{}]; version files [{}]. Keep feature PRs version-free and let release-please create the version-only release PR.",
+            "{} PR mixes ordinary shipping changes with release-please-owned version fields: ordinary [{}]; version fields [{}]. Keep feature PRs version-free and let release-please create the version-only release PR.",
             component.id,
-            ordinary_shipping_changes.join(", "),
-            changed_version_files.join(", ")
+            changes.ordinary.join(", "),
+            changes.version_fields.join(", ")
         ));
         return Ok(true);
     }

--- a/xtask/src/checks/release_versions/gate/ownership.rs
+++ b/xtask/src/checks/release_versions/gate/ownership.rs
@@ -1,0 +1,263 @@
+use regex::Regex;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use super::super::files::{
+    read_cargo_lock_package_version, read_cargo_package_version, read_gradle_version_code,
+    read_gradle_version_name, read_json_version, read_npm_package_lock_version,
+};
+use super::super::git::git_show;
+use super::super::{Component, ReleaseContext, ReleaseResult, VersionFile, VersionKind};
+
+pub(super) struct ManagedPrChanges {
+    pub(super) version_fields: Vec<String>,
+    pub(super) ordinary: Vec<String>,
+}
+
+pub(super) fn classify(
+    root: &Path,
+    component: &Component,
+    compare_ref: &str,
+    head: &str,
+    changed: Vec<String>,
+) -> ReleaseResult<ManagedPrChanges> {
+    let mut version_fields = BTreeSet::new();
+    let mut ordinary = BTreeSet::new();
+
+    for path in changed {
+        let files = component
+            .version_files
+            .iter()
+            .filter(|file| file.path == path)
+            .collect::<Vec<_>>();
+        if files.is_empty() {
+            ordinary.insert(path);
+            continue;
+        }
+
+        let before = git_show(root, compare_ref, &path)?;
+        let after = git_show(root, head, &path)?;
+        let field_changed = version_field_changed(&files, &before, &after)?;
+        if field_changed {
+            version_fields.insert(path.clone());
+        }
+        if ordinary_content_changed(&files, &before, &after, field_changed)? {
+            ordinary.insert(path);
+        }
+    }
+
+    Ok(ManagedPrChanges {
+        version_fields: version_fields.into_iter().collect(),
+        ordinary: ordinary.into_iter().collect(),
+    })
+}
+
+fn version_field_changed(files: &[&VersionFile], before: &str, after: &str) -> ReleaseResult<bool> {
+    for file in files {
+        if version_field_value(file, before)? != version_field_value(file, after)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn version_field_value(file: &VersionFile, content: &str) -> ReleaseResult<Option<String>> {
+    let value = match file.kind {
+        VersionKind::CargoPackage => read_cargo_package_version(content, file.package.as_deref())?,
+        VersionKind::CargoLockPackage => {
+            read_cargo_lock_package_version(content, file.package.as_deref())?
+        }
+        VersionKind::ReadmeVersionLine => read_readme_version(content)?,
+        VersionKind::ChangelogHeading => release_headings(content).join("\n"),
+        VersionKind::JsonVersion => read_json_version(content, file.json_pointer.as_deref())?,
+        VersionKind::JsonNoVersion => return Ok(None),
+        VersionKind::NpmPackageLock => {
+            read_npm_package_lock_version(content, file.package.as_deref())?
+        }
+        VersionKind::GradleVersionName => read_gradle_version_name(content)?,
+        VersionKind::GradleVersionCode => read_gradle_version_code(content)?.to_string(),
+    };
+    Ok(Some(value))
+}
+
+fn ordinary_content_changed(
+    files: &[&VersionFile],
+    before: &str,
+    after: &str,
+    field_changed: bool,
+) -> ReleaseResult<bool> {
+    if files
+        .iter()
+        .any(|file| file.kind == VersionKind::ChangelogHeading)
+    {
+        // A new semver heading identifies the whole generated release entry as
+        // release-please output. With no heading change, prose-only edits are
+        // ordinary content and do not claim release ownership.
+        return Ok(!field_changed && before != after);
+    }
+
+    Ok(normalize_non_version_content(files, before)?
+        != normalize_non_version_content(files, after)?)
+}
+
+fn normalize_non_version_content(files: &[&VersionFile], content: &str) -> ReleaseResult<String> {
+    if files.iter().any(|file| {
+        matches!(
+            file.kind,
+            VersionKind::JsonVersion | VersionKind::JsonNoVersion | VersionKind::NpmPackageLock
+        )
+    }) {
+        return normalize_json(files, content);
+    }
+    if files.iter().any(|file| {
+        matches!(
+            file.kind,
+            VersionKind::GradleVersionName | VersionKind::GradleVersionCode
+        )
+    }) {
+        return normalize_gradle(content);
+    }
+    if files
+        .iter()
+        .any(|file| file.kind == VersionKind::CargoPackage)
+    {
+        return normalize_cargo_manifest(files, content);
+    }
+    if files
+        .iter()
+        .any(|file| file.kind == VersionKind::CargoLockPackage)
+    {
+        return normalize_cargo_lock(files, content);
+    }
+    if files
+        .iter()
+        .any(|file| file.kind == VersionKind::ReadmeVersionLine)
+    {
+        return normalize_readme(content);
+    }
+    Ok(content.to_owned())
+}
+
+fn normalize_json(files: &[&VersionFile], content: &str) -> ReleaseResult<String> {
+    let mut value: serde_json::Value =
+        serde_json::from_str(content).release_context("invalid JSON version file")?;
+    for file in files {
+        match file.kind {
+            VersionKind::JsonVersion => {
+                let pointer = file.json_pointer.as_deref().unwrap_or("/version");
+                let field = value
+                    .pointer_mut(pointer)
+                    .with_release_context(|| format!("missing JSON version field at {pointer}"))?;
+                *field = serde_json::Value::String("__VERSION__".to_owned());
+            }
+            VersionKind::NpmPackageLock => {
+                let root_version = value
+                    .get_mut("version")
+                    .release_context("missing package-lock root version")?;
+                *root_version = serde_json::Value::String("__VERSION__".to_owned());
+                let package_version = value
+                    .pointer_mut("/packages//version")
+                    .release_context("missing package-lock packages[''] version")?;
+                *package_version = serde_json::Value::String("__VERSION__".to_owned());
+            }
+            VersionKind::JsonNoVersion => {}
+            _ => {}
+        }
+    }
+    serde_json::to_string(&value).release_context("failed to normalize JSON version file")
+}
+
+fn normalize_gradle(content: &str) -> ReleaseResult<String> {
+    let name = Regex::new(r#"(?m)^(\s*versionName\s*=\s*)"[^"]+""#)
+        .release_context("invalid versionName normalization regex")?;
+    let code = Regex::new(r"(?m)^(\s*versionCode\s*=\s*)\d+")
+        .release_context("invalid versionCode normalization regex")?;
+    let marker = Regex::new(r"x-release-please-version-code(?:\s+\S+)?")
+        .release_context("invalid versionCode marker normalization regex")?;
+    let normalized = name.replace_all(content, r#"${1}"__VERSION__""#);
+    let normalized = code.replace_all(&normalized, "${1}1");
+    Ok(marker
+        .replace_all(&normalized, "x-release-please-version-code __VERSION__")
+        .into_owned())
+}
+
+fn normalize_cargo_manifest(files: &[&VersionFile], content: &str) -> ReleaseResult<String> {
+    let mut value: toml::Value =
+        toml::from_str(content).release_context("invalid Cargo version manifest")?;
+    for file in files {
+        if file.kind != VersionKind::CargoPackage {
+            continue;
+        }
+        let package = value
+            .get_mut("package")
+            .and_then(toml::Value::as_table_mut)
+            .release_context("missing [package] table")?;
+        package.insert(
+            "version".to_owned(),
+            toml::Value::String("__VERSION__".to_owned()),
+        );
+    }
+    toml::to_string(&value).release_context("failed to normalize Cargo version manifest")
+}
+
+fn normalize_cargo_lock(files: &[&VersionFile], content: &str) -> ReleaseResult<String> {
+    let packages = files
+        .iter()
+        .filter(|file| file.kind == VersionKind::CargoLockPackage)
+        .map(|file| {
+            file.package
+                .as_deref()
+                .release_context("cargo_lock_package requires package")
+        })
+        .collect::<ReleaseResult<BTreeSet<_>>>()?;
+    let version = Regex::new(r#"(?m)^(\s*version\s*=\s*)"[^"]+""#)
+        .release_context("invalid Cargo.lock version normalization regex")?;
+    let mut normalized = String::new();
+    for (index, section) in content.split("[[package]]").enumerate() {
+        if index > 0 {
+            normalized.push_str("[[package]]");
+        }
+        if section.lines().any(|line| {
+            packages
+                .iter()
+                .any(|package| line.trim() == format!(r#"name = "{package}""#))
+        }) {
+            normalized.push_str(&version.replace(section, r#"${1}"__VERSION__""#));
+        } else {
+            normalized.push_str(section);
+        }
+    }
+    Ok(normalized)
+}
+
+fn read_readme_version(content: &str) -> ReleaseResult<String> {
+    let regex =
+        Regex::new(r"(?m)^Version:\s*(\S+)").release_context("invalid README version regex")?;
+    regex
+        .captures(content)
+        .and_then(|captures| captures.get(1))
+        .map(|value| value.as_str().to_owned())
+        .release_context("missing 'Version:' line")
+}
+
+fn normalize_readme(content: &str) -> ReleaseResult<String> {
+    let regex =
+        Regex::new(r"(?m)^Version:\s*\S+\b(?:\s+<!-- x-release-please-version -->)?[ \t]*$")
+            .release_context("invalid README version normalization regex")?;
+    if !regex.is_match(content) {
+        return Err(super::super::ReleaseVersionError::msg(
+            "missing 'Version:' line",
+        ));
+    }
+    Ok(regex.replace(content, "Version: __VERSION__").into_owned())
+}
+
+fn release_headings(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| line.strip_prefix("## ["))
+        .filter_map(|line| line.split_once(']').map(|(version, _)| version))
+        .filter(|version| semver::Version::parse(version).is_ok())
+        .map(ToOwned::to_owned)
+        .collect()
+}

--- a/xtask/src/checks/release_versions/git.rs
+++ b/xtask/src/checks/release_versions/git.rs
@@ -290,7 +290,7 @@ pub(super) fn check_gradle_version_code_increased(
     Ok(())
 }
 
-fn git_show(root: &Path, reference: &str, path: &str) -> ReleaseResult<String> {
+pub(super) fn git_show(root: &Path, reference: &str, path: &str) -> ReleaseResult<String> {
     git_output(root, &["show", &format!("{reference}:{path}")])
 }
 

--- a/xtask/src/checks/release_versions/git.rs
+++ b/xtask/src/checks/release_versions/git.rs
@@ -22,7 +22,8 @@ pub(super) fn latest_tag(root: &Path, prefix: &str) -> ReleaseResult<Option<Stri
 }
 
 pub(super) fn tag_exists(root: &Path, tag: &str) -> ReleaseResult<bool> {
-    let output = Command::new("git")
+    let mut command = git_command_without_local_env()?;
+    let output = command
         .arg("-C")
         .arg(root)
         .args(["rev-parse", "-q", "--verify"])
@@ -193,7 +194,7 @@ pub(super) fn changed_paths_since_ref(
     head: &str,
     paths: &[String],
 ) -> ReleaseResult<Vec<String>> {
-    let mut command = Command::new("git");
+    let mut command = git_command_without_local_env()?;
     command
         .arg("-C")
         .arg(root)
@@ -222,7 +223,8 @@ pub(super) fn merge_base(root: &Path, base: &str, head: &str) -> ReleaseResult<S
 }
 
 fn git_output(root: &Path, args: &[&str]) -> ReleaseResult<String> {
-    let output = Command::new("git")
+    let mut command = git_command_without_local_env()?;
+    let output = command
         .arg("-C")
         .arg(root)
         .args(args)
@@ -236,6 +238,33 @@ fn git_output(root: &Path, args: &[&str]) -> ReleaseResult<String> {
         );
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Build a Git command that honors its explicit `-C <root>` target even when
+/// xtask is launched from a Git hook. Git exports repository-local variables
+/// such as `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` to hooks; those
+/// variables take precedence over `-C` and can silently redirect fixture or
+/// comparison commands back into the caller's real worktree.
+fn git_command_without_local_env() -> ReleaseResult<Command> {
+    let local_env = Command::new("git")
+        .args(["rev-parse", "--local-env-vars"])
+        .output()
+        .release_context("failed to list repository-local Git environment variables")?;
+    if !local_env.status.success() {
+        release_bail!(
+            "git rev-parse --local-env-vars failed: {}",
+            String::from_utf8_lossy(&local_env.stderr).trim()
+        );
+    }
+
+    let mut command = Command::new("git");
+    for variable in String::from_utf8_lossy(&local_env.stdout)
+        .lines()
+        .filter(|variable| !variable.is_empty())
+    {
+        command.env_remove(variable);
+    }
+    Ok(command)
 }
 
 pub(super) fn compare_ref_for_component(

--- a/xtask/src/checks/release_versions/release_please.rs
+++ b/xtask/src/checks/release_versions/release_please.rs
@@ -138,11 +138,83 @@ pub(super) fn validate_release_please_ownership(
         .collect::<BTreeSet<_>>();
 
     validate_owner_paths("release-please-config.json", &managed_paths, &config_paths)?;
+    validate_release_please_tag_prefixes(components, config_packages)?;
     validate_owner_paths(
         ".release-please-manifest.json",
         &managed_paths,
         &manifest_paths,
     )
+}
+
+fn validate_release_please_tag_prefixes(
+    components: &[Component],
+    config_packages: &serde_json::Map<String, serde_json::Value>,
+) -> ReleaseResult<()> {
+    for component in components
+        .iter()
+        .filter(|component| component.release_please_managed)
+    {
+        let package = config_packages
+            .get(&component.release_please_path)
+            .and_then(serde_json::Value::as_object)
+            .with_release_context(|| {
+                format!(
+                    "release-please-config.json package {} must be an object",
+                    component.release_please_path
+                )
+            })?;
+        let release_component = package
+            .get("component")
+            .and_then(serde_json::Value::as_str)
+            .with_release_context(|| {
+                format!(
+                    "release-please-config.json package {} is missing string field component",
+                    component.release_please_path
+                )
+            })?;
+        let include_v = package
+            .get("include-v-in-tag")
+            .and_then(serde_json::Value::as_bool)
+            .with_release_context(|| {
+                format!(
+                    "release-please-config.json package {} is missing boolean field include-v-in-tag",
+                    component.release_please_path
+                )
+            })?;
+        let include_component = match package.get("include-component-in-tag") {
+            Some(value) => value.as_bool().with_release_context(|| {
+                format!(
+                    "release-please-config.json package {} field include-component-in-tag must be boolean",
+                    component.release_please_path
+                )
+            })?,
+            None => true,
+        };
+        let separator = package
+            .get("tag-separator")
+            .and_then(serde_json::Value::as_str)
+            .with_release_context(|| {
+                format!(
+                    "release-please-config.json package {} is missing string field tag-separator",
+                    component.release_please_path
+                )
+            })?;
+        let version_prefix = if include_v { "v" } else { "" };
+        let derived_prefix = if include_component {
+            format!("{release_component}{separator}{version_prefix}")
+        } else {
+            version_prefix.to_owned()
+        };
+        if derived_prefix != component.tag_prefix {
+            release_bail!(
+                "release-please-config.json package {} derives tag prefix {}, expected {} from release/components.toml",
+                component.release_please_path,
+                derived_prefix,
+                component.tag_prefix
+            );
+        }
+    }
+    Ok(())
 }
 
 fn validate_owner_paths(
@@ -253,6 +325,7 @@ pub(super) fn fixup_items(
 }
 
 pub(super) fn release_please_dispatch_items(
+    root: &Path,
     components: &[Component],
     release_outputs: &str,
 ) -> ReleaseResult<Vec<ReleasePleaseDispatchItem>> {
@@ -277,6 +350,7 @@ pub(super) fn release_please_dispatch_items(
         }
     }
 
+    let versions = read_release_please_manifest(root)?;
     for component in components {
         if !component.release_please_managed {
             continue;
@@ -289,6 +363,20 @@ pub(super) fn release_please_dispatch_items(
             .get(&tag_key)
             .and_then(|value| value.as_str())
             .with_release_context(|| format!("release outputs missing {tag_key}"))?;
+        let version = versions
+            .get(&component.release_please_path)
+            .with_release_context(|| {
+                format!(
+                    ".release-please-manifest.json is missing path {}",
+                    component.release_please_path
+                )
+            })?;
+        let expected_tag = format!("{}{}", component.tag_prefix, version);
+        if tag != expected_tag {
+            release_bail!(
+                "release output {tag_key} is {tag}, expected {expected_tag} from release/components.toml and .release-please-manifest.json"
+            );
+        }
         items.push(ReleasePleaseDispatchItem {
             id: component.id.clone(),
             workflow: component.release_workflow.clone(),

--- a/xtask/src/checks/release_versions/release_please.rs
+++ b/xtask/src/checks/release_versions/release_please.rs
@@ -93,6 +93,75 @@ pub(super) fn check_manifest_versions(
     Ok(errors)
 }
 
+pub(super) fn validate_release_please_ownership(
+    root: &Path,
+    components: &[Component],
+) -> ReleaseResult<()> {
+    let all_component_paths = components
+        .iter()
+        .map(|component| component.release_please_path.clone())
+        .collect::<BTreeSet<_>>();
+    if all_component_paths.len() != components.len() {
+        let duplicate = components
+            .iter()
+            .find_map(|component| {
+                (components
+                    .iter()
+                    .filter(|candidate| {
+                        candidate.release_please_path == component.release_please_path
+                    })
+                    .count()
+                    > 1)
+                .then_some(component.release_please_path.as_str())
+            })
+            .unwrap_or("<unknown>");
+        release_bail!("duplicate release_please_path {duplicate}");
+    }
+
+    let config_path = root.join("release-please-config.json");
+    let config_content = std::fs::read_to_string(&config_path)
+        .release_context("failed to read release-please-config.json")?;
+    let config: serde_json::Value = serde_json::from_str(&config_content)
+        .release_context("failed to parse release-please-config.json")?;
+    let config_packages = config
+        .get("packages")
+        .and_then(serde_json::Value::as_object)
+        .release_context("release-please-config.json is missing object field packages")?;
+    let config_paths = config_packages.keys().cloned().collect::<BTreeSet<_>>();
+    let manifest_paths = read_release_please_manifest(root)?
+        .into_keys()
+        .collect::<BTreeSet<_>>();
+    let managed_paths = components
+        .iter()
+        .filter(|component| component.release_please_managed)
+        .map(|component| component.release_please_path.clone())
+        .collect::<BTreeSet<_>>();
+
+    validate_owner_paths("release-please-config.json", &managed_paths, &config_paths)?;
+    validate_owner_paths(
+        ".release-please-manifest.json",
+        &managed_paths,
+        &manifest_paths,
+    )
+}
+
+fn validate_owner_paths(
+    source: &str,
+    expected: &BTreeSet<String>,
+    actual: &BTreeSet<String>,
+) -> ReleaseResult<()> {
+    let missing = expected.difference(actual).cloned().collect::<Vec<_>>();
+    let unexpected = actual.difference(expected).cloned().collect::<Vec<_>>();
+    if !missing.is_empty() || !unexpected.is_empty() {
+        release_bail!(
+            "{source} ownership does not match release/components.toml: missing [{}]; unexpected [{}]",
+            missing.join(", "),
+            unexpected.join(", ")
+        );
+    }
+    Ok(())
+}
+
 pub(super) fn fixups(
     root: &Path,
     components: &[Component],
@@ -103,6 +172,12 @@ pub(super) fn fixups(
         .iter()
         .find(|component| component.id == component_id)
         .with_release_context(|| format!("unknown release component {component_id}"))?;
+    if !component.release_please_managed {
+        release_bail!(
+            "release-please fixups cannot modify unmanaged component {}",
+            component.id
+        );
+    }
 
     match component.id.as_str() {
         "cli" => run_cargo_update(root, "axon", version),
@@ -190,7 +265,22 @@ pub(super) fn release_please_dispatch_items(
     let released_paths = parse_paths_released(paths_released)?;
     let mut items = Vec::new();
 
+    for released_path in &released_paths {
+        let component = components
+            .iter()
+            .find(|component| component.release_please_path == *released_path)
+            .with_release_context(|| {
+                format!("release outputs include unknown release path {released_path}")
+            })?;
+        if !component.release_please_managed {
+            release_bail!("release outputs include unmanaged release path {released_path}");
+        }
+    }
+
     for component in components {
+        if !component.release_please_managed {
+            continue;
+        }
         if !released_paths.contains(&component.release_please_path) {
             continue;
         }
@@ -301,3 +391,7 @@ fn parse_paths_released(paths_released: &str) -> ReleaseResult<BTreeSet<String>>
     };
     Ok(paths)
 }
+
+#[cfg(test)]
+#[path = "release_please_tests.rs"]
+mod tests;

--- a/xtask/src/checks/release_versions/release_please_tests.rs
+++ b/xtask/src/checks/release_versions/release_please_tests.rs
@@ -26,7 +26,7 @@ fn ownership_requires_config_and_manifest_to_match_managed_paths() {
     let root = tempfile::tempdir().unwrap();
     std::fs::write(
         root.path().join("release-please-config.json"),
-        r#"{"packages":{"apps/palette":{"release-type":"simple"}}}"#,
+        r#"{"packages":{"apps/palette":{"component":"palette","release-type":"simple","include-v-in-tag":true,"tag-separator":"-"}}}"#,
     )
     .unwrap();
     std::fs::write(
@@ -50,7 +50,7 @@ fn ownership_rejects_unmanaged_path_in_release_please_config() {
     let root = tempfile::tempdir().unwrap();
     std::fs::write(
         root.path().join("release-please-config.json"),
-        r#"{"packages":{".":{"release-type":"simple"},"apps/palette":{"release-type":"simple"}}}"#,
+        r#"{"packages":{".":{"component":"cli","release-type":"simple","include-v-in-tag":true,"tag-separator":"-"},"apps/palette":{"component":"palette","release-type":"simple","include-v-in-tag":true,"tag-separator":"-"}}}"#,
     )
     .unwrap();
     std::fs::write(
@@ -76,7 +76,7 @@ fn ownership_rejects_missing_managed_manifest_path() {
     let root = tempfile::tempdir().unwrap();
     std::fs::write(
         root.path().join("release-please-config.json"),
-        r#"{"packages":{"apps/palette":{"release-type":"simple"}}}"#,
+        r#"{"packages":{"apps/palette":{"component":"palette","release-type":"simple","include-v-in-tag":true,"tag-separator":"-"}}}"#,
     )
     .unwrap();
     std::fs::write(root.path().join(".release-please-manifest.json"), "{}").unwrap();
@@ -95,7 +95,7 @@ fn ownership_rejects_two_components_claiming_one_release_path() {
     let root = tempfile::tempdir().unwrap();
     std::fs::write(
         root.path().join("release-please-config.json"),
-        r#"{"packages":{"apps/shared":{"release-type":"simple"}}}"#,
+        r#"{"packages":{"apps/shared":{"component":"palette","release-type":"simple","include-v-in-tag":true,"tag-separator":"-"}}}"#,
     )
     .unwrap();
     std::fs::write(
@@ -117,6 +117,52 @@ fn ownership_rejects_two_components_claiming_one_release_path() {
 }
 
 #[test]
+fn ownership_rejects_release_please_tag_configuration_drift() {
+    let cases = [
+        (
+            "component",
+            r#"{"packages":{"apps/palette":{"component":"desktop","include-v-in-tag":true,"tag-separator":"-"}}}"#,
+            "desktop-v",
+        ),
+        (
+            "include-v-in-tag",
+            r#"{"packages":{"apps/palette":{"component":"palette","include-v-in-tag":false,"tag-separator":"-"}}}"#,
+            "palette-",
+        ),
+        (
+            "tag-separator",
+            r#"{"packages":{"apps/palette":{"component":"palette","include-v-in-tag":true,"tag-separator":"_"}}}"#,
+            "palette_v",
+        ),
+        (
+            "include-component-in-tag",
+            r#"{"packages":{"apps/palette":{"component":"palette","include-v-in-tag":true,"include-component-in-tag":false,"tag-separator":"-"}}}"#,
+            "v",
+        ),
+    ];
+
+    for (field, config, derived_prefix) in cases {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("release-please-config.json"), config).unwrap();
+        std::fs::write(
+            root.path().join(".release-please-manifest.json"),
+            r#"{"apps/palette":"1.0.0"}"#,
+        )
+        .unwrap();
+
+        let error = validate_release_please_ownership(
+            root.path(),
+            &[component("palette", "apps/palette", true)],
+        )
+        .expect_err("release-please tag settings must derive the component tag prefix");
+        let message = error.to_string();
+        assert!(message.contains("apps/palette"), "{field}: {message}");
+        assert!(message.contains(derived_prefix), "{field}: {message}");
+        assert!(message.contains("palette-v"), "{field}: {message}");
+    }
+}
+
+#[test]
 fn dispatch_rejects_release_output_for_unmanaged_component() {
     let components = [
         component("cli", ".", false),
@@ -128,7 +174,7 @@ fn dispatch_rejects_release_output_for_unmanaged_component() {
         "palette_tag": "palette-v1.0.0"
     }"#;
 
-    let error = release_please_dispatch_items(&components, outputs)
+    let error = release_please_dispatch_items(Path::new("."), &components, outputs)
         .expect_err("release-please must not dispatch an unmanaged component");
     assert!(error.to_string().contains("unmanaged release path ."));
 }
@@ -141,7 +187,7 @@ fn dispatch_rejects_unknown_release_output_path() {
         "palette_tag": "palette-v1.0.0"
     }"#;
 
-    let error = release_please_dispatch_items(&components, outputs)
+    let error = release_please_dispatch_items(Path::new("."), &components, outputs)
         .expect_err("unknown release-please output paths must fail closed");
     assert!(
         error

--- a/xtask/src/checks/release_versions/release_please_tests.rs
+++ b/xtask/src/checks/release_versions/release_please_tests.rs
@@ -1,0 +1,161 @@
+use super::*;
+use crate::checks::release_versions::{Component, VersionFile, VersionKind};
+
+fn component(id: &str, path: &str, managed: bool) -> Component {
+    let version_file = VersionFile {
+        kind: VersionKind::JsonVersion,
+        path: format!("{id}.json"),
+        package: None,
+        json_pointer: Some("/version".to_owned()),
+    };
+    Component {
+        id: id.to_owned(),
+        name: id.to_owned(),
+        tag_prefix: format!("{id}-v"),
+        release_please_path: path.to_owned(),
+        release_workflow: format!("{id}-release.yml"),
+        shipping_paths: vec![id.to_owned()],
+        version_source: version_file.clone(),
+        version_files: vec![version_file],
+        release_please_managed: managed,
+    }
+}
+
+#[test]
+fn ownership_requires_config_and_manifest_to_match_managed_paths() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(
+        root.path().join("release-please-config.json"),
+        r#"{"packages":{"apps/palette":{"release-type":"simple"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join(".release-please-manifest.json"),
+        r#"{"apps/palette":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    validate_release_please_ownership(
+        root.path(),
+        &[
+            component("cli", ".", false),
+            component("palette", "apps/palette", true),
+        ],
+    )
+    .expect("declared ownership matches both release-please files");
+}
+
+#[test]
+fn ownership_rejects_unmanaged_path_in_release_please_config() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(
+        root.path().join("release-please-config.json"),
+        r#"{"packages":{".":{"release-type":"simple"},"apps/palette":{"release-type":"simple"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join(".release-please-manifest.json"),
+        r#"{"apps/palette":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let error = validate_release_please_ownership(
+        root.path(),
+        &[
+            component("cli", ".", false),
+            component("palette", "apps/palette", true),
+        ],
+    )
+    .expect_err("release-please config must not own unmanaged cli");
+    assert!(error.to_string().contains("release-please-config.json"));
+    assert!(error.to_string().contains("unexpected [.]"));
+}
+
+#[test]
+fn ownership_rejects_missing_managed_manifest_path() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(
+        root.path().join("release-please-config.json"),
+        r#"{"packages":{"apps/palette":{"release-type":"simple"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(root.path().join(".release-please-manifest.json"), "{}").unwrap();
+
+    let error = validate_release_please_ownership(
+        root.path(),
+        &[component("palette", "apps/palette", true)],
+    )
+    .expect_err("managed palette path must be present in release-please manifest");
+    assert!(error.to_string().contains(".release-please-manifest.json"));
+    assert!(error.to_string().contains("missing [apps/palette]"));
+}
+
+#[test]
+fn ownership_rejects_two_components_claiming_one_release_path() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(
+        root.path().join("release-please-config.json"),
+        r#"{"packages":{"apps/shared":{"release-type":"simple"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join(".release-please-manifest.json"),
+        r#"{"apps/shared":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let error = validate_release_please_ownership(
+        root.path(),
+        &[
+            component("palette", "apps/shared", true),
+            component("android", "apps/shared", true),
+        ],
+    )
+    .expect_err("a release-please path must have exactly one component owner");
+    assert!(error.to_string().contains("duplicate release_please_path"));
+    assert!(error.to_string().contains("apps/shared"));
+}
+
+#[test]
+fn dispatch_rejects_release_output_for_unmanaged_component() {
+    let components = [
+        component("cli", ".", false),
+        component("palette", "apps/palette", true),
+    ];
+    let outputs = r#"{
+        "paths_released": "[\".\", \"apps/palette\"]",
+        "cli_tag": "v1.0.0",
+        "palette_tag": "palette-v1.0.0"
+    }"#;
+
+    let error = release_please_dispatch_items(&components, outputs)
+        .expect_err("release-please must not dispatch an unmanaged component");
+    assert!(error.to_string().contains("unmanaged release path ."));
+}
+
+#[test]
+fn dispatch_rejects_unknown_release_output_path() {
+    let components = [component("palette", "apps/palette", true)];
+    let outputs = r#"{
+        "paths_released": "[\"apps/unknown\"]",
+        "palette_tag": "palette-v1.0.0"
+    }"#;
+
+    let error = release_please_dispatch_items(&components, outputs)
+        .expect_err("unknown release-please output paths must fail closed");
+    assert!(
+        error
+            .to_string()
+            .contains("unknown release path apps/unknown")
+    );
+}
+
+#[test]
+fn fixups_reject_unmanaged_component() {
+    let root = tempfile::tempdir().unwrap();
+    let components = [component("cli", ".", false)];
+
+    let error = fixups(root.path(), &components, "cli", "1.0.1")
+        .expect_err("release-please fixups must not write unmanaged components");
+    assert!(error.to_string().contains("unmanaged component cli"));
+}

--- a/xtask/src/checks/release_versions_tests.rs
+++ b/xtask/src/checks/release_versions_tests.rs
@@ -852,6 +852,76 @@ fn managed_android_feature_pr_rejects_a_manual_release_heading() {
 }
 
 #[test]
+fn managed_android_changelog_only_pr_rejects_a_manual_release_heading() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "android-v1.3.2"]);
+    fs::write(
+        fixture.path("apps/android/CHANGELOG.md"),
+        "# Changelog\n\n## [1.3.3]\n\n## [1.3.2]\n",
+    )
+    .unwrap();
+    fixture.git(&["add", "apps/android/CHANGELOG.md"]);
+    fixture.git(&["commit", "-m", "docs(android): add manual release heading"]);
+
+    let plans =
+        plan(fixture.root(), Some("android-v1.3.2"), "HEAD", GateMode::Pr).expect("release plan");
+    let android = plans.iter().find(|plan| plan.id == "android").unwrap();
+    assert!(
+        !android.changed,
+        "a changelog-only edit is not a shipping change"
+    );
+
+    let error = check(
+        fixture.root(),
+        Some("android-v1.3.2"),
+        "HEAD",
+        GateMode::Pr,
+        false,
+    )
+    .expect_err("a manual semver heading must not bypass managed release ownership");
+    let message = error.to_string();
+    assert!(
+        message.contains(
+            "changes release-please-owned version fields without a synchronized managed release version change"
+        ),
+        "unexpected error: {message}"
+    );
+    assert!(message.contains("apps/android/CHANGELOG.md"));
+}
+
+#[test]
+fn managed_android_changelog_only_pr_allows_prose_edits() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "android-v1.3.2"]);
+    fs::write(
+        fixture.path("apps/android/CHANGELOG.md"),
+        "# Changelog\n\n## [1.3.2]\n\n- Clarify the existing release notes.\n",
+    )
+    .unwrap();
+    fixture.git(&["add", "apps/android/CHANGELOG.md"]);
+    fixture.git(&["commit", "-m", "docs(android): clarify release notes"]);
+
+    let plans =
+        plan(fixture.root(), Some("android-v1.3.2"), "HEAD", GateMode::Pr).expect("release plan");
+    let android = plans.iter().find(|plan| plan.id == "android").unwrap();
+    assert!(
+        !android.changed,
+        "a prose-only changelog edit is not a shipping change"
+    );
+
+    check(
+        fixture.root(),
+        Some("android-v1.3.2"),
+        "HEAD",
+        GateMode::Pr,
+        false,
+    )
+    .expect("prose-only changelog edits do not claim release ownership");
+}
+
+#[test]
 fn android_change_allows_version_code_increase() {
     let fixture = Fixture::new();
     fixture.init_repo();
@@ -1244,6 +1314,55 @@ fn release_please_manifest_check_skips_unmanaged_cli_component() {
 }
 
 #[test]
+fn manual_bump_rejects_release_please_managed_components() {
+    let fixture = Fixture::new();
+    let before = fs::read_to_string(fixture.path("apps/android/app/build.gradle.kts")).unwrap();
+
+    let error = bump_component_version(fixture.root(), "android", BumpLevel::Patch)
+        .expect_err("release-please-managed components must reject manual bumps");
+
+    assert!(
+        error
+            .to_string()
+            .contains("android is release-please-managed and cannot be bumped manually")
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.path("apps/android/app/build.gradle.kts")).unwrap(),
+        before,
+        "the rejected bump must not mutate managed version files"
+    );
+}
+
+#[test]
+fn release_plan_ignores_inherited_repository_local_git_environment() {
+    let outer = Fixture::new();
+    outer.init_repo();
+    let outer_git_dir = outer.path(".git");
+    let outer_index = outer_git_dir.join("index");
+    let test_binary = std::env::current_exe().expect("resolve the xtask test binary");
+
+    let output = std::process::Command::new(test_binary)
+        .args([
+            "checks::release_versions::tests::managed_android_changelog_only_pr_rejects_a_manual_release_heading",
+            "--exact",
+            "--nocapture",
+        ])
+        .env("GIT_DIR", &outer_git_dir)
+        .env("GIT_WORK_TREE", outer.root())
+        .env("GIT_INDEX_FILE", &outer_index)
+        .env("GIT_PREFIX", "")
+        .output()
+        .expect("run a release-plan regression under hook-like Git environment variables");
+
+    assert!(
+        output.status.success(),
+        "release planning must honor fixture roots under inherited hook variables; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn release_please_dispatch_plan_uses_manifest_metadata() {
     let fixture = Fixture::new();
     let release_outputs = r#"{
@@ -1258,6 +1377,56 @@ fn release_please_dispatch_plan_uses_manifest_metadata() {
             workflow: "palette-release.yml".to_owned(),
             tag: "palette-v5.10.2".to_owned(),
         }]
+    );
+}
+
+#[test]
+fn release_please_dispatch_plan_rejects_a_tag_with_the_wrong_prefix() {
+    let fixture = Fixture::new();
+    let release_outputs = r#"{
+  "paths_released": "[\"apps/palette-tauri\"]",
+  "palette_tag": "desktop-v5.10.2"
+}"#;
+
+    let error = release_please_dispatch_plan(fixture.root(), release_outputs)
+        .expect_err("release output tags must use the component prefix");
+    let message = error.to_string();
+    assert!(
+        message.contains("palette_tag"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("desktop-v5.10.2"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("palette-v5.10.2"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
+fn release_please_dispatch_plan_rejects_a_tag_with_the_wrong_manifest_version() {
+    let fixture = Fixture::new();
+    let release_outputs = r#"{
+  "paths_released": "[\"apps/palette-tauri\"]",
+  "palette_tag": "palette-v5.10.3"
+}"#;
+
+    let error = release_please_dispatch_plan(fixture.root(), release_outputs)
+        .expect_err("release output tags must use the release-please manifest version");
+    let message = error.to_string();
+    assert!(
+        message.contains("palette_tag"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("palette-v5.10.3"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("palette-v5.10.2"),
+        "unexpected error: {message}"
     );
 }
 
@@ -1791,7 +1960,24 @@ fn write(path: &Path, content: &str) {
 }
 
 fn git(root: &Path, args: &[&str]) {
-    let status = std::process::Command::new("git")
+    let local_env = std::process::Command::new("git")
+        .args(["rev-parse", "--local-env-vars"])
+        .output()
+        .expect("list repository-local Git environment variables");
+    assert!(
+        local_env.status.success(),
+        "git rev-parse --local-env-vars failed: {}",
+        String::from_utf8_lossy(&local_env.stderr)
+    );
+
+    let mut command = std::process::Command::new("git");
+    for variable in String::from_utf8_lossy(&local_env.stdout)
+        .lines()
+        .filter(|variable| !variable.is_empty())
+    {
+        command.env_remove(variable);
+    }
+    let status = command
         .arg("-C")
         .arg(root)
         .args(args)

--- a/xtask/src/checks/release_versions_tests.rs
+++ b/xtask/src/checks/release_versions_tests.rs
@@ -739,7 +739,35 @@ fn managed_android_feature_pr_defers_the_release_bump() {
 }
 
 #[test]
-fn managed_android_feature_pr_rejects_mixed_version_file_ownership() {
+fn managed_android_gradle_config_pr_defers_when_version_fields_are_unchanged() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "android-v1.3.2"]);
+    let gradle_path = fixture.path("apps/android/app/build.gradle.kts");
+    let mut gradle = fs::read_to_string(&gradle_path).unwrap();
+    gradle.push_str(
+        r#"
+dependencies {
+    implementation("androidx.core:core-ktx:1.17.0")
+}
+"#,
+    );
+    fs::write(&gradle_path, gradle).unwrap();
+    fixture.git(&["add", "apps/android/app/build.gradle.kts"]);
+    fixture.git(&["commit", "-m", "build(android): update dependency"]);
+
+    check(
+        fixture.root(),
+        Some("android-v1.3.2"),
+        "HEAD",
+        GateMode::Pr,
+        false,
+    )
+    .expect("ordinary Gradle config changes defer the managed release bump");
+}
+
+#[test]
+fn managed_android_feature_pr_rejects_mixed_version_field_ownership() {
     let fixture = Fixture::new();
     fixture.init_repo();
     fixture.git(&["tag", "android-v1.3.2"]);
@@ -748,8 +776,9 @@ fn managed_android_feature_pr_rejects_mixed_version_file_ownership() {
         "package axon\n\nclass Feature\n",
     );
     let gradle_path = fixture.path("apps/android/app/build.gradle.kts");
-    let mut gradle = fs::read_to_string(&gradle_path).unwrap();
-    gradle.push_str("// manual version-file edit\n");
+    let gradle = fs::read_to_string(&gradle_path)
+        .unwrap()
+        .replace("versionCode = 6", "versionCode = 7");
     fs::write(&gradle_path, gradle).unwrap();
     fixture.git(&[
         "add",
@@ -769,14 +798,57 @@ fn managed_android_feature_pr_rejects_mixed_version_file_ownership() {
         GateMode::Pr,
         false,
     )
-    .expect_err("feature PR must not edit release-please-owned version files");
+    .expect_err("feature PR must not edit release-please-owned version fields");
     let message = error.to_string();
     assert!(
-        message.contains("mixes ordinary shipping changes with release-please-owned version files"),
+        message
+            .contains("mixes ordinary shipping changes with release-please-owned version fields"),
         "unexpected error: {message}"
     );
     assert!(message.contains("apps/android/app/build.gradle.kts"));
     assert!(message.contains("apps/android/app/src/main/kotlin/Feature.kt"));
+}
+
+#[test]
+fn managed_android_feature_pr_rejects_a_manual_release_heading() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "android-v1.3.2"]);
+    write(
+        &fixture.path("apps/android/app/src/main/kotlin/Feature.kt"),
+        "package axon\n\nclass Feature\n",
+    );
+    fs::write(
+        fixture.path("apps/android/CHANGELOG.md"),
+        "# Changelog\n\n## [1.3.3]\n\n## [1.3.2]\n",
+    )
+    .unwrap();
+    fixture.git(&[
+        "add",
+        "apps/android/app/src/main/kotlin/Feature.kt",
+        "apps/android/CHANGELOG.md",
+    ]);
+    fixture.git(&[
+        "commit",
+        "-m",
+        "feat(android): mix feature and release notes",
+    ]);
+
+    let error = check(
+        fixture.root(),
+        Some("android-v1.3.2"),
+        "HEAD",
+        GateMode::Pr,
+        false,
+    )
+    .expect_err("a feature PR must not add a release heading");
+    let message = error.to_string();
+    assert!(
+        message
+            .contains("mixes ordinary shipping changes with release-please-owned version fields"),
+        "unexpected error: {message}"
+    );
+    assert!(message.contains("apps/android/CHANGELOG.md"));
 }
 
 #[test]
@@ -803,7 +875,6 @@ fn android_change_allows_version_code_increase() {
     fs::write(
         fixture.path(".release-please-manifest.json"),
         r#"{
-  ".": "1.0.0",
   "apps/palette-tauri": "5.10.2",
   "apps/android": "1.3.3",
   "apps/chrome-extension": "0.2.0"
@@ -814,6 +885,7 @@ fn android_change_allows_version_code_increase() {
     fixture.git(&[
         "add",
         "apps/android/app/build.gradle.kts",
+        "apps/android/CHANGELOG.md",
         ".release-please-manifest.json",
     ]);
     fixture.git(&["commit", "-m", "bump android version"]);
@@ -897,6 +969,98 @@ fn managed_chrome_asset_pr_defers_the_release_bump() {
 }
 
 #[test]
+fn managed_chrome_config_pr_defers_when_version_fields_are_unchanged() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "chrome-ext-v0.2.0"]);
+    fs::write(
+        fixture.path("apps/chrome-extension/manifest.json"),
+        r#"{"manifest_version":3,"version":"0.2.0","permissions":["storage"]}"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/chrome-extension/package.json"),
+        r#"{"name":"axon-chrome-extension","version":"0.2.0","dependencies":{"example":"1.0.0"}}"#,
+    )
+    .unwrap();
+    fixture.git(&[
+        "add",
+        "apps/chrome-extension/manifest.json",
+        "apps/chrome-extension/package.json",
+    ]);
+    fixture.git(&["commit", "-m", "build(chrome): update runtime config"]);
+
+    check(
+        fixture.root(),
+        Some("chrome-ext-v0.2.0"),
+        "HEAD",
+        GateMode::Pr,
+        false,
+    )
+    .expect("ordinary Chrome config changes defer the managed release bump");
+}
+
+#[test]
+fn managed_chrome_pr_rejects_version_bump_mixed_into_manifest_config() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "chrome-ext-v0.2.0"]);
+    fs::write(
+        fixture.path("apps/chrome-extension/manifest.json"),
+        r#"{"manifest_version":3,"version":"0.2.1","permissions":["storage"]}"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/chrome-extension/package.json"),
+        r#"{"name":"axon-chrome-extension","version":"0.2.1"}"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/chrome-extension/CHANGELOG.md"),
+        "# Changelog\n\n## [0.2.1]\n\n## [0.2.0]\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.path(".release-please-manifest.json"),
+        r#"{
+  "apps/palette-tauri": "5.10.2",
+  "apps/android": "1.3.2",
+  "apps/chrome-extension": "0.2.1"
+}
+"#,
+    )
+    .unwrap();
+    fixture.git(&[
+        "add",
+        "apps/chrome-extension/manifest.json",
+        "apps/chrome-extension/package.json",
+        "apps/chrome-extension/CHANGELOG.md",
+        ".release-please-manifest.json",
+    ]);
+    fixture.git(&[
+        "commit",
+        "-m",
+        "feat(chrome): mix permission and release bump",
+    ]);
+
+    let error = check(
+        fixture.root(),
+        Some("chrome-ext-v0.2.0"),
+        "HEAD",
+        GateMode::Pr,
+        false,
+    )
+    .expect_err("ordinary manifest changes must not ride a managed version bump");
+    let message = error.to_string();
+    assert!(
+        message
+            .contains("mixes ordinary shipping changes with release-please-owned version fields"),
+        "unexpected error: {message}"
+    );
+    assert!(message.contains("apps/chrome-extension/manifest.json"));
+}
+
+#[test]
 fn main_mode_marks_changed_since_latest_tag() {
     let fixture = Fixture::new();
     fixture.init_repo();
@@ -937,7 +1101,6 @@ fn pr_mode_allows_release_please_source_fixup_after_tag_exists() {
     fs::write(
         fixture.path(".release-please-manifest.json"),
         r#"{
-  ".": "1.0.0",
   "apps/palette-tauri": "5.10.2",
   "apps/android": "1.3.2",
   "apps/chrome-extension": "0.2.1"
@@ -1031,14 +1194,11 @@ fn release_manifest_requires_release_please_path() {
 #[test]
 fn release_please_manifest_matches_component_versions() {
     let fixture = Fixture::new();
-    // "." (cli) is deliberately left wrong here too (9.9.9), to prove the
-    // next test's "cli is exempt" behavior isn't just "any mismatch is
-    // ignored" — palette is release-please-managed and must still be
-    // checked, so mismatching it must still produce an error.
+    // Palette is release-please-managed and must agree with its source
+    // version even though the unmanaged CLI is absent from this manifest.
     fs::write(
         fixture.path(".release-please-manifest.json"),
         r#"{
-  ".": "9.9.9",
   "apps/palette-tauri": "9.9.9",
   "apps/android": "1.3.2",
   "apps/chrome-extension": "0.2.0"
@@ -1061,9 +1221,8 @@ fn release_please_manifest_matches_component_versions() {
 fn release_please_manifest_check_skips_unmanaged_cli_component() {
     // cli's release/components.toml entry sets release_please_managed =
     // false (release-please can no longer open PRs for it — see the comment
-    // there and CLAUDE.md's Release Pipeline section). A "." entry that's
-    // missing entirely, or present but wrong, must NOT produce an error:
-    // release-please no longer owns that path at all.
+    // there and CLAUDE.md's Release Pipeline section). The "." entry must be
+    // absent because release-please no longer owns that path at all.
     let fixture = Fixture::new();
     fs::write(
         fixture.path(".release-please-manifest.json"),
@@ -1088,25 +1247,34 @@ fn release_please_manifest_check_skips_unmanaged_cli_component() {
 fn release_please_dispatch_plan_uses_manifest_metadata() {
     let fixture = Fixture::new();
     let release_outputs = r#"{
-  "paths_released": "[\".\", \"apps/palette-tauri\"]",
-  "cli_tag": "v1.0.0",
+  "paths_released": "[\"apps/palette-tauri\"]",
   "palette_tag": "palette-v5.10.2"
 }"#;
     let items = release_please_dispatch_plan(fixture.root(), release_outputs).unwrap();
     assert_eq!(
         items,
-        vec![
-            ReleasePleaseDispatchItem {
-                id: "cli".to_owned(),
-                workflow: "release.yml".to_owned(),
-                tag: "v1.0.0".to_owned(),
-            },
-            ReleasePleaseDispatchItem {
-                id: "palette".to_owned(),
-                workflow: "palette-release.yml".to_owned(),
-                tag: "palette-v5.10.2".to_owned(),
-            },
-        ]
+        vec![ReleasePleaseDispatchItem {
+            id: "palette".to_owned(),
+            workflow: "palette-release.yml".to_owned(),
+            tag: "palette-v5.10.2".to_owned(),
+        }]
+    );
+}
+
+#[test]
+fn release_please_dispatch_plan_rejects_unmanaged_cli_output() {
+    let fixture = Fixture::new();
+    let release_outputs = r#"{
+  "paths_released": "[\".\"]",
+  "cli_tag": "v1.0.0"
+}"#;
+    let error = release_please_dispatch_plan(fixture.root(), release_outputs)
+        .expect_err("release-please must not dispatch the unmanaged CLI");
+    assert!(
+        error
+            .to_string()
+            .contains("release outputs include unmanaged release path ."),
+        "unexpected error: {error}"
     );
 }
 
@@ -1407,10 +1575,17 @@ impl Fixture {
         )
         .expect("release/components.toml fixture exists");
         write(&self.path("release/components.toml"), &manifest);
+        let release_please_config = fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../release-please-config.json"),
+        )
+        .expect("release-please-config.json fixture exists");
+        write(
+            &self.path("release-please-config.json"),
+            &release_please_config,
+        );
         write(
             &self.path(".release-please-manifest.json"),
             r#"{
-  ".": "1.0.0",
   "apps/palette-tauri": "5.10.2",
   "apps/android": "1.3.2",
   "apps/chrome-extension": "0.2.0"

--- a/xtask/src/checks/release_versions_tests.rs
+++ b/xtask/src/checks/release_versions_tests.rs
@@ -67,6 +67,37 @@ fn reads_component_manifest() {
 }
 
 #[test]
+fn release_plan_serializes_release_please_ownership_for_every_component() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+
+    let plans = plan(fixture.root(), None, "HEAD", GateMode::Main).expect("release plan");
+    let serialized = serde_json::to_value(plans).expect("serialize release plan");
+    let components = serialized.as_array().expect("component array");
+    let ownership = components
+        .iter()
+        .map(|component| {
+            (
+                component["id"].as_str().expect("component id"),
+                component["release_please_managed"]
+                    .as_bool()
+                    .expect("serialized release-please ownership"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        ownership,
+        [
+            ("cli", false),
+            ("palette", true),
+            ("android", true),
+            ("chrome", true),
+        ]
+    );
+}
+
+#[test]
 fn cargo_package_version_reader_ignores_workspace_version() {
     let content = r#"
 [workspace.package]
@@ -681,6 +712,74 @@ fn android_change_requires_version_code_increase() {
 }
 
 #[test]
+fn managed_android_feature_pr_defers_the_release_bump() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "android-v1.3.2"]);
+    write(
+        &fixture.path("apps/android/app/src/main/kotlin/Feature.kt"),
+        "package axon\n\nclass Feature\n",
+    );
+    fixture.git(&["add", "apps/android/app/src/main/kotlin/Feature.kt"]);
+    fixture.git(&["commit", "-m", "feat(android): add feature"]);
+
+    check(
+        fixture.root(),
+        Some("android-v1.3.2"),
+        "HEAD",
+        GateMode::Pr,
+        false,
+    )
+    .expect("release-please-managed feature PR defers its version bump");
+
+    let plans =
+        plan(fixture.root(), Some("android-v1.3.2"), "HEAD", GateMode::Pr).expect("release plan");
+    let android = plans.iter().find(|plan| plan.id == "android").unwrap();
+    assert!(android.changed, "the full plan retains the shipping change");
+}
+
+#[test]
+fn managed_android_feature_pr_rejects_mixed_version_file_ownership() {
+    let fixture = Fixture::new();
+    fixture.init_repo();
+    fixture.git(&["tag", "android-v1.3.2"]);
+    write(
+        &fixture.path("apps/android/app/src/main/kotlin/Feature.kt"),
+        "package axon\n\nclass Feature\n",
+    );
+    let gradle_path = fixture.path("apps/android/app/build.gradle.kts");
+    let mut gradle = fs::read_to_string(&gradle_path).unwrap();
+    gradle.push_str("// manual version-file edit\n");
+    fs::write(&gradle_path, gradle).unwrap();
+    fixture.git(&[
+        "add",
+        "apps/android/app/src/main/kotlin/Feature.kt",
+        "apps/android/app/build.gradle.kts",
+    ]);
+    fixture.git(&[
+        "commit",
+        "-m",
+        "feat(android): mix feature and release ownership",
+    ]);
+
+    let error = check(
+        fixture.root(),
+        Some("android-v1.3.2"),
+        "HEAD",
+        GateMode::Pr,
+        false,
+    )
+    .expect_err("feature PR must not edit release-please-owned version files");
+    let message = error.to_string();
+    assert!(
+        message.contains("mixes ordinary shipping changes with release-please-owned version files"),
+        "unexpected error: {message}"
+    );
+    assert!(message.contains("apps/android/app/build.gradle.kts"));
+    assert!(message.contains("apps/android/app/src/main/kotlin/Feature.kt"));
+}
+
+#[test]
 fn android_change_allows_version_code_increase() {
     let fixture = Fixture::new();
     fixture.init_repo();
@@ -764,7 +863,7 @@ version = "1.1.0"
 }
 
 #[test]
-fn chrome_assets_change_requires_chrome_bump() {
+fn managed_chrome_asset_pr_defers_the_release_bump() {
     let fixture = Fixture::new();
     fixture.init_repo();
     fixture.git(&["tag", "chrome-ext-v0.2.0"]);
@@ -777,15 +876,24 @@ fn chrome_assets_change_requires_chrome_bump() {
     fixture.git(&["add", "apps/chrome-extension/assets/axon-glyph.svg"]);
     fixture.git(&["commit", "-m", "change asset"]);
 
-    let error = check(
+    check(
         fixture.root(),
         Some("chrome-ext-v0.2.0"),
         "HEAD",
         GateMode::Pr,
         false,
     )
-    .expect_err("chrome asset change requires bump");
-    assert!(error.to_string().contains("release version check failed"));
+    .expect("release-please-managed asset PR defers its version bump");
+
+    let plans = plan(
+        fixture.root(),
+        Some("chrome-ext-v0.2.0"),
+        "HEAD",
+        GateMode::Pr,
+    )
+    .expect("release plan");
+    let chrome = plans.iter().find(|plan| plan.id == "chrome").unwrap();
+    assert!(chrome.changed, "the full plan retains the shipping change");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make release-please the sole version owner for palette, Android, and Chrome while keeping CLI manual
- compare managed version fields instead of whole files so ordinary feature/config edits defer cleanly and mixed ownership fails closed
- derive the exact release owner/tag contract from release/components.toml and release-please configuration
- make auto-tag retry-safe, remote-main fresh for new tags, and recoverable when an existing correct tag needs its GitHub Release or artifact dispatch after main advances
- reject manual bump-version calls for release-please-managed components
- isolate release-planner Git commands from repository-local variables inherited through hooks

## Verification

- cargo test --locked -p xtask release_versions -- --nocapture (74 passed)
- cargo test --locked --test workflow_shapes -- --nocapture (31 passed)
- hostile inherited-Git-environment regression preserved the real HEAD, index, and shared config
- cargo clippy --locked -p xtask --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo xtask generated-contracts check
- actionlint .github/workflows/auto-tag.yml
- git diff --check
- independent final rereview: no blockers