### PR TITLE
fix(ci): run MCP smoke through skipped ancestors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -930,7 +930,9 @@ jobs:
     name: mcp-smoke
     runs-on: ubuntu-24.04
     needs: [changes, binary-smoke-build]
-    if: ${{ needs.binary-smoke-build.result == 'success' && needs.changes.outputs.run_mcp_smoke == 'true' }}
+    # A skipped web-panel ancestor propagates through binary-smoke-build unless
+    # this downstream consumer explicitly evaluates its own result contract.
+    if: ${{ always() && needs.binary-smoke-build.result == 'success' && needs.changes.outputs.run_mcp_smoke == 'true' }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v5

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -920,6 +920,19 @@ fn binary_smoke_survives_skipped_ancestors_after_its_build_succeeds() {
 }
 
 #[test]
+fn mcp_smoke_survives_skipped_ancestors_after_its_build_succeeds() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let mcp_smoke = workflow_job_block(workflow, "mcp-smoke");
+
+    assert!(mcp_smoke.lines().any(|line| {
+        line.trim()
+            == "if: ${{ always() && needs.binary-smoke-build.result == 'success' && needs.changes.outputs.run_mcp_smoke == 'true' }}"
+    }));
+    assert!(mcp_smoke.contains("needs.binary-smoke-build.result == 'success'"));
+    assert!(mcp_smoke.contains("needs.changes.outputs.run_mcp_smoke == 'true'"));
+}
+
+#[test]
 fn kache_migration_inputs_have_cargo_rerun_triggers() {
     for crate_name in [
         "axon-graph",


### PR DESCRIPTION
## Summary
- force evaluation of the MCP smoke condition after intentionally skipped ancestors
- preserve both the successful binary artifact and changed-path route gates
- add a workflow-shape regression for the exact job-level condition

## Root cause
Main CI run 31311517936 set `run_mcp_smoke=true`, but GitHub propagated the intentionally skipped `web-panel` ancestor through `binary-smoke-build` and skipped `mcp-smoke` before evaluating its condition. The stable gate then correctly failed.

## Verification
- direct `rustc --test tests/workflow_shapes.rs`: 52 passed
- targeted skipped-ancestor regression: passed
- `actionlint .github/workflows/ci.yml`
- `cargo fmt --all -- --check`
- `git diff --check`

Bead: axon_rust-rnj27