### PR TITLE
fix(ci): install NASM for Windows cross-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,10 +459,11 @@ jobs:
   windows-build:
     name: windows-build (axon.exe)
     # Cross-compiled from Linux with the mingw-w64 (x86_64-pc-windows-gnu)
-    # toolchain. A previous cargo-zigbuild attempt failed because zig does not
-    # bundle the Windows platform headers (sched.h / windows.h) that
-    # aws-lc-sys's jitterentropy code needs; mingw-w64 ships those headers, so
-    # aws-lc-sys and ring both cross-build cleanly (the resulting axon.exe was
+    # toolchain plus NASM for BoringSSL's x86_64 assembly. A previous
+    # cargo-zigbuild attempt failed because zig does not bundle the Windows
+    # platform headers (sched.h / windows.h) that aws-lc-sys's jitterentropy
+    # code needs; mingw-w64 ships those headers, so aws-lc-sys and ring both
+    # cross-build cleanly (the resulting axon.exe was
     # smoke-tested on Windows 11: it runs, loads the full CLI, and resolves
     # native C:\ paths). Running on the Linux runner avoids the slow
     # GitHub-hosted Windows VM and its 2x minute billing.
@@ -492,10 +493,11 @@ jobs:
           # the same toolchain cargo uses under the repo override.
           toolchain: 1.97.1
           targets: x86_64-pc-windows-gnu
-      - name: Install mingw-w64
+      - name: Install mingw-w64 and NASM
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends mingw-w64
+          sudo apt-get install -y --no-install-recommends mingw-w64 nasm
+          nasm -v
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: axon-windows-gnu

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -692,6 +692,11 @@ fn ci_keeps_expensive_artifacts_off_ordinary_pull_requests() {
     assert!(mcp_smoke.contains("'ci:full'"));
     assert!(windows_check.contains("github.event_name == 'pull_request'"));
     assert!(windows_build.contains("'ci:full'"));
+    assert!(
+        windows_build.contains("sudo apt-get install -y --no-install-recommends mingw-w64 nasm")
+            && windows_build.contains("nasm -v"),
+        "the Windows GNU cross-build must install and verify NASM for BoringSSL assembly"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Installs and verifies NASM in the Linux-hosted x86_64-pc-windows-gnu build because BoringSSL failed with No CMAKE_ASM_NASM_COMPILER. Adds a workflow-shape regression assertion. Clean Kache-disabled pre-push validation passed: 22 changed-path tests, 33 workflow tests, generated contracts, docs checks, and the release-version gate. This CI-only change requires no additional version bump.