### PR TITLE
fix(kache): key extra build inputs for SQLx migrations and boring-sys2

### DIFF
--- a/.kache.toml
+++ b/.kache.toml
@@ -1,0 +1,2 @@
+[cache]
+exclude = ["$CARGO_HOME/registry/src/**/boring-sys2-*/**"]

--- a/crates/axon-ledger/build.rs
+++ b/crates/axon-ledger/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/migrations");
+}

--- a/crates/axon-ledger/kache.toml
+++ b/crates/axon-ledger/kache.toml
@@ -1,0 +1,1 @@
+extra_inputs = ["src/migrations/**/*.sql"]

--- a/crates/axon-observe/build.rs
+++ b/crates/axon-observe/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/migrations");
+}

--- a/crates/axon-observe/kache.toml
+++ b/crates/axon-observe/kache.toml
@@ -1,0 +1,1 @@
+extra_inputs = ["src/migrations/**/*.sql"]


### PR DESCRIPTION
- key SQLx migration inputs into Kache's cache key so migration file changes bust the cache
- bypass Kache for the non-hermetic boring-sys2 build (its build script isn't reproducible enough to safely cache)

Two small, related Kache correctness fixes.