### PR TITLE
ci: allow cold artifact dispatch builds to finish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -116,7 +116,7 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ci-pool-ops
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
       actions: write  # required to dispatch artifact workflows


### PR DESCRIPTION
## Summary
- increase the release artifact-dispatch job timeout from 10 to 20 minutes
- prevent cold `xtask` builds from canceling component artifact dispatch

## Evidence
- hosted release run 31339351789 was canceled at the 10-minute job limit while still compiling dependencies
- `actionlint .github/workflows/release-please.yml`
- `git diff --check`

Tracks axon_rust-4uzfo.