### PR TITLE
fix(release): repair stale Android versionCode

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,7 +91,10 @@ jobs:
             while read -r fixup; do
               component="$(jq -r '.id' <<<"$fixup")"
               version="$(jq -r '.version' <<<"$fixup")"
-              ./target/debug/xtask release-please-fixups --component "$component" --version "$version"
+              ./target/debug/xtask release-please-fixups \
+                --component "$component" \
+                --version "$version" \
+                --base "origin/$base_branch"
             done < <(jq -c '.[]' fixup-plan.json)
             fixup_commit_created=false
             if ! git diff --quiet; then

--- a/xtask/src/checks/release_versions.rs
+++ b/xtask/src/checks/release_versions.rs
@@ -216,9 +216,14 @@ pub fn print_plans(plans: &[ComponentPlan], json: bool) -> ReleaseResult<()> {
     Ok(())
 }
 
-pub fn release_please_fixups(root: &Path, component_id: &str, version: &str) -> ReleaseResult<()> {
+pub fn release_please_fixups(
+    root: &Path,
+    component_id: &str,
+    version: &str,
+    base: Option<&str>,
+) -> ReleaseResult<()> {
     let manifest = load_manifest(root)?;
-    release_please::fixups(root, &manifest.components, component_id, version)
+    release_please::fixups(root, &manifest.components, component_id, version, base)
 }
 
 pub fn release_please_fixup_plan(

--- a/xtask/src/checks/release_versions/files.rs
+++ b/xtask/src/checks/release_versions/files.rs
@@ -351,7 +351,10 @@ pub(super) fn replace_gradle_version_name(content: &str, next: &str) -> ReleaseR
     Ok(regex.replace(content, format!(r#"$1"{next}""#)).to_string())
 }
 
-pub(super) fn increment_gradle_version_code(content: &str) -> ReleaseResult<String> {
+pub(super) fn increment_gradle_version_code_above(
+    content: &str,
+    minimum: u64,
+) -> ReleaseResult<String> {
     let regex = Regex::new(r#"(?m)^(\s*versionCode\s*=\s*)(\d+)"#)
         .release_context("invalid versionCode replacement regex")?;
     let captures = regex
@@ -361,11 +364,21 @@ pub(super) fn increment_gradle_version_code(content: &str) -> ReleaseResult<Stri
         .parse()
         .release_context("versionCode is not an integer")?;
     validate_gradle_version_code(current)?;
-    let next = current
+    let incremented = current
         .checked_add(1)
         .release_context("versionCode overflowed while bumping")?;
+    let next = incremented.max(
+        minimum
+            .checked_add(1)
+            .release_context("base versionCode overflowed while bumping")?,
+    );
     validate_gradle_version_code(next)?;
     Ok(regex.replace(content, format!("${{1}}{next}")).to_string())
+}
+
+#[cfg(test)]
+pub(super) fn increment_gradle_version_code(content: &str) -> ReleaseResult<String> {
+    increment_gradle_version_code_above(content, 0)
 }
 
 fn validate_gradle_version_code(code: u64) -> ReleaseResult<u64> {

--- a/xtask/src/checks/release_versions/release_please.rs
+++ b/xtask/src/checks/release_versions/release_please.rs
@@ -7,8 +7,10 @@ use super::{
     Component, ReleaseContext, ReleaseResult, VersionKind, read_version, write_version_file,
 };
 use crate::checks::release_versions::files::{
-    increment_gradle_version_code, read_gradle_version_name, replace_gradle_version_name,
+    increment_gradle_version_code_above, read_gradle_version_code, read_gradle_version_name,
+    replace_gradle_version_name,
 };
+use crate::checks::release_versions::git::git_show;
 
 mod ownership;
 
@@ -107,6 +109,7 @@ pub(super) fn fixups(
     components: &[Component],
     component_id: &str,
     version: &str,
+    base: Option<&str>,
 ) -> ReleaseResult<()> {
     let component = components
         .iter()
@@ -130,7 +133,7 @@ pub(super) fn fixups(
                 version,
             )
         }
-        "android" => android_fixup(root, component, version),
+        "android" => android_fixup(root, component, version, base),
         "chrome" => write_release_version_files(root, component, version),
         other => release_bail!("unsupported release-please fixup component {other}"),
     }
@@ -263,6 +266,7 @@ pub(super) fn android_fixup(
     root: &Path,
     component: &Component,
     version: &str,
+    base: Option<&str>,
 ) -> ReleaseResult<()> {
     let version_file = component
         .version_files
@@ -279,14 +283,33 @@ pub(super) fn android_fixup(
         );
     }
 
+    let current_code = read_gradle_version_code(&content)?;
+    let base_code = base
+        .map(|base| {
+            git_show(root, base, &version_file.path)
+                .with_release_context(|| {
+                    format!(
+                        "failed to read base Android version file {} at {base}",
+                        version_file.path
+                    )
+                })
+                .and_then(|base_content| read_gradle_version_code(&base_content))
+        })
+        .transpose()?
+        .unwrap_or(0);
+
     if read_gradle_version_name(&content)? == version
         && version_code_marker_matches(&content, version)
+        && current_code > base_code
     {
         return Ok(());
     }
 
     let renamed = replace_gradle_version_name(&content, version)?;
-    let updated = stamp_version_code_marker(&increment_gradle_version_code(&renamed)?, version)?;
+    let updated = stamp_version_code_marker(
+        &increment_gradle_version_code_above(&renamed, base_code)?,
+        version,
+    )?;
     std::fs::write(&path, updated)
         .with_release_context(|| format!("failed to write {}", version_file.path))?;
     Ok(())

--- a/xtask/src/checks/release_versions/release_please_tests.rs
+++ b/xtask/src/checks/release_versions/release_please_tests.rs
@@ -313,7 +313,7 @@ fn fixups_reject_axon_native_component() {
     let root = tempfile::tempdir().unwrap();
     let components = [component("cli", ".", ReleaseDriver::AxonNative)];
 
-    let error = fixups(root.path(), &components, "cli", "1.0.1")
+    let error = fixups(root.path(), &components, "cli", "1.0.1", None)
         .expect_err("release-please fixups must not write axon-native components");
     assert!(
         error

--- a/xtask/src/checks/release_versions_tests.rs
+++ b/xtask/src/checks/release_versions_tests.rs
@@ -1196,7 +1196,7 @@ fn pr_mode_allows_release_please_source_fixup_after_tag_exists() {
     fixture.git(&["commit", "-m", "chore(main): release chrome-ext 0.2.1"]);
     fixture.git(&["tag", "chrome-ext-v0.2.1"]);
 
-    release_please_fixups(fixture.root(), "chrome", "0.2.1").unwrap();
+    release_please_fixups(fixture.root(), "chrome", "0.2.1", None).unwrap();
     fixture.git(&[
         "add",
         "apps/chrome-extension/manifest.json",
@@ -1235,7 +1235,7 @@ fn release_please_fixups_must_be_committed_before_pr_validation() {
     ]);
     fixture.git(&["commit", "-m", "chore(main): release chrome-ext 0.2.1"]);
 
-    release_please_fixups(fixture.root(), "chrome", "0.2.1").unwrap();
+    release_please_fixups(fixture.root(), "chrome", "0.2.1", None).unwrap();
     let error = check(fixture.root(), Some("HEAD~1"), "HEAD", GateMode::Pr, false)
         .expect_err("dirty source fixups must not make a changelog-only HEAD valid");
     assert!(
@@ -1652,7 +1652,7 @@ fn release_please_fixup_plan_rejects_an_invalid_base_ref() {
 #[test]
 fn chrome_fixup_updates_manifest_and_package_versions() {
     let fixture = Fixture::new();
-    release_please_fixups(fixture.root(), "chrome", "0.3.0").unwrap();
+    release_please_fixups(fixture.root(), "chrome", "0.3.0", None).unwrap();
 
     let manifest = fs::read_to_string(fixture.path("apps/chrome-extension/manifest.json")).unwrap();
     let package = fs::read_to_string(fixture.path("apps/chrome-extension/package.json")).unwrap();
@@ -1684,13 +1684,91 @@ fn android_fixup_increments_version_code() {
     )
     .unwrap();
 
-    release_please_fixups(fixture.root(), "android", "1.5.1").unwrap();
-    release_please_fixups(fixture.root(), "android", "1.5.1").unwrap();
+    release_please_fixups(fixture.root(), "android", "1.5.1", None).unwrap();
+    release_please_fixups(fixture.root(), "android", "1.5.1", None).unwrap();
 
     let content = fs::read_to_string(fixture.path("apps/android/app/build.gradle.kts")).unwrap();
     assert_eq!(read_gradle_version_name(&content).unwrap(), "1.5.1");
     assert_eq!(read_gradle_version_code(&content).unwrap(), 15);
     assert!(content.contains("x-release-please-version-code 1.5.1"));
+}
+
+#[test]
+fn android_fixup_repairs_force_refreshed_stale_version_code() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.path(".release-please-manifest.json"),
+        r#"{
+  "apps/palette-tauri": "5.10.2",
+  "apps/android": "1.6.4",
+  "apps/chrome-extension": "0.2.0"
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/android/CHANGELOG.md"),
+        "# Changelog\n\n## [1.6.4]\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/android/app/build.gradle.kts"),
+        r#"android {
+    defaultConfig {
+        versionCode = 20 // x-release-please-version-code 1.6.4
+        // x-release-please-start-version
+        versionName = "1.6.4"
+        // x-release-please-end
+    }
+}
+"#,
+    )
+    .unwrap();
+    fixture.init_repo();
+    fixture.git(&["checkout", "-b", "release-android"]);
+
+    fs::write(
+        fixture.path(".release-please-manifest.json"),
+        r#"{
+  "apps/palette-tauri": "5.10.2",
+  "apps/android": "2.0.0",
+  "apps/chrome-extension": "0.2.0"
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/android/CHANGELOG.md"),
+        "# Changelog\n\n## [2.0.0]\n\n## [1.6.4]\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.path("apps/android/app/build.gradle.kts"),
+        r#"android {
+    defaultConfig {
+        versionCode = 20 // x-release-please-version-code 2.0.0
+        // x-release-please-start-version
+        versionName = "2.0.0"
+        // x-release-please-end
+    }
+}
+"#,
+    )
+    .unwrap();
+    fixture.git(&["add", "."]);
+    fixture.git(&["commit", "-m", "chore(main): release android 2.0.0"]);
+
+    release_please_fixups(fixture.root(), "android", "2.0.0", Some("main")).unwrap();
+
+    let content = fs::read_to_string(fixture.path("apps/android/app/build.gradle.kts")).unwrap();
+    assert_eq!(read_gradle_version_name(&content).unwrap(), "2.0.0");
+    assert_eq!(read_gradle_version_code(&content).unwrap(), 21);
+    assert!(content.contains("x-release-please-version-code 2.0.0"));
+
+    fixture.git(&["add", "apps/android/app/build.gradle.kts"]);
+    fixture.git(&["commit", "-m", "chore: apply release-please fixups"]);
+    check(fixture.root(), Some("main"), "HEAD", GateMode::Pr, false)
+        .expect("repaired force-refreshed release branch passes version checks");
 }
 
 #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -127,6 +127,8 @@ enum Command {
         component: String,
         #[arg(long)]
         version: String,
+        #[arg(long, default_value = "origin/main")]
+        base: String,
     },
     /// Print release-please postprocessing needed for a release PR branch diff.
     ReleasePleaseFixupPlan {
@@ -230,9 +232,16 @@ fn main() -> Result<()> {
         Command::BumpVersion { component, level } => Ok(
             checks::release_versions::bump_component_version(&root, &component, level)?,
         ),
-        Command::ReleasePleaseFixups { component, version } => Ok(
-            checks::release_versions::release_please_fixups(&root, &component, &version)?,
-        ),
+        Command::ReleasePleaseFixups {
+            component,
+            version,
+            base,
+        } => Ok(checks::release_versions::release_please_fixups(
+            &root,
+            &component,
+            &version,
+            Some(&base),
+        )?),
         Command::ReleasePleaseFixupPlan { base, head, json } => {
             let items = checks::release_versions::release_please_fixup_plan(&root, &base, &head)?;
             checks::release_versions::print_release_please_fixup_plan(&items, json)?;


### PR DESCRIPTION
## Summary
- pass the release PR's explicit base ref into Android release fixups
- raise versionCode deterministically above both the current and base values
- cover the force-refresh regression and prove the full PR release-version gate passes

## Bead
axon_rust-ig013: Make Android release fixup repair stale versionCode

## Testing
- cargo test -q -p xtask (461 passed)
- cargo clippy -p xtask --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- actionlint .github/workflows/release-please.yml
- pre-commit and path-aware pre-push hooks (29 changed-path tests, 51 workflow-shape tests, generated contracts, structural checks)

## Review
- Lavra review: clean, no actionable introduced findings
- Goal verification: PASS, 4/4 acceptance criteria at Exists/Substantive/Wired levels

## Knowledge Captured
- repair and validation must consume the same explicit branch-relative base
- idempotency must validate the complete postcondition before returning