### PR TITLE
fix(ci): resolve PR 538 review findings

### DIFF
--- a/.github/workflows/ci-timing-report.yml
+++ b/.github/workflows/ci-timing-report.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Build timing report
         env:
           GH_TOKEN: ${{ github.token }}
@@ -46,7 +46,7 @@ jobs:
           if [[ -z "$BASELINE_SHA" && -z "$CANDIDATE_SHA" ]]; then args+=(--recent "$SAMPLES"); fi
           python3 scripts/ci/report_workflow_timings.py "${args[@]}"
           cat ci-timing.md >> "$GITHUB_STEP_SUMMARY"
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: ci-timing-report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           RUN_LEFTHOOK_SPEED: ${{ steps.classify.outputs.hooks == 'true' || steps.classify.outputs.full_ci == 'true' }}
           RUN_PALETTE: ${{ steps.classify.outputs.palette == 'true' || steps.classify.outputs.ci_all == 'true' || steps.classify.outputs.full_ci == 'true' }}
           RUN_WINDOWS_CHECK: ${{ github.event_name == 'pull_request' && (steps.classify.outputs.rust == 'true' || steps.classify.outputs.ci_all == 'true' || steps.classify.outputs.full_ci == 'true') && contains(github.event.pull_request.labels.*.name, 'ci:full') }}
-          RUN_WINDOWS_BUILD: ${{ github.event_name == 'pull_request' && (steps.classify.outputs.rust == 'true' || steps.classify.outputs.web == 'true' || steps.classify.outputs.ci_all == 'true' || steps.classify.outputs.full_ci == 'true') && contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+          RUN_WINDOWS_BUILD: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main' && (steps.classify.outputs.rust == 'true' || steps.classify.outputs.web == 'true' || steps.classify.outputs.release == 'true' || steps.classify.outputs.auto_tag == 'true' || steps.classify.outputs.ci_all == 'true' || steps.classify.outputs.full_ci == 'true')) || (github.event_name == 'pull_request' && (steps.classify.outputs.rust == 'true' || steps.classify.outputs.web == 'true' || steps.classify.outputs.ci_all == 'true' || steps.classify.outputs.full_ci == 'true') && contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
           RUN_WEB: ${{ steps.classify.outputs.web == 'true' || steps.classify.outputs.ci_all == 'true' || steps.classify.outputs.full_ci == 'true' || contains(github.event.pull_request.labels.*.name, 'ci:full') }}
           RUN_CHROME: ${{ steps.classify.outputs.chrome == 'true' || steps.classify.outputs.ci_all == 'true' || steps.classify.outputs.full_ci == 'true' }}
           RUN_CLIPPY: ${{ steps.classify.outputs.rust == 'true' || steps.classify.outputs.ci_all == 'true' || steps.classify.outputs.full_ci == 'true' }}
@@ -291,7 +291,7 @@ jobs:
         run: ./target/debug/xtask check-release-versions --head HEAD --mode main --json > auto-tag-release-plan.json
       - name: Upload auto-tag release plan
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.auto_tag == 'true' }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: axon-auto-tag-release-plan-${{ github.sha }}
           path: auto-tag-release-plan.json
@@ -363,7 +363,7 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.run_ci_contracts == 'true' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.97.1"
@@ -633,7 +633,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: xtask-windows
       - name: create web assets placeholder
@@ -658,63 +658,39 @@ jobs:
 
   windows-build:
     name: windows-build (axon.exe)
-    # Cross-compiled from Linux with the mingw-w64 (x86_64-pc-windows-gnu)
-    # toolchain plus NASM for BoringSSL's x86_64 assembly. A previous
-    # cargo-zigbuild attempt failed because zig does not bundle the Windows
-    # platform headers (sched.h / windows.h) that aws-lc-sys's jitterentropy
-    # code needs; mingw-w64 ships those headers, so aws-lc-sys and ring both
-    # cross-build cleanly (the resulting axon.exe was
-    # smoke-tested on Windows 11: it runs, loads the full CLI, and resolves
-    # native C:\ paths). Running on the Linux runner avoids the slow
-    # GitHub-hosted Windows VM and its 2x minute billing.
-    #
-    # The cfg(windows) AXON_DATA_DIR path-regression test is NOT run here: it
-    # would require executing the windows-gnu test binary under wine (the
-    # Ubuntu wine64 package ships no /usr/bin/wine* wrapper, and a full
-    # lib-test recompile roughly doubles the job time). The test still lives in
-    # src/core/paths_tests.rs and was confirmed passing on Windows 11 against
-    # this cross-compiled binary.
-    #
-    # Kept on ubuntu-latest: on the self-hosted unraid runner rustc failed to
-    # execute (os error 2) with missing target .d files — a runner env/workspace
-    # issue. This cross-compile is proven on ubuntu-latest, so pin it here.
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Tags are created only after CI succeeds on main. Build the same release
+    # binary on native Windows here so auto-tag cannot publish an immutable
+    # release whose Windows artifact fails later in release.yml.
+    runs-on: windows-latest
+    timeout-minutes: 45
     needs: [changes, rust-contracts, web-panel]
-    # Native Windows is built by release.yml. Pull requests can opt into this
-    # cross-build with ci:full without rebuilding it on every main push.
-    if: ${{ always() && needs.changes.outputs.run_windows_build == 'true' && needs.rust-contracts.result == 'success' && needs.web-panel.result == 'success' }}
-    env:
-      CC_x86_64_pc_windows_gnu: x86_64-w64-mingw32-gcc
-      CXX_x86_64_pc_windows_gnu: x86_64-w64-mingw32-g++
-      AR_x86_64_pc_windows_gnu: x86_64-w64-mingw32-ar
+    if: ${{ always() && needs.changes.outputs.run_windows_build == 'true' && needs.rust-contracts.result == 'success' && (needs.web-panel.result == 'success' || needs.web-panel.result == 'skipped') }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          # Match rust-toolchain.toml so the Windows target is installed on
-          # the same toolchain cargo uses under the repo override.
           toolchain: 1.97.1
-          targets: x86_64-pc-windows-gnu
-      - name: Install mingw-w64 and NASM
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends mingw-w64 nasm
-          nasm -v
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          shared-key: axon-windows-gnu
-      - uses: actions/download-artifact@v5
+          shared-key: axon-windows-release
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        if: ${{ needs.web-panel.result == 'success' }}
         with:
           name: axon-web-assets
           path: apps/web/out
-      - name: cargo build -p axon (windows-gnu cross)
-        run: cargo build --locked -p axon --target x86_64-pc-windows-gnu
+      - name: Use fallback web assets when the web app is unchanged
+        if: ${{ needs.web-panel.result == 'skipped' }}
+        shell: bash
+        run: |
+          mkdir -p apps/web/out
+          echo "AXON_ALLOW_FALLBACK_WEB_ASSETS=1" >> "$GITHUB_ENV"
+      - name: cargo build axon release binary
+        run: cargo build --release --locked --bin axon
       - name: Upload axon.exe artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: axon-windows-x86_64
-          path: target/x86_64-pc-windows-gnu/debug/axon.exe
+          path: target/release/axon.exe
           if-no-files-found: error
 
   web-panel:
@@ -1147,15 +1123,20 @@ jobs:
     needs: [changes, rust-contracts, web-panel]
     if: ${{ always() && needs.changes.outputs.run_binary_smoke_build == 'true' && needs.rust-contracts.result == 'success' && (needs.web-panel.result == 'success' || needs.web-panel.result == 'skipped') }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/setup-rust-kache
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Set up Rust with local-only Kache for pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: ./.github/actions/setup-rust-kache
+      - name: Set up Rust with shared Kache for trusted pushes
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: ./.github/actions/setup-rust-kache
         with:
           s3-access-key: ${{ secrets.KACHE_S3_ACCESS_KEY }}
           s3-secret-key: ${{ secrets.KACHE_S3_SECRET_KEY }}
           s3-endpoint: ${{ vars.KACHE_S3_ENDPOINT }}
           s3-bucket: ${{ vars.KACHE_S3_BUCKET }}
           s3-prefix: ${{ vars.KACHE_S3_PREFIX }}
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: ${{ needs.web-panel.result == 'success' }}
         with:
           name: axon-web-assets
@@ -1168,7 +1149,7 @@ jobs:
       - name: cargo build axon
         run: cargo build --locked --bin axon
       - name: Upload smoke binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: axon-linux-smoke
           path: target/debug/axon
@@ -1192,7 +1173,7 @@ jobs:
       TEI_URL: http://127.0.0.1:52000
       QDRANT_URL: http://127.0.0.1:53333
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/download-artifact@v5
         with:
           name: axon-linux-smoke

--- a/.github/workflows/palette-release.yml
+++ b/.github/workflows/palette-release.yml
@@ -44,7 +44,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Resolve and validate version
         id: version
         run: |
@@ -86,13 +86,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           sparse-checkout: apps/palette-tauri
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 11.3.0
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,28 +20,11 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
-  changes:
-    name: release-please changes
-    runs-on: ci-pool-ops
-    timeout-minutes: 10
-    outputs:
-      release_please: ${{ steps.classify.outputs.release_please }}
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 2
-          persist-credentials: false
-      - name: Classify release-please paths
-        id: classify
-        env:
-          EVENT_NAME: ${{ github.event_name == 'workflow_dispatch' && 'workflow_dispatch' || 'push' }}
-          HEAD_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
-        run: python3 scripts/ci/changed_paths.py --event "$EVENT_NAME" --output "$GITHUB_OUTPUT"
-
   release-please:
-    needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && needs.changes.outputs.release_please == 'true') }}
+    # A workflow_run payload has no push "before" SHA. Reconstructing the
+    # change range as HEAD^..HEAD loses earlier commits from a multi-commit
+    # push, so run release-please after every successful main CI completion.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ci-pool-ops
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           sparse-checkout: |
             apps/web

--- a/scripts/ci/report_workflow_timings.py
+++ b/scripts/ci/report_workflow_timings.py
@@ -23,17 +23,21 @@ def gh_api_collection(
     path: str,
     collection: str,
     fields: dict[str, str] | None = None,
+    limit: int | None = None,
 ) -> list[dict[str, Any]]:
-    """Return every page from a GitHub API collection response."""
+    """Return every page, or the requested prefix, from an API collection."""
     page = 1
     per_page = 100
     records: list[dict[str, Any]] = []
     while True:
         page_fields = dict(fields or {})
-        page_fields.update({"per_page": str(per_page), "page": str(page)})
+        page_size = per_page if limit is None else min(per_page, limit - len(records))
+        if page_size <= 0:
+            return records
+        page_fields.update({"per_page": str(page_size), "page": str(page)})
         batch = gh_api(path, page_fields)[collection]
         records.extend(batch)
-        if len(batch) < per_page:
+        if len(batch) < page_size or (limit is not None and len(records) >= limit):
             return records
         page += 1
 
@@ -64,17 +68,30 @@ def duration(seconds: float) -> str:
 
 
 def run_record(repo: str, label: str, run: dict[str, Any]) -> dict[str, Any]:
+    attempt = int(run.get("run_attempt") or 1)
+    attempt_run = run
+    jobs_path = f"repos/{repo}/actions/runs/{run['id']}/jobs"
+    if attempt > 1:
+        attempt_run = gh_api(
+            f"repos/{repo}/actions/runs/{run['id']}/attempts/{attempt}"
+        )
+        jobs_path = f"repos/{repo}/actions/runs/{run['id']}/attempts/{attempt}/jobs"
     jobs = gh_api_collection(
-        f"repos/{repo}/actions/runs/{run['id']}/jobs",
+        jobs_path,
         "jobs",
-        {"filter": "latest", "per_page": "100"},
+        {"filter": "latest"},
     )
     executed = [job for job in jobs if job.get("conclusion") != "skipped"]
-    job_seconds = {
-        job["name"]: seconds_between(job.get("started_at"), job.get("completed_at"))
+    job_seconds = [
+        (
+            job["name"],
+            seconds_between(job.get("started_at"), job.get("completed_at")),
+        )
         for job in executed
-    }
-    longest_name, longest_seconds = max(job_seconds.items(), key=lambda item: item[1], default=("-", 0.0))
+    ]
+    longest_name, longest_seconds = max(
+        job_seconds, key=lambda item: item[1], default=("-", 0.0)
+    )
     return {
         "label": label,
         "workflow_id": run["workflow_id"],
@@ -85,8 +102,11 @@ def run_record(repo: str, label: str, run: dict[str, Any]) -> dict[str, Any]:
         "conclusion": run.get("conclusion") or run.get("status"),
         "head_sha": run["head_sha"],
         "url": run["html_url"],
-        "wall_seconds": seconds_between(run.get("created_at"), run.get("updated_at")),
-        "runner_seconds": sum(job_seconds.values()),
+        "run_attempt": attempt,
+        "wall_seconds": seconds_between(
+            attempt_run.get("created_at"), attempt_run.get("updated_at")
+        ),
+        "runner_seconds": sum(seconds for _, seconds in job_seconds),
         "executed_jobs": len(executed),
         "skipped_jobs": len(jobs) - len(executed),
         "longest_job": longest_name,
@@ -95,7 +115,9 @@ def run_record(repo: str, label: str, run: dict[str, Any]) -> dict[str, Any]:
             {
                 "name": job["name"],
                 "conclusion": job.get("conclusion"),
-                "seconds": seconds_between(job.get("started_at"), job.get("completed_at")),
+                "seconds": seconds_between(
+                    job.get("started_at"), job.get("completed_at")
+                ),
                 "runner": job.get("runner_name") or "",
             }
             for job in jobs
@@ -138,14 +160,16 @@ def recent_runs(
 ) -> list[dict[str, Any]]:
     selected: list[dict[str, Any]] = []
     for workflow in workflows:
-        fields = {"status": "completed", "per_page": str(limit)}
+        fields = {"status": "completed"}
         if branch:
             fields["branch"] = branch
-        payload = gh_api(
+        workflow_runs = gh_api_collection(
             f"repos/{repo}/actions/workflows/{workflow['id']}/runs",
+            "workflow_runs",
             fields,
+            limit=limit,
         )
-        selected.extend(payload["workflow_runs"][:limit])
+        selected.extend(workflow_runs)
     return selected
 
 
@@ -171,7 +195,9 @@ def render(
                 "|---|---|---:|---:|---:|---:|---|",
             ]
         )
-        by_snapshot = {(record["label"], record["workflow_id"]): record for record in records}
+        by_snapshot = {
+            (record["label"], record["workflow_id"]): record for record in records
+        }
         for label in labels:
             for workflow in workflows:
                 record = by_snapshot.get((label, workflow["id"]))
@@ -209,7 +235,13 @@ def render(
                 f"{duration(percentile(walls, 0.95))} | {duration(statistics.median(runners))} |"
             )
 
-    lines.extend(["", "Runner time is the sum of non-skipped job durations; wall time is end-to-end run duration.", ""])
+    lines.extend(
+        [
+            "",
+            "Runner time is the sum of non-skipped job durations; wall time is end-to-end run duration.",
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 

--- a/tests/test_report_workflow_timings.py
+++ b/tests/test_report_workflow_timings.py
@@ -95,6 +95,86 @@ class PaginationTests(unittest.TestCase):
 
         self.assertEqual(runs, final)
 
+    def test_recent_inventory_honors_limits_above_one_page(self) -> None:
+        first = [{"id": index} for index in range(100)]
+        final = [{"id": 100}]
+        workflows = [{"id": 7}]
+        with patch.object(
+            timings,
+            "gh_api",
+            side_effect=[{"workflow_runs": first}, {"workflow_runs": final}],
+        ) as api:
+            runs = timings.recent_runs("dinglebear-ai/axon", "main", 101, workflows)
+
+        self.assertEqual(len(runs), 101)
+        self.assertEqual(api.call_args_list[0].args[1]["per_page"], "100")
+        self.assertEqual(api.call_args_list[1].args[1]["per_page"], "1")
+
+
+class TimingAccuracyTests(unittest.TestCase):
+    @staticmethod
+    def sample_run(**overrides: object) -> dict[str, object]:
+        run: dict[str, object] = {
+            "id": 42,
+            "workflow_id": 7,
+            "path": ".github/workflows/ci.yml",
+            "name": "CI",
+            "event": "push",
+            "conclusion": "success",
+            "head_sha": "abc",
+            "html_url": "https://example.invalid/run/42",
+            "created_at": "2026-08-08T00:00:00Z",
+            "updated_at": "2026-08-08T00:10:00Z",
+        }
+        run.update(overrides)
+        return run
+
+    def test_rerun_wall_time_uses_attempt_specific_metadata(self) -> None:
+        attempt = {
+            "created_at": "2026-08-08T00:09:00Z",
+            "updated_at": "2026-08-08T00:10:00Z",
+        }
+        with patch.object(
+            timings,
+            "gh_api",
+            side_effect=[attempt, {"jobs": []}],
+        ) as api:
+            record = timings.run_record(
+                "dinglebear-ai/axon",
+                "candidate",
+                self.sample_run(run_attempt=2),
+            )
+
+        self.assertEqual(record["run_attempt"], 2)
+        self.assertEqual(record["wall_seconds"], 60.0)
+        self.assertIn("/attempts/2", api.call_args_list[0].args[0])
+        self.assertIn("/attempts/2/jobs", api.call_args_list[1].args[0])
+
+    def test_duplicate_job_names_are_counted_independently(self) -> None:
+        jobs = [
+            {
+                "name": "build",
+                "conclusion": "success",
+                "started_at": "2026-08-08T00:00:00Z",
+                "completed_at": "2026-08-08T00:00:05Z",
+            },
+            {
+                "name": "build",
+                "conclusion": "success",
+                "started_at": "2026-08-08T00:00:00Z",
+                "completed_at": "2026-08-08T00:00:07Z",
+            },
+        ]
+        with patch.object(timings, "gh_api", return_value={"jobs": jobs}):
+            record = timings.run_record(
+                "dinglebear-ai/axon", "candidate", self.sample_run()
+            )
+
+        self.assertEqual(record["runner_seconds"], 12.0)
+        self.assertEqual(record["executed_jobs"], 2)
+        self.assertEqual(record["longest_job"], "build")
+        self.assertEqual(record["longest_job_seconds"], 7.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -843,6 +843,18 @@ fn release_please_fixups_validate_and_forward_pr_branch_refs() {
 }
 
 #[test]
+fn release_please_runs_after_every_successful_main_ci_completion() {
+    let workflow = include_str!("../.github/workflows/release-please.yml");
+    let release = workflow_job_block(workflow, "release-please");
+
+    assert!(!workflow.contains("release-please changes"));
+    assert!(!workflow.contains("scripts/ci/changed_paths.py"));
+    assert!(!workflow.contains("git rev-parse HEAD^"));
+    assert!(!release.contains("needs: changes"));
+    assert!(release.contains("github.event.workflow_run.conclusion == 'success'"));
+}
+
+#[test]
 fn ci_keeps_expensive_artifacts_off_ordinary_pull_requests() {
     let workflow = include_str!("../.github/workflows/ci.yml");
     let changes = workflow_job_block(workflow, "changes");
@@ -859,11 +871,35 @@ fn ci_keeps_expensive_artifacts_off_ordinary_pull_requests() {
     assert!(windows_check.contains("needs.changes.outputs.run_windows_check"));
     assert!(windows_build.contains("needs.changes.outputs.run_windows_build"));
     assert!(changes.contains("RUN_MCP_SMOKE:") && changes.contains("'ci:full'"));
-    assert!(
-        windows_build.contains("sudo apt-get install -y --no-install-recommends mingw-w64 nasm")
-            && windows_build.contains("nasm -v"),
-        "the Windows GNU cross-build must install and verify NASM for BoringSSL assembly"
-    );
+    assert!(changes.contains("github.event_name == 'push'"));
+    assert!(changes.contains("github.ref == 'refs/heads/main'"));
+    assert!(changes.contains("steps.classify.outputs.auto_tag == 'true'"));
+    assert!(windows_build.contains("runs-on: windows-latest"));
+    assert!(windows_build.contains("cargo build --release --locked --bin axon"));
+    assert!(windows_build.contains("path: target/release/axon.exe"));
+}
+
+#[test]
+fn pull_request_binary_build_never_receives_shared_cache_secrets() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let build = workflow_job_block(workflow, "binary-smoke-build");
+    let (_, pr_and_after) = build
+        .split_once("name: Set up Rust with local-only Kache for pull requests")
+        .expect("pull requests have a local-only Kache setup step");
+    let (pr_step, trusted_and_after) = pr_and_after
+        .split_once("name: Set up Rust with shared Kache for trusted pushes")
+        .expect("trusted pushes have a separate shared-cache setup step");
+    let trusted_step = trusted_and_after
+        .split_once("- uses: actions/download-artifact@")
+        .expect("cache setup precedes artifact download")
+        .0;
+
+    assert!(pr_step.contains("github.event_name == 'pull_request'"));
+    assert!(!pr_step.contains("KACHE_S3_ACCESS_KEY"));
+    assert!(!pr_step.contains("KACHE_S3_SECRET_KEY"));
+    assert!(trusted_step.contains("github.event_name != 'pull_request'"));
+    assert!(trusted_step.contains("KACHE_S3_ACCESS_KEY"));
+    assert!(trusted_step.contains("KACHE_S3_SECRET_KEY"));
 }
 
 #[test]
@@ -940,7 +976,7 @@ fn ci_builds_web_assets_once_for_binary_artifact_jobs() {
         ("windows-build", windows),
     ] {
         assert!(
-            job.contains("uses: actions/download-artifact@v5")
+            job.contains("uses: actions/download-artifact@")
                 && job.contains("name: axon-web-assets"),
             "{name} must reuse the web-panel artifact"
         );


### PR DESCRIPTION
## Summary
- keep PR binary builds on local-only Kache while trusted pushes retain shared cache credentials
- require a native Windows release build in main CI before auto-tag can publish
- run release-please after every successful main CI completion so multi-commit pushes cannot be misclassified
- make timing reports attempt-aware, preserve duplicate-named jobs, and paginate recent-run inventories
- pin every mutable third-party action introduced since PR #538

## Review scope
Lavra review of all changes merged from PR #538 through PR #541. This resolves every finding filed under `axon_rust-juiu8`.

## Verification
- `python3 -m unittest tests/test_report_workflow_timings.py` (6 passed)
- `cargo test --locked --test workflow_shapes` (49 passed)
- `actionlint .github/workflows/*.yml`
- `ruff format --check` and `ruff check` for changed Python
- live timing smoke against rerun 31288664298: attempt 2 wall time = 450s
- Zizmor comparison: no new finding classes; unpinned-use findings reduced by 19
- lefthook pre-commit and pre-push gates
