### PR TITLE
fix(release): support exact-tag artifact backfills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
         description: "Attach artifacts to an existing release-please v* release"
         type: boolean
         default: false
+      release_tag:
+        description: "Existing v* tag to rebuild and publish (manual backfill only)"
+        type: string
+        required: false
+        default: ""
 
 concurrency:
   group: release-${{ github.ref }}
@@ -42,6 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           sparse-checkout: |
             apps/web
             assets
@@ -76,6 +82,8 @@ jobs:
       # Cargo.toml/Cargo.lock, which broke every build. LFS blobs come down as
       # pointers (lfs: false default) and are not needed to build.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
       - uses: ./.github/actions/setup-rust-kache
         with:
           toolchain: 1.97.1
@@ -164,6 +172,8 @@ jobs:
       # Cargo.toml/Cargo.lock, which broke every build. LFS blobs come down as
       # pointers (lfs: false default) and are not needed to build.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
@@ -237,9 +247,10 @@ jobs:
     # Attach artifacts only when release-please dispatches this workflow on an
     # existing v* release tag.
     if: >-
-      startsWith(github.ref, 'refs/tags/v') &&
       github.event_name == 'workflow_dispatch' &&
-      inputs.publish
+      inputs.publish &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+      startsWith(inputs.release_tag, 'v'))
     permissions:
       contents: write
     steps:
@@ -260,7 +271,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${{ inputs.release_tag || github.ref_name }}"
           gh release view "$tag" >/dev/null
           gh release upload "$tag" dist/axon-linux-x86_64.tar.gz.minisig --clobber
       - name: Attach artifacts to release
@@ -269,7 +280,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${{ inputs.release_tag || github.ref_name }}"
           gh release view "$tag" >/dev/null
           gh release upload "$tag" \
             dist/axon-linux-x86_64.tar.gz \

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -1517,6 +1517,27 @@ fn release_capability_smokes_provide_the_required_tei_endpoint() {
 }
 
 #[test]
+fn release_manual_backfill_builds_and_publishes_the_exact_existing_tag() {
+    let workflow = include_str!("../.github/workflows/release.yml");
+    assert!(workflow.contains("release_tag:"));
+    assert_eq!(
+        workflow
+            .matches("ref: ${{ inputs.release_tag || github.ref }}")
+            .count(),
+        3,
+        "every source checkout must use the requested immutable release tag"
+    );
+    assert!(workflow.contains("startsWith(inputs.release_tag, 'v')"));
+    assert_eq!(
+        workflow
+            .matches("tag=\"${{ inputs.release_tag || github.ref_name }}\"")
+            .count(),
+        2,
+        "both release upload steps must target the requested release"
+    );
+}
+
+#[test]
 fn release_artifact_actions_are_immutable_and_renovate_managed() {
     let workflows = [
         include_str!("../.github/workflows/release.yml"),


### PR DESCRIPTION
## Summary
- add an optional `release_tag` manual-dispatch input
- force all source checkouts to the exact requested immutable tag
- publish artifacts to that existing release without moving the tag
- add workflow-shape coverage for checkout and upload provenance

## Verification
- `actionlint .github/workflows/release.yml`
- `cargo test --test workflow_shapes` (51 passed)
- lefthook pre-commit and pre-push gates

Follow-up for axon_rust-juiu8.6 and the assetless v7.2.12 release.