### PR TITLE
fix(release): configure offline capability endpoints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,9 +109,10 @@ jobs:
       - name: Verify release acquisition capabilities
         env:
           # `capabilities` initializes Config before reporting compile-time
-          # features. A live TEI service is not contacted by this command, but
-          # the required endpoint must still be syntactically present.
+          # features. Live providers are not contacted by this command, but
+          # both required endpoints must still be syntactically present.
           TEI_URL: http://127.0.0.1:1
+          QDRANT_URL: http://127.0.0.1:1
         run: |
           set -euo pipefail
           target/release/axon capabilities > capabilities.json
@@ -208,8 +209,9 @@ jobs:
         shell: pwsh
         env:
           # Keep this smoke self-contained; `capabilities` validates the
-          # required endpoint but does not connect to TEI.
+          # required endpoints but does not connect to either provider.
           TEI_URL: http://127.0.0.1:1
+          QDRANT_URL: http://127.0.0.1:1
         run: |
           $ErrorActionPreference = 'Stop'
           $capabilities = (& target/release/axon.exe capabilities | ConvertFrom-Json)

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -1498,7 +1498,7 @@ fn release_builds_web_assets_once_for_both_native_targets() {
 }
 
 #[test]
-fn release_capability_smokes_provide_the_required_tei_endpoint() {
+fn release_capability_smokes_provide_required_provider_endpoints() {
     let workflow = include_str!("../.github/workflows/release.yml");
     for job_name in ["axon-linux", "axon-windows"] {
         let job = workflow_job_block(workflow, job_name);
@@ -1512,6 +1512,10 @@ fn release_capability_smokes_provide_the_required_tei_endpoint() {
         assert!(
             smoke.contains("TEI_URL: http://127.0.0.1:1"),
             "{job_name} capability smoke must satisfy Config without a live TEI service"
+        );
+        assert!(
+            smoke.contains("QDRANT_URL: http://127.0.0.1:1"),
+            "{job_name} capability smoke must satisfy Config without a live Qdrant service"
         );
     }
 }


### PR DESCRIPTION
## Summary
- provide both required offline provider URLs to native release capability checks
- retain TLS-client and build-feature verification without live provider dependencies
- extend regression coverage to TEI and Qdrant on Linux and Windows

## Verification
- `actionlint .github/workflows/release.yml`
- actual `axon capabilities` invocation with offline endpoints
- targeted workflow-shape test
- lefthook pre-commit and pre-push gates

Completes axon_rust-juiu8.6 after hosted backfill verification surfaced the second required endpoint.