### PR TITLE
fix(release): validate committed fixups

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,13 +88,17 @@ jobs:
               version="$(jq -r '.version' <<<"$fixup")"
               cargo xtask release-please-fixups --component "$component" --version "$version"
             done < <(jq -c '.[]' fixup-plan.json)
+            fixup_commit_created=false
+            if ! git diff --quiet; then
+              git add --update
+              git commit -m "chore: apply release-please fixups"
+              fixup_commit_created=true
+            fi
             cargo xtask check-release-versions \
               --base "origin/$base_branch" \
               --head HEAD \
               --mode pr
-            if ! git diff --quiet; then
-              git add --update
-              git commit -m "chore: apply release-please fixups"
+            if [[ "$fixup_commit_created" == true ]]; then
               git push origin HEAD:"$branch"
             fi
             git checkout "$base_ref"

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -673,6 +673,19 @@ fn release_please_fixups_validate_and_forward_pr_branch_refs() {
         plan_args.contains("--base \"origin/$base_branch\"") && plan_args.contains("--head HEAD"),
         "the fixup planner itself must compare the release branch with its reported base branch"
     );
+    let commit_position = fixups
+        .find("git commit -m \"chore: apply release-please fixups\"")
+        .expect("generated fixups are committed");
+    let check_position = fixups
+        .find("cargo xtask check-release-versions")
+        .expect("release version check exists");
+    let push_position = fixups
+        .find("git push origin HEAD:\"$branch\"")
+        .expect("validated fixups are pushed");
+    assert!(
+        commit_position < check_position && check_position < push_position,
+        "release fixups must be committed before HEAD validation and pushed only after validation"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- commit generated release-please fixups before validating `HEAD`
- push the release branch only after the release-version gate passes
- add a workflow-shape regression for commit/check/push ordering

## Verification
- actionlint `.github/workflows/release-please.yml`
- focused workflow-shape regression: 1 passed
- full path-aware pre-push workflow suite
- generated contracts: up to date

Fixes the post-merge failure in run 31253578798.