### PR TITLE
fix(incus): keep TEI on host by default

### DIFF
--- a/.github/actions/setup-rust-kache/action.yml
+++ b/.github/actions/setup-rust-kache/action.yml
@@ -184,9 +184,24 @@ runs:
         fi
         mkdir -p "$cache_dir"
 
+        # Cargo resolves a bare RUSTC_WRAPPER through PATH for every compiler
+        # process. Persistent farm jobs have observed transient ENOENT failures
+        # late in otherwise healthy builds. Resolve the installed executable once
+        # and give Cargo an absolute path for every compiler invocation.
+        kache_bin="$(command -v kache)"
+        [ -n "$kache_bin" ] && [ -x "$kache_bin" ] || {
+          echo "::error::kache executable is unavailable after installation"
+          exit 1
+        }
+        kache_bin="$(readlink -f "$kache_bin")"
+        [ -n "$kache_bin" ] && [ -x "$kache_bin" ] || {
+          echo "::error::kache executable could not be resolved to an absolute path"
+          exit 1
+        }
+
         {
-          echo "RUSTC_WRAPPER=kache"
-          echo "CARGO_BUILD_RUSTC_WRAPPER=kache"
+          echo "RUSTC_WRAPPER=$kache_bin"
+          echo "CARGO_BUILD_RUSTC_WRAPPER=$kache_bin"
           echo "KACHE_CACHE_DIR=$cache_dir"
           # Incremental compilation and a compile wrapper do not compose.
           echo "CARGO_INCREMENTAL=0"

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -1,15 +1,17 @@
-# Axon Incus deployment — nested Docker for qdrant/tei/chrome, native axon
+# Axon Incus deployment — host TEI, nested Chrome/qdrant, optional native axon
 
-One Incus system container (`axon-container-profile`) runs:
+The Incus host owns GPU-backed TEI. One Incus system container
+(`axon-container-profile`) runs:
 
-- **tei/chrome as nested Docker containers**, via
-  a full Docker Engine + Compose internally, using `docker-compose.prod.yaml`
-  largely unchanged.
+- **Chrome and optional bundled qdrant as nested Docker containers**, using
+  `docker-compose.prod.yaml`;
+- **TEI externally on the Incus host by default**, reached through
+  `AXON_EXTERNAL_TEI_URL`; nested GPU TEI requires the explicit
+  `AXON_INCUS_TEI_MODE=bundled` override; and
 - **the axon binary deployed atomically into Incus**, with
   `axon-native.service` disabled by default. Dookie's host service owns the
-  shared SQLite queue; TEI and Chrome remain inside Incus. Set
-  `AXON_INCUS_RUN_SERVER=true` only when the guest uses an Incus-exclusive
-  database that host processes never open.
+  shared SQLite queue. Set `AXON_INCUS_RUN_SERVER=true` only when the guest
+  uses an Incus-exclusive database that host processes never open.
 
 The container base is Ubuntu 26.04, matching dookie's glibc baseline. This is
 intentional: host-built Axon binaries can be deployed directly into the native
@@ -25,10 +27,10 @@ See `docs/superpowers/plans/2026-07-07-incus-zabbly-upgrade.md` for the
 (retained, harmless) Incus 6.3+/Zabbly upgrade this deployment builds on, and
 `axon_rust-4m749` (beads epic) for the full architecture history — including
 the same-day pivot to native Incus OCI containers and revert back to nested
-Docker for qdrant/tei/chrome, after native OCI's GPU-compute path was found
-genuinely broken (`CUDA_ERROR_OUT_OF_MEMORY` during TEI warmup) on this
-host/Incus version. See bead `axon_rust-4m749.2`'s comments for the full
-diagnostic trail if you're wondering why qdrant/tei/chrome aren't native OCI.
+Docker for qdrant/chrome. TEI now runs on the Incus host, avoiding the nested
+NVIDIA cgroup boundary entirely. The earlier nested-GPU diagnostic trail is
+retained in bead `axon_rust-4m749.2` for installations that explicitly opt in
+to `AXON_INCUS_TEI_MODE=bundled`.
 
 ## Why axon is native, not nested-Docker
 
@@ -44,9 +46,8 @@ Running axon as a native binary via systemd sidesteps that hop entirely.
 `bootstrap.sh` atomically installs a validated host-built binary and refreshes
 `axon-native.service`, but leaves the service disabled unless explicitly
 enabled. SQLite WAL files cannot coordinate a queue safely across an Incus bind
-mount: host and guest can retain different WAL inode generations. Dookie
-therefore runs Axon's server on the host and reaches Incus-hosted TEI/Chrome
-through loopback proxy devices.
+mount: host and guest can retain different WAL inode generations. Dookie therefore runs Axon's server and TEI on the host. Chrome remains
+inside Incus and is exposed through loopback proxy devices.
 
 ## Migrating a legacy guest to Ubuntu 26.04
 
@@ -107,17 +108,13 @@ incus profile edit axon-container-profile < deploy/incus/profile.yaml
 
 Key config, and why:
 
-- `limits.memory: 24GiB` (hard) — derived as 16GiB qdrant (its own existing
-  production cap, justified by its own OOM history) + 2GiB TEI + 2GiB chrome
-  + 1GiB axon + 1GiB dockerd overhead, +~14% headroom. Re-verify this still
-  matches dookie's actual available headroom before relying on it — it was
-  derived once, not continuously monitored.
-- `nvidia.runtime: "true"` + `nvidia.driver.capabilities: all` — gives the
-  OUTER Incus container GPU/driver visibility (`nvidia-smi` works directly
-  in it). The GPU-compute workload (TEI) runs in a NESTED Docker container
-  inside this one, and gets its own GPU access via the nested dockerd's own
-  `nvidia-container-toolkit` — this is a real, working double-hop, confirmed
-  end-to-end with the actual production TEI image (bead `.2`).
+- `limits.memory: 24GiB` (hard) — retains headroom for the optional bundled
+  qdrant and bundled-TEI modes. Dookie's normal external-qdrant/external-TEI
+  deployment uses materially less memory, but the conservative cap keeps the
+  explicit bundled modes available without silently changing the profile.
+- `nvidia.runtime: "true"` + `nvidia.driver.capabilities: all` retain the
+  GPU path only for the explicit `AXON_INCUS_TEI_MODE=bundled` fallback. The
+  normal deployment keeps TEI on the Incus host and skips nested NVIDIA setup.
 - `security.nesting: "true"`, `security.privileged: "false"`,
   `security.syscalls.intercept.{mknod,setxattr}: "true"` — required for the
   nested Docker Engine to function inside an unprivileged Incus container.
@@ -146,7 +143,7 @@ UID 1000 to:
 
 | Host path | Container path | Purpose |
 |---|---|---|
-| `~/.axon-incus` | `/mnt/axon-data` | jobs.db, config.toml, .env, qdrant storage, TEI cache, artifacts, logs, screenshots — everything `docker-compose.prod.yaml` expects under `${AXON_HOME}` |
+| `~/.axon-incus` | `/mnt/axon-data` | jobs.db, config.toml, .env, optional bundled qdrant/TEI data, artifacts, logs, screenshots — everything the guest expects under `${AXON_HOME}` |
 | `~/.axon-incus-gemini` | `/mnt/axon-gemini` (read-only) | Gemini CLI auth (`oauth_creds.json`, `gemini-credentials.json`, etc.) |
 
 **This is a deliberate, permanent fork from `~/.axon`, not a temporary
@@ -180,7 +177,7 @@ needed.
   has no visibility into the host filesystem outside its declared disk
   devices at all.
 
-### Known fragility — nvidia-procfs device
+### Bundled TEI only — nvidia-procfs device
 
 A third device, `nvidia-procfs` (bind-mounting
 `/proc/driver/nvidia/gpus/<pci-address>` from host to the same path in the
@@ -197,10 +194,10 @@ incus config device add <container> nvidia-procfs disk \
   path=/proc/driver/nvidia/gpus/0000:03:00.0
 ```
 
-This is a required boot-time step in `bootstrap.sh` (bead `.5`), not a
-one-time fix — see that bead for the automated version.
+This boot-time step runs only when `AXON_INCUS_TEI_MODE=bundled`; external
+host TEI skips it entirely.
 
-### Required — nvidia-container-toolkit inside the container
+### Bundled TEI only — nvidia-container-toolkit inside the container
 
 The nested Docker Engine needs its own `nvidia-container-toolkit` + CDI
 registration to expose the GPU to `docker run --gpus all` — the outer

--- a/deploy/incus/axon-incus-bootstrap.env.example
+++ b/deploy/incus/axon-incus-bootstrap.env.example
@@ -4,6 +4,12 @@
 # Required for external-qdrant mode (this deployment's mode on dookie):
 AXON_EXTERNAL_QDRANT_URL=http://100.120.242.29:53333
 
+# TEI runs on the Incus host, not as nested Docker inside the guest. The guest
+# reaches the host through the incusbr0 gateway. Nested TEI requires an
+# explicit AXON_INCUS_TEI_MODE=bundled override.
+AXON_INCUS_TEI_MODE=external
+AXON_EXTERNAL_TEI_URL=http://10.47.200.1:52000
+
 # Optional — defaults to $HOME/.axon/.env if unset. Set explicitly here since
 # systemd services don't have a shell $HOME by default.
 AXON_ENV_FILE=/home/jmagar/.axon/.env

--- a/deploy/incus/axon-incus-bootstrap.service
+++ b/deploy/incus/axon-incus-bootstrap.service
@@ -8,8 +8,9 @@ Requires=incus.service
 Type=oneshot
 # Mode is fixed at install time — this deployment (dookie) always uses the
 # external-qdrant override, since qdrant lives on tootie for RAM reasons.
-# AXON_EXTERNAL_QDRANT_URL and AXON_ENV_FILE are read from the environment
-# file below rather than hardcoded here.
+# AXON_EXTERNAL_QDRANT_URL, AXON_EXTERNAL_TEI_URL, AXON_INCUS_TEI_MODE,
+# and AXON_ENV_FILE are read from the environment file below rather than
+# hardcoded here.
 # No leading "-": this file is required, not optional. external-qdrant mode
 # hard-requires AXON_EXTERNAL_QDRANT_URL, which only comes from here — a
 # missing file should fail loudly and distinctly at the systemd level

--- a/deploy/incus/bootstrap.sh
+++ b/deploy/incus/bootstrap.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # Idempotent bootstrap for axon's Incus deployment.
 #
-# Split model (confirmed in production 2026-07-08, bead axon_rust-4m749.3):
-#   - tei/chrome run as NESTED DOCKER containers
-#     inside the Incus container — they need the GPU-passthrough Docker
-#     Engine setup this script builds.
+# Split model:
+#   - TEI runs on the Incus HOST by default and is consumed through
+#     AXON_EXTERNAL_TEI_URL. Nested GPU TEI is an explicit opt-in only.
+#   - Chrome and optional bundled qdrant run as nested Docker containers.
 #   - axon's binary is deployed into Incus, but its native service is disabled
 #     by default because the host CLI and an Incus process cannot safely share
 #     a bind-mounted SQLite WAL. Set AXON_INCUS_RUN_SERVER=true only when the
 #     host never opens that database. A containerized axon
-#     talking to nested-Docker qdrant/tei/chrome over the "jakenet" bridge
-#     needs no NAT hairpin of its own, but publishing axon's port back out to
+#     talking to nested-Docker qdrant/chrome and host TEI needs no NAT hairpin
+#     of its own, but publishing axon's port back out to
 #     the host (for SWAG/Cloudflare) requires an extra NAT hop through
 #     Docker's own port-proxy for every single request; that hop was found to
 #     silently reset connections in this environment (TCP handshake
@@ -18,8 +18,8 @@
 #     on the same bridge/docker-proxy mechanism worked fine — i.e. axon
 #     specifically, not nested Docker networking in general. Native + systemd
 #     sidesteps that hop entirely: axon binds directly to the Incus
-#     container's own network namespace, and only reads from
-#     qdrant/tei/chrome over their already-published localhost ports.
+#     container's own network namespace and reaches the selected providers
+#     through their explicit URLs.
 #
 # Usage:
 #   deploy/incus/bootstrap.sh [external-qdrant|bundled-qdrant]
@@ -39,9 +39,8 @@
 # Safe to re-run at any time (idempotent) — including to redeploy a new axon
 # binary build after a code change. Also the intended entry point for the
 # companion systemd unit (axon-incus-bootstrap.service) that re-runs this on
-# every host boot, since boot.autostart=true alone does not re-apply the
-# known-fragile nvidia-procfs device, re-verify GPU access, or restart the
-# native axon service.
+# every host boot, since boot.autostart=true alone does not reconcile provider
+# topology, verify health, or refresh the optional native axon service.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -53,6 +52,7 @@ GPU_PCI_ADDRESS="${AXON_GPU_PCI_ADDRESS:-0000:03:00.0}"
 DEPLOY_PATH="/opt/axon-deploy"
 HOST_AXON_BINARY="${AXON_INCUS_BINARY:-$REPO_ROOT/target/release-fast/axon}"
 MODE="${1:-external-qdrant}"
+TEI_MODE="${AXON_INCUS_TEI_MODE:-external}"
 RUN_INCUS_SERVER="${AXON_INCUS_RUN_SERVER:-false}"
 
 log() { echo "[bootstrap] $*"; }
@@ -62,12 +62,28 @@ case "$MODE" in
   external-qdrant|bundled-qdrant) ;;
   *) fatal "unknown mode '$MODE' (expected 'external-qdrant' or 'bundled-qdrant')" ;;
 esac
+case "$TEI_MODE" in
+  external|bundled) ;;
+  *) fatal "AXON_INCUS_TEI_MODE must be external or bundled" ;;
+esac
 case "$RUN_INCUS_SERVER" in
   true|false) ;;
   *) fatal "AXON_INCUS_RUN_SERVER must be true or false" ;;
 esac
 if [ "$MODE" = "external-qdrant" ] && [ -z "${AXON_EXTERNAL_QDRANT_URL:-}" ]; then
   fatal "AXON_EXTERNAL_QDRANT_URL must be set for external-qdrant mode"
+fi
+tei_unit_environment=""
+if [ "$TEI_MODE" = "external" ]; then
+  [ -n "${AXON_EXTERNAL_TEI_URL:-}" ] || fatal "AXON_EXTERNAL_TEI_URL must be set when AXON_INCUS_TEI_MODE=external"
+  case "$AXON_EXTERNAL_TEI_URL" in
+    http://*|https://*) ;;
+    *) fatal "AXON_EXTERNAL_TEI_URL must be an http:// or https:// URL" ;;
+  esac
+  case "$AXON_EXTERNAL_TEI_URL" in
+    *[[:space:]]*) fatal "AXON_EXTERNAL_TEI_URL contains whitespace" ;;
+  esac
+  tei_unit_environment="Environment=TEI_URL=${AXON_EXTERNAL_TEI_URL}"
 fi
 
 ### 1. Profile: create from the committed definition if missing. Never
@@ -123,7 +139,7 @@ guest_os="$(incus exec "$CONTAINER_NAME" -- sh -c '. /etc/os-release; printf "%s
 [ "$guest_os" = "ubuntu:26.04" ] || fatal "${CONTAINER_NAME} is ${guest_os}, not ubuntu:26.04; recreate it with the documented Incus migration before deploying a host-built binary"
 
 ### 5. Install Docker inside the container if missing (idempotent). Needed
-### for the nested qdrant/tei/chrome services. Axon's native binary is pushed
+### for nested Chrome, optional qdrant, and opt-in bundled TEI. Axon's native binary is pushed
 ### from the host in step 15 and is not built inside this guest.
 if ! incus exec "$CONTAINER_NAME" -- sh -c 'command -v docker' >/dev/null 2>&1; then
   log "Docker not found inside container, installing..."
@@ -145,8 +161,10 @@ else
   log "Docker already present inside container"
 fi
 
+if [ "$TEI_MODE" = "bundled" ]; then
 ### 6. Install nvidia-container-toolkit inside the container (idempotent).
-### REQUIRED for the nested Docker Engine to expose the GPU to containers via
+### REQUIRED only when nested TEI is explicitly enabled, so the nested Docker
+### Engine can expose the GPU to containers via
 ### `docker run --gpus all` — confirmed missing from a from-scratch container
 ### build 2026-07-08: without it, `docker run --gpus all ...` fails with
 ### "failed to discover GPU vendor from CDI: no known GPU vendor found" even
@@ -212,6 +230,9 @@ for _ in 1 2 3; do
   sleep 3
 done
 [ "$gpu_ok" = "1" ] || fatal "GPU verification failed after 3 attempts — refusing to start TEI in a broken state. Check the nvidia-procfs device and host NVIDIA driver."
+else
+  log "using host-owned TEI at ${AXON_EXTERNAL_TEI_URL}; skipping nested NVIDIA setup"
+fi
 
 ### Resolve the env file now — needed by the network-name lookup (10), the
 ### axon-native systemd unit (16), and the actual push (13).
@@ -232,7 +253,7 @@ case "$container_data_path" in
 esac
 
 ### 9. Sync deploy artifacts (compose files + config/) into the container.
-### Only used for the nested qdrant/tei/chrome services now — axon itself is
+### Used for nested Chrome, optional qdrant, and opt-in bundled TEI. Axon itself is
 ### built from the full repo tree separately in step 15.
 log "syncing compose files + config into ${DEPLOY_PATH}"
 incus exec "$CONTAINER_NAME" -- mkdir -p "$DEPLOY_PATH"
@@ -299,30 +320,30 @@ else
   incus file push --mode 0600 "$env_file_on_host" "$CONTAINER_NAME$container_data_path/.env"
 fi
 
-### 13. Bring up ONLY the nested-Docker services — qdrant (explicit bundled mode)/tei/
-### chrome, never axon itself (see split-model rationale at the top of this
-### file). Explicit service names, not a bare `up -d`, so this stays correct
-### even if docker-compose.prod.yaml's `axon` service definition changes
-### later.
+### 13. Bring up only the selected nested-Docker services. Chrome is always
+### nested, qdrant is optional, and TEI is nested only when explicitly opted in.
+docker_services="axon-chrome"
 if [ "$MODE" = "bundled-qdrant" ]; then
   log "=== bundled qdrant IS starting locally (explicit bundled-qdrant mode) ==="
-  incus exec "$CONTAINER_NAME" \
-    --cwd "$DEPLOY_PATH" \
-    -- docker compose --env-file .env -f docker-compose.prod.yaml up -d axon-qdrant axon-tei axon-chrome
+  docker_services="axon-qdrant $docker_services"
 else
   log "=== bundled qdrant is NOT starting, using external QDRANT_URL=${AXON_EXTERNAL_QDRANT_URL} ==="
-  incus exec "$CONTAINER_NAME" \
-    --cwd "$DEPLOY_PATH" \
-    -- docker compose --env-file .env -f docker-compose.prod.yaml up -d axon-tei axon-chrome
 fi
+if [ "$TEI_MODE" = "bundled" ]; then
+  log "=== bundled TEI IS starting locally (explicit AXON_INCUS_TEI_MODE=bundled) ==="
+  docker_services="axon-tei $docker_services"
+else
+  log "=== bundled TEI is NOT starting, using external TEI_URL=${AXON_EXTERNAL_TEI_URL} ==="
+  incus exec "$CONTAINER_NAME" --cwd "$DEPLOY_PATH" -- \
+    docker compose --env-file .env -f docker-compose.prod.yaml stop axon-tei >/dev/null 2>&1 || true
+  incus exec "$CONTAINER_NAME" --cwd "$DEPLOY_PATH" -- \
+    docker compose --env-file .env -f docker-compose.prod.yaml rm -f axon-tei >/dev/null 2>&1 || true
+fi
+incus exec "$CONTAINER_NAME" -- sh -c \
+  "cd $DEPLOY_PATH && docker compose --env-file .env -f docker-compose.prod.yaml up -d $docker_services"
 
-### 14. Health-check polling for the nested-Docker services — EXPLICIT
-### bounded timeout/retry (36 * 10s = 360s max). No open-ended "wait until
-### ready" loop. Assumes axon-tei/axon-chrome(/axon-qdrant) define
-### healthchecks (true today).
+### 14. Health-check polling for nested services and the selected TEI provider.
 log "polling for nested-Docker services healthy (bounded: up to 360s)"
-docker_services="axon-tei axon-chrome"
-[ "$MODE" = "bundled-qdrant" ] && docker_services="axon-qdrant $docker_services"
 healthy=0
 for _ in $(seq 1 36); do
   statuses="$(incus exec "$CONTAINER_NAME" -- sh -c \
@@ -335,6 +356,19 @@ for _ in $(seq 1 36); do
 done
 if [ "$healthy" != "1" ]; then
   fatal "not all nested-Docker services reported healthy within the bounded window (360s) — inspect 'docker compose ps' inside $CONTAINER_NAME"
+fi
+if [ "$TEI_MODE" = "external" ]; then
+  log "polling for external TEI healthy at ${AXON_EXTERNAL_TEI_URL}"
+  tei_healthy=0
+  for _ in $(seq 1 36); do
+    if incus exec "$CONTAINER_NAME" -- curl -fsS --max-time 4 \
+      "${AXON_EXTERNAL_TEI_URL%/}/health" >/dev/null 2>&1; then
+      tei_healthy=1
+      break
+    fi
+    sleep 10
+  done
+  [ "$tei_healthy" = "1" ] || fatal "external TEI did not become healthy within 360s: ${AXON_EXTERNAL_TEI_URL}"
 fi
 
 ### 15. Deploy the already-validated host binary. The Ubuntu guest shares
@@ -388,6 +422,7 @@ EnvironmentFile=$container_data_path/.env
 Environment=AXON_HOME=$container_data_path
 Environment=AXON_DATA_DIR=$container_data_path
 Environment=AXON_HTTP_HOST=0.0.0.0
+$tei_unit_environment
 WorkingDirectory=$container_data_path
 ExecStart=/usr/local/bin/axon serve
 Restart=always

--- a/tests/compose_env_contract.rs
+++ b/tests/compose_env_contract.rs
@@ -452,6 +452,46 @@ fn shell_scripts_share_canonical_env_resolution() {
     );
 }
 
+#[test]
+fn incus_bootstrap_defaults_to_host_owned_tei() {
+    let bootstrap = fs::read_to_string("deploy/incus/bootstrap.sh")
+        .expect("Incus bootstrap should be readable");
+    let env = fs::read_to_string("deploy/incus/axon-incus-bootstrap.env.example")
+        .expect("Incus bootstrap env example should be readable");
+
+    assert!(
+        bootstrap.contains("TEI_MODE=\"${AXON_INCUS_TEI_MODE:-external}\""),
+        "Incus bootstrap should default TEI to the host-owned external provider"
+    );
+    assert!(
+        bootstrap.contains("AXON_EXTERNAL_TEI_URL must be set"),
+        "external TEI mode should fail closed without a reachable provider URL"
+    );
+    assert!(
+        bootstrap.contains("docker_services=\"axon-chrome\"")
+            && bootstrap.contains("docker_services=\"axon-tei $docker_services\""),
+        "nested TEI should be added only by the explicit bundled mode"
+    );
+    assert!(
+        bootstrap
+            .contains("docker compose --env-file .env -f docker-compose.prod.yaml stop axon-tei")
+            && bootstrap.contains(
+                "docker compose --env-file .env -f docker-compose.prod.yaml rm -f axon-tei"
+            ),
+        "external mode should remove stale nested TEI state"
+    );
+    assert!(
+        !bootstrap.contains("up -d axon-tei axon-chrome")
+            && !bootstrap.contains("up -d axon-qdrant axon-tei axon-chrome"),
+        "bootstrap must not start nested TEI unconditionally"
+    );
+    assert!(
+        env.contains("AXON_INCUS_TEI_MODE=external")
+            && env.contains("AXON_EXTERNAL_TEI_URL=http://10.47.200.1:52000"),
+        "dookie example should point the guest at host TEI through incusbr0"
+    );
+}
+
 fn env_example_keys() -> BTreeSet<String> {
     const ENV_EXAMPLE: &str = include_str!("../.env.example");
 

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -817,6 +817,26 @@ fn rust_ci_uses_the_repository_toolchain_pin() {
 }
 
 #[test]
+fn kache_wrapper_uses_a_verified_absolute_path() {
+    let setup = include_str!("../.github/actions/setup-rust-kache/action.yml");
+    assert!(
+        setup.contains(r#"kache_bin="$(command -v kache)""#)
+            && setup.contains(r#"kache_bin="$(readlink -f "$kache_bin")""#),
+        "the shared Rust setup must resolve the installed wrapper to an absolute path"
+    );
+    assert!(
+        setup.contains(r#"echo "RUSTC_WRAPPER=$kache_bin""#)
+            && setup.contains(r#"echo "CARGO_BUILD_RUSTC_WRAPPER=$kache_bin""#),
+        "Cargo wrapper variables must use the verified executable path"
+    );
+    assert!(
+        !setup.contains(r#"echo "RUSTC_WRAPPER=kache""#)
+            && !setup.contains(r#"echo "CARGO_BUILD_RUSTC_WRAPPER=kache""#),
+        "the shared Rust setup must not rely on repeated PATH lookup for the wrapper"
+    );
+}
+
+#[test]
 fn kache_daemon_probe_is_pipefail_safe() {
     let setup = include_str!("../.github/actions/setup-rust-kache/action.yml");
     assert!(


### PR DESCRIPTION
## Summary

- make external host-owned TEI the default Incus topology
- require and verify `AXON_EXTERNAL_TEI_URL` from inside the guest
- remove stale nested `axon-tei` state in external mode
- keep nested GPU TEI as an explicit `AXON_INCUS_TEI_MODE=bundled` fallback
- document the host TEI topology and add a regression contract

## Runtime evidence

- removed the nested `axon-tei` container and three TEI proxy devices from the live `axon` Incus instance
- started pinned TEI `ghcr.io/huggingface/text-embeddings-inference:89-1.9` on the DOOKIE host with the RTX 4070
- TEI health is green and a real embedding returned 1,024 dimensions
- `axon doctor` reports `all_ok=true`
- two Young Office generated-lead runs and their automated review follow-ups completed successfully
- the daily Young Office timer is enabled for August 6, 2026 at 04:35 EDT

## Verification

- `bash -n deploy/incus/bootstrap.sh`
- ShellCheck, excluding only existing source-resolution and literal-template informational rules
- `cargo fmt --all -- --check`
- compiled contract binary: `incus_bootstrap_defaults_to_host_owned_tei` passed
- generated contracts, monolith policy, and rustfmt pre-commit checks passed
- full structural checks and repository CI gate merge
