### PR TITLE
fix(ci): run the scheduled security audit through skipped rust-contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -905,7 +905,10 @@ jobs:
     runs-on: ci-pool-rust
     timeout-minutes: 30
     needs: [changes, rust-contracts]
-    if: ${{ needs.changes.outputs.run_security == 'true' }}
+    # The weekly cron routes the security audit while intentionally skipping
+    # rust-contracts, so this job must evaluate its own route decision through
+    # the skipped ancestor instead of inheriting the cascade (see mcp-smoke).
+    if: ${{ always() && needs.changes.outputs.run_security == 'true' && (needs.rust-contracts.result == 'success' || needs.rust-contracts.result == 'skipped') }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust-kache

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -933,6 +933,21 @@ fn mcp_smoke_survives_skipped_ancestors_after_its_build_succeeds() {
 }
 
 #[test]
+fn security_survives_the_scheduled_skip_of_rust_contracts() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let security = workflow_job_block(workflow, "security");
+
+    // The weekly cron routes run_security=true while rust-contracts is
+    // intentionally skipped; without always() the skipped ancestor cascades,
+    // security never runs, and ci-gate fails every scheduled run.
+    assert!(security.contains("needs: [changes, rust-contracts]"));
+    assert!(security.lines().any(|line| {
+        line.trim()
+            == "if: ${{ always() && needs.changes.outputs.run_security == 'true' && (needs.rust-contracts.result == 'success' || needs.rust-contracts.result == 'skipped') }}"
+    }));
+}
+
+#[test]
 fn kache_migration_inputs_have_cargo_rerun_triggers() {
     for crate_name in [
         "axon-graph",


### PR DESCRIPTION
## Summary
The weekly cron ([run 31355298379](https://github.com/dinglebear-ai/axon/actions/runs/31355298379)) failed at ci-gate with `security was skipped even though its required condition is true`, even though the same SHA passed on push.

Root cause: on `schedule`, the classifier routes only `security` (+ CodeQL keys), so `rust-contracts` is intentionally skipped. `security` has `needs: [changes, rust-contracts]` and an `if:` without `always()`, so the skipped ancestor cascaded and `security` never ran — while ci-gate (correctly) demanded it. Every scheduled CI run has been failing this way.

Fix mirrors the mcp-smoke skipped-ancestor treatment from #547:
- `security` now evaluates its own route decision through the skipped ancestor: runs when `run_security == 'true'` and `rust-contracts` either succeeded or was intentionally skipped.
- New shape test `security_survives_the_scheduled_skip_of_rust_contracts` pins the exact `if:` contract in `tests/workflow_shapes.rs`.

## Testing
- `cargo test --test workflow_shapes` — 53 passed (includes the new test)
- `actionlint .github/workflows/ci.yml` — clean

Closes bead `axon_rust-f9bma`.