### PR TITLE
fix: complete identifier scrub and repair shell-lint hook glob

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -89,13 +89,13 @@ jobs:
 
       - name: Validate helper shell scripts
         run: |
-          bash -n scripts/build-on-steamy.sh scripts/test-ask-gemma4.sh scripts/test-build-on-steamy-safety.sh
+          bash -n scripts/build-on-winhost.sh scripts/test-ask-gemma4.sh scripts/test-build-on-winhost-safety.sh
           if command -v shellcheck >/dev/null 2>&1; then
-            shellcheck scripts/build-on-steamy.sh scripts/test-ask-gemma4.sh scripts/test-build-on-steamy-safety.sh
+            shellcheck scripts/build-on-winhost.sh scripts/test-ask-gemma4.sh scripts/test-build-on-winhost-safety.sh
           else
             echo "shellcheck not found; skipped optional shell lint" >&2
           fi
-          scripts/test-build-on-steamy-safety.sh
+          scripts/test-build-on-winhost-safety.sh
 
   image-build-smoke:
     name: image-build-smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1805,7 +1805,7 @@ Remediation of the 10 surviving findings from the four-PR code review of
 
 - **build-windows.sh** — new cross-compile script that builds the Palette Tauri
   or `axon.exe` Windows executable on devhost and ships it to Winhost's Desktop
-  via `scp`, replacing the old `build-on-steamy.sh` repo-sync approach.
+  via `scp`, replacing the old `build-on-winhost.sh` repo-sync approach.
 
 ### Fixed
 
@@ -1894,7 +1894,7 @@ Remediation of the 10 surviving findings from the four-PR code review of
 - Android: `DocumentScreen`, `SourcesScreen`, `MapTab`, `ResearchTab` wired into
   the expanded nav graph.
 - Android: `libs.versions.toml` dependency updates for new form/nav requirements.
-- `scripts/build-on-steamy.sh`: minor fixes to sync paths.
+- `scripts/build-on-winhost.sh`: minor fixes to sync paths.
 
 ## [4.11.0] - 2026-05-27
 
@@ -2069,7 +2069,7 @@ Remediation of the 10 surviving findings from the four-PR code review of
 - OpenAI-compatible LLM backend support for llama.cpp-style endpoints via
   `AXON_LLM_BACKEND=openai-compat`, `AXON_OPENAI_BASE_URL`,
   `AXON_OPENAI_API_KEY`, and `AXON_OPENAI_MODEL`.
-- Tauri palette deployment helper `scripts/build-on-steamy.sh` for building a
+- Tauri palette deployment helper `scripts/build-on-winhost.sh` for building a
   Windows executable and placing it on Winhost's desktop.
 - Job progress presentation helpers and additional ask/query logging around
   retrieval, context assembly, and LLM synthesis.

--- a/docs/development/desktop-palette-testing.md
+++ b/docs/development/desktop-palette-testing.md
@@ -24,7 +24,7 @@ drive agent-os directly via the Windows-MCP tool available through Labby.
 
 The portable Windows `.exe` is produced by `tauri build --no-bundle` and shipped
 by the `palette-windows` job in `.github/workflows/release.yml`. To build one
-locally for testing, use `scripts/build-on-steamy.sh` / `scripts/build-windows.sh`
+locally for testing, use `scripts/build-on-winhost.sh` / `scripts/build-windows.sh`
 (both default to `--target palette-tauri`), or build directly:
 
 ```bash

--- a/docs/sessions/2026-05-26-openai-compat-palette-steamy.md
+++ b/docs/sessions/2026-05-26-openai-compat-palette-steamy.md
@@ -53,7 +53,7 @@ Implemented and configured the OpenAI-compatible LLM path, added ask-path diagno
 | modified | `src/cli/**`, `src/jobs/**`, `src/services/ingest/**`, `tests/setup_check_cli.rs` | Job progress/status and ingest handling changes present in the worktree. |
 | created | `src/cli/commands/job_progress.rs` | Shared job progress presentation. |
 | modified | `apps/palette-tauri/**` | Palette settings, window behavior, output formatting, Aurora color alignment, icons, and Windows build metadata. |
-| created | `scripts/build-on-steamy.sh`, `scripts/test-ask-gemma4.sh`, `docker-compose.llama.yaml` | Local deployment/testing helpers for Gemma/llama.cpp and Winhost build delivery. |
+| created | `scripts/build-on-winhost.sh`, `scripts/test-ask-gemma4.sh`, `docker-compose.llama.yaml` | Local deployment/testing helpers for Gemma/llama.cpp and Winhost build delivery. |
 
 ## Beads Activity
 

--- a/docs/sessions/2026-05-26-pr139-review-remediation-closeout.md
+++ b/docs/sessions/2026-05-26-pr139-review-remediation-closeout.md
@@ -54,7 +54,7 @@ The PR branch currently differs from `origin/main` by 165 paths according to `gi
 | modified | `.env.example`, `config.example.toml`, `docs/CONFIG.md`, `docs/env-migration-matrix.md`, `docs/mcp/ENV.md`, `README.md`, `CHANGELOG.md` | - | Document and expose `AXON_LLM_BACKEND=openai-compat` and `AXON_OPENAI_*` config. | `git diff --name-status origin/main...HEAD` |
 | modified | `.github/workflows/ci.yml`, `.github/workflows/compose-smoke.yml`, `lefthook.yml` | - | Add palette CI, Tauri crate tests, llama compose validation, and helper script linting. | `git log origin/main..HEAD` |
 | created | `docker-compose.llama.yaml` | - | Provide llama.cpp OpenAI-compatible runtime path. | `git diff --stat origin/main...HEAD` |
-| created | `scripts/build-on-steamy.sh`, `scripts/test-ask-gemma4.sh`, `scripts/test-build-on-steamy-safety.sh` | - | Add Winhost Windows build workflow, Gemma smoke test helper, and destructive-sync safety test. | `bash -n`, `shellcheck`, safety test verification from session |
+| created | `scripts/build-on-winhost.sh`, `scripts/test-ask-gemma4.sh`, `scripts/test-build-on-winhost-safety.sh` | - | Add Winhost Windows build workflow, Gemma smoke test helper, and destructive-sync safety test. | `bash -n`, `shellcheck`, safety test verification from session |
 | modified/created | `apps/palette-tauri/**` | - | Palette UI, Aurora styling, Tauri bridge hardening, tests, icons, settings fallback, async job display, request formatting, and dependency cleanup. | `pnpm --dir apps/palette-tauri test/typecheck/vite:build`; Tauri cargo tests |
 | modified | `src/core/config/**`, `src/services/llm_backend/**`, `src/services/debug.rs`, `src/services/search/synthesis.rs`, `src/vector/ops/commands/suggest.rs` | - | Add and route OpenAI-compatible LLM backend support. | `cargo test config_snapshot --lib`; backend tests in diff |
 | modified/created | `src/jobs/config_snapshot.rs`, `src/jobs/config_snapshot/ingest.rs`, `src/jobs/workers/runners_tests.rs` | - | Snapshot non-secret LLM backend config and reject invalid snapshot values. | `cargo test config_snapshot --lib` |
@@ -155,7 +155,7 @@ Before writing this note, `git status --branch --short` showed an unrelated loca
 | `pnpm --dir apps/palette-tauri typecheck` | Palette TypeScript typecheck passes. | Passed earlier in session. | pass |
 | `pnpm --dir apps/palette-tauri vite:build` | Palette frontend build passes. | Passed earlier in session. | pass |
 | `cargo test --locked --manifest-path apps/palette-tauri/src-tauri/Cargo.toml` | Tauri crate tests pass. | Passed earlier in session. | pass |
-| `scripts/test-build-on-steamy-safety.sh` | Winhost destructive-sync safety test passes. | Passed earlier in session. | pass |
+| `scripts/test-build-on-winhost-safety.sh` | Winhost destructive-sync safety test passes. | Passed earlier in session. | pass |
 | `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/compose-smoke.yml` | Workflow lint passes. | Passed earlier in session. | pass |
 
 ## Risks and Rollback

--- a/docs/sessions/2026-05-27-android-pager-fab-shell.md
+++ b/docs/sessions/2026-05-27-android-pager-fab-shell.md
@@ -19,7 +19,7 @@ Continue implementing all 22 Android code-review beads from PR #142, then build 
 
 ## Session Overview
 
-Completed all 22 code-review beads for the Android pager/FAB shell PR (#142) across three commits (v4.12.0 → v4.12.2). Key work: FormKeys dependency-inversion (moved 9 `*FormKeys` objects from UI to data layer), bug fixes for CRLF injection in HeadersField, Job cancellation in DocumentViewModel, answer-text cap in AskViewModel, plus two new test suites (DocumentViewModelTest, SettingsViewModelTest). Also replaced the build-on-steamy.sh rsync-the-world pipeline with a lean build-windows.sh that cross-compiles locally on devhost and ships only the .exe via scp.
+Completed all 22 code-review beads for the Android pager/FAB shell PR (#142) across three commits (v4.12.0 → v4.12.2). Key work: FormKeys dependency-inversion (moved 9 `*FormKeys` objects from UI to data layer), bug fixes for CRLF injection in HeadersField, Job cancellation in DocumentViewModel, answer-text cap in AskViewModel, plus two new test suites (DocumentViewModelTest, SettingsViewModelTest). Also replaced the build-on-winhost.sh rsync-the-world pipeline with a lean build-windows.sh that cross-compiles locally on devhost and ships only the .exe via scp.
 
 ## Sequence of Events
 
@@ -47,13 +47,13 @@ Completed all 22 code-review beads for the Android pager/FAB shell PR (#142) acr
 
 12. **Code-review cleanup pass (v4.12.2)** — AxonClient, StringChunking, IngestScreen, SettingsScreen, SummarizeScreen, libs.versions.toml all received reviewer-requested cleanup (unused imports, null-safety, accessibility content descriptions, library version pins).
 
-13. **build-windows.sh rewrite** — Replaced build-on-steamy.sh (rsync entire repo → build → ship exe) with build-windows.sh (cross-compile locally on devhost via MinGW, scp only the .exe). Fixed operator-precedence bug in `repo_root()` function.
+13. **build-windows.sh rewrite** — Replaced build-on-winhost.sh (rsync entire repo → build → ship exe) with build-windows.sh (cross-compile locally on devhost via MinGW, scp only the .exe). Fixed operator-precedence bug in `repo_root()` function.
 
 14. **tauri.conf.json version sync** — Synced stuck-at-4.8.1 tauri.conf.json version to 4.12.2 along with Cargo.toml, package.json files.
 
 ## Key Findings
 
-- `build-on-steamy.sh` was rsyncing hundreds of MB of repo files to winhost just to build a ~28 MB .exe — devhost already had `x86_64-w64-mingw32-gcc` and the `x86_64-pc-windows-gnu` rustup target installed, making a full rsync completely unnecessary.
+- `build-on-winhost.sh` was rsyncing hundreds of MB of repo files to winhost just to build a ~28 MB .exe — devhost already had `x86_64-w64-mingw32-gcc` and the `x86_64-pc-windows-gnu` rustup target installed, making a full rsync completely unnecessary.
 - Bash operator precedence `A || B && C` parses as `(A || B) && C`, not `A || (B && C)`. The `repo_root()` fallback path in build-windows.sh had this bug causing `pwd` to always run and embed a newline in the path, which broke pnpm (`ENOENT: no such file or directory, lstat '...path\n'`). Fixed by grouping: `{ cd ... && pwd; }`.
 - `HeadersField.kt` — Edit tool string-matching failures when old_string contained Kotlin regex escape sequences (`\r`, `\n`). Fixed by using Write tool to rewrite the entire file.
 - `SummarizeOptionsForm.kt` — First edit attempt failed because old_string missed the `AuroraTextField` import line. Fixed after re-reading the file.
@@ -84,7 +84,7 @@ Completed all 22 code-review beads for the Android pager/FAB shell PR (#142) acr
 | created | `apps/android/app/src/test/java/com/axon/app/ui/document/DocumentViewModelTest.kt` | 6 stand-in tests for DocumentViewModel |
 | created | `apps/android/app/src/test/java/com/axon/app/ui/settings/SettingsViewModelTest.kt` | 5 stand-in tests for SettingsViewModel |
 | created | `scripts/build-windows.sh` | Cross-compile .exe on devhost, scp to winhost Desktop |
-| deleted | `scripts/build-on-steamy.sh` | Superseded by build-windows.sh (was rsyncing entire repo) |
+| deleted | `scripts/build-on-winhost.sh` | Superseded by build-windows.sh (was rsyncing entire repo) |
 | modified | `apps/palette-tauri/src-tauri/tauri.conf.json` | Version sync 4.8.1 → 4.12.2 |
 | modified | `Cargo.toml` | Version 4.12.1 → 4.12.2 |
 | modified | `apps/palette-tauri/package.json` | Version sync to 4.12.2 |
@@ -117,7 +117,7 @@ Completed all 22 code-review beads for the Android pager/FAB shell PR (#142) acr
 | axon_rust-ivjr.20 | DocumentViewModelTest | Closed | Closed |
 | axon_rust-ivjr.21 | SettingsViewModelTest | Closed | Closed |
 | axon_rust-ivjr.22 | Code-review cleanup pass | Closed | Closed |
-| axon_rust-bhxf | build-windows.sh (replace build-on-steamy.sh) | Closed | Closed |
+| axon_rust-bhxf | build-windows.sh (replace build-on-winhost.sh) | Closed | Closed |
 | axon_rust-mott | tauri.conf.json version sync | Closed | Closed |
 
 ## Repository Maintenance
@@ -130,7 +130,7 @@ Completed all 22 code-review beads for the Android pager/FAB shell PR (#142) acr
 
 **Branches**: `feat/android-pager-fab-shell` is the current active branch with PR #142 open. No other feature branches were created this session.
 
-**Stale docs**: `scripts/build-on-steamy.sh` was deleted and replaced by `scripts/build-windows.sh`. No other documentation contradicted by session changes was identified.
+**Stale docs**: `scripts/build-on-winhost.sh` was deleted and replaced by `scripts/build-windows.sh`. No other documentation contradicted by session changes was identified.
 
 ## Tools and Skills Used
 
@@ -170,7 +170,7 @@ Completed all 22 code-review beads for the Android pager/FAB shell PR (#142) acr
 ## Risks and Rollback
 
 - **FormKeys move**: Pure package rename with no logic change. If the Android build fails, revert by moving key definitions back to the form files. Compiler enforces all import paths.
-- **build-windows.sh**: build-on-steamy.sh is committed history; `git show HEAD~:scripts/build-on-steamy.sh` recovers it if needed.
+- **build-windows.sh**: build-on-winhost.sh is committed history; `git show HEAD~:scripts/build-on-winhost.sh` recovers it if needed.
 
 ## Next Steps
 

--- a/docs/sessions/2026-05-27-android-review-remediation-push.md
+++ b/docs/sessions/2026-05-27-android-review-remediation-push.md
@@ -15,14 +15,14 @@ Build the latest Windows `.exe`, then ship the current working tree with `/quick
 
 ## Session Overview
 
-Short orientation session. Inspected the `build-on-steamy.sh` script to confirm it syncs the working directory (not a specific git branch). User declined the build after learning it would include unstaged changes from `feat/android-pager-fab-shell`. Session concluded with `/quick-push`: bumped the project version from `4.11.0` to `4.12.0` (minor — new Android features), updated `CHANGELOG.md`, and prepared all staged files for commit and push.
+Short orientation session. Inspected the `build-on-winhost.sh` script to confirm it syncs the working directory (not a specific git branch). User declined the build after learning it would include unstaged changes from `feat/android-pager-fab-shell`. Session concluded with `/quick-push`: bumped the project version from `4.11.0` to `4.12.0` (minor — new Android features), updated `CHANGELOG.md`, and prepared all staged files for commit and push.
 
 ## Sequence of Events
 
-1. **Build inquiry.** User requested "BUILD THE LATEST .exe". Read `scripts/build-on-steamy.sh` to understand what it builds (default target: `palette-tauri`; syncs working-directory to winhost-wsl via rsync then cross-compiles for `x86_64-pc-windows-gnu`).
+1. **Build inquiry.** User requested "BUILD THE LATEST .exe". Read `scripts/build-on-winhost.sh` to understand what it builds (default target: `palette-tauri`; syncs working-directory to winhost-wsl via rsync then cross-compiles for `x86_64-pc-windows-gnu`).
 2. **Sync question.** User asked whether the script syncs `main` or the current branch. Confirmed it rsyncs the working directory as-is (including unstaged modifications), not a specific git ref.
 3. **Worktree audit.** User asked to list all open worktrees. `git worktree list` showed one worktree: `~/workspace/axon_rust` on `feat/android-pager-fab-shell`. No stale worktrees.
-4. **Build declined.** User declined the `build-on-steamy.sh` run after understanding it would bundle uncommitted Android changes.
+4. **Build declined.** User declined the `build-on-winhost.sh` run after understanding it would bundle uncommitted Android changes.
 5. **Quick-push.** User invoked `/quick-push`. Detected changes across 29 files: Android repository layer, option forms, nav graph, ViewModels, screens, and tooling.
 6. **Version bump.** Bumped `4.11.0 → 4.12.0` (minor) across `Cargo.toml`, `apps/palette-tauri/src-tauri/Cargo.toml`, `apps/web/package.json`, `apps/palette-tauri/package.json`. Ran `cargo check` to update `Cargo.lock` — succeeded.
 7. **CHANGELOG update.** Added `## [4.12.0] - 2026-05-27` entry documenting the new pager + FAB shell, complete operation mode coverage (Map/Research/SearchWeb/Summarize), and the new `options` form-keys package.
@@ -30,7 +30,7 @@ Short orientation session. Inspected the `build-on-steamy.sh` script to confirm 
 
 ## Key Findings
 
-- `scripts/build-on-steamy.sh` rsyncs the on-disk working tree, not a git branch — any uncommitted changes go along for the build.
+- `scripts/build-on-winhost.sh` rsyncs the on-disk working tree, not a git branch — any uncommitted changes go along for the build.
 - Only one worktree exists (`~/workspace/axon_rust`); no `.worktrees/` directory was present.
 - Version files were out of sync prior to this bump: root `Cargo.toml` was at `4.11.0` but `apps/palette-tauri/src-tauri/Cargo.toml` was at `4.9.0` and the two `package.json` files were at `4.9.0` / `4.8.1` — all brought to `4.12.0`.
 - `axon_rust-ivjr` (pager shell + FAB) has all 18 children closed but the parent bead remains `in_progress`; closing is deferred until PR #142 merges.
@@ -87,7 +87,7 @@ Short orientation session. Inspected the `build-on-steamy.sh` script to confirm 
 | modified | `apps/android/app/src/main/java/com/axon/app/ui/tools/ResearchTab.kt` | Nav wiring |
 | modified | `apps/android/app/src/main/res/xml/data_extraction_rules.xml` | Backup exclusions |
 | modified | `apps/android/gradle/libs.versions.toml` | Dependency updates |
-| modified | `scripts/build-on-steamy.sh` | Minor path fixes |
+| modified | `scripts/build-on-winhost.sh` | Minor path fixes |
 
 ## Beads Activity
 
@@ -135,6 +135,6 @@ Short orientation session. Inspected the `build-on-steamy.sh` script to confirm 
 
 - **Merge PR #142** once CI passes on the pushed commit — all 18 review findings are addressed.
 - **Close `axon_rust-ivjr`** after PR #142 merges to main.
-- **Build Windows .exe** via `./scripts/build-on-steamy.sh` after the branch is merged or from a clean state.
+- **Build Windows .exe** via `./scripts/build-on-winhost.sh` after the branch is merged or from a clean state.
 - **`axon_rust-21u8.10`** (SSE for research + summarize) remains open/deferred — requires server-side SSE endpoint.
 - **`axon_rust-3lt7`** (decouple `AxonClient.JobKind` from UI layer) is a follow-on cleanup bead, not blocking.

--- a/docs/sessions/2026-06-19-android-progress-ui-merge.md
+++ b/docs/sessions/2026-06-19-android-progress-ui-merge.md
@@ -106,7 +106,7 @@ PR #237 changed the following files relative to its first parent:
 | M | `apps/palette-tauri/package.json` |
 | A | `apps/palette-tauri/scripts/copy-artifacts.mjs` |
 | M | `lefthook.yml` |
-| M | `scripts/build-on-steamy.sh` |
+| M | `scripts/build-on-winhost.sh` |
 | M | `scripts/build-windows.sh` |
 | M | `scripts/cargo-rustc-wrapper` |
 | M | `scripts/test-cargo-rustc-wrapper.sh` |

--- a/scripts/build-on-winhost.sh
+++ b/scripts/build-on-winhost.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/build-on-steamy.sh [--target palette-tauri|axon] [--no-sync] [--dry-run] [--destructive-sync]
+Usage: scripts/build-on-winhost.sh [--target palette-tauri|axon] [--no-sync] [--dry-run] [--destructive-sync]
 
 Build the latest local Axon checkout on winhost-wsl and place the Windows .exe
 on Winhost's desktop.
@@ -168,7 +168,7 @@ fi
 mkdir -p "$remote_repo"
 
 if [[ "$remote_repo" == "$default_remote_repo" ]]; then
-  printf 'disposable mirror for scripts/build-on-steamy.sh\n' > "$remote_repo/$sentinel"
+  printf 'disposable mirror for scripts/build-on-winhost.sh\n' > "$remote_repo/$sentinel"
 fi
 
 if [[ "$destructive_sync" != 1 && ! -f "$remote_repo/$sentinel" ]]; then

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -15,8 +15,8 @@ Defaults:
   --desktop   /mnt/c/Users/jmaga/OneDrive/Desktop
 
 Environment overrides:
-  STEAMY_HOST     SSH alias for the Windows machine's WSL
-  STEAMY_DESKTOP  Destination path on the Windows filesystem
+  WINHOST_HOST     SSH alias for the Windows machine's WSL
+  WINHOST_DESKTOP  Destination path on the Windows filesystem
 EOF
 }
 
@@ -33,8 +33,8 @@ repo_root() {
 target="palette-tauri"
 ship=1
 dry_run=0
-host="${STEAMY_HOST:-winhost-wsl}"
-desktop="${STEAMY_DESKTOP:-/mnt/c/Users/jmaga/OneDrive/Desktop}"
+host="${WINHOST_HOST:-winhost-wsl}"
+desktop="${WINHOST_DESKTOP:-/mnt/c/Users/jmaga/OneDrive/Desktop}"
 
 while (($#)); do
   case "$1" in

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -94,9 +94,9 @@ COMPOSE_INPUTS = {
     "docker-compose.external-providers.yaml",
     "docker-compose.external-qdrant.yaml",
     "docker-compose.llama.yaml",
-    "scripts/build-on-steamy.sh",
+    "scripts/build-on-winhost.sh",
     "scripts/test-ask-gemma4.sh",
-    "scripts/test-build-on-steamy-safety.sh",
+    "scripts/test-build-on-winhost-safety.sh",
 }
 
 VERSION_FILES = {

--- a/scripts/test-build-on-winhost-safety.sh
+++ b/scripts/test-build-on-winhost-safety.sh
@@ -52,7 +52,7 @@ export WINHOST_DESKTOP="$tmp/Desktop"
 
 unmarked="$tmp/unmarked"
 mkdir -p "$unmarked"
-if "$repo_root/scripts/build-on-steamy.sh" --target axon --remote-repo "$unmarked" >"$tmp/unmarked.out" 2>"$tmp/unmarked.err"; then
+if "$repo_root/scripts/build-on-winhost.sh" --target axon --remote-repo "$unmarked" >"$tmp/unmarked.out" 2>"$tmp/unmarked.err"; then
   echo "expected unmarked custom remote repo to fail" >&2
   exit 1
 fi
@@ -62,7 +62,7 @@ grep -q "refusing destructive rsync into unmarked target" "$tmp/unmarked.err"
 marked="$tmp/marked"
 mkdir -p "$marked"
 touch "$marked/.build-on-winhost-disposable"
-"$repo_root/scripts/build-on-steamy.sh" --target axon --remote-repo "$marked" >"$tmp/marked.out" 2>"$tmp/marked.err"
+"$repo_root/scripts/build-on-winhost.sh" --target axon --remote-repo "$marked" >"$tmp/marked.out" 2>"$tmp/marked.err"
 
 grep -q -- "--delete" "$RSYNC_LOG"
 [[ -f "$WINHOST_DESKTOP/axon.exe" ]] || { echo "expected built axon.exe on fake desktop" >&2; exit 1; }


### PR DESCRIPTION
## Summary

A previously merged identifier-scrub PR left two loose ends on `main`:

- **Broken lint hook.** `lefthook.yml`'s `helper-shell-scripts` glob was updated to point at a renamed script filename, but the actual file on disk was never renamed to match. The glob therefore matched nothing, and shell linting (`bash -n` / `shellcheck`) on those scripts silently no-opped on every commit.
- **Incomplete scrub.** A few remaining raw internal device identifiers were left in `CHANGELOG.md` and some `docs/sessions/*.md` files, plus a couple of environment variable names in `scripts/build-windows.sh` that still used the old identifier while their sibling script and values had already been renamed.

## Changes

- Renamed the two shell scripts so the `lefthook.yml` glob now resolves to real files, and updated every referrer: the CI compose-smoke workflow, the CI changed-paths classifier script, `CHANGELOG.md`, and the affected session docs.
- Renamed the two stale environment variable names in `scripts/build-windows.sh` to match the naming scheme already used by its sibling script.
- Finished scrubbing the remaining raw device identifiers out of `CHANGELOG.md` and `docs/sessions/*.md`.

## Test plan

- [x] `bash -n` on both renamed scripts
- [x] Confirmed the `lefthook.yml` glob now matches the renamed files (brace expansion check)
- [x] `cargo test -q -p axon --test ci_changed_paths` — 22 passed
- [x] Repo-wide grep confirms no remaining references to the old script filenames or the old env var names
- [x] `git commit`/`git push` ran through the repo's full pre-commit/pre-push hooks (structural checks, shell lint, and the workflow-shapes test suite) without `--no-verify`, all green