### PR TITLE
fix(release): make capability smoke self-contained

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,11 @@ jobs:
       - name: cargo build --release --bin axon
         run: cargo build --release --locked --bin axon
       - name: Verify release acquisition capabilities
+        env:
+          # `capabilities` initializes Config before reporting compile-time
+          # features. A live TEI service is not contacted by this command, but
+          # the required endpoint must still be syntactically present.
+          TEI_URL: http://127.0.0.1:1
         run: |
           set -euo pipefail
           target/release/axon capabilities > capabilities.json
@@ -191,6 +196,10 @@ jobs:
           CARGO_BUILD_RUSTC_WRAPPER: ""
       - name: Verify release acquisition capabilities
         shell: pwsh
+        env:
+          # Keep this smoke self-contained; `capabilities` validates the
+          # required endpoint but does not connect to TEI.
+          TEI_URL: http://127.0.0.1:1
         run: |
           $ErrorActionPreference = 'Stop'
           $capabilities = (& target/release/axon.exe capabilities | ConvertFrom-Json)

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -1498,6 +1498,25 @@ fn release_builds_web_assets_once_for_both_native_targets() {
 }
 
 #[test]
+fn release_capability_smokes_provide_the_required_tei_endpoint() {
+    let workflow = include_str!("../.github/workflows/release.yml");
+    for job_name in ["axon-linux", "axon-windows"] {
+        let job = workflow_job_block(workflow, job_name);
+        let smoke = job
+            .split("- name: Verify release acquisition capabilities")
+            .nth(1)
+            .expect("release job has a capability smoke")
+            .split("- name: Package")
+            .next()
+            .expect("capability smoke precedes packaging");
+        assert!(
+            smoke.contains("TEI_URL: http://127.0.0.1:1"),
+            "{job_name} capability smoke must satisfy Config without a live TEI service"
+        );
+    }
+}
+
+#[test]
 fn release_artifact_actions_are_immutable_and_renovate_managed() {
     let workflows = [
         include_str!("../.github/workflows/release.yml"),


### PR DESCRIPTION
## Summary
- provide the required TEI endpoint to Linux and Windows release capability checks
- keep the smoke offline while still validating TLS client initialization and build features
- add workflow-shape regression coverage for both native targets

## Verification
- `actionlint .github/workflows/release.yml`
- `cargo test --test workflow_shapes` (50 passed)
- lefthook pre-commit and pre-push gates

Tracks axon_rust-juiu8.6.