### PR TITLE
ci: synchronize outstanding workflow and cache fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          package-manager-cache: false
       # NOT dead: the "Palette OpenAPI type drift" contract step below shells
       # out to pnpm and hard-fails without it. It was removed earlier in this
       # branch as unused because the job's visible install command is `npm ci`.
@@ -559,10 +558,11 @@ jobs:
   windows-build:
     name: windows-build (axon.exe)
     # Cross-compiled from Linux with the mingw-w64 (x86_64-pc-windows-gnu)
-    # toolchain. A previous cargo-zigbuild attempt failed because zig does not
-    # bundle the Windows platform headers (sched.h / windows.h) that
-    # aws-lc-sys's jitterentropy code needs; mingw-w64 ships those headers, so
-    # aws-lc-sys and ring both cross-build cleanly (the resulting axon.exe was
+    # toolchain plus NASM for BoringSSL's x86_64 assembly. A previous
+    # cargo-zigbuild attempt failed because zig does not bundle the Windows
+    # platform headers (sched.h / windows.h) that aws-lc-sys's jitterentropy
+    # code needs; mingw-w64 ships those headers, so aws-lc-sys and ring both
+    # cross-build cleanly (the resulting axon.exe was
     # smoke-tested on Windows 11: it runs, loads the full CLI, and resolves
     # native C:\ paths). Running on the Linux runner avoids the slow
     # GitHub-hosted Windows VM and its 2x minute billing.
@@ -580,6 +580,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [changes, rust-contracts, web-panel]
+    # Main keeps the pre-release Windows compatibility gate. Pull requests opt
+    # in with ci:full so ordinary PRs avoid the duplicate cross-build cost.
     if: ${{ always() && needs.rust-contracts.result == 'success' && needs.web-panel.result == 'success' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true') && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
     env:
       CC_x86_64_pc_windows_gnu: x86_64-w64-mingw32-gcc
@@ -593,10 +595,11 @@ jobs:
           # the same toolchain cargo uses under the repo override.
           toolchain: 1.97.1
           targets: x86_64-pc-windows-gnu
-      - name: Install mingw-w64
+      - name: Install mingw-w64 and NASM
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends mingw-w64
+          sudo apt-get install -y --no-install-recommends mingw-w64 nasm
+          nasm -v
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: axon-windows-gnu
@@ -660,8 +663,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          package-manager-cache: false
       - name: Install web panel dependencies
         run: npm ci --prefix apps/web
       - name: Test web panel
@@ -1152,7 +1154,13 @@ jobs:
     runs-on: ci-pool-ops
     timeout-minutes: 10
     needs: [changes, binary-smoke-build]
-    if: ${{ needs.binary-smoke-build.result == 'success' }}
+    # always() is required, not decorative: a skipped ancestor (web-panel, on any
+    # PR that touches no web files) propagates through the needs graph and skips
+    # this job even though binary-smoke-build succeeded and the condition below
+    # is true. ci-gate then correctly fails with "binary-smoke was skipped even
+    # though its required condition is true". The explicit result check still
+    # gates execution.
+    if: ${{ always() && needs.binary-smoke-build.result == 'success' }}
     steps:
       - uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,7 @@ jobs:
   changes:
     name: changes
     runs-on: [self-hosted, unraid]
+    timeout-minutes: 10
     outputs:
       docker: ${{ steps.classify.outputs.docker == 'true' || steps.classify.outputs.full_ci == 'true' }}
     steps:
@@ -43,6 +44,7 @@ jobs:
   build:
     name: build-and-push
     runs-on: [self-hosted, unraid]
+    timeout-minutes: 30
     needs: [changes]
     if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || needs.changes.outputs.docker == 'true' }}
     steps:

--- a/.kache.toml
+++ b/.kache.toml
@@ -1,0 +1,2 @@
+[cache]
+exclude = ["$CARGO_HOME/registry/src/**/boring-sys2-*/**"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,17 @@ lto = false
 codegen-units = 256
 strip = true
 
+[profile.dev]
+# CI recompiles from scratch on every job (CARGO_INCREMENTAL=0 is required
+# under the kache rustc-wrapper), and full DWARF is a large share of that
+# time — which the build then discards anyway via -C strip=debuginfo.
+# "line-tables-only" keeps file/line in panics and backtraces, which is what
+# CI logs are read for. Override with CARGO_PROFILE_DEV_DEBUG=full for a
+# debugger session. Matches labby, cortex, yarr and soma.
+# The per-package spider override below is unaffected: opt-level and debug are
+# independent knobs.
+debug = "line-tables-only"
+
 [profile.dev.package.spider]
 opt-level = 2
 

--- a/crates/axon-graph/build.rs
+++ b/crates/axon-graph/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/migrations");
+}

--- a/crates/axon-graph/kache.toml
+++ b/crates/axon-graph/kache.toml
@@ -1,0 +1,1 @@
+extra_inputs = ["src/migrations/**/*.sql"]

--- a/crates/axon-jobs/build.rs
+++ b/crates/axon-jobs/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/migrations");
+}

--- a/crates/axon-jobs/kache.toml
+++ b/crates/axon-jobs/kache.toml
@@ -1,0 +1,1 @@
+extra_inputs = ["src/migrations/**/*.sql"]

--- a/crates/axon-ledger/build.rs
+++ b/crates/axon-ledger/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/migrations");
+}

--- a/crates/axon-ledger/kache.toml
+++ b/crates/axon-ledger/kache.toml
@@ -1,0 +1,1 @@
+extra_inputs = ["src/migrations/**/*.sql"]

--- a/crates/axon-memory/build.rs
+++ b/crates/axon-memory/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/migrations");
+}

--- a/crates/axon-memory/kache.toml
+++ b/crates/axon-memory/kache.toml
@@ -1,0 +1,1 @@
+extra_inputs = ["src/migrations/**/*.sql"]

--- a/crates/axon-observe/build.rs
+++ b/crates/axon-observe/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/migrations");
+}

--- a/crates/axon-observe/kache.toml
+++ b/crates/axon-observe/kache.toml
@@ -1,0 +1,1 @@
+extra_inputs = ["src/migrations/**/*.sql"]

--- a/docs/sessions/2026-05-04-dolt-remotesapi-squirts.md
+++ b/docs/sessions/2026-05-04-dolt-remotesapi-squirts.md
@@ -36,7 +36,7 @@ Enabled Dolt's HTTP remotes API for the existing Dolt SQL server container on `e
 - `edgehost` resolves to Tailscale address `198.51.100.2`.
 - The running container is `dolthub/dolt-sql-server:latest`.
 - The image entrypoint checks `/etc/dolt/servercfg.d` for a single YAML server config and starts `dolt sql-server --config=<file>` when present.
-- Before the config mount was added, Docker published `33110`, but the container refused `10.6.0.34:8000` because `remotesapi` was not actually running.
+- Before the config mount was added, Docker published `33110`, but the container refused `192.0.2.11:8000` because `remotesapi` was not actually running.
 - After mounting the config in the expected path, logs showed `Starting http server on :8000`.
 
 ## Technical Decisions

--- a/docs/sessions/2026-07-23-live-runtime-config-and-sidecar-recovery.md
+++ b/docs/sessions/2026-07-23-live-runtime-config-and-sidecar-recovery.md
@@ -92,7 +92,7 @@ Neither bead was claimed, implemented, or closed in this session.
 
 | command | result |
 |---|---|
-| `incus list axon --format csv -c ns4` | Axon container running at `10.47.200.55` |
+| `incus list axon --format csv -c ns4` | Axon container running at `192.0.2.15` |
 | `incus exec axon -- systemctl show axon-native.service ...` | Active native service; `/mnt/axon-data/.env` confirmed |
 | `incus exec axon -- docker ps -a --filter name=axon-tei --filter name=axon-chrome ...` | Both sidecars healthy |
 | `incus exec axon -- ... /usr/local/bin/axon doctor --json` | `all_ok: true`; Qdrant, TEI, Chrome, and SQLite healthy; advisories remain |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,7 +55,7 @@ pre-commit:
       glob: "crates/axon-api/src/mcp_schema.rs"
       run: scripts/with_timeout.sh 30 -- scripts/check_mcp_schema_doc.sh
     helper-shell-scripts:
-      glob: "scripts/{build-on-winhost,test-ask-gemma4}.sh"
+      glob: "scripts/{build-on-steamy,test-ask-gemma4}.sh"
       run: >
         scripts/with_timeout.sh 30 --
         bash -c '

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -15,8 +15,8 @@ Defaults:
   --desktop   /mnt/c/Users/jmaga/OneDrive/Desktop
 
 Environment overrides:
-  STEAMY_HOST     SSH alias for the Windows machine's WSL
-  STEAMY_DESKTOP  Destination path on the Windows filesystem
+  WINHOST_HOST     SSH alias for the Windows machine's WSL
+  WINHOST_DESKTOP  Destination path on the Windows filesystem
 EOF
 }
 
@@ -33,8 +33,8 @@ repo_root() {
 target="palette-tauri"
 ship=1
 dry_run=0
-host="${STEAMY_HOST:-winhost-wsl}"
-desktop="${STEAMY_DESKTOP:-/mnt/c/Users/jmaga/OneDrive/Desktop}"
+host="${WINHOST_HOST:-winhost-wsl}"
+desktop="${WINHOST_DESKTOP:-/mnt/c/Users/jmaga/OneDrive/Desktop}"
 
 while (($#)); do
   case "$1" in

--- a/scripts/check-env-config-boundary.py
+++ b/scripts/check-env-config-boundary.py
@@ -94,6 +94,7 @@ IGNORED_TOKENS = {
     "OPENAI_COMPAT_SECRET",  # fake secret string literal in runners_tests.rs redaction test, not an env var
     "GEMINI_DEFAULT_COMPLETION_CONCURRENCY",  # Rust const (default concurrency) in core/llm/types.rs, not an env var
     "OPENAI_DEFAULT_COMPLETION_CONCURRENCY",  # Rust const (default concurrency) in core/llm/types.rs, not an env var
+    "GITHUB_ENV",  # GitHub Actions command file, not axon runtime config
     "GITHUB_REF",  # GitHub Actions runtime variable, not axon runtime config
     "GITHUB_SHA",  # GitHub Actions runtime variable, not axon runtime config
 }

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -694,6 +694,46 @@ fn ci_keeps_expensive_artifacts_off_ordinary_pull_requests() {
     assert!(mcp_smoke.contains("'ci:full'"));
     assert!(windows_check.contains("github.event_name == 'pull_request'"));
     assert!(windows_build.contains("'ci:full'"));
+    assert!(windows_build.contains("github.event_name != 'pull_request'"));
+    assert!(
+        windows_build.contains("sudo apt-get install -y --no-install-recommends mingw-w64 nasm")
+            && windows_build.contains("nasm -v"),
+        "the Windows GNU cross-build must install and verify NASM for BoringSSL assembly"
+    );
+}
+
+#[test]
+fn binary_smoke_survives_skipped_ancestors_after_its_build_succeeds() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let binary_smoke = workflow_job_block(workflow, "binary-smoke");
+
+    assert!(binary_smoke.contains("always()"));
+    assert!(binary_smoke.contains("needs.binary-smoke-build.result == 'success'"));
+}
+
+#[test]
+fn kache_migration_inputs_have_cargo_rerun_triggers() {
+    for crate_name in [
+        "axon-graph",
+        "axon-jobs",
+        "axon-ledger",
+        "axon-memory",
+        "axon-observe",
+    ] {
+        let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("crates")
+            .join(crate_name);
+        let kache = std::fs::read_to_string(crate_dir.join("kache.toml"))
+            .unwrap_or_else(|error| panic!("failed to read {crate_name}/kache.toml: {error}"));
+        let build = std::fs::read_to_string(crate_dir.join("build.rs"))
+            .unwrap_or_else(|error| panic!("failed to read {crate_name}/build.rs: {error}"));
+
+        assert!(kache.contains("src/migrations/**/*.sql"));
+        assert!(
+            build.contains("cargo:rerun-if-changed=src/migrations"),
+            "{crate_name} must make Cargo revisit migration inputs before Kache re-keys them"
+        );
+    }
 }
 
 #[test]
@@ -729,6 +769,36 @@ fn ci_builds_web_assets_once_for_binary_artifact_jobs() {
             && binary_smoke_build.contains("AXON_ALLOW_FALLBACK_WEB_ASSETS=1"),
         "release-only smoke builds must use fallback web assets without rebuilding the panel"
     );
+}
+
+#[test]
+fn ci_disables_setup_node_archive_cache_on_self_hosted_node_jobs() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+
+    assert_eq!(
+        workflow.matches("package-manager-cache: false").count(),
+        2,
+        "rust-contracts and web-panel should disable setup-node archive caching"
+    );
+    assert!(
+        !workflow.contains("Isolate npm cache") && !workflow.contains("Clean up npm cache"),
+        "persistent self-hosted runners should keep npm's local cache warm across jobs"
+    );
+
+    for job_name in ["rust-contracts", "web-panel"] {
+        let job = workflow_job_block(workflow, job_name);
+        assert!(
+            job.contains("package-manager-cache: false"),
+            "{job_name} must opt out of setup-node's expensive cache archive step"
+        );
+        assert!(
+            !job.lines().any(|line| {
+                let line = line.trim();
+                line == "cache: npm" || line.starts_with("cache-dependency-path:")
+            }),
+            "{job_name} must not ask setup-node to archive npm cache contents"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- consolidate the outstanding CI, cache, Windows-build, and identifier-scrub branches into one linear change
- add Kache migration inputs and build-script rerun triggers for SQLite-owning crates
- preserve Windows pre-release coverage and add workflow regression assertions

## Lavra review
- fixed and closed the migration-trigger finding
- fixed and closed the Windows coverage finding
- added and closed the binary-smoke regression-test finding

## Verification
- actionlint
- cargo fmt --all -- --check
- workflow_shapes (36 passed)
- ci_changed_paths (23 passed)
- env_config_boundary (1 passed)
- generated-contract drift checks
- repository structure and monolith checks
- kache doctor (all checks passed)
- exact tree match against the fully reviewed integration commit